### PR TITLE
Bound the real-time drain past wall-clock end_time by logical progress

### DIFF
--- a/docs/source/developer_guide/data_structures/overview/execution_layer.rst
+++ b/docs/source/developer_guide/data_structures/overview/execution_layer.rst
@@ -29,18 +29,24 @@ Current implementation
     minimum over the graph's per-node schedule entries.
 
     **End-of-run enforcement.** ``end_time`` bounds the run in *evaluation*
-    time — the loop exits once the next evaluation time reaches it. The
-    real-time executor additionally enforces it against the **wall clock**:
-    ``advance_realtime`` ends the run as soon as the wall clock passes
-    ``end_time``, even if earlier-scheduled work remains. Without this, a
-    node that re-schedules itself every ``MIN_TD`` while each cycle burns
-    real wall time (the shape of a permanently failing adaptor retry loop)
-    advances evaluation time by only one microsecond per cycle and can
-    starve the logical bound almost indefinitely at 100% CPU. This is a
-    recorded deviation from the ``ext/main`` Python runtime, whose run loop
-    bounds only evaluation time and shares the starvation. Work scheduled
-    before ``end_time`` but not yet evaluated when the wall clock reaches it
-    is dropped, exactly as ``request_stop()`` would drop it.
+    time — the loop exits once the next evaluation time reaches it. A
+    real-time graph may lag the wall clock (cycles cost more wall time than
+    their logical spacing); once the wall clock passes ``end_time`` the
+    executor **drains**: remaining scheduled work still evaluates at its
+    scheduled (logical) times up to ``end_time``, matching the ``ext/main``
+    Python runtime and the ported wall-clock scheduler tests, which rely on
+    a lagging graph delivering its alarms late rather than dropping them.
+    The drain is bounded by *logical progress*: a cycle that advances
+    evaluation time by exactly ``MIN_TD`` makes no material progress, and
+    after ``max_immediate_drain_cycles`` (1024) consecutive such cycles past
+    wall-clock ``end_time`` the run ends. Without that bound, a node that
+    re-schedules itself every ``MIN_TD`` while each cycle burns real wall
+    time (the shape of a permanently failing adaptor retry loop) advances
+    evaluation time one microsecond per cycle and starves the logical bound
+    almost indefinitely at 100% CPU — a starvation the Python runtime
+    shares; the bound is the recorded deviation. Immediate (``MIN_TD``)
+    cascades deeper than the bound are cut off exactly as
+    ``request_stop()`` would cut them.
 
 Pause / resume (the cursor protocol)
 ------------------------------------

--- a/src/hgraph/runtime/executor.cpp
+++ b/src/hgraph/runtime/executor.cpp
@@ -92,6 +92,7 @@ namespace hgraph
             DateTime                     end_time{MAX_ET};
             DateTime                     evaluation_time{MIN_ST};
             DateTime                     last_time_allowed_push{MIN_DT};
+            std::uint32_t                immediate_drain_cycles{0};
             ErrorCaptureOptions          error_capture_options{};
             bool                         cleanup_on_error{true};
 
@@ -277,6 +278,12 @@ namespace hgraph
             return next;
         }
 
+        // Consecutive MIN_TD-only cycles tolerated once the wall clock has
+        // passed end_time before the run is cut off. Deep enough for any sane
+        // immediate cascade (feedback chains) inside a drain; a busy retry
+        // loop exceeds it almost immediately.
+        constexpr std::uint32_t max_immediate_drain_cycles = 1024;
+
         [[nodiscard]] DateTime advance_realtime(RealTimeExecutorStorage &state, DateTime next_scheduled_time)
         {
             const DateTime target = std::min(next_scheduled_time, state.end_time);
@@ -305,16 +312,25 @@ namespace hgraph
             }
 
             wall_now = current_wall_time();
-            if (wall_now >= state.end_time)
-            {
-                // end_time is also a wall-clock bound: a busy-rescheduling
-                // graph advances evaluation time by MIN_TD per cycle and
-                // would starve the logical bound indefinitely (see
-                // execution_layer.rst, end-of-run enforcement).
-                state.set_evaluation_time(state.end_time);
-                return state.end_time;
-            }
             const DateTime next = std::min(target, std::max(next_cycle, wall_now));
+            if (wall_now >= state.end_time && next <= next_cycle)
+            {
+                // Past wall-clock end_time the executor only drains: a lagging
+                // graph still evaluates its scheduled work at the scheduled
+                // times, but a graph advancing exactly MIN_TD per cycle is
+                // making no material logical progress (the shape of a failing
+                // retry loop) and would starve the end_time bound indefinitely
+                // (see execution_layer.rst, end-of-run enforcement).
+                if (++state.immediate_drain_cycles > max_immediate_drain_cycles)
+                {
+                    state.set_evaluation_time(state.end_time);
+                    return state.end_time;
+                }
+            }
+            else
+            {
+                state.immediate_drain_cycles = 0;
+            }
             state.set_evaluation_time(next);
             return next;
         }

