### PR TITLE
Add opt-in recursion guard on consecutive MIN_TD cycles

### DIFF
--- a/docs/source/developer_guide/data_structures/overview/execution_layer.rst
+++ b/docs/source/developer_guide/data_structures/overview/execution_layer.rst
@@ -48,6 +48,25 @@ Current implementation
     cascades deeper than the bound are cut off exactly as
     ``request_stop()`` would cut them.
 
+    **Opt-in recursion guard.** A run of consecutive ``MIN_TD`` cycles is
+    usually the evaluation-graph equivalent of infinite recursion — a
+    feedback/retry shape that re-schedules itself every cycle and never
+    settles. ``GraphExecutorBuilder::max_consecutive_immediate_cycles(n)``
+    (default ``0`` = disabled) arms a guard in **both** run modes: the run
+    loop counts consecutive cycles that advance evaluation time by exactly
+    ``MIN_TD`` (any larger advance resets the count). When the count
+    reaches ``n``, the executor evaluates **one further cycle** with a
+    temporary ``LifecycleObserver`` recording every evaluated node's
+    ``diagnostic::node_path`` (nested graphs included, capped at 256
+    entries), then throws ``RecursiveEvaluationError`` whose message names
+    the consecutive-cycle count, the evaluation time, and the recorded
+    per-node evaluation path of that last cycle. The same text is logged
+    through the run logger before the throw. If the loop settles during
+    the recording cycle the guard disarms and the run continues. The guard
+    shares the consecutive-``MIN_TD`` counter with the real-time drain
+    bound above; past wall-clock ``end_time`` whichever limit is lower
+    fires first (the drain ends the run quietly, the guard throws).
+
 Pause / resume (the cursor protocol)
 ------------------------------------
 

--- a/include/hgraph/runtime/executor.h
+++ b/include/hgraph/runtime/executor.h
@@ -13,6 +13,7 @@
 #include <hgraph/runtime/node_error.h>
 
 #include <memory>
+#include <stdexcept>
 
 namespace spdlog
 {
@@ -34,6 +35,21 @@ namespace hgraph
     {
         Simulation,
         RealTime,
+    };
+
+    /**
+     * Thrown by ``GraphExecutorView::run()`` when the opt-in recursion guard
+     * (``GraphExecutorBuilder::max_consecutive_immediate_cycles``) trips: the
+     * graph evaluated the configured number of consecutive cycles that each
+     * advanced evaluation time by exactly ``MIN_TD`` — the evaluation-graph
+     * shape of infinite recursion. The message carries the per-node
+     * evaluation path of the last cycle (design record: execution_layer.rst,
+     * *Opt-in recursion guard*).
+     */
+    class HGRAPH_EXPORT RecursiveEvaluationError : public std::runtime_error
+    {
+      public:
+        using std::runtime_error::runtime_error;
     };
 
     /** Schema/config descriptor for a graph executor. */
@@ -213,6 +229,14 @@ namespace hgraph
         GraphExecutorBuilder &logger(std::shared_ptr<spdlog::logger> logger);
         GraphExecutorBuilder &error_capture_options(ErrorCaptureOptions options) noexcept;
         GraphExecutorBuilder &cleanup_on_error(bool value) noexcept;
+        /**
+         * Arm the opt-in recursion guard: after ``limit`` consecutive cycles
+         * that each advance evaluation time by exactly ``MIN_TD``, the run
+         * records one further cycle's per-node evaluation path and throws
+         * ``RecursiveEvaluationError``. ``0`` (the default) disables the
+         * guard. Applies to both run modes.
+         */
+        GraphExecutorBuilder &max_consecutive_immediate_cycles(std::uint32_t limit) noexcept;
         /** Register a lifecycle observer for this executor's run (see ``LifecycleObserver``). */
         GraphExecutorBuilder &add_lifecycle_observer(LifecycleObserver *observer);
 
@@ -224,6 +248,7 @@ namespace hgraph
         [[nodiscard]] const std::shared_ptr<spdlog::logger> &logger() const noexcept;
         [[nodiscard]] ErrorCaptureOptions error_capture_options() const noexcept;
         [[nodiscard]] bool cleanup_on_error() const noexcept;
+        [[nodiscard]] std::uint32_t max_consecutive_immediate_cycles() const noexcept;
         [[nodiscard]] const std::vector<LifecycleObserver *> &lifecycle_observers() const noexcept;
         [[nodiscard]] GraphTypeRef graph_type() const;
         [[nodiscard]] ExecutorTypeRef type() const;
@@ -240,6 +265,7 @@ namespace hgraph
         std::shared_ptr<spdlog::logger>  logger_{};
         ErrorCaptureOptions             error_capture_options_{};
         bool                            cleanup_on_error_{true};
+        std::uint32_t                   max_consecutive_immediate_cycles_{0};
         std::vector<LifecycleObserver *> lifecycle_observers_{};
         mutable ExecutorTypeRef          type_{};
     };

