### PR TITLE
Add core RFC process and foundation proposals

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -168,6 +168,12 @@ artifacts.
 
 ## Git Hygiene
 
+- Develop every change on a dedicated non-`main` branch and merge it through a
+  pull request. Do not commit or push changes directly to `main`.
+- A change that affects this repository and a downstream project requires a
+  separate branch and pull request in each repository. Cross-link the related
+  pull requests so the complete change remains traceable.
+- Keep each branch and pull request focused on one coherent change.
 - The worktree may contain unrelated user or concurrent-agent changes. Ignore
   them unless they directly affect the task; never revert them.
 - Keep edits and staging scoped to the requested task.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -17,3 +17,4 @@ Developer Guide
 
    user_guide/index
    developer_guide/index
+   rfc/index

--- a/docs/source/rfc/index.rst
+++ b/docs/source/rfc/index.rst
@@ -1,0 +1,19 @@
+hgraph RFCs
+===========
+
+The RFC catalogue records proposed and accepted changes to hgraph's public
+types, runtime, operator model, extension surface, and cross-language contract.
+RFCs live with the core code they govern. Domain-specific proposals remain in
+their downstream repository unless and until they require a generally useful
+hgraph change.
+
+The lifecycle, required sections, numbering, and proposal/implementation
+workflow are defined by :doc:`rfc_0000`.
+
+.. toctree::
+   :maxdepth: 2
+
+   rfc_0000
+   rfc_0001_typed_frame_metadata
+   rfc_0002_temporal_types
+   rfc_0003_extension_scalar_registration

--- a/docs/source/rfc/rfc_0000.rst
+++ b/docs/source/rfc/rfc_0000.rst
@@ -1,0 +1,120 @@
+RFC 0000: RFC Process
+=====================
+
+:Status: Proposed
+:Author: Howard Henson
+:Created: 2026-07-23
+:Target: Project governance
+
+Summary
+-------
+
+Material changes to hgraph's public contract begin with a numbered RFC in this
+directory. The proposal is reviewed before implementation becomes the basis of
+the design, and the accepted RFC is maintained as the durable explanation of
+the resulting contract.
+
+Scope
+-----
+
+An RFC is required for a new or materially changed:
+
+* public C++ or Python type;
+* operator family or dispatch convention;
+* runtime, scheduling, persistence, or wire-format contract;
+* downstream extension or binary-interface facility; or
+* cross-project capability that will be owned by ``hg_cpp``.
+
+Small fixes that restore documented behaviour, private refactoring, tests, and
+editorial corrections do not require an RFC.
+
+Repository ownership
+--------------------
+
+The RFC belongs in the repository that owns the implementation. A downstream
+requirement that may need a generic hgraph facility is first explored in its
+own repository. Once proposed for the core, its core RFC is placed here and the
+downstream document links to it rather than maintaining a second normative
+specification.
+
+Numbering and filenames
+-----------------------
+
+RFC numbers are allocated monotonically and are never reused. The filename is
+``rfc_NNNN_short_title.rst`` except for this process RFC. A rejected,
+withdrawn, or superseded RFC retains its number and history.
+
+Statuses
+--------
+
+``Proposed``
+   The design is under review or its implementation has not yet merged.
+
+``Accepted``
+   The implementation and its conformance tests have merged. The RFC describes
+   the shipped contract and records any differences from the original
+   proposal.
+
+``Rejected``
+   The proposal was considered and declined, with the reason recorded.
+
+``Withdrawn``
+   The author stopped pursuing the proposal.
+
+``Superseded``
+   A later RFC replaces this one; both documents link to each other.
+
+Workflow
+--------
+
+1. Create a topic branch and add the proposed RFC as the first commit. The RFC
+   is ``Proposed`` and contains no implementation.
+2. Review the public contract, ownership boundary, performance implications,
+   C++/Python parity, compatibility, and acceptance criteria.
+3. Supply the implementation and tests in subsequent commits on a PR branch.
+   Update the RFC in those commits whenever implementation experience changes
+   the design.
+4. The implementation PR must identify its RFC. Once the implementation is
+   accepted for merge, update the RFC status to ``Accepted`` in the same change
+   so code and design cannot land with contradictory states.
+5. Later behavioural changes update the accepted RFC or, for a material
+   redesign, introduce a superseding RFC.
+
+All work follows the repository policy in ``AGENTS.md``: use a non-default
+branch and merge through a pull request. A change spanning hgraph and a
+downstream extension uses separate linked PRs.
+
+Required structure
+------------------
+
+Each feature RFC contains, as applicable:
+
+* metadata: number, title, status, author, creation date, and target;
+* summary and motivation;
+* ownership boundary;
+* detailed C++ and Python contract;
+* runtime representation and operator/dispatch semantics;
+* compatibility, migration, and serialization consequences;
+* performance and memory considerations;
+* alternatives considered and unresolved questions;
+* acceptance criteria and test plan;
+* implementation status after work begins; and
+* stable references to standards, papers, or prior art.
+
+Policy selectors
+----------------
+
+A scalar policy known at wiring time should normally select an operator
+implementation through overload resolution. A genuinely time-varying policy is
+normally represented by a graph that switches between those implementations.
+An RFC proposing a per-tick branch inside a generic node must justify why
+dispatch or graph composition cannot express the contract and include
+performance evidence.
+
+Amendments
+----------
+
+Editorial clarifications may update an RFC directly. A change to accepted
+semantics must be visible in the RFC history and implementation PR. Historical
+motivation and rejected alternatives should not be erased merely because the
+final API is smaller than the initial proposal.

