### PR TITLE
Linux build

### DIFF
--- a/include/hgraph/lib/std/operators/impl/container_impl.h
+++ b/include/hgraph/lib/std/operators/impl/container_impl.h
@@ -162,7 +162,8 @@ namespace hgraph::stdlib
             Bool contains_all = ts.valid();
             if (contains_all)
             {
-                for (const ValueView &value : item.base().as_set().values())
+                const auto &item_set = item.base().as_set();
+                for (const ValueView &value : item_set.values())
                 {
                     if (!ts.base().as_set().contains(value))
                     {

--- a/include/hgraph/runtime/evaluation_clock.h
+++ b/include/hgraph/runtime/evaluation_clock.h
@@ -27,10 +27,10 @@ namespace hgraph
     {
         const void *context{nullptr};
 
-        [[nodiscard]] DateTime (*evaluation_time_impl)(const void *context, const void *memory) noexcept = nullptr;
-        [[nodiscard]] DateTime (*now_impl)(const void *context, const void *memory) noexcept = nullptr;
-        [[nodiscard]] TimeDelta (*cycle_time_impl)(const void *context, const void *memory) noexcept = nullptr;
-        [[nodiscard]] DateTime (*next_cycle_evaluation_time_impl)(const void *context,
+        DateTime (*evaluation_time_impl)(const void *context, const void *memory) noexcept = nullptr;
+        DateTime (*now_impl)(const void *context, const void *memory) noexcept = nullptr;
+        TimeDelta (*cycle_time_impl)(const void *context, const void *memory) noexcept = nullptr;
+        DateTime (*next_cycle_evaluation_time_impl)(const void *context,
                                                                   const void *memory) noexcept = nullptr;
     };
 

--- a/include/hgraph/runtime/executor.h
+++ b/include/hgraph/runtime/executor.h
@@ -40,15 +40,15 @@ namespace hgraph
 
         void (*run_impl)(const void *context, const GraphExecutorView &executor) = nullptr;
         void (*request_stop_impl)(const void *context, void *memory) noexcept = nullptr;
-        [[nodiscard]] bool (*stop_requested_impl)(const void *context, const void *memory) noexcept = nullptr;
-        [[nodiscard]] DateTime (*start_time_impl)(const void *context, const void *memory) noexcept = nullptr;
-        [[nodiscard]] DateTime (*end_time_impl)(const void *context, const void *memory) noexcept = nullptr;
-        [[nodiscard]] GraphView (*graph_impl)(const void *context, void *memory) = nullptr;
-        [[nodiscard]] EvaluationClockStorageRef (*evaluation_clock_ref_impl)(const void *context,
+        bool (*stop_requested_impl)(const void *context, const void *memory) noexcept = nullptr;
+        DateTime (*start_time_impl)(const void *context, const void *memory) noexcept = nullptr;
+        DateTime (*end_time_impl)(const void *context, const void *memory) noexcept = nullptr;
+        GraphView (*graph_impl)(const void *context, void *memory) = nullptr;
+        EvaluationClockStorageRef (*evaluation_clock_ref_impl)(const void *context,
                                                                              void *memory) noexcept = nullptr;
         void (*mark_push_update_pending_impl)(const void *context, void *memory) = nullptr;
-        [[nodiscard]] bool (*is_push_update_pending_impl)(const void *context, void *memory) noexcept = nullptr;
-        [[nodiscard]] bool (*reset_push_update_pending_impl)(const void *context, void *memory) noexcept = nullptr;
+        bool (*is_push_update_pending_impl)(const void *context, void *memory) noexcept = nullptr;
+        bool (*reset_push_update_pending_impl)(const void *context, void *memory) noexcept = nullptr;
     };
 
     /** Real-time push queue projection over the root graph executor. */

--- a/include/hgraph/runtime/graph.h
+++ b/include/hgraph/runtime/graph.h
@@ -134,21 +134,21 @@ struct HGRAPH_EXPORT GraphEdge
         void (*schedule_node_impl)(const void *context, const GraphView &graph, std::size_t node_index,
                                    DateTime when) = nullptr;
 
-        [[nodiscard]] bool (*started_impl)(const void *context, const void *memory) noexcept = nullptr;
-        [[nodiscard]] bool (*evaluating_impl)(const void *context, const void *memory) noexcept = nullptr;
-        [[nodiscard]] DateTime (*evaluation_time_impl)(const void *context, const void *memory) noexcept = nullptr;
-        [[nodiscard]] DateTime (*next_scheduled_time_impl)(const void *context, const void *memory) noexcept = nullptr;
-        [[nodiscard]] std::size_t (*node_count_impl)(const void *context, const void *memory) noexcept = nullptr;
-        [[nodiscard]] NodeView (*node_at_impl)(const void *context, void *memory, std::size_t index) = nullptr;
-        [[nodiscard]] DateTime (*node_scheduled_time_impl)(const void *context, const void *memory,
+        bool (*started_impl)(const void *context, const void *memory) noexcept = nullptr;
+        bool (*evaluating_impl)(const void *context, const void *memory) noexcept = nullptr;
+        DateTime (*evaluation_time_impl)(const void *context, const void *memory) noexcept = nullptr;
+        DateTime (*next_scheduled_time_impl)(const void *context, const void *memory) noexcept = nullptr;
+        std::size_t (*node_count_impl)(const void *context, const void *memory) noexcept = nullptr;
+        NodeView (*node_at_impl)(const void *context, void *memory, std::size_t index) = nullptr;
+        DateTime (*node_scheduled_time_impl)(const void *context, const void *memory,
                                                            std::size_t index) noexcept = nullptr;
-        [[nodiscard]] GlobalStateView (*global_state_impl)(const void *context, void *memory) = nullptr;
+        GlobalStateView (*global_state_impl)(const void *context, void *memory) = nullptr;
         /** This graph's OWN trait entry (no parent walk); invalid view when absent. */
-        [[nodiscard]] ValueView (*trait_impl)(const void *context, void *memory,
+        ValueView (*trait_impl)(const void *context, void *memory,
                                               std::string_view name) noexcept = nullptr;
-        [[nodiscard]] RootGraphView (*root_impl)(const void *context, const GraphView &graph) = nullptr;
-        [[nodiscard]] GraphExecutorView (*graph_executor_impl)(const void *context, void *memory) = nullptr;
-        [[nodiscard]] NodeView (*parent_node_impl)(const void *context, void *memory) = nullptr;
+        RootGraphView (*root_impl)(const void *context, const GraphView &graph) = nullptr;
+        GraphExecutorView (*graph_executor_impl)(const void *context, void *memory) = nullptr;
+        NodeView (*parent_node_impl)(const void *context, void *memory) = nullptr;
     };
 
     using GraphTypeBinding = TypeBinding<GraphTypeMetaData, GraphOps>;

--- a/include/hgraph/runtime/node.h
+++ b/include/hgraph/runtime/node.h
@@ -106,11 +106,11 @@ namespace hgraph
 
         void (*attach_graph_impl)(const void *context, void *memory, GraphValue *graph,
                                   std::size_t node_index) = nullptr;
-        [[nodiscard]] GraphValue *(*graph_impl)(const void *context, const void *memory) noexcept = nullptr;
-        [[nodiscard]] std::size_t (*node_index_impl)(const void *context, const void *memory) noexcept = nullptr;
-        [[nodiscard]] std::string_view (*label_impl)(const void *context, const void *memory) noexcept = nullptr;
+        GraphValue *(*graph_impl)(const void *context, const void *memory) noexcept = nullptr;
+        std::size_t (*node_index_impl)(const void *context, const void *memory) noexcept = nullptr;
+        std::string_view (*label_impl)(const void *context, const void *memory) noexcept = nullptr;
 
-        [[nodiscard]] bool (*started_impl)(const void *context, const void *memory) noexcept = nullptr;
+        bool (*started_impl)(const void *context, const void *memory) noexcept = nullptr;
         void (*start_impl)(const void *context, const NodeView &view, DateTime evaluation_time) = nullptr;
         void (*stop_impl)(const void *context, const NodeView &view, DateTime evaluation_time) = nullptr;
         // Returns true when the node completed its evaluation, false when the node
@@ -118,28 +118,28 @@ namespace hgraph
         // protocol in the execution-layer docs). Ordinary nodes always return true.
         bool (*evaluate_impl)(const void *context, const NodeView &view, DateTime evaluation_time) = nullptr;
 
-        [[nodiscard]] bool (*has_input_impl)(const void *context, const void *memory) noexcept = nullptr;
-        [[nodiscard]] bool (*has_output_impl)(const void *context, const void *memory) noexcept = nullptr;
-        [[nodiscard]] bool (*has_state_impl)(const void *context, const void *memory) noexcept = nullptr;
-        [[nodiscard]] bool (*has_scalars_impl)(const void *context, const void *memory) noexcept = nullptr;
-        [[nodiscard]] bool (*has_scheduler_impl)(const void *context, const void *memory) noexcept = nullptr;
-        [[nodiscard]] bool (*has_error_output_impl)(const void *context, const void *memory) noexcept = nullptr;
-        [[nodiscard]] bool (*has_recordable_state_impl)(const void *context, const void *memory) noexcept = nullptr;
+        bool (*has_input_impl)(const void *context, const void *memory) noexcept = nullptr;
+        bool (*has_output_impl)(const void *context, const void *memory) noexcept = nullptr;
+        bool (*has_state_impl)(const void *context, const void *memory) noexcept = nullptr;
+        bool (*has_scalars_impl)(const void *context, const void *memory) noexcept = nullptr;
+        bool (*has_scheduler_impl)(const void *context, const void *memory) noexcept = nullptr;
+        bool (*has_error_output_impl)(const void *context, const void *memory) noexcept = nullptr;
+        bool (*has_recordable_state_impl)(const void *context, const void *memory) noexcept = nullptr;
 
-        [[nodiscard]] TSInputView (*input_view_impl)(const void *context, void *memory,
+        TSInputView (*input_view_impl)(const void *context, void *memory,
                                                      DateTime evaluation_time) = nullptr;
-        [[nodiscard]] TSOutputView (*output_view_impl)(const void *context, void *memory,
+        TSOutputView (*output_view_impl)(const void *context, void *memory,
                                                        DateTime evaluation_time) = nullptr;
-        [[nodiscard]] ValueView (*state_view_impl)(const void *context, void *memory) = nullptr;
+        ValueView (*state_view_impl)(const void *context, void *memory) = nullptr;
         void (*replace_state_impl)(const void *context, void *memory, Value value) = nullptr;
-        [[nodiscard]] ValueView (*scalars_view_impl)(const void *context, void *memory) = nullptr;
-        [[nodiscard]] NodeSchedulerState *(*scheduler_state_impl)(const void *context, void *memory) = nullptr;
-        [[nodiscard]] GlobalStateView (*global_state_view_impl)(const void *context, void *memory) = nullptr;
-        [[nodiscard]] EvaluationClockStorageRef (*evaluation_clock_ref_impl)(const void *context,
+        ValueView (*scalars_view_impl)(const void *context, void *memory) = nullptr;
+        NodeSchedulerState *(*scheduler_state_impl)(const void *context, void *memory) = nullptr;
+        GlobalStateView (*global_state_view_impl)(const void *context, void *memory) = nullptr;
+        EvaluationClockStorageRef (*evaluation_clock_ref_impl)(const void *context,
                                                                              void *memory) = nullptr;
-        [[nodiscard]] TSOutputView (*error_output_view_impl)(const void *context, void *memory,
+        TSOutputView (*error_output_view_impl)(const void *context, void *memory,
                                                              DateTime evaluation_time) = nullptr;
-        [[nodiscard]] TSOutputView (*recordable_state_view_impl)(const void *context, void *memory,
+        TSOutputView (*recordable_state_view_impl)(const void *context, void *memory,
                                                                  DateTime evaluation_time) = nullptr;
 
         const void *extended_view_type_id{nullptr};

--- a/include/hgraph/types/call_args.h
+++ b/include/hgraph/types/call_args.h
@@ -370,13 +370,13 @@ namespace hgraph
         }
 
         template <typename ParamsTuple, typename DefaultsTuple, std::size_t... I>
-        void validate_default_args(std::string_view call_name,
+        void validate_default_args([[maybe_unused]] std::string_view call_name,
                                    const DefaultsTuple &defaults,
-                                   std::string_view parameter_kind,
+                                   [[maybe_unused]] std::string_view parameter_kind,
                                    std::index_sequence<I...>)
         {
             constexpr std::size_t param_count = std::tuple_size_v<ParamsTuple>;
-            std::array<bool, param_count> filled{};
+            [[maybe_unused]] std::array<bool, param_count> filled{};
 
             (
                 [&] {
@@ -424,8 +424,8 @@ namespace hgraph
             constexpr std::size_t caller_params = caller_visible_param_count<ParamsTuple>();
             constexpr auto        slot_to_param = positional_slot_to_param_index<ParamsTuple>();
             std::array<bool, param_count> filled{};
-            bool                          seen_named = false;
-            std::size_t                   positional = 0;
+            [[maybe_unused]] bool seen_named = false;
+            [[maybe_unused]] std::size_t positional = 0;
 
             (
                 [&] {
@@ -511,8 +511,8 @@ namespace hgraph
         [[nodiscard]] consteval std::size_t bound_arg_index(std::index_sequence<I...>)
         {
             std::size_t found      = npos;
-            bool        seen_named = false;
-            std::size_t positional = 0;
+            [[maybe_unused]] bool        seen_named = false;
+            [[maybe_unused]] std::size_t positional = 0;
 
             (
                 [&] {

--- a/include/hgraph/types/subgraph_wiring.h
+++ b/include/hgraph/types/subgraph_wiring.h
@@ -80,7 +80,7 @@ namespace hgraph
         {
             return []<std::size_t... I>(std::index_sequence<I...>) {
                 std::array<std::size_t, Count> positions{};
-                std::size_t                    next = 0;
+                [[maybe_unused]] std::size_t   next = 0;
                 (
                     [&] {
                         using P = std::remove_cvref_t<std::tuple_element_t<I, Params>>;

--- a/include/hgraph/types/time_series/ts_output/alternative.h
+++ b/include/hgraph/types/time_series/ts_output/alternative.h
@@ -28,6 +28,9 @@ namespace hgraph::detail
     class TSOutputAlternativeStore
     {
       public:
+        struct ToRefAlternativeState;
+        struct RefLinkAlternativeState;
+
         TSOutputAlternativeStore() noexcept;
         TSOutputAlternativeStore(const TSOutputAlternativeStore &) = delete;
         TSOutputAlternativeStore &operator=(const TSOutputAlternativeStore &) = delete;
@@ -56,9 +59,6 @@ namespace hgraph::detail
                                                                std::size_t child_id);
 
       private:
-        struct ToRefAlternativeState;
-        struct RefLinkAlternativeState;
-
         struct AlternativeKey
         {
             const TSOutput              *source_output{nullptr};
@@ -90,5 +90,20 @@ namespace hgraph::detail
             ref_link_alternatives_{};
     };
 }  // namespace hgraph::detail
+
+namespace std
+{
+    template<>
+    struct default_delete<hgraph::detail::TSOutputAlternativeStore::ToRefAlternativeState>
+    {
+        void operator()(hgraph::detail::TSOutputAlternativeStore::ToRefAlternativeState *) noexcept;
+    };
+
+    template<>
+    struct default_delete<hgraph::detail::TSOutputAlternativeStore::RefLinkAlternativeState>
+    {
+        void operator()(hgraph::detail::TSOutputAlternativeStore::RefLinkAlternativeState *) noexcept;
+    };
+}  // namespace std
 
 #endif  // HGRAPH_CPP_TS_OUTPUT_ALTERNATIVE_H

--- a/include/hgraph/types/utils/memory_utils.h
+++ b/include/hgraph/types/utils/memory_utils.h
@@ -246,6 +246,11 @@ namespace hgraph
          * Stored in the per-plan byte block referenced by
          * ``StoragePlan::lifecycle_context``. The component array immediately
          * follows the ``CompositeState`` header in memory.
+         * 
+         * Note, this code could be significalntly simplified by using a flexible array member for the component array, 
+         * but that is not standard C++ as of 26 and would require compiler-specific GCC/Clang extensions and is not supported by MSVC. 
+         * Alternative is zero-size array member, but that is also not standard C++ even though supported by all compilers. Having -pendantic
+         * will cause warnings.
          */
         struct CompositeState
         {
@@ -254,14 +259,10 @@ namespace hgraph
 
             /** Byte offset from the start of the state block to the first component descriptor. */
             [[nodiscard]] static constexpr size_t components_offset() noexcept {
-                constexpr size_t alignment = alignof(CompositeComponent);
-                const size_t     offset    = sizeof(CompositeState);
-                if constexpr (alignment <= 1) {
-                    return offset;
-                } else {
-                    const size_t mask = alignment - 1;
-                    return (offset + mask) & ~mask;
-                }
+                static_assert(std::is_standard_layout_v<CompositeState>);
+                static_assert(std::is_standard_layout_v<CompositeComponent>);
+                struct Layout { CompositeState state; CompositeComponent first; };
+                return offsetof(Layout, first);
             }
 
             /** Total state-block size needed to hold ``component_count`` components. */

--- a/src/hgraph/runtime/map_node.cpp
+++ b/src/hgraph/runtime/map_node.cpp
@@ -709,13 +709,11 @@ namespace hgraph
         // terminal forwarding outputs hold links INTO it.
         descriptor.storage_plan = &node_storage_plan_for(descriptor.schema, {}, fields);
 
-        const auto &context = register_map_node_context(
-            std::move(spec), descriptor.storage_plan->component(map_storage_field_name).offset);
-
         descriptor.callbacks.stop            = &map_node_stop;
         descriptor.ops.evaluate_impl         = &map_evaluate_impl;
         descriptor.ops.extended_view_type_id = MapNodeView::node_view_type_id();
-        descriptor.ops.extended_view_context = &context;
+        descriptor.ops.extended_view_context = &register_map_node_context(
+            std::move(spec), descriptor.storage_plan->component(map_storage_field_name).offset);
 
         return NodeBuilder::from_descriptor(std::move(descriptor));
     }

--- a/src/hgraph/runtime/mesh_node.cpp
+++ b/src/hgraph/runtime/mesh_node.cpp
@@ -949,13 +949,11 @@ namespace hgraph
         // forward into it (and read it as their self-context).
         descriptor.storage_plan = &node_storage_plan_for(descriptor.schema, {}, fields);
 
-        const auto &context = register_mesh_node_context(
-            std::move(spec), descriptor.storage_plan->component(mesh_storage_field_name).offset);
-
         descriptor.callbacks.stop            = &mesh_node_stop;
         descriptor.ops.evaluate_impl         = &mesh_evaluate_impl;
         descriptor.ops.extended_view_type_id = MeshNodeView::node_view_type_id();
-        descriptor.ops.extended_view_context = &context;
+        descriptor.ops.extended_view_context = &register_mesh_node_context(
+            std::move(spec), descriptor.storage_plan->component(mesh_storage_field_name).offset);
 
         return NodeBuilder::from_descriptor(std::move(descriptor));
     }

--- a/src/hgraph/runtime/nested_graph_node.cpp
+++ b/src/hgraph/runtime/nested_graph_node.cpp
@@ -218,16 +218,14 @@ namespace hgraph
         }};
         descriptor.storage_plan = &node_storage_plan_for(descriptor.schema, fields);
 
-        const auto &context = register_single_nested_graph_context(
-            std::move(spec),
-            options,
-            descriptor.storage_plan->component(child_graph_field_name).offset);
-
         descriptor.callbacks.start = &single_nested_graph_start;
         descriptor.callbacks.stop  = &single_nested_graph_stop;
         descriptor.ops.evaluate_impl = &single_nested_graph_evaluate_impl;
         descriptor.ops.extended_view_type_id = SingleNestedGraphNodeView::node_view_type_id();
-        descriptor.ops.extended_view_context = &context;
+        descriptor.ops.extended_view_context = &register_single_nested_graph_context(
+            std::move(spec),
+            options,
+            descriptor.storage_plan->component(child_graph_field_name).offset);
 
         return descriptor;
     }

--- a/src/hgraph/runtime/node.cpp
+++ b/src/hgraph/runtime/node.cpp
@@ -321,10 +321,9 @@ namespace hgraph
             {
                 const auto *component = plan.find_component("input");
                 if (component == nullptr) { throw std::logic_error("Node storage plan is missing input"); }
-                const auto &input_builder = input_builder_for(*schema.input_schema, std::move(input_endpoint));
                 std::construct_at(MemoryUtils::cast<TSInput>(
                                       MemoryUtils::advance(memory, component->offset)),
-                                  input_builder);
+                                  input_builder_for(*schema.input_schema, std::move(input_endpoint)));
                 constructed.push_back(component);
             }
 

--- a/src/hgraph/runtime/push_source_node.cpp
+++ b/src/hgraph/runtime/push_source_node.cpp
@@ -25,15 +25,15 @@ namespace hgraph
         {
             const MemoryUtils::StoragePlan *storage_plan{nullptr};
 
-            [[nodiscard]] const ValueTypeMetaData &(*sender_schema_impl)(const void *context) = nullptr;
-            [[nodiscard]] bool (*output_compatible_impl)(const void *context,
+            const ValueTypeMetaData &(*sender_schema_impl)(const void *context) = nullptr;
+            bool (*output_compatible_impl)(const void *context,
                                                          const TSValueTypeMetaData &output_schema) = nullptr;
             void (*start_impl)(const void *context,
                                void *storage,
                                const TSValueTypeMetaData &output_schema) = nullptr;
             void (*stop_impl)(const void *context, void *storage) = nullptr;
-            [[nodiscard]] bool (*send_impl)(const void *context, void *storage, Value value) = nullptr;
-            [[nodiscard]] bool (*emit_next_impl)(const void *context,
+            bool (*send_impl)(const void *context, void *storage, Value value) = nullptr;
+            bool (*emit_next_impl)(const void *context,
                                                  void *storage,
                                                  const TSOutputView &output) = nullptr;
         };
@@ -572,21 +572,21 @@ namespace hgraph
             },
         };
         const auto &plan = node_storage_plan_for(schema, fields);
-        const auto &context = register_push_source_node_context(
+        const auto *context = &register_push_source_node_context(
             output_schema,
             policy,
             plan.component(push_source_policy_field_name).offset,
             std::move(on_start));
 
         NodeCallbacks callbacks;
-        callbacks.start = [&context](const NodeView &view, DateTime) {
-            push_source_start(context, view);
+        callbacks.start = [context](const NodeView &view, DateTime) {
+            push_source_start(*context, view);
         };
-        callbacks.evaluate = [&context](const NodeView &view, DateTime evaluation_time) {
-            push_source_eval(context, view, evaluation_time);
+        callbacks.evaluate = [context](const NodeView &view, DateTime evaluation_time) {
+            push_source_eval(*context, view, evaluation_time);
         };
-        callbacks.stop = [&context](const NodeView &view, DateTime) {
-            push_source_stop(context, view);
+        callbacks.stop = [context](const NodeView &view, DateTime) {
+            push_source_stop(*context, view);
         };
 
         NodeTypeDescriptor descriptor;

--- a/src/hgraph/runtime/reduce_node.cpp
+++ b/src/hgraph/runtime/reduce_node.cpp
@@ -591,13 +591,11 @@ namespace hgraph
         // destroy before the field (the nested_/switch_ direction).
         descriptor.storage_plan = &node_storage_plan_for(descriptor.schema, fields);
 
-        const auto &context = register_reduce_node_context(
-            std::move(spec), descriptor.storage_plan->component(reduce_storage_field_name).offset);
-
         descriptor.callbacks.stop            = &reduce_node_stop;
         descriptor.ops.evaluate_impl         = &reduce_evaluate_impl;
         descriptor.ops.extended_view_type_id = ReduceNodeView::node_view_type_id();
-        descriptor.ops.extended_view_context = &context;
+        descriptor.ops.extended_view_context = &register_reduce_node_context(
+            std::move(spec), descriptor.storage_plan->component(reduce_storage_field_name).offset);
 
         return NodeBuilder::from_descriptor(std::move(descriptor));
     }

--- a/src/hgraph/runtime/switch_node.cpp
+++ b/src/hgraph/runtime/switch_node.cpp
@@ -419,13 +419,11 @@ namespace hgraph
         // so the output must be destroyed before this storage field.
         descriptor.storage_plan = &node_storage_plan_for(descriptor.schema, fields);
 
-        const auto &context = register_switch_node_context(
-            std::move(spec), descriptor.storage_plan->component(switch_storage_field_name).offset);
-
         descriptor.callbacks.stop            = &switch_node_stop;
         descriptor.ops.evaluate_impl         = &switch_evaluate_impl;
         descriptor.ops.extended_view_type_id = SwitchNodeView::node_view_type_id();
-        descriptor.ops.extended_view_context = &context;
+        descriptor.ops.extended_view_context = &register_switch_node_context(
+            std::move(spec), descriptor.storage_plan->component(switch_storage_field_name).offset);
 
         return NodeBuilder::from_descriptor(std::move(descriptor));
     }

--- a/src/hgraph/types/metadata/ts_data_fixed_structured_plan.cpp
+++ b/src/hgraph/types/metadata/ts_data_fixed_structured_plan.cpp
@@ -317,9 +317,9 @@ namespace hgraph::ts_data_plan_factory_detail
             element_data_offsets.push_back(child_binding->plan() == &root_plan ? 0 : child_aux_offset);
         }
 
-        const auto &ops = fixed_structured_ts_data_ops(schema, root_plan, value_offset, aux_offset, tracking_offset,
-                                                       std::move(element_bindings), std::move(element_data_offsets));
-        return &TSDataBinding::intern(schema, root_plan, ops);
+        return &TSDataBinding::intern(schema, root_plan,
+            fixed_structured_ts_data_ops(schema, root_plan, value_offset, aux_offset, tracking_offset,
+                                         std::move(element_bindings), std::move(element_data_offsets)));
     }
 
     [[nodiscard]] const MemoryUtils::StoragePlan *synthesise_fixed_plan(const TSValueTypeMetaData &schema)

--- a/src/hgraph/types/time_series/ts_data/proxy.cpp
+++ b/src/hgraph/types/time_series/ts_data/proxy.cpp
@@ -1225,7 +1225,8 @@ namespace hgraph
             throw std::invalid_argument("bind_tsd_proxy requires a source TSD with the same key schema");
         }
 
-        const auto &layout = proxy.as_dict().layout();
+        const auto &dict   = proxy.as_dict();
+        const auto &layout = dict.layout();
         if (layout.element_binding == nullptr)
         {
             throw std::logic_error("bind_tsd_proxy requires an element binding");

--- a/src/hgraph/types/time_series/ts_output/alternative.cpp
+++ b/src/hgraph/types/time_series/ts_output/alternative.cpp
@@ -809,6 +809,25 @@ namespace hgraph::detail
         }
     };
 
+}  // namespace hgraph::detail
+
+namespace std
+{
+    void default_delete<hgraph::detail::TSOutputAlternativeStore::ToRefAlternativeState>::operator()(
+        hgraph::detail::TSOutputAlternativeStore::ToRefAlternativeState *p) noexcept
+    {
+        delete p;
+    }
+
+    void default_delete<hgraph::detail::TSOutputAlternativeStore::RefLinkAlternativeState>::operator()(
+        hgraph::detail::TSOutputAlternativeStore::RefLinkAlternativeState *p) noexcept
+    {
+        delete p;
+    }
+}  // namespace std
+
+namespace hgraph::detail
+{
     TSOutputAlternativeStore::TSOutputAlternativeStore() noexcept = default;
     TSOutputAlternativeStore::TSOutputAlternativeStore(TSOutputAlternativeStore &&) noexcept = default;
     TSOutputAlternativeStore &TSOutputAlternativeStore::operator=(TSOutputAlternativeStore &&) noexcept = default;

--- a/tests/cpp/header_compile_check.cpp
+++ b/tests/cpp/header_compile_check.cpp
@@ -52,11 +52,11 @@ void instantiate_memory_utils() {
     assert(plan.valid());
     assert(plan.layout.size == sizeof(std::int32_t));
 
-    const auto &tuple_plan = MemoryUtils::tuple_plan({&plan, &plan});
+    [[maybe_unused]] const auto &tuple_plan = MemoryUtils::tuple_plan({&plan, &plan});
     assert(tuple_plan.is_tuple());
     assert(tuple_plan.component_count() == 2);
 
-    const auto &array_plan = MemoryUtils::array_plan(plan, 4);
+    [[maybe_unused]] const auto &array_plan = MemoryUtils::array_plan(plan, 4);
     assert(array_plan.is_array());
     assert(array_plan.array_count() == 4);
 
@@ -66,7 +66,7 @@ void instantiate_memory_utils() {
 
 void instantiate_intern_table() {
     hgraph::InternTable<int, int> table;
-    const int &v = table.emplace(7, 7);
+    [[maybe_unused]] const int &v = table.emplace(7, 7);
     assert(v == 7);
 }
 
@@ -79,7 +79,7 @@ void instantiate_slot_stores() {
     KeySlotStore keys(MemoryUtils::plan_for<std::int32_t>(), hgraph::key_slot_store_ops_for<std::int32_t>());
     KeyMirroredValueSlotStore mirrored_values(keys, MemoryUtils::plan_for<std::int32_t>());
     int          k = 42;
-    auto         result = keys.insert(k);
+    [[maybe_unused]] auto result = keys.insert(k);
     assert(result.inserted);
     assert(keys.contains(k));
     assert(mirrored_values.has_slot(result.slot));
@@ -96,7 +96,7 @@ void instantiate_slot_stores() {
 void instantiate_schema() {
     using hgraph::TypeRegistry;
     auto       &registry = TypeRegistry::instance();
-    const auto *standard_int_meta = registry.value_type("int");
+    [[maybe_unused]] const auto *standard_int_meta = registry.value_type("int");
     assert(standard_int_meta != nullptr);
     assert(standard_int_meta == registry.scalar_binding<std::int64_t>()->type_meta);
 
@@ -105,7 +105,7 @@ void instantiate_schema() {
     assert(int_meta->kind == hgraph::ValueTypeKind::Atomic);
     assert(int_meta == registry.value_type("int32"));
 
-    const auto *ts_int = registry.ts(int_meta);
+    [[maybe_unused]] const auto *ts_int = registry.ts(int_meta);
     assert(ts_int != nullptr);
     assert(ts_int->kind == hgraph::TSTypeKind::TS);
 }
@@ -121,13 +121,13 @@ void instantiate_plan_factory() {
     const auto *int_meta   = registry.register_scalar<std::int32_t>("int32");
     const auto *float_meta = registry.register_scalar<float>("float32");
 
-    const auto *int_plan   = factory.plan_for(int_meta);
-    const auto *float_plan = factory.plan_for(float_meta);
+    [[maybe_unused]] const auto *int_plan   = factory.plan_for(int_meta);
+    [[maybe_unused]] const auto *float_plan = factory.plan_for(float_meta);
     assert(int_plan == &MemoryUtils::plan_for<std::int32_t>());
     assert(float_plan == &MemoryUtils::plan_for<float>());
 
     const auto *tuple_meta = registry.tuple({int_meta, float_meta});
-    const auto *tuple_plan = factory.plan_for(tuple_meta);
+    [[maybe_unused]] const auto *tuple_plan = factory.plan_for(tuple_meta);
     assert(tuple_plan != nullptr);
     assert(tuple_plan->is_tuple());
     assert(tuple_plan->component_count() == 2);

--- a/tests/cpp/test_bundle_builder.cpp
+++ b/tests/cpp/test_bundle_builder.cpp
@@ -138,7 +138,8 @@ TEST_CASE("BundleBuilder: moves owned field values")
     builder.set("field", std::move(field));
     Value bundle = builder.build();
 
-    const auto &stored = bundle.view().as_bundle().field("field").checked_as<BundleMoveCountingScalar>();
+    auto        field_view = bundle.view().as_bundle().field("field");
+    const auto &stored     = field_view.checked_as<BundleMoveCountingScalar>();
     REQUIRE(stored.value == 13);
     REQUIRE(BundleMoveCountingScalar::copy_constructs == 0);
     REQUIRE(BundleMoveCountingScalar::copy_assigns == 0);

--- a/tests/cpp/test_context_node.cpp
+++ b/tests/cpp/test_context_node.cpp
@@ -73,7 +73,8 @@ TEST_CASE("context source publishes the reference captured during start")
     CHECK_FALSE(view.global_state().contains(key));
 
     view.stop();
-    const auto &cleared = view.node_at(1).state().checked_as<TimeSeriesReference>();
+    auto        state_view = view.node_at(1).state();
+    const auto &cleared    = state_view.checked_as<TimeSeriesReference>();
     CHECK(cleared.is_empty());
     CHECK(cleared.target_schema() == nullptr);
 }

--- a/tests/cpp/test_error_handling.cpp
+++ b/tests/cpp/test_error_handling.cpp
@@ -263,7 +263,7 @@ TEST_CASE("error handling: exception_time_series captures a node throw")
     set_replay_values<Int>(gb.global_state(), "x", values<Int>(5, -3, 7));
 
     GraphExecutorValue ex = run_graph(std::move(gb), MIN_ST, MAX_ET);
-    const auto        &gs = ex.view().graph().global_state();
+    auto               gs = ex.view().graph().global_state();
 
     // The throw cycle (x=-3) ticks the error. This node throws before writing
     // output; write-then-throw output is deliberately unspecified.
@@ -280,7 +280,7 @@ TEST_CASE("error handling: exception_time_series catches non-standard exceptions
     set_replay_values<Int>(gb.global_state(), "x", values<Int>(5, -3, 7));
 
     GraphExecutorValue ex = run_graph(std::move(gb), MIN_ST, MAX_ET);
-    const auto        &gs = ex.view().graph().global_state();
+    auto gs = ex.view().graph().global_state();
 
     CHECK_OUTPUT(get_recorded_values<Int>(gs, "out"), values<Int>(15, none, 21));
     CHECK_OUTPUT(get_recorded_values<Str>(gs, "err"), values<Str>(none, "unknown error"s));
@@ -295,7 +295,7 @@ TEST_CASE("error handling: a clean run never ticks the error output")
     set_replay_values<Int>(gb.global_state(), "x", values<Int>(1, 2, 3));
 
     GraphExecutorValue ex = run_graph(std::move(gb), MIN_ST, MAX_ET);
-    const auto        &gs = ex.view().graph().global_state();
+    auto gs = ex.view().graph().global_state();
 
     CHECK_OUTPUT(get_recorded_values<Int>(gs, "out"), values<Int>(2, 4, 6));
     CHECK_OUTPUT(get_recorded_values<Str>(gs, "err"), values<Str>());
@@ -310,7 +310,7 @@ TEST_CASE("error handling: try_except over a sub-graph routes value and exceptio
     set_replay_values<Int>(gb.global_state(), "x", values<Int>(5, -3, 7));
 
     GraphExecutorValue ex = run_graph(std::move(gb), MIN_ST, MAX_ET);
-    const auto        &gs = ex.view().graph().global_state();
+    auto gs = ex.view().graph().global_state();
 
     CHECK_OUTPUT(get_recorded_values<Int>(gs, "out"), values<Int>(10, none, 14));
     CHECK_OUTPUT(get_recorded_values<Str>(gs, "err"), values<Str>(none, "negative input"s));
@@ -325,7 +325,7 @@ TEST_CASE("error handling: try_except catches non-standard exceptions as unknown
     set_replay_values<Int>(gb.global_state(), "x", values<Int>(5, -3, 7));
 
     GraphExecutorValue ex = run_graph(std::move(gb), MIN_ST, MAX_ET);
-    const auto        &gs = ex.view().graph().global_state();
+    auto gs = ex.view().graph().global_state();
 
     CHECK_OUTPUT(get_recorded_values<Int>(gs, "out"), values<Int>(15, none, 21));
     CHECK_OUTPUT(get_recorded_values<Str>(gs, "err"), values<Str>(none, "unknown error"s));
@@ -340,7 +340,7 @@ TEST_CASE("error handling: try_except over a sink sub-graph yields just the erro
     set_replay_values<Int>(gb.global_state(), "x", values<Int>(5, -3, 7));
 
     GraphExecutorValue ex = run_graph(std::move(gb), MIN_ST, MAX_ET);
-    const auto        &gs = ex.view().graph().global_state();
+    auto gs = ex.view().graph().global_state();
 
     CHECK_OUTPUT(get_recorded_values<Str>(gs, "err"), values<Str>(none, "sink negative"s));
 }

--- a/tests/cpp/test_memory_utils.cpp
+++ b/tests/cpp/test_memory_utils.cpp
@@ -340,10 +340,10 @@ TEST_CASE("memory utils storage plans expose copy and move assignment hooks", "[
 TEST_CASE("memory utils composite and array plans forward assignment support from child plans", "[memory utils]") {
     TrackedValue::reset();
 
-    const auto &tuple_plan = MemoryUtils::named_tuple()
-                                 .add_field("value", MemoryUtils::plan_for<TrackedValue>())
-                                 .add_field("count", MemoryUtils::plan_for<uint32_t>())
-                                 .build();
+    auto        tuple_builder = MemoryUtils::named_tuple()
+                                    .add_field("value", MemoryUtils::plan_for<TrackedValue>())
+                                    .add_field("count", MemoryUtils::plan_for<uint32_t>());
+    const auto &tuple_plan    = tuple_builder.build();
     REQUIRE(tuple_plan.can_copy_assign());
     REQUIRE(tuple_plan.can_move_assign());
 
@@ -456,16 +456,17 @@ TEST_CASE("memory utils supports custom inline policies and aligned heap ownersh
 }
 
 TEST_CASE("memory utils caches tuple and named tuple plans and supports nesting", "[memory utils]") {
-    const auto &point = MemoryUtils::named_tuple().add_field<uint16_t>("x").add_field<uint16_t>("y").build();
+    auto        point_builder = MemoryUtils::named_tuple().add_field<uint16_t>("x").add_field<uint16_t>("y");
+    const auto &point         = point_builder.build();
 
     const auto &point_again =
         MemoryUtils::named_tuple_plan({{"x", &MemoryUtils::plan_for<uint16_t>()}, {"y", &MemoryUtils::plan_for<uint16_t>()}});
 
-    const auto &payload = MemoryUtils::tuple()
-                              .add_type<uint8_t>()
-                              .add_plan(point)
-                              .add_plan(MemoryUtils::named_tuple_plan({{"id", &MemoryUtils::plan_for<uint32_t>()}}))
-                              .build();
+    auto        payload_builder = MemoryUtils::tuple()
+                                      .add_type<uint8_t>()
+                                      .add_plan(point)
+                                      .add_plan(MemoryUtils::named_tuple_plan({{"id", &MemoryUtils::plan_for<uint32_t>()}}));
+    const auto &payload         = payload_builder.build();
 
     REQUIRE(&point == &point_again);
     REQUIRE(point.is_named_tuple());
@@ -486,12 +487,14 @@ TEST_CASE("memory utils caches tuple and named tuple plans and supports nesting"
 }
 
 TEST_CASE("memory utils caches array plans and exposes homogeneous array metadata", "[memory utils]") {
-    const auto &point = MemoryUtils::named_tuple().add_field<uint16_t>("x").add_field<uint16_t>("y").build();
+    auto        point_builder = MemoryUtils::named_tuple().add_field<uint16_t>("x").add_field<uint16_t>("y");
+    const auto &point         = point_builder.build();
 
     const auto &points       = MemoryUtils::array_plan(point, 3);
     const auto &points_again = MemoryUtils::array_plan(point, 3);
     const auto &empty_values = MemoryUtils::array_plan<uint32_t>(0);
-    const auto &payload      = MemoryUtils::tuple().add_type<uint8_t>().add_plan(points).build();
+    auto        payload_builder = MemoryUtils::tuple().add_type<uint8_t>().add_plan(points);
+    const auto &payload         = payload_builder.build();
 
     REQUIRE(&points == &points_again);
     REQUIRE(points.is_array());
@@ -514,7 +517,8 @@ TEST_CASE("memory utils caches array plans and exposes homogeneous array metadat
 }
 
 TEST_CASE("memory utils stores composite components in trailing composite-state storage", "[memory utils]") {
-    const auto &point = MemoryUtils::named_tuple().add_field<uint16_t>("x").add_field<uint16_t>("y").build();
+    auto        point_builder = MemoryUtils::named_tuple().add_field<uint16_t>("x").add_field<uint16_t>("y");
+    const auto &point         = point_builder.build();
 
     const auto *state = point.composite_state();
     REQUIRE(state != nullptr);
@@ -542,10 +546,12 @@ TEST_CASE("memory utils composite builders reject invalid tuple and named tuple 
 TEST_CASE("memory utils nested composite handles construct and destroy in deterministic order", "[memory utils]") {
     LifecycleRecorder::reset();
 
-    const auto &inner = MemoryUtils::named_tuple().add_field<OrderedValue<2>>("lhs").add_field<OrderedValue<3>>("rhs").build();
+    auto        inner_builder = MemoryUtils::named_tuple().add_field<OrderedValue<2>>("lhs").add_field<OrderedValue<3>>("rhs");
+    const auto &inner         = inner_builder.build();
 
     {
-        const auto                  &outer = MemoryUtils::tuple().add_type<OrderedValue<1>>().add_plan(inner).build();
+        auto        outer_builder = MemoryUtils::tuple().add_type<OrderedValue<1>>().add_plan(inner);
+        const auto &outer         = outer_builder.build();
         MemoryUtils::StorageHandle<> handle(outer);
         REQUIRE(handle.is_owning());
     }
@@ -556,10 +562,10 @@ TEST_CASE("memory utils nested composite handles construct and destroy in determ
 TEST_CASE("memory utils composite handles deep-copy nested child payloads", "[memory utils]") {
     TrackedValue::reset();
 
-    const auto &composite = MemoryUtils::named_tuple()
-                                .add_field("value", MemoryUtils::plan_for<TrackedValue>())
-                                .add_field("count", MemoryUtils::plan_for<uint32_t>())
-                                .build();
+    auto        composite_builder = MemoryUtils::named_tuple()
+                                       .add_field("value", MemoryUtils::plan_for<TrackedValue>())
+                                       .add_field("count", MemoryUtils::plan_for<uint32_t>());
+    const auto &composite         = composite_builder.build();
 
     {
         MemoryUtils::StorageHandle<> source(composite);
@@ -629,7 +635,8 @@ TEST_CASE("memory utils array handles deep-copy element payloads", "[memory util
 TEST_CASE("memory utils composite plans clean up partial construction on owning handle creation", "[memory utils]") {
     PartiallyConstructedValue::reset();
 
-    const auto &composite = MemoryUtils::tuple().add_type<PartiallyConstructedValue>().add_type<ThrowsOnDefault>().build();
+    auto        composite_builder = MemoryUtils::tuple().add_type<PartiallyConstructedValue>().add_type<ThrowsOnDefault>();
+    const auto &composite         = composite_builder.build();
 
     REQUIRE_THROWS_AS(MemoryUtils::StorageHandle<>{composite}, std::runtime_error);
     REQUIRE(PartiallyConstructedValue::destroyed == 1);

--- a/tests/cpp/test_runtime_value_view.cpp
+++ b/tests/cpp/test_runtime_value_view.cpp
@@ -196,7 +196,8 @@ TEST_CASE("testing set_output_value moves owned scalar values")
     view.start(t1);
     view.evaluate(t1);
 
-    const auto &output_value = node.view().output(t1).value().checked_as<MoveCountingScalar>();
+    auto        output_view  = node.view().output(t1).value();
+    const auto &output_value = output_view.checked_as<MoveCountingScalar>();
     REQUIRE(output_value.value == 17);
     REQUIRE(MoveCountingScalar::copy_constructs == 0);
     REQUIRE(MoveCountingScalar::copy_assigns == 0);

--- a/tests/cpp/test_shared_output_node.cpp
+++ b/tests/cpp/test_shared_output_node.cpp
@@ -86,7 +86,8 @@ TEST_CASE("shared output source publishes the reference captured during start")
     CHECK_FALSE(view.global_state().contains(path));
 
     view.stop();
-    const auto &cleared = view.node_at(1).state().checked_as<TimeSeriesReference>();
+    auto        state_view = view.node_at(1).state();
+    const auto &cleared    = state_view.checked_as<TimeSeriesReference>();
     CHECK(cleared.is_empty());
     CHECK(cleared.target_schema() == nullptr);
 }

--- a/tests/cpp/test_slot_utils.cpp
+++ b/tests/cpp/test_slot_utils.cpp
@@ -122,6 +122,9 @@ namespace
 
         TrackedPayload(const TrackedPayload &other) : value(other.value) { ++constructed; }
 
+        TrackedPayload &operator=(const TrackedPayload &) = default;
+        TrackedPayload &operator=(TrackedPayload &&)      = default;
+
         ~TrackedPayload() { ++destroyed; }
 
         static void reset() {

--- a/tests/cpp/test_ts_input.cpp
+++ b/tests/cpp/test_ts_input.cpp
@@ -105,9 +105,8 @@ TEST_CASE("TSInput builds a non-peered TSB root with nested peered terminals")
     const auto *nested   = registry.tsb("TSInputNested", {{"x", ts_int}});
     const auto *root     = registry.tsb("TSInputRoot", {{"a", ts_int}, {"nested", nested}});
 
-    const auto &builder = TSInputBuilderFactory::checked_builder_for(
-        *root,
-        nested_input_schema(root, nested, ts_int));
+    auto        schema  = nested_input_schema(root, nested, ts_int);
+    const auto &builder = TSInputBuilderFactory::checked_builder_for(*root, schema);
     TSOutput output{*ts_int};
     TSOutput replacement{*ts_int};
     const auto t1 = MIN_ST;


### PR DESCRIPTION
I left a couple for `dengling-reference` warnings as there are known false positives by the g++ compiler. Did not want to disable the warning altogether because  there were other parts of the code where they were helpful to avoid crashes 