--- a/src/hgraph/runtime/executor.cpp
+++ b/src/hgraph/runtime/executor.cpp
@@ -1,19 +1,26 @@
+#include <hgraph/runtime/diagnostic_path.h>
 #include <hgraph/runtime/executor.h>
 #include <hgraph/runtime/lifecycle_observer.h>
 #include <hgraph/runtime/logger.h>
 #include <hgraph/types/metadata/type_record_registry.h>
 #include <hgraph/util/scope.h>
 
+#include <fmt/chrono.h>
+#include <fmt/format.h>
+
 #include <algorithm>
 #include <atomic>
 #include <chrono>
 #include <condition_variable>
+#include <cstdint>
 #include <deque>
 #include <exception>
 #include <memory>
 #include <mutex>
 #include <stdexcept>
+#include <string>
 #include <utility>
+#include <vector>
 
 namespace hgraph
 {
@@ -40,6 +47,7 @@ namespace hgraph
                   cleanup_on_error(builder.cleanup_on_error()),
                   run_logging_enabled(builder.logger() != nullptr)
             {
+                immediate_cycle_limit = builder.max_consecutive_immediate_cycles();
                 for (LifecycleObserver *observer : builder.lifecycle_observers()) { lifecycle_observers.add(observer); }
             }
 
@@ -56,6 +64,8 @@ namespace hgraph
             DateTime         end_time{MAX_ET};
             DateTime         evaluation_time{MIN_ST};
             DateTime         cycle_wall_start{current_wall_time()};
+            std::uint32_t    immediate_cycle_limit{0};
+            std::uint32_t    consecutive_immediate_cycles{0};
             ErrorCaptureOptions error_capture_options{};
             std::atomic_bool stop_requested{false};
             bool             cleanup_on_error{true};
@@ -77,6 +87,7 @@ namespace hgraph
                   cleanup_on_error(builder.cleanup_on_error()),
                   run_logging_enabled(builder.logger() != nullptr)
             {
+                immediate_cycle_limit = builder.max_consecutive_immediate_cycles();
                 for (LifecycleObserver *observer : builder.lifecycle_observers()) { lifecycle_observers.add(observer); }
             }
 
@@ -92,7 +103,8 @@ namespace hgraph
             DateTime                     end_time{MAX_ET};
             DateTime                     evaluation_time{MIN_ST};
             DateTime                     last_time_allowed_push{MIN_DT};
-            std::uint32_t                immediate_drain_cycles{0};
+            std::uint32_t                immediate_cycle_limit{0};
+            std::uint32_t                consecutive_immediate_cycles{0};
             ErrorCaptureOptions          error_capture_options{};
             bool                         cleanup_on_error{true};
 
@@ -313,23 +325,18 @@ namespace hgraph
 
             wall_now = current_wall_time();
             const DateTime next = std::min(target, std::max(next_cycle, wall_now));
-            if (wall_now >= state.end_time && next <= next_cycle)
+            if (wall_now >= state.end_time && next <= next_cycle &&
+                state.consecutive_immediate_cycles >= max_immediate_drain_cycles)
             {
                 // Past wall-clock end_time the executor only drains: a lagging
                 // graph still evaluates its scheduled work at the scheduled
                 // times, but a graph advancing exactly MIN_TD per cycle is
                 // making no material logical progress (the shape of a failing
                 // retry loop) and would starve the end_time bound indefinitely
-                // (see execution_layer.rst, end-of-run enforcement).
-                if (++state.immediate_drain_cycles > max_immediate_drain_cycles)
-                {
-                    state.set_evaluation_time(state.end_time);
-                    return state.end_time;
-                }
-            }
-            else
-            {
-                state.immediate_drain_cycles = 0;
+                // (see execution_layer.rst, end-of-run enforcement). The
+                // counter is maintained by the run loop.
+                state.set_evaluation_time(state.end_time);
+                return state.end_time;
             }
             state.set_evaluation_time(next);
             return next;
@@ -353,6 +360,49 @@ namespace hgraph
             return graph.schema()->push_source_nodes_end > 0;
         }
 