--- a/docs/source/rfc/rfc_0001_typed_frame_metadata.rst
+++ b/docs/source/rfc/rfc_0001_typed_frame_metadata.rst
@@ -1,0 +1,126 @@
+RFC 0001: Typed Frame Metadata
+==============================
+
+:Status: Proposed
+:Author: Howard Henson
+:Created: 2026-07-23
+:Target: Next ``hg_cpp`` minor release
+
+Summary
+-------
+
+Extend ``Frame[Rows]`` to ``Frame[Rows, Metadata]`` while retaining one Arrow
+table as the complete value and interchange representation. Frame-level
+metadata is encoded field by field in the Arrow schema metadata; it is not a
+second side object and is not repeated as table rows or columns.
+
+Motivation
+----------
+
+Versioned tabular datasets need identity, immutable revision, as-of time,
+provenance, and schema version to apply to a complete table. Repeating those
+values on each row wastes space and permits row-level disagreement. Keeping
+them outside Arrow loses information at the C++/Python and persistence
+boundaries.
+
+Type contract
+-------------
+
+The public forms are:
+
+.. code-block:: text
+
+   C++:    FrameOf<RowSchema, MetadataSchema>
+   Python: Frame[RowSchema, MetadataSchema]
+
+The existing one-argument form remains metadata-free. ``RowSchema`` describes
+the Arrow columns. ``MetadataSchema`` is a named Bundle/CompoundScalar schema
+describing one immutable logical value for the whole frame.
+
+Arrow representation
+--------------------
+
+Reserved byte-string entries in ``arrow::Schema::metadata`` are:
+
+``hgraph.metadata.schema``
+   Optional qualified Bundle name. It supports discovery and fast validation,
+   but is not required for conformance.
+
+``hgraph.metadata.version``
+   Field-encoding version.
+
+``hgraph.metadata.field.<name>``
+   One entry for each populated metadata field.
+
+Strings, integers, floating-point values, booleans, enums, dates, datetimes,
+times, and durations use their deterministic UTF-8 field representation.
+Nested Bundles, tuples, lists, sets, and maps use the schema-directed JSON
+codec. Opaque Python objects, callables, and values without a deterministic
+codec are rejected. Unrelated Arrow metadata is preserved.
+
+The declared ``MetadataSchema`` is authoritative. When the optional type marker
+is present it must match. When absent, successful schema-directed decoding of
+the field entries establishes conformance. Reflective decoding may use a
+registered marker; markerless decoding requires the caller or typed Frame
+boundary to supply the schema.
+
+Public operations
+-----------------
+
+``with_frame_metadata``
+   Return a Frame/table with a schema-directed metadata value encoded.
+
+``frame_metadata``
+   Decode with an explicit schema, or reflectively when the optional marker is
+   present and registered.
+
+``has_frame_metadata``
+   Detect reserved hgraph metadata entries.
+
+``without_frame_metadata``
+   Remove only reserved hgraph entries as an explicit lossy conversion.
+
+Operator semantics
+------------------
+
+Row filtering, sorting, slicing, and row-preserving projection preserve
+metadata. Column replacement and schema-changing projection preserve it unless
+the output type explicitly changes the metadata schema. Concatenation requires
+equal hgraph metadata by default. A join, group, split, or merge whose correct
+metadata is not structurally determined requires an explicit output policy.
+
+Compatibility and performance
+-----------------------------
+
+``Frame[Rows]`` and existing metadata-free Arrow tables remain valid. The Frame
+still stores one shared Arrow table handle, so the change adds no side
+allocation to the native value. Encoding cost is proportional to populated
+metadata fields and is paid when metadata is attached or decoded, not for each
+row.
+
+Acceptance criteria
+-------------------
+
+* C++ and Python type resolution and round trips use the same Arrow table.
+* Marker-bearing and markerless schema-directed decoding are tested.
+* Missing required fields, incompatible markers, unsupported values, and
+  implicit metadata loss are rejected.
+* Structural table transforms follow the propagation rules above.
+* Direct Arrow C-stream and FrameStore paths preserve schema metadata.
+* Installed-SDK tests prove downstream C++ use.
+
+Implementation status
+---------------------
+
+Implementation is planned for subsequent commits after review of this
+proposal. It will cover the type system, Arrow codec, Python bridge,
+table-operator propagation, and conformance tests. This RFC remains
+``Proposed`` until that implementation is accepted for merge.
+
+Versioned-dataset proof
+-----------------------
+
+The proving fixture stores dataset identity, immutable revision, as-of time,
+source, and schema version as frame metadata. Each row contains independently
+filterable domain data. The fixture proves that row operations do not duplicate
+or discard the dataset-level fields.