--- a/tests/cpp/test_realtime_execution.cpp
+++ b/tests/cpp/test_realtime_execution.cpp
@@ -237,9 +237,10 @@ TEST_CASE("real-time executor honours end_time on the wall clock under busy resc
     // real wall time is the shape of a permanently failing adaptor retry
     // loop: evaluation time advances one microsecond per cycle, so the
     // logical end_time bound alone would need hundreds of thousands of
-    // cycles. The wall clock passing end_time must end the run.
+    // cycles. Once the wall clock passes end_time, the bounded drain
+    // (max_immediate_drain_cycles) must end the run.
     constexpr TimeDelta run_window{250'000};
-    constexpr auto      cycle_cost = std::chrono::milliseconds{2};
+    constexpr auto      cycle_cost = std::chrono::milliseconds{1};
 
     std::atomic_int eval_count{0};
 
@@ -277,9 +278,64 @@ TEST_CASE("real-time executor honours end_time on the wall clock under busy resc
 
     const TimeDelta elapsed = hgraph::testing::wall_now() - start_time;
     CHECK(eval_count.load() > 0);
-    // Generous CI margin: the fixed executor returns at ~run_window; the
-    // starved one needs run_window / MIN_TD cycles at cycle_cost each.
-    CHECK(elapsed < TimeDelta{5'000'000});
+    // Generous CI margin: the bounded drain returns after at most
+    // run_window plus ~max_immediate_drain_cycles cycles at cycle_cost;
+    // the starved executor needs run_window / MIN_TD cycles.
+    CHECK(elapsed < TimeDelta{15'000'000});
+}
+
+TEST_CASE("real-time executor drains a lagging graph to its logical end_time")
+{
+    using namespace hgraph;
+
+    // A graph whose cycles cost more wall time than their logical spacing
+    // lags the wall clock; scheduled work must still evaluate at its
+    // scheduled logical times after the wall clock passes end_time (the
+    // ported wall-clock scheduler tests rely on late alarm delivery). Ticks
+    // land at start, +50ms and +100ms; each costs ~80ms wall, so the wall
+    // clock passes the 150ms end_time before the drain completes.
+    constexpr TimeDelta step{50'000};
+    constexpr TimeDelta run_window{150'000};
+    constexpr auto      cycle_cost = std::chrono::milliseconds{80};
+
+    std::atomic_int       eval_count{0};
+    std::vector<DateTime> stamps;
+
+    auto       &registry = TypeRegistry::instance();
+    const auto *int_meta = registry.register_scalar<Int>("int");
+    const auto *ts_int   = registry.ts(int_meta);
+
+    NodeTypeMetaData schema;
+    schema.display_name      = "lagging_source";
+    schema.output_schema     = ts_int;
+    schema.node_kind         = NodeKind::PullSource;
+    schema.schedule_on_start = true;
+
+    NodeCallbacks callbacks;
+    callbacks.evaluate = [&eval_count, &stamps, cycle_cost, step](const NodeView &view, DateTime evaluation_time) {
+        ++eval_count;
+        stamps.push_back(evaluation_time);
+        std::this_thread::sleep_for(cycle_cost);
+        testing::set_output_value(view, evaluation_time, Int{eval_count.load()});
+        view.graph_value()->schedule_node(view.node_index(), evaluation_time + step);
+    };
+
+    GraphBuilder graph_builder;
+    graph_builder.add_node(NodeBuilder::native(std::move(schema), std::move(callbacks)));
+
+    const DateTime start_time = hgraph::testing::wall_now();
+
+    GraphExecutorBuilder executor_builder;
+    executor_builder.graph_builder(std::move(graph_builder))
+        .mode(GraphExecutorMode::RealTime)
+        .start_time(start_time)
+        .end_time(start_time + run_window);
+
+    GraphExecutorValue executor = executor_builder.make_executor();
+    executor.view().run();
+
+    REQUIRE(eval_count.load() == 3);
+    CHECK(stamps == std::vector<DateTime>{start_time, start_time + step, start_time + step + step});
 }
 
 TEST_CASE("real-time executor evaluates root push queues after pending update signal")


### PR DESCRIPTION
## Summary

Fixes the macOS CI failures on `main` introduced by #18 (merged with the first-cut design before the correction landed on its branch).

#18 stopped the real-time run outright when the wall clock passed `end_time`. The ported wall-clock scheduler tests reject that on slow runners, and rightly so: a lagging-but-progressing graph must **drain** — scheduled work still evaluates at its scheduled logical times after the wall clock passes `end_time` (`ext/main` parity; the ported tests rely on late alarm delivery). `Test macos-26` jobs on `main` currently fail `test_wall_clock_scheduler` / `test_wall_clock_scheduler_reschedule` because the final alarm tick is dropped.

This change replaces the hard wall-clock stop with a drain bounded by **logical progress**: past wall-clock `end_time`, after `max_immediate_drain_cycles` (1024) consecutive cycles that each advance evaluation time by exactly `MIN_TD` (no material progress — the busy retry-loop signature), the run ends. Legitimate drains reset the counter every cycle. The starvation protection #18 aimed for is preserved: the busy-loop test still returns promptly.

## Test plan

- New test: lagging source (50 ms logical steps, 80 ms cycle cost, 150 ms window) — wall clock passes `end_time` mid-run; all three ticks still evaluate at their exact scheduled logical times. Deterministic encoding of the slow-macOS scenario.
- Busy-loop test from #18 retained (cycle cost tuned to 1 ms): starves without the bound, returns promptly with it.
- Ported wall-clock scheduler tests: 5/5 pass against the new executor.
- Full ctest 1206/1206, full Python suite 1512 passed / 10 skipped, real-time group ASAN+UBSAN clean (validated on the identical tree at `runtime/wall-clock-end-time@4b46f794`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)