+        /**
+         * Records the diagnostic path of every node evaluated during one
+         * cycle for the opt-in recursion guard (execution_layer.rst).
+         */
+        struct ImmediateCycleRecorder final : LifecycleObserver
+        {
+            static constexpr std::size_t max_recorded_nodes = 256;
+
+            std::vector<std::string> paths{};
+            std::size_t              dropped{0};
+
+            void on_before_node_evaluation(const NodeView &node) override
+            {
+                if (paths.size() < max_recorded_nodes) { paths.push_back(diagnostic::node_path(node)); }
+                else { ++dropped; }
+            }
+
+            void reset()
+            {
+                paths.clear();
+                dropped = 0;
+            }
+        };
+
+        [[noreturn]] void throw_recursive_evaluation_error(spdlog::logger &logger,
+                                                           std::uint32_t consecutive_cycles,
+                                                           DateTime evaluation_time,
+                                                           const ImmediateCycleRecorder &recorder)
+        {
+            std::string message = fmt::format(
+                "potential recursive evaluation loop: {} consecutive MIN_TD evaluation cycles at {:%Y-%m-%d %H:%M:%S}; "
+                "nodes evaluated in the last cycle:",
+                consecutive_cycles, evaluation_time);
+            for (const std::string &path : recorder.paths)
+            {
+                message += "\n  ";
+                message += path;
+            }
+            if (recorder.dropped > 0) { message += fmt::format("\n  ... and {} further node evaluations", recorder.dropped); }
+            logger.error(message);
+            throw RecursiveEvaluationError(message);
+        }
+
         template <typename Storage, typename Advance>
         void run_storage(Storage &state, Advance advance)
         {
@@ -369,6 +419,9 @@ namespace hgraph
                 }
             });
 
+            ImmediateCycleRecorder recorder;
+            bool                   recorded_cycle = false;
+
             while (!state.stop_requested.load(std::memory_order_acquire))
             {
                 DateTime next = graph.next_scheduled_time();
@@ -378,6 +431,7 @@ namespace hgraph
                     next = state.end_time;
                 }
 