--- a/docs/source/rfc/rfc_0002_temporal_types.rst
+++ b/docs/source/rfc/rfc_0002_temporal_types.rst
@@ -1,0 +1,88 @@
+RFC 0002: Temporal Types, Zones, and Ranges
+===========================================
+
+:Status: Proposed
+:Author: Howard Henson
+:Created: 2026-07-23
+:Target: Incremental core foundation
+
+Summary
+-------
+
+Distinguish absolute engine time, civil time, named-zone interpretation,
+calendar-relative periods, and time ranges in the core type system.
+Domain-specific calendars, sessions, and scheduling policy remain extension
+concerns.
+
+Type model
+----------
+
+``Instant`` and ``Duration``
+   UTC timeline values. Existing ``DateTime`` and ``TimeDelta`` remain
+   compatibility aliases.
+
+``CivilDate``, ``CivilTime``, and ``CivilDateTime``
+   Calendar fields with no zone or offset.
+
+``Period``
+   Calendar-relative years, months, and days; it is not implicitly convertible
+   to an elapsed ``Duration``.
+
+``ZoneId``
+   A validated named-zone identifier.
+
+``ZonedDateTime``
+   An instant paired with zone identity and the resolved offset.
+
+``TimeRange[T]``
+   An ordered interval with explicit open/closed endpoints and deterministic
+   containment, emptiness, intersection, and adjacency.
+
+Zone resolution
+---------------
+
+Civil-time resolution must explicitly select ``reject``, ``earliest``, or
+``latest`` for an ambiguous fold, and ``reject``, ``next_valid``, or
+``previous_valid`` for a nonexistent gap. The default is rejection. A process
+or platform local zone must never be inferred silently.
+
+Ownership
+---------
+
+``hg_cpp`` owns the general scalar schemas, interval algebra, and eventual
+timezone-resolution boundary. Downstream libraries own business dates,
+calendars, sessions, day-count conventions, and domain-specific iteration
+policy.
+
+Compatibility and portability
+-----------------------------
+
+The aliases preserve current engine APIs. A timezone backend must be pinned and
+must report its database version for reproducible serialization and replay.
+RFC 9557 provides the target form for serializing a timestamp together with
+offset and named-zone intent.
+
+Acceptance criteria
+-------------------
+
+* Native scalar and TS schemas have C++/Python parity.
+* Range construction and boundary algebra are tested.
+* Named-zone resolution covers folds, gaps, historical transitions, and every
+  explicit policy.
+* Duration-versus-period behaviour is tested across DST changes.
+* C++ and Python round trips preserve offset and named-zone identity.
+
+Implementation status
+---------------------
+
+The proposed initial value/type slice covers aliases, civil values, ``Period``,
+syntactic ``ZoneId`` validation, ``ZonedDateTime``, policy enums, and
+``TimeRange`` algebra. Timezone database resolution, RFC 9557 serialization,
+range iteration/merge, and calendar arithmetic remain later work. Status
+remains ``Proposed`` until the accepted implementation scope is merged.
+
+References
+----------
+
+* RFC 9557, *Date and Time on the Internet: Timestamps with Additional
+  Information*, 2024: https://www.rfc-editor.org/rfc/rfc9557