+                const DateTime previous_evaluation_time = state.evaluation_time;
                 const DateTime evaluation_time = advance(state, next);
                 if (state.stop_requested.load(std::memory_order_acquire) ||
                     evaluation_time == MAX_DT ||
@@ -385,7 +439,34 @@ namespace hgraph
                 {
                     break;
                 }
-                if (!graph.evaluate(evaluation_time))
+
+                if (evaluation_time == previous_evaluation_time + MIN_TD) { ++state.consecutive_immediate_cycles; }
+                else { state.consecutive_immediate_cycles = 0; }
+
+                const bool guard_tripped = state.immediate_cycle_limit > 0 &&
+                    state.consecutive_immediate_cycles >= state.immediate_cycle_limit;
+                if (guard_tripped && recorded_cycle)
+                {
+                    throw_recursive_evaluation_error(*state.logger,
+                                                     state.consecutive_immediate_cycles,
+                                                     evaluation_time,
+                                                     recorder);
+                }
+                if (!guard_tripped && recorded_cycle)
+                {
+                    // The loop settled during the recording cycle; disarm.
+                    recorder.reset();
+                    recorded_cycle = false;
+                }
+                const bool recording_this_cycle = guard_tripped && !recorded_cycle;
+                if (recording_this_cycle) { state.lifecycle_observers.add(&recorder); }
+                auto remove_recorder = UnwindCleanupGuard([&] {
+                    if (recording_this_cycle) { state.lifecycle_observers.remove(&recorder); }
+                });
+                const bool completed = graph.evaluate(evaluation_time);
+                remove_recorder.complete();
+                if (recording_this_cycle) { recorded_cycle = true; }
+                if (!completed)
                 {
                     // The root graph has no enclosing mesh to resolve a pause; a false here
                     // means a pausing node (e.g. a mesh_subscribe) escaped its mesh scope.
@@ -1044,6 +1125,12 @@ namespace hgraph
         return *this;
     }
 
+    GraphExecutorBuilder &GraphExecutorBuilder::max_consecutive_immediate_cycles(std::uint32_t limit) noexcept
+    {
+        max_consecutive_immediate_cycles_ = limit;
+        return *this;
+    }
+
     GraphExecutorBuilder &GraphExecutorBuilder::add_lifecycle_observer(LifecycleObserver *observer)
     {
         if (observer != nullptr) { lifecycle_observers_.push_back(observer); }
@@ -1088,6 +1175,11 @@ namespace hgraph
     bool GraphExecutorBuilder::cleanup_on_error() const noexcept
     {
         return cleanup_on_error_;
+    }
+
+    std::uint32_t GraphExecutorBuilder::max_consecutive_immediate_cycles() const noexcept
+    {
+        return max_consecutive_immediate_cycles_;
     }
 
     const std::vector<LifecycleObserver *> &GraphExecutorBuilder::lifecycle_observers() const noexcept

--- a/tests/cpp/test_realtime_execution.cpp
+++ b/tests/cpp/test_realtime_execution.cpp
@@ -284,6 +284,61 @@ TEST_CASE("real-time executor honours end_time on the wall clock under busy resc
     CHECK(elapsed < TimeDelta{15'000'000});
 }
 
+TEST_CASE("real-time executor recursion guard trips without waiting for end_time")
+{
+    using namespace hgraph;
+
+    // With the opt-in guard armed, a busy MIN_TD loop throws promptly during
+    // the run window instead of spinning until the drain bound cuts it off.
+    std::atomic_int eval_count{0};
+
+    auto       &registry = TypeRegistry::instance();
+    const auto *int_meta = registry.register_scalar<Int>("int");
+    const auto *ts_int   = registry.ts(int_meta);
+
+    NodeTypeMetaData schema;
+    schema.display_name      = "busy_guarded_source";
+    schema.output_schema     = ts_int;
+    schema.node_kind         = NodeKind::PullSource;
+    schema.schedule_on_start = true;
+
+    NodeCallbacks callbacks;
+    callbacks.evaluate = [&eval_count](const NodeView &view, DateTime evaluation_time) {
+        ++eval_count;
+        testing::set_output_value(view, evaluation_time, Int{eval_count.load()});
+        view.graph_value()->schedule_node(view.node_index(), evaluation_time + MIN_TD);
+    };
+
+    GraphBuilder graph_builder;
+    graph_builder.add_node(NodeBuilder::native(std::move(schema), std::move(callbacks)));
+
+    const DateTime start_time = hgraph::testing::wall_now();
+
+    GraphExecutorBuilder executor_builder;
+    executor_builder.graph_builder(std::move(graph_builder))
+        .mode(GraphExecutorMode::RealTime)
+        .start_time(start_time)
+        .end_time(start_time + TimeDelta{60'000'000})
+        .max_consecutive_immediate_cycles(50);
+
+    GraphExecutorValue executor = executor_builder.make_executor();
+
+    std::string message;
+    try
+    {
+        executor.view().run();
+        FAIL("expected RecursiveEvaluationError");
+    }
+    catch (const RecursiveEvaluationError &error)
+    {
+        message = error.what();
+    }
+
+    CHECK(message.find("busy_guarded_source") != std::string::npos);
+    // Nowhere near the 60s end_time: the guard tripped after ~51 cycles.
+    CHECK(hgraph::testing::wall_now() - start_time < TimeDelta{10'000'000});
+}
+
 TEST_CASE("real-time executor drains a lagging graph to its logical end_time")
 {
     using namespace hgraph;

--- a/tests/cpp/test_simulation_execution.cpp
+++ b/tests/cpp/test_simulation_execution.cpp
@@ -29,6 +29,7 @@
 #include <catch2/catch_test_macros.hpp>
 
 #include <cstdint>
+#include <string>
 
 #include <utility>
 
@@ -274,4 +275,95 @@ TEST_CASE("simulation: a self-rescheduling source drives multiple cycles over ti
     // output); the downstream add_one was re-evaluated each cycle and tracked it.
     CHECK(graph.node_at(0).output(MIN_ST).value().checked_as<std::int32_t>() == 2);
     CHECK(graph.node_at(1).output(MIN_ST).value().checked_as<std::int32_t>() == 3);
+}
+
+namespace
+{
+    using namespace hgraph;
+
+    hgraph::NodeBuilder immediate_rescheduling_source(const char *display_name,
+                                                      int *eval_count,
+                                                      int burst_length,
+                                                      int total_evaluations)
+    {
+        auto       &registry = TypeRegistry::instance();
+        const auto *int_meta = registry.register_scalar<Int>("int");
+        const auto *ts_int   = registry.ts(int_meta);
+
+        NodeTypeMetaData schema;
+        schema.display_name      = display_name;
+        schema.output_schema     = ts_int;
+        schema.node_kind         = NodeKind::PullSource;
+        schema.schedule_on_start = true;
+
+        NodeCallbacks callbacks;
+        callbacks.evaluate = [eval_count, burst_length, total_evaluations](const NodeView &view,
+                                                                           DateTime evaluation_time) {
+            ++(*eval_count);
+            hgraph::testing::set_output_value(view, evaluation_time, Int{*eval_count});
+            if (*eval_count >= total_evaluations) { return; }
+            const bool burst_boundary = burst_length > 0 && (*eval_count % burst_length) == 0;
+            const TimeDelta delay = burst_boundary ? TimeDelta{1'000} : MIN_TD;
+            view.graph_value()->schedule_node(view.node_index(), evaluation_time + delay);
+        };
+
+        return NodeBuilder::native(std::move(schema), std::move(callbacks));
+    }
+}  // namespace
+
+TEST_CASE("simulation: the opt-in recursion guard trips on a sustained MIN_TD loop")
+{
+    using namespace hgraph;
+
+    int eval_count = 0;
+
+    GraphBuilder graph_builder;
+    // burst_length 0: reschedules +MIN_TD forever (until the guard trips).
+    graph_builder.add_node(immediate_rescheduling_source("busy_loop_source", &eval_count, 0, 1'000'000));
+
+    GraphExecutorBuilder executor_builder;
+    executor_builder.graph_builder(std::move(graph_builder))
+        .start_time(MIN_ST)
+        .end_time(MIN_ST + TimeDelta{3'600'000'000})
+        .max_consecutive_immediate_cycles(50);
+
+    GraphExecutorValue executor = executor_builder.make_executor();
+
+    std::string message;
+    try
+    {
+        executor.view().run();
+        FAIL("expected RecursiveEvaluationError");
+    }
+    catch (const RecursiveEvaluationError &error)
+    {
+        message = error.what();
+    }
+
+    // The guard trips at the limit, records one further cycle, then throws.
+    CHECK(eval_count >= 50);
+    CHECK(eval_count <= 55);
+    CHECK(message.find("potential recursive evaluation loop") != std::string::npos);
+    CHECK(message.find("busy_loop_source") != std::string::npos);
+}
+
+TEST_CASE("simulation: immediate bursts below the guard limit do not trip it")
+{
+    using namespace hgraph;
+
+    int eval_count = 0;
+
+    GraphBuilder graph_builder;
+    // Bursts of 10 immediate cycles separated by 1ms jumps, 60 evaluations total.
+    graph_builder.add_node(immediate_rescheduling_source("bursty_source", &eval_count, 10, 60));
+
+    GraphExecutorBuilder executor_builder;
+    executor_builder.graph_builder(std::move(graph_builder))
+        .start_time(MIN_ST)
+        .end_time(MIN_ST + TimeDelta{3'600'000'000})
+        .max_consecutive_immediate_cycles(50);
+
+    GraphExecutorValue executor = executor_builder.make_executor();
+    CHECK_NOTHROW(executor.view().run());
+    CHECK(eval_count == 60);
 }


### PR DESCRIPTION
## Summary

A sustained run of `MIN_TD` evaluation cycles is usually the evaluation-graph equivalent of infinite recursion — a feedback/retry shape that re-schedules itself every cycle and never settles (the shape behind the #19 drain bound, but caught during the run rather than only past `end_time`).

`GraphExecutorBuilder::max_consecutive_immediate_cycles(n)` (default `0` = disabled) arms the guard in **both** run modes:

- The run loop counts consecutive cycles that advance evaluation time by exactly `MIN_TD`; any larger advance resets the count.
- At the limit, the executor evaluates **one further cycle** with a temporary `LifecycleObserver` recording every evaluated node's `diagnostic::node_path` (nested graphs included, capped at 256 entries), so the offending evaluation path is captured before breaking out.
- It then logs the path through the run logger and throws `RecursiveEvaluationError` carrying the same text, e.g.:

```
potential recursive evaluation loop: 51 consecutive MIN_TD evaluation cycles at 1970-01-01 00:00:00.000052; nodes evaluated in the last cycle:
  [].busy_loop_source<0>
```

- If the loop settles during the recording cycle, the guard disarms and the run continues.
- The consecutive-`MIN_TD` counter is now shared with the real-time drain bound from #19 (which reads it instead of keeping its own count); past wall-clock `end_time`, whichever limit is lower fires first.

Design record: `execution_layer.rst` (*Opt-in recursion guard*), updated in the same change.

## Test plan

- Simulation: sustained `MIN_TD` loop with limit 50 → throws `RecursiveEvaluationError`; message carries the loop shape and the node's diagnostic path; ~51 evaluations, not millions.
- Simulation: bursts of 10 immediate cycles separated by 1 ms jumps → completes all 60 evaluations, no trip (counter resets on progress).
- Real-time: busy loop with limit 50 and a 60 s window → throws within a fraction of a second, well before `end_time` or the drain bound.
- Full ctest suite green, full Python suite 1546 passed / 10 skipped (including the ported wall-clock scheduler tests), real-time + simulation groups clean under ASAN + UBSAN.

🤖 Generated with [Claude Code](https://claude.com/claude-code)