--- a/docs/source/rfc/rfc_0003_extension_scalar_registration.rst
+++ b/docs/source/rfc/rfc_0003_extension_scalar_registration.rst
@@ -1,0 +1,78 @@
+RFC 0003: Downstream Python Scalar Registration
+================================================
+
+:Status: Proposed
+:Author: Howard Henson
+:Created: 2026-07-23
+:Target: Unscheduled
+
+Summary
+-------
+
+Provide a public bridge API through which a downstream native extension can
+associate one of its Python classes with the native scalar schema it owns.
+This removes the need for extensions to mutate ``hgraph._types`` internals in
+order to use ``TS[ExtensionType]`` in Python wiring.
+
+Motivation
+----------
+
+The C++ static schema machinery already lets an extension register a custom
+scalar with the shared ``TypeRegistry``. A nanobind extension can also expose
+the corresponding Python class. Today there is no public operation connecting
+those two facts, so Python type resolution falls back to the opaque ``object``
+schema unless the extension edits the private ``_SCALAR_NAMES`` map.
+
+Proposed contract
+-----------------
+
+The bridge should expose an idempotent function conceptually equivalent to:
+
+.. code-block:: python
+
+   register_native_scalar_type(PythonType, native_value_type)
+
+The association is process-wide, holds a strong reference to the Python type,
+and participates in both Python-annotation-to-schema and
+schema-to-Python-type reflection. Re-registering the same pair succeeds;
+attempting to associate either side with a conflicting counterpart fails.
+
+The C++ helper supplied to downstream modules should accept the native scalar
+type and Python class, ensure the scalar is registered in the shared
+``TypeRegistry``, and install the same association without importing private
+Python modules.
+
+Ownership and constraints
+-------------------------
+
+The registry and public hook belong in ``hg_cpp`` because every extension with
+native scalar types needs them. The extension owns the class, conversion
+traits, scalar name, lifecycle, and package import order. Registration must not
+create a second runtime/type registry or require Python for pure C++ use.
+
+Compatibility and performance
+-----------------------------
+
+Built-in mappings remain unchanged. Lookup is performed during wiring and
+reflection, not during node evaluation. The design must be safe across repeated
+module imports and must preserve the single process-wide native schema pointer
+required by downstream ABI contracts.
+
+Acceptance criteria
+-------------------
+
+* A separately built test extension registers a custom C++ scalar and Python
+  class using only public installed headers and bridge functions.
+* ``TS[ExtensionType]`` resolves to the extension's native scalar schema.
+* Native values round-trip through a Python-authored graph and reflect back to
+  the registered class.
+* Duplicate identical registration is harmless and conflicting registration
+  is rejected deterministically.
+* Pure C++ consumers remain independent of the Python runtime.
+
+Implementation status
+---------------------
+
+No core implementation is included. A downstream test extension that currently
+requires a private type mapping will provide the proving integration for this
+RFC.


### PR DESCRIPTION
## Summary

- establish the numbered RFC catalogue and lifecycle for public hgraph changes
- propose typed Arrow-backed Frame metadata (RFC 0001)
- propose core temporal types, zones, and ranges (RFC 0002)
- propose a public downstream Python scalar-registration hook (RFC 0003)
- record the branch/PR policy for core and downstream changes

## Why

The core implementation needs a proposal-first process that keeps generally useful hgraph facilities separate from downstream domain concerns. These RFCs define the ownership boundary, C++/Python contract, compatibility expectations, and acceptance criteria before implementation is added.

## Impact

This PR is documentation and governance only. All feature RFCs remain `Proposed`; no runtime, type-system, operator, or Python implementation is included.

## Validation

- `sphinx-build -W --keep-going -b html docs/source <temporary-output>`
- `git diff --check origin/main...HEAD`
