### PR TITLE
Implement typed Frame metadata and extension scalar registration

### DIFF
--- a/docs/source/developer_guide/parity_matrix.rst
+++ b/docs/source/developer_guide/parity_matrix.rst
@@ -416,6 +416,19 @@ Types and scalars
    * - ``TSL``
      - Full
      - Fixed and dynamic.
+   * - ``Frame[Rows, Metadata]``
+     - Full for typed value transport and metadata-aware table transforms
+     - Metadata is encoded field by field in Arrow schema metadata: supported
+       atomics as plain strings and nested fields as JSON. Sorting, filtering,
+       and column projection preserve it; concat requires equality; join
+       requires an explicit metadata policy. C++ and Python bridge round trips
+       use the same table representation.
+   * - Downstream native scalar registration
+     - Full
+     - Installed C++ and public Python hooks associate extension-owned scalar
+       schemas with Python classes for annotation resolution, reflection, and
+       value conversion. Registration is process-wide, idempotent for an
+       identical pair, and rejects conflicts.
    * - ``REF``
      - Full
      - Wiring marker + runtime retargeting; executor-level tests

--- a/docs/source/developer_guide/python_integration.rst
+++ b/docs/source/developer_guide/python_integration.rst
@@ -84,6 +84,32 @@ listener seeds via ``register_standard_types()`` and the Python module (when it
 is built) must seed at import via a ``register_builtin_value_types()`` entry
 point — the two must agree on names and aliases.
 
+Downstream native scalar classes
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+A downstream nanobind module associates an extension-owned C++ scalar with its
+Python class through the installed
+``hgraph/python/native_scalar_registration.h`` header:
+
+.. code-block:: cpp
+
+   auto cls = nanobind::class_<Price>(module, "Price");
+   hgraph::python_bridge::register_native_scalar_type<Price>(
+       cls, "extension.price");
+
+The helper registers the scalar in the shared ``TypeRegistry`` and installs a
+process-wide, bidirectional class/schema association. The same pair may be
+registered repeatedly; a class or schema already paired with a different
+counterpart is rejected. The registry retains the Python class, so
+``TS[Price]`` resolves to the native schema and schema reflection returns the
+same class.
+
+The equivalent public Python operation is
+``register_native_scalar_type(PythonType, native_value_type)`` from
+``hgraph``. ``native_value_type`` may be a registered schema name or native
+``ValueType`` handle. Extensions should not import or mutate
+``hgraph._types``.
+
 Hosting a Python node
 ---------------------
 

--- a/docs/source/developer_guide/record_replay_table.rst
+++ b/docs/source/developer_guide/record_replay_table.rst
@@ -167,6 +167,17 @@ Arrow directly. Schema semantics (ruling):
 - a schema on an **output** is *exact* — the produced frame must have
   **exactly** that schema.
 
+The typed value also supports ``Frame[Rows, Metadata]``. Frame-level metadata
+is encoded field by field into the Arrow schema metadata, not stored in a
+second native object and not repeated as Arrow columns. A reserved schema key
+records the qualified hgraph Bundle type; supported atomic fields use plain
+strings and structured fields use the native schema-directed JSON codec.
+Direct ``FrameStore`` reads and writes therefore preserve metadata as part of
+the Arrow representation. Serializing a stream whose *row payload* is itself a
+metadata-bearing Frame into the generic bitemporal table layout is not yet
+defined; a backend must preserve or explicitly transform those schema entries
+when that case is added.
+
 ``TableSchema`` maps to an Arrow schema (``value_time``/``as_of`` as
 timestamp columns; partition keys; removed as a bool column). The serializer
 ops write **directly into Arrow array builders** (append per tick), so the

--- a/docs/source/rfc/rfc_0001_typed_frame_metadata.rst
+++ b/docs/source/rfc/rfc_0001_typed_frame_metadata.rst
@@ -112,10 +112,12 @@ Acceptance criteria
 Implementation status
 ---------------------
 
-Implementation is planned for subsequent commits after review of this
-proposal. It will cover the type system, Arrow codec, Python bridge,
-table-operator propagation, and conformance tests. This RFC remains
-``Proposed`` until that implementation is accepted for merge.
+The implementation is complete on its implementation PR. It covers the
+two-parameter C++ and Python Frame type, field-wise Arrow schema codec,
+marker-bearing and markerless decoding, Python conversion validation,
+metadata-aware table overloads, installed-SDK use, and C++/Python conformance
+tests. The RFC remains ``Proposed`` until that implementation is accepted for
+merge, at which point this status changes to ``Accepted`` in the same PR.
 
 Versioned-dataset proof
 -----------------------

--- a/docs/source/rfc/rfc_0003_extension_scalar_registration.rst
+++ b/docs/source/rfc/rfc_0003_extension_scalar_registration.rst
@@ -42,6 +42,30 @@ type and Python class, ensure the scalar is registered in the shared
 ``TypeRegistry``, and install the same association without importing private
 Python modules.
 
+Public surface
+--------------
+
+Python extensions may call:
+
+.. code-block:: python
+
+   from hgraph import register_native_scalar_type
+
+   register_native_scalar_type(PythonType, "extension.scalar_name")
+
+The second argument may instead be the native ``ValueType`` handle. Native
+nanobind modules normally use the installed header:
+``hgraph/python/native_scalar_registration.h``. Its templated overload accepts
+the extension-owned C++ scalar type and Python class, registers the scalar
+through the shared ``TypeRegistry``, and installs the same bidirectional
+association.
+
+The shared runtime owns the registry. Python annotation resolution consults it
+before opaque-object fallback, schema reflection consults its reverse mapping,
+and schema-free value inference uses the registered conversion operations.
+The test-only complete-registry reset clears these associations because its
+schema pointers are invalidated at the same time.
+
 Ownership and constraints
 -------------------------
 
@@ -73,6 +97,10 @@ Acceptance criteria
 Implementation status
 ---------------------
 
-No core implementation is included. A downstream test extension that currently
-requires a private type mapping will provide the proving integration for this
-RFC.
+The implementation is complete on its implementation PR. A separately built
+test extension uses only the installed SDK to register a custom native scalar,
+resolve ``TS[ExtensionType]``, reflect its Python class, and round-trip a value
+through a Python-authored graph. It also verifies harmless duplicate
+registration and deterministic conflicts on both sides. This RFC remains
+``Proposed`` until the implementation is accepted for merge, when it changes
+to ``Accepted`` in the same PR.

--- a/docs/source/user_guide/data_and_analytics.rst
+++ b/docs/source/user_guide/data_and_analytics.rst
@@ -65,3 +65,46 @@ projection execute in C++. Python expression filters remain a Python-owned
 compatibility path because ``pyarrow.compute.Expression`` is itself a Python
 scalar. Series-to-tuple conversion is native and represents Arrow nulls as
 unset tuple elements.
+
+Typed frame metadata
+~~~~~~~~~~~~~~~~~~~~
+
+``Frame[Rows, Metadata]`` stores frame-level identity and provenance in the
+Arrow table's own schema metadata. It is intended for values such as an as-of
+time, source, universe definition, or plan version that apply to the complete
+table and must not be repeated on every row. The C++ spelling is
+``FrameOf<Rows, Metadata>``; the Python value remains an ordinary
+``pyarrow.Table``.
+
+The metadata schema must be a named ``CompoundScalar``/``Bundle``. The codec
+uses these reserved byte-string entries in the Arrow schema metadata:
+
+* ``hgraph.metadata.schema`` optionally identifies the qualified hgraph
+  metadata schema;
+* ``hgraph.metadata.version`` identifies the metadata wire format; and
+* ``hgraph.metadata.field.<name>`` stores each populated field separately.
+
+Supported atomic fields (``str``, ``int``, ``float``, ``bool``, enums, dates,
+datetimes, times, and durations) use their plain string form. Tuple, Bundle,
+list, set, and map fields use the existing schema-directed JSON codec. Binary,
+opaque Python objects, callables, and other values without that codec are
+rejected. Unrelated Arrow schema metadata is retained.
+
+Use ``with_frame_metadata(table, value)`` to return a table with encoded
+metadata and ``frame_metadata(table, MetadataType)`` to decode it. The schema
+argument is authoritative, so a table remains compliant when its field entries
+match that schema but the optional ``hgraph.metadata.schema`` marker is absent.
+When the marker is present, ``frame_metadata(table)`` can resolve the registered
+schema reflectively and an explicitly supplied schema is checked for
+compatibility. Markerless metadata cannot be decoded reflectively and therefore
+requires the schema argument. The ``has_frame_metadata`` predicate detects any
+reserved hgraph entry;
+``without_frame_metadata`` removes only the reserved hgraph entries. The C++
+functions have the same names and operate on ``Frame``/``Value``.
+
+Sorting, filtering, and column replacement preserve the Arrow schema metadata.
+Concatenation requires equal hgraph metadata on both inputs and preserves it. A
+join has no generally correct metadata rule, so metadata-bearing frames do not
+match the row-only join overload: choose and implement the result metadata
+explicitly. The Python bridge rejects missing or incompatible encoded metadata,
+and rejects a metadata-bearing table supplied to ``Frame[Rows]``.

--- a/include/hgraph/lib/std/operators/impl/data_frame_impl.h
+++ b/include/hgraph/lib/std/operators/impl/data_frame_impl.h
@@ -569,6 +569,101 @@ namespace hgraph::stdlib
         }
     };
 
+    /** Metadata-bearing overloads preserve the Arrow schema metadata. */
+    struct sorted_metadata_frame_impl
+    {
+        static constexpr auto name = "sorted_metadata_frame";
+        static auto defaults() { return std::tuple{arg<"descending">(Bool{false})}; }
+        static void eval(In<"ts", TS<FrameOf<ScalarVar<"R">, ScalarVar<"M">>>> ts,
+                         Scalar<"by", Str> by, Scalar<"descending", Bool> descending,
+                         Out<TS<FrameOf<ScalarVar<"R">, ScalarVar<"M">>>> out)
+        {
+            out.set(data_frame_detail::sort_frame(ts.value(), by.value(), descending.value()));
+        }
+    };
+
+    struct concat_metadata_frame_impl
+    {
+        static constexpr auto name = "concat_metadata_frame";
+        static void eval(In<"ts1", TS<FrameOf<ScalarVar<"R">, ScalarVar<"M">>>> ts1,
+                         In<"ts2", TS<FrameOf<ScalarVar<"R">, ScalarVar<"M">>>> ts2,
+                         Out<TS<FrameOf<ScalarVar<"R">, ScalarVar<"M">>>> out)
+        {
+            out.set(data_frame_detail::concat_frames(ts1.value(), ts2.value()));
+        }
+    };
+
+    struct filter_metadata_frame_impl
+    {
+        static constexpr auto name = "filter_metadata_frame";
+        static bool requires_(const ResolutionMap &, OperatorCallContext context)
+        {
+            const auto *predicate = time_series_schema_at(context, 1);
+            const auto *frame = ts_value_schema_at(context, 0);
+            return frame != nullptr && TypeRegistry::instance().is_frame(frame) &&
+                   frame->key_type != nullptr && predicate != nullptr &&
+                   predicate->kind == TSTypeKind::TSB;
+        }
+        static void eval(In<"ts", TS<FrameOf<ScalarVar<"R">, ScalarVar<"M">>>> ts,
+                         In<"predicate", TsVar<"P">> predicate,
+                         Out<TS<FrameOf<ScalarVar<"R">, ScalarVar<"M">>>> out)
+        {
+            auto &erased = const_cast<TSInputView &>(predicate.base());
+            out.set(data_frame_detail::filter_frame_by_bundle(ts.value(), erased));
+        }
+    };
+
+    struct filter_cs_metadata_frame_impl
+    {
+        static constexpr auto name = "filter_cs_metadata_frame";
+        static bool requires_(const ResolutionMap &, OperatorCallContext context)
+        {
+            const auto *predicate = ts_value_schema_at(context, 1);
+            const auto *frame = ts_value_schema_at(context, 0);
+            return frame != nullptr && TypeRegistry::instance().is_frame(frame) &&
+                   frame->key_type != nullptr && predicate != nullptr &&
+                   predicate->value_kind() == ValueTypeKind::Bundle;
+        }
+        static void eval(In<"ts", TS<FrameOf<ScalarVar<"R">, ScalarVar<"M">>>> ts,
+                         In<"predicate", TS<ScalarVar<"P">>> predicate,
+                         Out<TS<FrameOf<ScalarVar<"R">, ScalarVar<"M">>>> out)
+        {
+            out.set(data_frame_detail::filter_frame_by_value(ts.value(), predicate.base().value()));
+        }
+    };
+
+    struct with_columns_metadata_frame_impl
+    {
+        static constexpr auto name = "with_columns_metadata_frame";
+        static void resolve_default_types(ResolutionMap &resolution, OperatorCallContext context)
+        {
+            if (resolution.find_scalar("O") != nullptr) { return; }
+            const auto *frame = ts_value_schema_at(context, 0);
+            if (frame != nullptr && TypeRegistry::instance().is_frame(frame) &&
+                frame->element_type != nullptr)
+            {
+                resolution.bind_scalar("O", frame->element_type);
+            }
+        }
+        static bool requires_(const ResolutionMap &, OperatorCallContext context)
+        {
+            const auto *columns = time_series_schema_at(context, 1);
+            const auto *frame = ts_value_schema_at(context, 0);
+            return frame != nullptr && TypeRegistry::instance().is_frame(frame) &&
+                   frame->key_type != nullptr && columns != nullptr &&
+                   columns->kind == TSTypeKind::TSB;
+        }
+        static void eval(In<"ts", TS<FrameOf<ScalarVar<"R">, ScalarVar<"M">>>> ts,
+                         In<"columns", TsVar<"C">> columns,
+                         Out<TS<FrameOf<ScalarVar<"O">, ScalarVar<"M">>>> out)
+        {
+            auto &erased = const_cast<TSInputView &>(columns.base());
+            out.set(data_frame_detail::replace_frame_columns(
+                ts.value(), erased,
+                static_cast<const TSOutputView &>(out).schema()->value_schema->element_type));
+        }
+    };
+
     namespace data_frame_impl_detail
     {
         [[nodiscard]] inline bool output_is_frame(const ResolutionMap &resolution)

--- a/include/hgraph/lib/testing/eval_node.h
+++ b/include/hgraph/lib/testing/eval_node.h
@@ -43,7 +43,7 @@ namespace hgraph::testing
     template <typename T, auto... Dimensions>
     struct harness_element<TS<ArrayOf<T, Dimensions...>>> { using type = Value; };
     template <typename T> struct harness_element<TS<SeriesOf<T>>> { using type = Series; };
-    template <typename T> struct harness_element<TS<FrameOf<T>>> { using type = Frame; };
+    template <typename T, typename M> struct harness_element<TS<FrameOf<T, M>>> { using type = Frame; };
     template <typename T, std::size_t Period, std::size_t MinPeriod>
     struct harness_element<TSW<T, Period, MinPeriod>>
     {

--- a/include/hgraph/python/native_scalar_registration.h
+++ b/include/hgraph/python/native_scalar_registration.h
@@ -1,0 +1,77 @@
+#ifndef HGRAPH_PYTHON_NATIVE_SCALAR_REGISTRATION_H
+#define HGRAPH_PYTHON_NATIVE_SCALAR_REGISTRATION_H
+
+#include <hgraph/config.h>
+
+#if HGRAPH_ENABLE_PYTHON_USER_NODES
+
+#include <hgraph/hgraph_export.h>
+#include <hgraph/types/static_schema.h>
+
+#include <nanobind/nanobind.h>
+
+#include <string_view>
+
+namespace hgraph::python_bridge
+{
+    /**
+     * Associate a Python class with a native atomic scalar schema.
+     *
+     * The association is process-wide and bidirectional. Registering the same
+     * pair more than once is harmless; associating either member with a
+     * different counterpart throws ``std::invalid_argument``.
+     */
+    HGRAPH_EXPORT void register_native_scalar_type(
+        nanobind::handle python_type,
+        const ValueTypeMetaData *native_value_type);
+
+    /** Return the registered native scalar schema for an exact Python class. */
+    [[nodiscard]] HGRAPH_EXPORT const ValueTypeMetaData *
+    native_scalar_type_for_python(nanobind::handle python_type);
+
+    /** Return the registered Python class for a native scalar schema. */
+    [[nodiscard]] HGRAPH_EXPORT nanobind::object
+    python_type_for_native_scalar(const ValueTypeMetaData *native_value_type);
+
+    /**
+     * Return the registered native scalar schema for a Python value.
+     *
+     * Exact class matches are preferred; registered base classes are accepted
+     * through Python's normal ``isinstance`` semantics.
+     */
+    [[nodiscard]] HGRAPH_EXPORT const ValueTypeMetaData *
+    native_scalar_type_for_value(nanobind::handle value);
+
+    /** Test-only lifecycle hook used when the complete hgraph registry resets. */
+    HGRAPH_EXPORT void clear_native_scalar_types() noexcept;
+
+    /**
+     * Register ``T`` through its ``scalar_descriptor`` and associate it with
+     * the supplied Python class.
+     */
+    template <typename T>
+    const ValueTypeMetaData *register_native_scalar_type(nanobind::handle python_type)
+    {
+        const auto *native_value_type = scalar_descriptor<T>::value_meta();
+        register_native_scalar_type(python_type, native_value_type);
+        return native_value_type;
+    }
+
+    /**
+     * Register ``T`` under an explicit native schema name and associate it
+     * with the supplied Python class.
+     */
+    template <typename T>
+    const ValueTypeMetaData *register_native_scalar_type(
+        nanobind::handle python_type,
+        std::string_view native_name)
+    {
+        const auto *native_value_type =
+            TypeRegistry::instance().register_scalar<T>(native_name);
+        register_native_scalar_type(python_type, native_value_type);
+        return native_value_type;
+    }
+}  // namespace hgraph::python_bridge
+
+#endif  // HGRAPH_ENABLE_PYTHON_USER_NODES
+#endif  // HGRAPH_PYTHON_NATIVE_SCALAR_REGISTRATION_H

--- a/include/hgraph/types/frame.h
+++ b/include/hgraph/types/frame.h
@@ -47,7 +47,7 @@ namespace hgraph
 
         [[nodiscard]] bool has_value() const noexcept { return table != nullptr; }
         /** True when the Arrow schema carries any reserved hgraph frame metadata. */
-        [[nodiscard]] bool has_metadata() const noexcept;
+        [[nodiscard]] HGRAPH_EXPORT bool has_metadata() const noexcept;
 
         friend bool operator==(const Frame &lhs, const Frame &rhs) noexcept
         {

--- a/include/hgraph/types/frame.h
+++ b/include/hgraph/types/frame.h
@@ -8,6 +8,7 @@
 #include <functional>
 #include <iosfwd>
 #include <memory>
+#include <string_view>
 
 namespace arrow
 {
@@ -16,6 +17,8 @@ namespace arrow
 
 namespace hgraph
 {
+    class Value;
+
     /**
      * The ``Frame`` scalar — a first-class table value backed by an **Apache
      * Arrow** table (design record: *Record/replay, tables and const_fn*,
@@ -43,6 +46,8 @@ namespace hgraph
         std::shared_ptr<arrow::Table> table{};
 
         [[nodiscard]] bool has_value() const noexcept { return table != nullptr; }
+        /** True when the Arrow schema carries any reserved hgraph frame metadata. */
+        [[nodiscard]] bool has_metadata() const noexcept;
 
         friend bool operator==(const Frame &lhs, const Frame &rhs) noexcept
         {
@@ -50,11 +55,38 @@ namespace hgraph
         }
     };
 
+    /** Reserved Arrow schema-metadata keys used by the field-wise codec. */
+    inline constexpr std::string_view frame_metadata_prefix{"hgraph.metadata."};
+    inline constexpr std::string_view frame_metadata_schema_key{"hgraph.metadata.schema"};
+    inline constexpr std::string_view frame_metadata_version_key{"hgraph.metadata.version"};
+    inline constexpr std::string_view frame_metadata_field_prefix{"hgraph.metadata.field."};
+
+    /**
+     * Encode a named Bundle value into the Arrow table's schema metadata.
+     * Atomic fields use their plain string form; structured fields use JSON.
+     * Existing non-hgraph Arrow metadata is preserved.
+     */
+    [[nodiscard]] HGRAPH_EXPORT Frame with_frame_metadata(Frame frame, Value metadata);
+    /**
+     * Decode metadata against a declared named Bundle schema. When no schema
+     * is supplied, the optional encoded schema marker is used for reflective
+     * loading; markerless metadata therefore requires an explicit schema.
+     */
+    [[nodiscard]] HGRAPH_EXPORT Value frame_metadata(
+        const Frame &frame, const ValueTypeMetaData *metadata_schema = nullptr);
+    /** True when the Arrow schema carries any reserved hgraph metadata entry. */
+    [[nodiscard]] HGRAPH_EXPORT bool has_frame_metadata(const Frame &frame) noexcept;
+    /** Compare only the reserved hgraph metadata entries on two Arrow schemas. */
+    [[nodiscard]] HGRAPH_EXPORT bool frame_metadata_equal(
+        const Frame &lhs, const Frame &rhs) noexcept;
+    /** Explicitly discard hgraph metadata while preserving unrelated Arrow metadata. */
+    [[nodiscard]] HGRAPH_EXPORT Frame without_frame_metadata(Frame frame);
+
     /** Render as ``frame[rows x cols]`` (diagnostics; not a data format). */
     std::ostream &operator<<(std::ostream &os, const Frame &value);
 
     /** Row count (0 for an empty frame) without exposing Arrow headers. */
-    [[nodiscard]] std::int64_t frame_rows(const Frame &value) noexcept;
+    [[nodiscard]] HGRAPH_EXPORT std::int64_t frame_rows(const Frame &value) noexcept;
 
     namespace static_schema_detail
     {

--- a/include/hgraph/types/metadata/type_registry.h
+++ b/include/hgraph/types/metadata/type_registry.h
@@ -259,13 +259,15 @@ namespace hgraph
         const ValueTypeMetaData *series(const ValueTypeMetaData *element_type);
         /** True when ``meta`` is the base Series schema or an interned ``Series[T]`` schema. */
         [[nodiscard]] bool is_series(const ValueTypeMetaData *meta) const;
-        /** A Frame parameterised by its column schema (``Frame[Schema]``, a
-            Bundle meta); shares the base ``frame`` storage plan + ops (the
-            :cpp:func:`series` pattern), distinct meta carrying the schema on
-            ``element_type`` so table operators can resolve columns. A null
-            schema returns the base (untyped) frame scalar. */
-        const ValueTypeMetaData *frame(const ValueTypeMetaData *column_schema);
-        /** True when ``meta`` is the base Frame schema or an interned ``Frame[Schema]`` schema. */
+        /** A Frame parameterised by its row schema and optional frame-level
+            metadata schema (``Frame[Row]`` or ``Frame[Row, Metadata]``).
+            Typed frames share the base ``frame`` storage plan and ops;
+            ``element_type`` carries the row schema and ``key_type`` carries
+            the schema for field-wise Arrow schema metadata. A null row schema
+            returns the base frame and cannot be combined with metadata. */
+        const ValueTypeMetaData *frame(const ValueTypeMetaData *column_schema,
+                                       const ValueTypeMetaData *metadata_schema = nullptr);
+        /** True for the base Frame or an interned row-only/metadata-bearing Frame schema. */
         [[nodiscard]] bool is_frame(const ValueTypeMetaData *meta) const;
         /** Intern a set value-schema for ``element_type``. */
         const ValueTypeMetaData *set(const ValueTypeMetaData *element_type);
@@ -659,7 +661,7 @@ namespace hgraph
         InternTable<const ValueTypeMetaData *, ValueTypeMetaData> mutable_list_cache_;
         InternTable<const ValueTypeMetaData *, ValueTypeMetaData> nullable_tuple_cache_;
         InternTable<const ValueTypeMetaData *, ValueTypeMetaData> series_cache_;
-        InternTable<const ValueTypeMetaData *, ValueTypeMetaData> frame_cache_;
+        InternTable<MapKey, ValueTypeMetaData, MapKeyHash> frame_cache_;
         InternTable<const ValueTypeMetaData *, ValueTypeMetaData> mutable_set_cache_;
         InternTable<MapKey, ValueTypeMetaData, MapKeyHash> map_cache_;
         InternTable<MapKey, ValueTypeMetaData, MapKeyHash> mutable_map_cache_;

--- a/include/hgraph/types/static_node.h
+++ b/include/hgraph/types/static_node.h
@@ -99,7 +99,7 @@ namespace hgraph
         template <typename C> struct delta_input { using type = Value; };
         template <typename V> struct delta_input<TS<V>> { using type = V; };
         template <typename V> struct delta_input<TS<SeriesOf<V>>> { using type = Series; };
-        template <typename V> struct delta_input<TS<FrameOf<V>>> { using type = Frame; };
+        template <typename V, typename M> struct delta_input<TS<FrameOf<V, M>>> { using type = Frame; };
         template <typename V, std::size_t P, std::size_t M> struct delta_input<TSW<V, P, M>> { using type = V; };
         template <> struct delta_input<SIGNAL> { using type = bool; };
         template <typename C> using delta_input_t = typename delta_input<C>::type;
@@ -614,11 +614,11 @@ namespace hgraph
         [[nodiscard]] const TSInputView &base() const noexcept { return *this; }
     };
 
-    template <fixed_string Name, typename TSchema, auto... TPolicies>
-    class In<Name, TS<FrameOf<TSchema>>, TPolicies...> : public TSInputView
+    template <fixed_string Name, typename TSchema, typename TMetadata, auto... TPolicies>
+    class In<Name, TS<FrameOf<TSchema, TMetadata>>, TPolicies...> : public TSInputView
     {
       public:
-        using schema                     = TS<FrameOf<TSchema>>;
+        using schema                     = TS<FrameOf<TSchema, TMetadata>>;
         using value_type                 = Frame;
         static constexpr auto field_name = Name;
         static constexpr auto activity   = static_node_detail::resolved_input_activity<TPolicies...>();
@@ -1072,11 +1072,11 @@ namespace hgraph
         }
     };
 
-    template <typename TSchema>
-    class Out<TS<FrameOf<TSchema>>> : public TSOutputView
+    template <typename TSchema, typename TMetadata>
+    class Out<TS<FrameOf<TSchema, TMetadata>>> : public TSOutputView
     {
       public:
-        using schema     = TS<FrameOf<TSchema>>;
+        using schema     = TS<FrameOf<TSchema, TMetadata>>;
         using value_type = Frame;
 
         Out(TSOutputView view, DateTime /*evaluation_time*/) noexcept : TSOutputView(std::move(view)) {}

--- a/include/hgraph/types/static_schema.h
+++ b/include/hgraph/types/static_schema.h
@@ -273,11 +273,12 @@ namespace hgraph
         using element_type = TElement;
     };
 
-    /** Arrow Frame scalar qualified by its column Bundle schema. Runtime storage is ``Frame``. */
-    template <typename TSchema>
+    /** Arrow Frame scalar qualified by row and optional Arrow-metadata Bundle schemas. */
+    template <typename TSchema, typename TMetadata = void>
     struct FrameOf
     {
         using schema_type = TSchema;
+        using metadata_type = TMetadata;
     };
 
     // -----------------------------------------------------------------
@@ -537,19 +538,28 @@ namespace hgraph
         }
     };
 
-    template <typename TSchema>
-    struct scalar_descriptor<FrameOf<TSchema>>
+    template <typename TSchema, typename TMetadata>
+    struct scalar_descriptor<FrameOf<TSchema, TMetadata>>
     {
         [[nodiscard]] static constexpr bool is_concrete() noexcept
         {
-            return scalar_descriptor<TSchema>::is_concrete();
+            return scalar_descriptor<TSchema>::is_concrete() &&
+                   (std::is_void_v<TMetadata> || scalar_descriptor<TMetadata>::is_concrete());
         }
 
         [[nodiscard]] static const ValueTypeMetaData *value_meta()
         {
             if constexpr (is_concrete())
             {
-                return TypeRegistry::instance().frame(scalar_descriptor<TSchema>::value_meta());
+                if constexpr (std::is_void_v<TMetadata>)
+                {
+                    return TypeRegistry::instance().frame(scalar_descriptor<TSchema>::value_meta());
+                }
+                else
+                {
+                    return TypeRegistry::instance().frame(scalar_descriptor<TSchema>::value_meta(),
+                                                          scalar_descriptor<TMetadata>::value_meta());
+                }
             }
             else { return nullptr; }
         }

--- a/include/hgraph/types/type_pattern.h
+++ b/include/hgraph/types/type_pattern.h
@@ -139,11 +139,13 @@ namespace hgraph
             p.children.push_back(std::move(element));
             return p;
         }
-        [[nodiscard]] static ScalarPattern frame(ScalarPattern schema)
+        [[nodiscard]] static ScalarPattern frame(ScalarPattern schema,
+                                                 std::optional<ScalarPattern> metadata = std::nullopt)
         {
             ScalarPattern p;
             p.kind = Kind::Frame;
             p.children.push_back(std::move(schema));
+            if (metadata.has_value()) { p.children.push_back(std::move(*metadata)); }
             return p;
         }
         [[nodiscard]] static ScalarPattern array(ScalarPattern element,
@@ -716,12 +718,20 @@ namespace hgraph
         }
     };
 
-    template <typename TSchema>
-    struct scalar_pattern_lower<FrameOf<TSchema>>
+    template <typename TSchema, typename TMetadata>
+    struct scalar_pattern_lower<FrameOf<TSchema, TMetadata>>
     {
         [[nodiscard]] static ScalarPattern lower()
         {
-            return ScalarPattern::frame(to_scalar_pattern<TSchema>());
+            if constexpr (std::is_void_v<TMetadata>)
+            {
+                return ScalarPattern::frame(to_scalar_pattern<TSchema>());
+            }
+            else
+            {
+                return ScalarPattern::frame(to_scalar_pattern<TSchema>(),
+                                            to_scalar_pattern<TMetadata>());
+            }
         }
     };
 }  // namespace hgraph

--- a/include/hgraph/types/type_resolution.h
+++ b/include/hgraph/types/type_resolution.h
@@ -212,12 +212,14 @@ namespace hgraph
         }
     };
 
-    template <typename TSchema>
-    struct scalar_resolver<FrameOf<TSchema>>
+    template <typename TSchema, typename TMetadata>
+    struct scalar_resolver<FrameOf<TSchema, TMetadata>>
     {
         [[nodiscard]] static const ValueTypeMetaData *resolve(const ResolutionMap &m)
         {
-            return TypeRegistry::instance().frame(scalar_resolver<TSchema>::resolve(m));
+            const auto *row = scalar_resolver<TSchema>::resolve(m);
+            if constexpr (std::is_void_v<TMetadata>) { return TypeRegistry::instance().frame(row); }
+            else { return TypeRegistry::instance().frame(row, scalar_resolver<TMetadata>::resolve(m)); }
         }
     };
 
@@ -411,8 +413,8 @@ namespace hgraph
         }
     };
 
-    template <typename TSchema>
-    struct scalar_unifier<FrameOf<TSchema>>
+    template <typename TSchema, typename TMetadata>
+    struct scalar_unifier<FrameOf<TSchema, TMetadata>>
     {
         static void unify(const ValueTypeMetaData *concrete, ResolutionMap &m)
         {
@@ -422,6 +424,21 @@ namespace hgraph
                 throw std::logic_error("expected a typed Frame scalar");
             }
             scalar_unifier<TSchema>::unify(concrete->element_type, m);
+            if constexpr (std::is_void_v<TMetadata>)
+            {
+                if (concrete->key_type != nullptr)
+                {
+                    throw std::logic_error("expected a metadata-free Frame scalar");
+                }
+            }
+            else
+            {
+                if (concrete->key_type == nullptr)
+                {
+                    throw std::logic_error("expected a metadata-bearing Frame scalar");
+                }
+                scalar_unifier<TMetadata>::unify(concrete->key_type, m);
+            }
         }
     };
 

--- a/python/hgraph/__init__.py
+++ b/python/hgraph/__init__.py
@@ -67,7 +67,10 @@ _hgraph._set_divide_by_zero_enum(DivideByZero)
 from ._wiring import _Combine as _CombineClass
 combine = _CombineClass()
 
-from ._types import Frame, TABLE, COMPOUND_SCALAR, COMPOUND_SCALAR_1, compound_scalar
+from ._types import (Frame, TABLE, COMPOUND_SCALAR, COMPOUND_SCALAR_1,
+                     compound_scalar, register_native_scalar_type)
+from ._frame import (frame_metadata, has_frame_metadata, without_frame_metadata,
+                     with_frame_metadata)
 from ._table import (ToTableMode, TableSchema, make_table_schema, table_schema,
                      table_shape, table_shape_from_schema, shape_of_table_type,
                      get_table_schema_date_key, get_table_schema_as_of_key)
@@ -104,7 +107,7 @@ __all__ = [
     "utc_now", "get_recorded_value", "get_recorder_api", "get_recording_label", "set_recorder_api", "set_recording_label", "EvaluationClock", "TSW_OUT", "get_context", "equal_lambdas", "is_feature_enabled",
     "GlobalContext", "GlobalState", "set_as_of", "set_table_schema_date_key", "set_table_schema_as_of_key",
     "set_record_replay_config", "frame_store_contains", "frame_store_read", "evaluate_const",
-    "Frame", "TABLE", "COMPOUND_SCALAR", "COMPOUND_SCALAR_1", "ToTableMode", "TableSchema", "make_table_schema", "table_schema",
+    "Frame", "with_frame_metadata", "frame_metadata", "has_frame_metadata", "without_frame_metadata", "register_native_scalar_type", "TABLE", "COMPOUND_SCALAR", "COMPOUND_SCALAR_1", "ToTableMode", "TableSchema", "make_table_schema", "table_schema",
     "table_shape", "table_shape_from_schema", "shape_of_table_type", "drop_dups",
     "get_table_schema_date_key", "get_table_schema_as_of_key",
     "ParseError", "IncorrectTypeBinding", "RequirementsNotMetWiringError",

--- a/python/hgraph/_frame.py
+++ b/python/hgraph/_frame.py
@@ -1,0 +1,36 @@
+"""Field-wise hgraph metadata encoded in an Arrow table schema."""
+
+from __future__ import annotations
+
+from . import _hgraph
+from ._types import _value_type
+
+
+def with_frame_metadata(table, metadata):
+    """Return an Arrow table carrying ``metadata`` in its schema metadata."""
+    return _hgraph._with_frame_metadata(table, _value_type(type(metadata)), metadata)
+
+
+def frame_metadata(table, metadata_type=None):
+    """Decode frame metadata, using its optional type marker when no type is supplied."""
+    if metadata_type is None:
+        return _hgraph._frame_metadata_reflective(table)
+    return _hgraph._frame_metadata(table, _value_type(metadata_type))
+
+
+def has_frame_metadata(table):
+    """Return whether ``table`` carries reserved hgraph metadata entries."""
+    return _hgraph._has_frame_metadata(table)
+
+
+def without_frame_metadata(table):
+    """Return an Arrow table with only the reserved hgraph metadata removed."""
+    return _hgraph._without_frame_metadata(table)
+
+
+__all__ = [
+    "with_frame_metadata",
+    "frame_metadata",
+    "has_frame_metadata",
+    "without_frame_metadata",
+]

--- a/python/hgraph/_types.py
+++ b/python/hgraph/_types.py
@@ -21,6 +21,22 @@ _COMPOUND_TYPE_CACHE = {}
 _TSB_SCHEMA_CLASSES = {}
 
 
+def register_native_scalar_type(python_type, native_value_type):
+    """Associate a Python class with a registered native scalar schema.
+
+    ``native_value_type`` may be the schema name or the native ``ValueType``
+    handle returned by the bridge. Downstream native modules normally use the
+    installed C++ helper, which installs the same process-wide association.
+    """
+    if not isinstance(python_type, type):
+        raise TypeError("python_type must be a Python class")
+    if isinstance(native_value_type, str):
+        native_value_type = _hgraph.value_type(native_value_type)
+    if not isinstance(native_value_type, _hgraph.ValueType):
+        raise TypeError("native_value_type must be a native schema name or ValueType")
+    _hgraph.register_native_scalar_type(python_type, native_value_type)
+
+
 def _register_bundle_class(meta, scalar):
     """Register reconstruction policy without exposing it as runtime semantics."""
     import inspect
@@ -659,6 +675,10 @@ def _compound_value_type(scalar, type_args=()):
 def _value_type(scalar):
     if isinstance(scalar, _hgraph.ValueType):
         return scalar
+    if isinstance(scalar, type):
+        native_value_type = _hgraph.native_scalar_value_type(scalar)
+        if native_value_type is not None:
+            return native_value_type
     if isinstance(scalar, _ArrayType):
         dimensions = tuple(0 if dimension == -1 else dimension
                            for dimension in scalar.dimensions) or (0,)
@@ -686,7 +706,9 @@ def _value_type(scalar):
         return _hgraph.value_type("series")   # element-untyped base
     if isinstance(scalar, _FrameType):
         try:
-            return _hgraph.frame_vt(_value_type(scalar.schema))
+            row = _value_type(scalar.schema)
+            return (_hgraph.frame_vt(row) if scalar.metadata is None
+                    else _hgraph.frame_vt(row, _value_type(scalar.metadata)))
         except _GenericType as error:
             raise _GenericType(
                 repr(scalar), _hgraph.scalar_pattern_frame(error.pattern)) from error
@@ -1245,25 +1267,35 @@ class _FrameMeta(type):
         # 'frame' scalar; the typed form carries its column bundle so table
         # operators can resolve columns (an input schema is a MINIMUM
         # requirement, an output schema is exact - the P4 ruling).
+        if isinstance(schema, tuple):
+            if len(schema) != 2:
+                raise TypeError("Frame expects Frame[Row] or Frame[Row, Metadata]")
+            return _FrameType(schema[0], schema[1])
         return _FrameType(schema)
 
 
 class _FrameType:
     """Frame[Schema]: resolves to the typed 'frame' scalar value type."""
 
-    __slots__ = ("schema",)
+    __slots__ = ("schema", "metadata")
 
-    def __init__(self, schema):
+    def __init__(self, schema, metadata=None):
         self.schema = schema
+        self.metadata = metadata
 
     def __repr__(self):
-        return f"Frame[{getattr(self.schema, '__name__', self.schema)!r}]"
+        row = getattr(self.schema, "__name__", self.schema)
+        if self.metadata is None:
+            return f"Frame[{row!r}]"
+        metadata = getattr(self.metadata, "__name__", self.metadata)
+        return f"Frame[{row!r}, {metadata!r}]"
 
     def __eq__(self, other):
-        return isinstance(other, _FrameType) and self.schema is other.schema
+        return (isinstance(other, _FrameType) and self.schema is other.schema
+                and self.metadata is other.metadata)
 
     def __hash__(self):
-        return hash((_FrameType, self.schema))
+        return hash((_FrameType, self.schema, self.metadata))
 
 
 class Frame(metaclass=_FrameMeta):

--- a/python/hgraph/reflection.py
+++ b/python/hgraph/reflection.py
@@ -112,6 +112,10 @@ def _wrap(handle):
 def _vt_to_py(vt):
     py = _VT_TO_PY.get(vt)
     if py is None:
+        reflected = _m.python_type_for_value(vt)
+        if isinstance(reflected, type):
+            py = reflected
+    if py is None:
         raise TypeError(
             f"scalar type is not a plain atomic python type (kind {_m.vt_kind(vt)}); "
             "decompose it further or read it from the schema"

--- a/python/module.cpp
+++ b/python/module.cpp
@@ -43,6 +43,7 @@
 #include <hgraph/types/value/specialized_views.h>
 #include <hgraph/types/value/value_builder.h>
 #include <hgraph/python/chrono.h>
+#include <hgraph/python/native_scalar_registration.h>
 
 #include <nanobind/nanobind.h>
 #include <nanobind/stl/optional.h>
@@ -165,9 +166,11 @@ NB_MODULE(_hgraph, m)
         python_bridge::bundle_class_registry().clear();
         python_bridge::bundle_class_info_registry().clear();
         python_bridge::tsb_compound_value_registry().clear();
+        python_bridge::clear_native_scalar_types();
         reset_all_registries();
         ++python_registry_generation;
         stdlib::register_standard_operators();
+        register_builtin_native_scalar_types();
         register_python_overloads();
     });
 }

--- a/python/py_bindings.h
+++ b/python/py_bindings.h
@@ -12,6 +12,7 @@
 namespace hgraph::python_bridge
 {
     void bind_type_system(nanobind::module_ &m);        // py_type_system.cpp
+    void register_builtin_native_scalar_types();        // py_type_system.cpp
     void bind_ports(nanobind::module_ &m);              // py_ports.cpp
     void bind_wiring(nanobind::module_ &m);             // py_wiring.cpp
     void bind_state_and_services(nanobind::module_ &m); // py_state_services.cpp

--- a/python/py_type_system.cpp
+++ b/python/py_type_system.cpp
@@ -7,12 +7,39 @@
 #include "py_wiring.h"
 #include "py_bindings.h"
 
+#include <hgraph/python/native_scalar_registration.h>
+
 namespace nb = nanobind;
 using namespace hgraph;
 using namespace hgraph::python_bridge;
 
 namespace hgraph::python_bridge
 {
+    void register_builtin_native_scalar_types()
+    {
+        const nb::module_ builtins = nb::module_::import_("builtins");
+        const nb::module_ datetime = nb::module_::import_("datetime");
+        const auto register_type = [](nb::handle python_type,
+                                      std::string_view native_name) {
+            const auto *meta = TypeRegistry::instance().value_type(native_name);
+            if (meta == nullptr)
+            {
+                throw std::logic_error(
+                    "built-in native scalar schema is not registered");
+            }
+            python_bridge::register_native_scalar_type(python_type, meta);
+        };
+        register_type(builtins.attr("bool"), "bool");
+        register_type(builtins.attr("int"), "int");
+        register_type(builtins.attr("float"), "float");
+        register_type(builtins.attr("str"), "str");
+        register_type(builtins.attr("bytes"), "bytes");
+        register_type(datetime.attr("datetime"), "datetime");
+        register_type(datetime.attr("date"), "date");
+        register_type(datetime.attr("time"), "time");
+        register_type(datetime.attr("timedelta"), "timedelta");
+    }
+
     void bind_type_system(nb::module_ &m)
     {
     nb::class_<PyTsType>(m, "TsType")
@@ -154,8 +181,21 @@ namespace hgraph::python_bridge
         if (meta == nullptr) { throw nb::value_error(("unknown value type: " + name).c_str()); }
         return PyValueType{meta};
     });
+    m.def("register_native_scalar_type",
+          [](nb::handle python_type, PyValueType native_value_type) {
+              python_bridge::register_native_scalar_type(
+                  python_type, native_value_type.meta);
+          });
+    m.def("native_scalar_value_type", [](nb::handle python_type) -> nb::object {
+        const auto *meta =
+            python_bridge::native_scalar_type_for_python(python_type);
+        return meta != nullptr ? nb::cast(PyValueType{meta}) : nb::none();
+    });
     m.def("python_type_for_value", [](PyValueType value) -> nb::object {
         if (value.meta == nullptr) { return nb::none(); }
+        nb::object native =
+            python_bridge::python_type_for_native_scalar(value.meta);
+        if (!native.is_none()) { return native; }
         const auto bundle = bundle_class_info_registry().find(value.meta);
         if (bundle != bundle_class_info_registry().end() && bundle->second.type.is_valid())
         {
@@ -173,6 +213,7 @@ namespace hgraph::python_bridge
         if (name == "bytes") { return builtins.attr("bytes"); }
         return nb::cast(value);
     });
+    register_builtin_native_scalar_types();
     m.def("ts", [](PyValueType v) { return PyTsType{TypeRegistry::instance().ts(v.meta)}; });
     m.def("ref_ts", [](PyTsType target) { return PyTsType{TypeRegistry::instance().ref(target.meta)}; });
     m.def("ref_target", [](PyTsType ref) { return PyTsType{TypeRegistry::instance().dereference(ref.meta)}; });
@@ -228,6 +269,38 @@ namespace hgraph::python_bridge
     m.def("frame_vt", [](PyValueType schema) {
         // Frame[Schema]: the typed frame meta carrying its column bundle.
         return PyValueType{TypeRegistry::instance().frame(schema.meta)};
+    });
+    m.def("frame_vt", [](PyValueType schema, PyValueType metadata) {
+        // Frame[Schema, Metadata]: metadata is encoded into Arrow schema metadata.
+        return PyValueType{TypeRegistry::instance().frame(schema.meta, metadata.meta)};
+    });
+    m.def("_with_frame_metadata", [](nb::handle table, PyValueType metadata_schema,
+                                      nb::handle metadata) {
+        Value frame_value = python_bridge::py_arrow_to_frame(table);
+        Value metadata_value = python_bridge::py_to_value_as(metadata, metadata_schema.meta);
+        Frame encoded = with_frame_metadata(
+            frame_value.view().checked_as<Frame>(), std::move(metadata_value));
+        return python_bridge::frame_to_py(encoded);
+    });
+    m.def("_frame_metadata", [](nb::handle table, PyValueType metadata_schema) {
+        Value frame_value = python_bridge::py_arrow_to_frame(table);
+        Value decoded = frame_metadata(
+            frame_value.view().checked_as<Frame>(), metadata_schema.meta);
+        return python_bridge::value_to_py(decoded.view());
+    });
+    m.def("_frame_metadata_reflective", [](nb::handle table) {
+        Value frame_value = python_bridge::py_arrow_to_frame(table);
+        Value decoded = frame_metadata(frame_value.view().checked_as<Frame>());
+        return python_bridge::value_to_py(decoded.view());
+    });
+    m.def("_has_frame_metadata", [](nb::handle table) {
+        Value frame_value = python_bridge::py_arrow_to_frame(table);
+        return has_frame_metadata(frame_value.view().checked_as<Frame>());
+    });
+    m.def("_without_frame_metadata", [](nb::handle table) {
+        Value frame_value = python_bridge::py_arrow_to_frame(table);
+        Frame stripped = without_frame_metadata(frame_value.view().checked_as<Frame>());
+        return python_bridge::frame_to_py(stripped);
     });
     m.def("table_schema_info", [](PyTsType ts, const std::string &date_key, const std::string &as_of_key) {
         // TABLE layout introspection (design record step 6): the C++ layout

--- a/python/tests/test_frame_metadata.py
+++ b/python/tests/test_frame_metadata.py
@@ -1,0 +1,150 @@
+from dataclasses import dataclass
+from datetime import datetime
+
+import pyarrow as pa
+import pytest
+
+from hgraph import (
+    CompoundScalar,
+    Frame,
+    TS,
+    frame_metadata,
+    has_frame_metadata,
+    pass_through,
+    without_frame_metadata,
+    with_frame_metadata,
+)
+from hgraph.test import eval_node
+
+
+@dataclass(frozen=True)
+class PriceRow(CompoundScalar):
+    instrument: str
+    value: float
+
+
+@dataclass(frozen=True)
+class SnapshotContext(CompoundScalar):
+    desk: str
+    sequence: int
+
+
+@dataclass(frozen=True)
+class SnapshotMetadata(CompoundScalar):
+    as_of: datetime
+    source: str
+    context: SnapshotContext
+
+
+@dataclass(frozen=True)
+class OtherMetadata(CompoundScalar):
+    as_of: datetime
+    source: str
+    context: SnapshotContext
+
+
+def test_typed_frame_metadata_is_encoded_in_arrow_schema_and_round_trips():
+    table = pa.table(
+        {"instrument": ["A"], "value": [101.5]},
+        metadata={b"external.owner": b"research"},
+    )
+    metadata = SnapshotMetadata(
+        as_of=datetime(2026, 1, 1),
+        source='fixture\n"α"',
+        context=SnapshotContext(desk="systematic", sequence=3),
+    )
+    value = with_frame_metadata(table, metadata)
+
+    assert isinstance(value, pa.Table)
+    assert value.schema.metadata[b"external.owner"] == b"research"
+    assert value.schema.metadata[b"hgraph.metadata.schema"].endswith(
+        b"::SnapshotMetadata"
+    )
+    assert value.schema.metadata[b"hgraph.metadata.version"] == b"1"
+    assert value.schema.metadata[b"hgraph.metadata.field.as_of"] == (
+        b"2026-01-01 00:00:00.000000"
+    )
+    assert value.schema.metadata[b"hgraph.metadata.field.source"] == (
+        'fixture\n"α"'.encode()
+    )
+    assert value.schema.metadata[b"hgraph.metadata.field.context"] == (
+        b'{"desk": "systematic", "sequence": 3}'
+    )
+    assert frame_metadata(value) == metadata
+
+    markerless_metadata = dict(value.schema.metadata)
+    del markerless_metadata[b"hgraph.metadata.schema"]
+    markerless = value.replace_schema_metadata(markerless_metadata)
+    assert has_frame_metadata(markerless)
+    assert frame_metadata(markerless, SnapshotMetadata) == metadata
+    with pytest.raises(ValueError, match="provide a metadata schema"):
+        frame_metadata(markerless)
+
+    result = eval_node(
+        pass_through,
+        [value],
+        resolution_dict={"ts": TS[Frame[PriceRow, SnapshotMetadata]]},
+    )[0]
+
+    assert isinstance(result, pa.Table)
+    assert result.equals(value)
+    assert frame_metadata(result, SnapshotMetadata) == metadata
+
+    markerless_result = eval_node(
+        pass_through,
+        [markerless],
+        resolution_dict={"ts": TS[Frame[PriceRow, SnapshotMetadata]]},
+    )[0]
+    assert markerless_result.equals(markerless)
+    assert frame_metadata(markerless_result, SnapshotMetadata) == metadata
+
+    row_only = without_frame_metadata(result)
+    assert not has_frame_metadata(row_only)
+    assert row_only.schema.metadata == {b"external.owner": b"research"}
+
+
+def test_typed_frame_metadata_contract_is_enforced_at_python_boundary():
+    table = pa.table({"instrument": ["A"], "value": [101.5]})
+    when = datetime(2026, 1, 1)
+    context = SnapshotContext(desk="systematic", sequence=3)
+
+    with pytest.raises(ValueError, match="named Bundle"):
+        TS[Frame[PriceRow, int]]
+
+    with pytest.raises(TypeError, match="requires metadata"):
+        eval_node(
+            pass_through,
+            [table],
+            resolution_dict={"ts": TS[Frame[PriceRow, SnapshotMetadata]]},
+        )
+
+    with pytest.raises(TypeError, match="incompatible"):
+        eval_node(
+            pass_through,
+            [
+                with_frame_metadata(
+                    table,
+                    OtherMetadata(
+                        as_of=when,
+                        source="fixture",
+                        context=context,
+                    ),
+                )
+            ],
+            resolution_dict={"ts": TS[Frame[PriceRow, SnapshotMetadata]]},
+        )
+
+    typed = with_frame_metadata(
+        table,
+        SnapshotMetadata(as_of=when, source="fixture", context=context),
+    )
+    markerless_metadata = dict(typed.schema.metadata)
+    del markerless_metadata[b"hgraph.metadata.schema"]
+    markerless = typed.replace_schema_metadata(markerless_metadata)
+
+    with pytest.raises(TypeError, match="row-only Frame"):
+        eval_node(
+            pass_through,
+            [markerless],
+            resolution_dict={"ts": TS[Frame[PriceRow]]},
+        )

--- a/python/value_conversion.cpp
+++ b/python/value_conversion.cpp
@@ -658,7 +658,7 @@ namespace hgraph::python_bridge
         result.view().assign_from_python(object);
         if (frame_target)
         {
-            const auto &frame = result.view().checked_as<Frame>();
+            const auto frame = result.view().checked_as<Frame>();
             const bool carries_metadata = frame.has_metadata();
             if (meta->key_type == nullptr && carries_metadata)
             {

--- a/python/value_conversion.cpp
+++ b/python/value_conversion.cpp
@@ -1,5 +1,6 @@
 #include "module_internal.h"
 
+#include <hgraph/python/native_scalar_registration.h>
 #include <hgraph/types/metadata/type_realization.h>
 
 #include <hgraph/lib/std/operators/arithmetic.h>
@@ -14,6 +15,7 @@
 #include <chrono>
 #include <cstdint>
 #include <memory>
+#include <optional>
 #include <ranges>
 #include <stdexcept>
 #include <string>
@@ -378,13 +380,6 @@ namespace hgraph::python_bridge
                 return py_to_value_as(object, meta);
             }
         }
-        // Python classes are callable too, but are scalar data for dispatch,
-        // context, and TS[object]. Only callable instances become runtime
-        // callables during schema-free inference.
-        if (PyType_Check(object.ptr()) == 0 && PyCallable_Check(object.ptr()) != 0)
-        {
-            return Value{python_value_callable(object)};
-        }
         const auto &date_time_types = python_datetime_types();
         if (nb::isinstance(object, date_time_types.datetime))
         {
@@ -423,6 +418,18 @@ namespace hgraph::python_bridge
                 throw nb::type_error("invalid Python timedelta value");
             }
             return Value{delta};
+        }
+        if (const auto *native =
+                python_bridge::native_scalar_type_for_value(object))
+        {
+            return py_to_value_as(object, native);
+        }
+        // Python classes are callable too, but are scalar data for dispatch,
+        // context, and TS[object]. Only unregistered callable instances become
+        // runtime callables during schema-free inference.
+        if (PyType_Check(object.ptr()) == 0 && PyCallable_Check(object.ptr()) != 0)
+        {
+            return Value{python_value_callable(object)};
         }
         if (nb::hasattr(object, "__arrow_c_stream__"))
         {
@@ -619,6 +626,12 @@ namespace hgraph::python_bridge
             boxed.as_any().begin_mutation().set(std::move(inferred));
             return boxed;
         }
+
+        // A typed Frame owns two schemas in one Arrow representation:
+        // element_type describes the columns and key_type describes the
+        // field-wise hgraph entries in the Arrow schema metadata. Validate
+        // those entries while the target schema is available.
+        const bool frame_target = meta != nullptr && TypeRegistry::instance().is_frame(meta);
         // Conversion goes through the binding's from_python operation; no
         // schema-kind switch is needed at this boundary.
         std::shared_ptr<const TypeRealizationSnapshot> conversion_snapshot;
@@ -643,6 +656,33 @@ namespace hgraph::python_bridge
         TypeRealizationScope realization_scope{snapshot};
         Value result{type};
         result.view().assign_from_python(object);
+        if (frame_target)
+        {
+            const auto &frame = result.view().checked_as<Frame>();
+            const bool carries_metadata = frame.has_metadata();
+            if (meta->key_type == nullptr && carries_metadata)
+            {
+                throw nb::type_error(
+                    "row-only Frame input cannot carry hgraph Arrow metadata; "
+                    "call without_frame_metadata() explicitly");
+            }
+            if (meta->key_type != nullptr && !carries_metadata)
+            {
+                throw nb::type_error(
+                    "typed Frame input requires metadata encoded in the Arrow schema");
+            }
+            if (carries_metadata)
+            {
+                try
+                {
+                    (void)frame_metadata(frame, meta->key_type);
+                }
+                catch (const std::exception &error)
+                {
+                    throw nb::type_error(error.what());
+                }
+            }
+        }
         return result;
     }
 

--- a/src/hgraph/lib/std/operators/data_frame_impl.cpp
+++ b/src/hgraph/lib/std/operators/data_frame_impl.cpp
@@ -530,20 +530,26 @@ namespace hgraph::stdlib
             {
                 throw std::runtime_error("sorted_: arrow take failed: " + sorted.status().ToString());
             }
-            return Frame{sorted->table()};
+            return Frame{sorted->table()->ReplaceSchemaMetadata(
+                frame.table->schema()->metadata())};
         }
 
         Frame concat_frames(const Frame &lhs, const Frame &rhs)
         {
             if (!lhs.has_value()) { return rhs; }
             if (!rhs.has_value()) { return lhs; }
+            if (!frame_metadata_equal(lhs, rhs))
+            {
+                throw std::invalid_argument("concat: frame metadata must be equal");
+            }
 
             auto result = arrow::ConcatenateTables({lhs.table, rhs.table});
             if (!result.ok())
             {
                 throw std::runtime_error("concat: arrow concatenate failed: " + result.status().ToString());
             }
-            return Frame{std::move(*result)};
+            return Frame{(*result)->ReplaceSchemaMetadata(
+                lhs.table->schema()->metadata())};
         }
 
         namespace
@@ -784,7 +790,8 @@ namespace hgraph::stdlib
                     throw std::runtime_error("filter_frame: Arrow filter failed: " +
                                              result.status().ToString());
                 }
-                return Frame{result->table()};
+                return Frame{result->table()->ReplaceSchemaMetadata(
+                    frame.table->schema()->metadata())};
             }
         }  // namespace
 
@@ -1146,8 +1153,9 @@ namespace hgraph::stdlib
                 fields.push_back(arrow::field(name, column->type()));
                 values.push_back(std::move(column));
             }
-            return Frame{arrow::Table::Make(arrow::schema(std::move(fields)),
-                                            std::move(values), frame.table->num_rows())};
+            return Frame{arrow::Table::Make(
+                arrow::schema(std::move(fields), frame.table->schema()->metadata()),
+                std::move(values), frame.table->num_rows())};
         }
         // -----------------------------------------------------------------
         // convert / combine frame targets
@@ -1357,14 +1365,19 @@ namespace hgraph::stdlib
         register_overload<to_data_frame, to_data_frame_impl>();
         register_overload<group_by, group_by_impl>();
         register_overload<sorted_, sorted_frame_impl>();
+        register_overload<sorted_, sorted_metadata_frame_impl>();
         register_overload<concat, concat_frame_impl>();
+        register_overload<concat, concat_metadata_frame_impl>();
         register_overload<data_frame::join, join_frame_impl>();
         register_overload<data_frame::filter_frame, filter_frame_impl>();
+        register_overload<data_frame::filter_frame, filter_metadata_frame_impl>();
         register_overload<data_frame::filter_cs, filter_cs_impl>();
+        register_overload<data_frame::filter_cs, filter_cs_metadata_frame_impl>();
         register_overload<data_frame::ungroup, ungroup_frame_impl>();
         register_overload<data_frame::ungroup_with_keys, ungroup_frame_with_keys_impl>();
         register_overload<data_frame::ungroup, ungroup_items_impl>();
         register_overload<data_frame::with_columns, with_columns_impl>();
+        register_overload<data_frame::with_columns, with_columns_metadata_frame_impl>();
         register_overload<convert, convert_tsd_to_frame_impl>();
         register_overload<convert, convert_frame_to_frame_impl>();
         register_overload<convert, convert_value_to_frame_impl>();

--- a/src/hgraph/python/bridge_state.cpp
+++ b/src/hgraph/python/bridge_state.cpp
@@ -1,4 +1,5 @@
 #include <hgraph/python/bridge_state.h>
+#include <hgraph/python/native_scalar_registration.h>
 
 #if HGRAPH_ENABLE_PYTHON_USER_NODES
 
@@ -9,8 +10,23 @@
 #include <hgraph/types/wired_fn.h>
 
 #include <stdexcept>
+#include <unordered_map>
 
 namespace hgraph::python_bridge {
+namespace {
+struct NativeScalarRegistrations {
+  std::unordered_map<PyObject *,
+                     std::pair<nb::object, const ValueTypeMetaData *>>
+      by_python_type;
+  std::unordered_map<const ValueTypeMetaData *, nb::object> by_native_type;
+};
+
+NativeScalarRegistrations &native_scalar_registrations() {
+  static auto *registrations = new NativeScalarRegistrations{};
+  return *registrations;
+}
+} // namespace
+
 nb::object &cmp_result_enum_slot() {
   static auto *slot = new nb::object{};
   return *slot;
@@ -66,6 +82,82 @@ bundle_class_info_registry() {
 std::unordered_map<const void *, const void *> &tsb_compound_value_registry() {
   static auto *registry = new std::unordered_map<const void *, const void *>{};
   return *registry;
+}
+
+void register_native_scalar_type(nb::handle python_type,
+                                 const ValueTypeMetaData *native_value_type) {
+  if (PyType_Check(python_type.ptr()) == 0) {
+    throw nb::type_error("python_type must be a Python class");
+  }
+  if (native_value_type == nullptr ||
+      native_value_type->value_kind() != ValueTypeKind::Atomic) {
+    throw nb::type_error("native_value_type must be an atomic scalar schema");
+  }
+
+  auto &registrations = native_scalar_registrations();
+  const auto python_entry =
+      registrations.by_python_type.find(python_type.ptr());
+  if (python_entry != registrations.by_python_type.end() &&
+      python_entry->second.second != native_value_type) {
+    throw std::invalid_argument("Python class is already registered to a "
+                                "different native scalar schema");
+  }
+  const auto native_entry =
+      registrations.by_native_type.find(native_value_type);
+  if (native_entry != registrations.by_native_type.end() &&
+      !native_entry->second.is(python_type)) {
+    throw std::invalid_argument("native scalar schema is already registered to "
+                                "a different Python class");
+  }
+  if (python_entry != registrations.by_python_type.end()) {
+    return;
+  }
+
+  nb::object retained = nb::borrow<nb::object>(python_type);
+  registrations.by_python_type.emplace(python_type.ptr(),
+                                       std::pair{retained, native_value_type});
+  registrations.by_native_type.emplace(native_value_type, std::move(retained));
+}
+
+const ValueTypeMetaData *
+native_scalar_type_for_python(nb::handle python_type) {
+  const auto &registrations = native_scalar_registrations();
+  const auto found = registrations.by_python_type.find(python_type.ptr());
+  return found == registrations.by_python_type.end() ? nullptr
+                                                     : found->second.second;
+}
+
+nb::object
+python_type_for_native_scalar(const ValueTypeMetaData *native_value_type) {
+  const auto &registrations = native_scalar_registrations();
+  const auto found = registrations.by_native_type.find(native_value_type);
+  return found == registrations.by_native_type.end()
+             ? nb::none()
+             : nb::borrow<nb::object>(found->second);
+}
+
+const ValueTypeMetaData *native_scalar_type_for_value(nb::handle value) {
+  if (!value.is_valid()) {
+    return nullptr;
+  }
+  if (const auto *exact =
+          native_scalar_type_for_python(nb::handle(Py_TYPE(value.ptr())))) {
+    return exact;
+  }
+  const auto &registrations = native_scalar_registrations();
+  for (const auto &[python_type, entry] : registrations.by_python_type) {
+    static_cast<void>(python_type);
+    if (nb::isinstance(value, entry.first)) {
+      return entry.second;
+    }
+  }
+  return nullptr;
+}
+
+void clear_native_scalar_types() noexcept {
+  auto &registrations = native_scalar_registrations();
+  registrations.by_native_type.clear();
+  registrations.by_python_type.clear();
 }
 } // namespace hgraph::python_bridge
 

--- a/src/hgraph/types/frame.cpp
+++ b/src/hgraph/types/frame.cpp
@@ -1,11 +1,175 @@
 #include <hgraph/types/frame.h>
+#include <hgraph/types/metadata/type_registry.h>
+#include <hgraph/types/static_schema.h>
+#include <hgraph/types/value/json_codec.h>
+#include <hgraph/types/value/specialized_views.h>
+#include <hgraph/types/value/value.h>
+#include <hgraph/types/value/value_builder.h>
 
 #include <arrow/table.h>
+#include <arrow/util/key_value_metadata.h>
 
+#include <algorithm>
+#include <map>
 #include <ostream>
+#include <set>
+#include <span>
+#include <stdexcept>
+#include <string>
+#include <utility>
 
 namespace hgraph
 {
+    namespace
+    {
+        constexpr std::string_view metadata_version{"1"};
+
+        [[nodiscard]] bool is_hgraph_metadata_key(std::string_view key) noexcept
+        {
+            return key.starts_with(frame_metadata_prefix);
+        }
+
+        [[nodiscard]] std::shared_ptr<arrow::KeyValueMetadata>
+        metadata_without_hgraph_entries(const std::shared_ptr<const arrow::KeyValueMetadata> &source)
+        {
+            auto result = source != nullptr ? source->Copy()
+                                            : std::make_shared<arrow::KeyValueMetadata>();
+            for (std::int64_t index = result->size(); index-- > 0;)
+            {
+                if (!is_hgraph_metadata_key(result->key(index))) { continue; }
+                const auto status = result->Delete(index);
+                if (!status.ok())
+                {
+                    throw std::runtime_error("frame metadata: could not remove reserved Arrow metadata: " +
+                                             status.ToString());
+                }
+            }
+            return result;
+        }
+
+        [[nodiscard]] const ValueTypeMetaData *require_metadata_schema(
+            const ValueTypeMetaData *schema)
+        {
+            if (schema == nullptr || !schema->is_named_bundle())
+            {
+                throw std::invalid_argument(
+                    "frame metadata must use a named Bundle schema");
+            }
+            return schema;
+        }
+
+        [[nodiscard]] std::string quote_json_string(std::string_view text)
+        {
+            return to_json_string(Value{Str{std::string{text}}}.view());
+        }
+
+        [[nodiscard]] std::string atomic_to_plain_text(const ValueView &field)
+        {
+            std::string encoded = to_json_string(field);
+            if (encoded.size() >= 2 && encoded.front() == '"' && encoded.back() == '"')
+            {
+                return std::string{
+                    from_json_string(scalar_descriptor<Str>::value_meta(), encoded).as<Str>()};
+            }
+            return encoded;
+        }
+
+        [[nodiscard]] Value atomic_from_plain_text(
+            const ValueTypeMetaData *schema, std::string_view encoded)
+        {
+            const auto &converter = json_converter(schema);
+            switch (converter.atomic_tag)
+            {
+                case JsonConverter::AtomicTag::Bool:
+                case JsonConverter::AtomicTag::Int:
+                case JsonConverter::AtomicTag::Float:
+                    return from_json_string(schema, encoded);
+                case JsonConverter::AtomicTag::Str:
+                case JsonConverter::AtomicTag::Date:
+                case JsonConverter::AtomicTag::DateTime:
+                case JsonConverter::AtomicTag::TimeDelta:
+                case JsonConverter::AtomicTag::Time:
+                    return from_json_string(schema, quote_json_string(encoded));
+                case JsonConverter::AtomicTag::None:
+                    // Named enums are atomic but use their member name as a JSON string.
+                    if (schema->is_enum())
+                    {
+                        return from_json_string(schema, quote_json_string(encoded));
+                    }
+                    break;
+            }
+            throw std::invalid_argument(
+                "frame metadata field has an unsupported atomic schema '" +
+                std::string{schema->name()} + "'");
+        }
+
+        [[nodiscard]] std::map<std::string, std::string>
+        hgraph_metadata_entries(const Frame &frame)
+        {
+            std::map<std::string, std::string> result;
+            if (!frame.has_value()) { return result; }
+            const auto &metadata = frame.table->schema()->metadata();
+            if (metadata == nullptr) { return result; }
+            for (std::int64_t index = 0; index < metadata->size(); ++index)
+            {
+                if (is_hgraph_metadata_key(metadata->key(index)))
+                {
+                    result[metadata->key(index)] = metadata->value(index);
+                }
+            }
+            return result;
+        }
+
+        [[nodiscard]] std::string required_metadata_value(
+            const arrow::KeyValueMetadata &metadata, std::string_view key)
+        {
+            auto value = metadata.Get(key);
+            if (!value.ok())
+            {
+                throw std::invalid_argument("frame metadata is missing required Arrow key '" +
+                                            std::string{key} + "'");
+            }
+            return std::move(*value);
+        }
+
+        [[nodiscard]] const ValueTypeMetaData *metadata_decode_schema(
+            const arrow::KeyValueMetadata &encoded,
+            const ValueTypeMetaData *metadata_schema)
+        {
+            const auto *expected = metadata_schema != nullptr
+                                       ? require_metadata_schema(metadata_schema)
+                                       : nullptr;
+            if (!encoded.Contains(frame_metadata_schema_key))
+            {
+                if (expected == nullptr)
+                {
+                    throw std::invalid_argument(
+                        "Frame metadata does not identify its schema; provide a metadata "
+                        "schema to decode markerless metadata");
+                }
+                return expected;
+            }
+
+            const std::string encoded_schema =
+                required_metadata_value(encoded, frame_metadata_schema_key);
+            const auto *actual = TypeRegistry::instance().value_type(encoded_schema);
+            if (actual == nullptr)
+            {
+                throw std::invalid_argument(
+                    "frame metadata identifies unknown schema '" + encoded_schema + "'");
+            }
+            if (expected != nullptr &&
+                !TypeRegistry::instance().bundle_is_a(actual, expected))
+            {
+                throw std::invalid_argument(
+                    "frame metadata schema '" + encoded_schema +
+                    "' is incompatible with declared schema '" +
+                    std::string{expected->name()} + "'");
+            }
+            return require_metadata_schema(actual);
+        }
+    }  // namespace
+
     std::ostream &operator<<(std::ostream &os, const Frame &value)
     {
         if (!value.has_value()) { return os << "frame[empty]"; }
@@ -14,5 +178,161 @@ namespace hgraph
     std::int64_t frame_rows(const Frame &value) noexcept
     {
         return value.has_value() ? value.table->num_rows() : 0;
+    }
+
+    bool Frame::has_metadata() const noexcept { return has_frame_metadata(*this); }
+
+    Frame with_frame_metadata(Frame frame, Value metadata)
+    {
+        if (!frame.has_value())
+        {
+            throw std::invalid_argument("cannot attach metadata to an empty Frame");
+        }
+        if (!metadata.has_value())
+        {
+            throw std::invalid_argument("cannot attach an unset frame metadata value");
+        }
+        const auto *schema = require_metadata_schema(metadata.schema());
+        const auto bundle = metadata.as_bundle();
+        auto encoded = metadata_without_hgraph_entries(frame.table->schema()->metadata());
+        encoded->Append(std::string{frame_metadata_schema_key}, std::string{schema->name()});
+        encoded->Append(std::string{frame_metadata_version_key}, std::string{metadata_version});
+
+        for (std::size_t index = 0; index < schema->field_count; ++index)
+        {
+            const auto field = bundle.at(index);
+            if (!field.has_value()) { continue; }
+            const auto *field_schema = schema->fields[index].type;
+            std::string value;
+            if (field_schema->value_kind() == ValueTypeKind::Atomic)
+            {
+                // Resolve the codec here even though atomic_to_plain_text also uses it:
+                // unsupported atomics must fail before mutating the Arrow schema.
+                (void)json_converter(field_schema);
+                value = atomic_to_plain_text(field);
+            }
+            else
+            {
+                value = to_json_string(field);
+            }
+            encoded->Append(std::string{frame_metadata_field_prefix} +
+                                std::string{schema->fields[index].name},
+                            std::move(value));
+        }
+        frame.table = frame.table->ReplaceSchemaMetadata(std::move(encoded));
+        return frame;
+    }
+
+    Value frame_metadata(const Frame &frame, const ValueTypeMetaData *metadata_schema)
+    {
+        if (!frame.has_value())
+        {
+            throw std::invalid_argument("cannot decode metadata from an empty Frame");
+        }
+        const auto &encoded = frame.table->schema()->metadata();
+        if (encoded == nullptr || !has_frame_metadata(frame))
+        {
+            throw std::invalid_argument("Frame does not carry hgraph metadata");
+        }
+        const std::string version = required_metadata_value(*encoded, frame_metadata_version_key);
+        if (version != metadata_version)
+        {
+            throw std::invalid_argument("unsupported hgraph frame metadata version '" + version + "'");
+        }
+
+        const auto *actual = metadata_decode_schema(*encoded, metadata_schema);
+        std::set<std::string> seen;
+        for (std::int64_t index = 0; index < encoded->size(); ++index)
+        {
+            const std::string &key = encoded->key(index);
+            if (!is_hgraph_metadata_key(key)) { continue; }
+            if (!seen.insert(key).second)
+            {
+                throw std::invalid_argument(
+                    "frame metadata contains duplicate Arrow key '" + key + "'");
+            }
+            if (key == frame_metadata_schema_key || key == frame_metadata_version_key)
+            {
+                continue;
+            }
+            if (!std::string_view{key}.starts_with(frame_metadata_field_prefix))
+            {
+                throw std::invalid_argument(
+                    "frame metadata contains unknown reserved Arrow key '" + key + "'");
+            }
+            const std::string_view field_name =
+                std::string_view{key}.substr(frame_metadata_field_prefix.size());
+            const bool declared = std::ranges::any_of(
+                std::span{actual->fields, actual->field_count},
+                [&](const ValueFieldMetaData &field) {
+                    return field.name != nullptr && field_name == field.name;
+                });
+            if (!declared)
+            {
+                throw std::invalid_argument(
+                    "frame metadata contains field '" + std::string{field_name} +
+                    "' that is not declared by schema '" +
+                    std::string{actual->name()} + "'");
+            }
+        }
+
+        BundleBuilder builder{ValuePlanFactory::instance().type_for(actual)};
+        for (std::size_t index = 0; index < actual->field_count; ++index)
+        {
+            const std::string key = std::string{frame_metadata_field_prefix} +
+                                    std::string{actual->fields[index].name};
+            auto value = encoded->Get(key);
+            if (!value.ok()) { continue; }
+            const auto *field_schema = actual->fields[index].type;
+            Value field = field_schema->value_kind() == ValueTypeKind::Atomic
+                              ? atomic_from_plain_text(field_schema, *value)
+                              : from_json_string(field_schema, *value);
+            builder.set(index, std::move(field));
+        }
+        return builder.build();
+    }
+
+    bool has_frame_metadata(const Frame &frame) noexcept
+    {
+        if (!frame.has_value()) { return false; }
+        const auto &metadata = frame.table->schema()->metadata();
+        if (metadata == nullptr) { return false; }
+        for (std::int64_t index = 0; index < metadata->size(); ++index)
+        {
+            if (is_hgraph_metadata_key(metadata->key(index))) { return true; }
+        }
+        return false;
+    }
+
+    bool frame_metadata_equal(const Frame &lhs, const Frame &rhs) noexcept
+    {
+        try
+        {
+            auto lhs_entries = hgraph_metadata_entries(lhs);
+            auto rhs_entries = hgraph_metadata_entries(rhs);
+            const auto lhs_schema = lhs_entries.find(std::string{frame_metadata_schema_key});
+            const auto rhs_schema = rhs_entries.find(std::string{frame_metadata_schema_key});
+            if (lhs_schema != lhs_entries.end() && rhs_schema != rhs_entries.end() &&
+                lhs_schema->second != rhs_schema->second)
+            {
+                return false;
+            }
+            lhs_entries.erase(std::string{frame_metadata_schema_key});
+            rhs_entries.erase(std::string{frame_metadata_schema_key});
+            return lhs_entries == rhs_entries;
+        }
+        catch (...)
+        {
+            return false;
+        }
+    }
+
+    Frame without_frame_metadata(Frame frame)
+    {
+        if (!frame.has_value() || !frame.has_metadata()) { return frame; }
+        auto metadata = metadata_without_hgraph_entries(frame.table->schema()->metadata());
+        frame.table = frame.table->ReplaceSchemaMetadata(
+            metadata->size() == 0 ? nullptr : std::move(metadata));
+        return frame;
     }
 }  // namespace hgraph

--- a/src/hgraph/types/metadata/type_registry.cpp
+++ b/src/hgraph/types/metadata/type_registry.cpp
@@ -1326,18 +1326,38 @@ namespace hgraph
         return meta->element_type != nullptr && series_cache_.find(meta->element_type) == meta;
     }
 
-    const ValueTypeMetaData *TypeRegistry::frame(const ValueTypeMetaData *column_schema)
+    const ValueTypeMetaData *TypeRegistry::frame(const ValueTypeMetaData *column_schema,
+                                                 const ValueTypeMetaData *metadata_schema)
     {
         const std::lock_guard lock(mutex_);
         const ValueTypeMetaData *base = value_type("frame");
         if (base == nullptr) { throw std::logic_error("frame scalar is not registered"); }
-        if (column_schema == nullptr) { return base; }
+        if (column_schema == nullptr)
+        {
+            if (metadata_schema != nullptr)
+            {
+                throw std::invalid_argument("frame metadata requires a row schema");
+            }
+            return base;
+        }
+        if (metadata_schema != nullptr && !metadata_schema->is_named_bundle())
+        {
+            throw std::invalid_argument(
+                "frame metadata must use a named Bundle schema");
+        }
 
-        const ValueTypeMetaData &meta = frame_cache_.intern(column_schema, [&]() {
+        const MapKey key{metadata_schema, column_schema};
+        const ValueTypeMetaData &meta = frame_cache_.intern(key, [&]() {
+            const std::string label = metadata_schema == nullptr
+                                          ? unary_label(base->name(), column_schema)
+                                          : std::string{base->name()} + "[" +
+                                                std::string{column_schema->name()} + ", " +
+                                                std::string{metadata_schema->name()} + "]";
             ValueTypeMetaData m(ValueTypeKind::Atomic,
                                 base->flags,
-                                store_name_interned(unary_label(base->name(), column_schema)));
+                                store_name_interned(label));
             m.element_type = column_schema;
+            m.key_type = metadata_schema;
             return m;
         });
         // Share the base frame storage plan + ops (arrow conversion is
@@ -1354,7 +1374,8 @@ namespace hgraph
         if (meta == nullptr) { return false; }
         const auto base = value_name_cache_.find("frame");
         if (base != value_name_cache_.end() && meta == base->second) { return true; }
-        return meta->element_type != nullptr && frame_cache_.find(meta->element_type) == meta;
+        return meta->element_type != nullptr &&
+               frame_cache_.find(MapKey{meta->key_type, meta->element_type}) == meta;
     }
 
     const ValueTypeMetaData *TypeRegistry::nullable_tuple(const ValueTypeMetaData *element_type)

--- a/src/hgraph/types/type_pattern.cpp
+++ b/src/hgraph/types/type_pattern.cpp
@@ -149,9 +149,16 @@ namespace hgraph
                        concrete->element_type != nullptr && !pattern.children.empty() &&
                        scalar_pattern_match(pattern.children[0], concrete->element_type, map);
             case ScalarPattern::Kind::Frame:
-                return TypeRegistry::instance().is_frame(concrete) &&
-                       concrete->element_type != nullptr && !pattern.children.empty() &&
-                       scalar_pattern_match(pattern.children[0], concrete->element_type, map);
+                if (!TypeRegistry::instance().is_frame(concrete) || concrete->element_type == nullptr ||
+                    pattern.children.empty() || pattern.children.size() > 2 ||
+                    !scalar_pattern_match(pattern.children[0], concrete->element_type, map))
+                {
+                    return false;
+                }
+                return pattern.children.size() == 1
+                           ? concrete->key_type == nullptr
+                           : concrete->key_type != nullptr &&
+                                 scalar_pattern_match(pattern.children[1], concrete->key_type, map);
             case ScalarPattern::Kind::Array:
             {
                 if (!TypeRegistry::is_array(concrete) || pattern.children.empty()) { return false; }
@@ -406,7 +413,11 @@ namespace hgraph
             case ScalarPattern::Kind::Series:
             case ScalarPattern::Kind::Frame:
             case ScalarPattern::Kind::Array:
-                return 1 + (!pattern.children.empty() ? scalar_pattern_rank(pattern.children[0]) / 2 : 0);
+            {
+                int rank = 1;
+                for (const ScalarPattern &child : pattern.children) { rank += scalar_pattern_rank(child) / 2; }
+                return rank;
+            }
             case ScalarPattern::Kind::FixedTuple:
             case ScalarPattern::Kind::Map:
             {
@@ -494,8 +505,14 @@ namespace hgraph
             }
             case ScalarPattern::Kind::Frame:
             {
-                const ValueTypeMetaData *schema = resolve_required_scalar_child(pattern, map);
-                return schema != nullptr ? TypeRegistry::instance().frame(schema) : nullptr;
+                if (pattern.children.empty() || pattern.children.size() > 2) { return nullptr; }
+                const ValueTypeMetaData *schema = scalar_pattern_resolve(pattern.children[0], map);
+                const ValueTypeMetaData *metadata = pattern.children.size() == 2
+                                                        ? scalar_pattern_resolve(pattern.children[1], map)
+                                                        : nullptr;
+                return schema != nullptr && (pattern.children.size() == 1 || metadata != nullptr)
+                           ? TypeRegistry::instance().frame(schema, metadata)
+                           : nullptr;
             }
             case ScalarPattern::Kind::Array:
             {
@@ -699,9 +716,13 @@ namespace hgraph
                                    pattern.children.empty() ? std::string{"scalar"}
                                                             : scalar_pattern_to_string(pattern.children[0]));
             case ScalarPattern::Kind::Frame:
-                return fmt::format("Frame[{}]",
-                                   pattern.children.empty() ? std::string{"schema"}
-                                                            : scalar_pattern_to_string(pattern.children[0]));
+                if (pattern.children.empty()) { return "Frame[schema]"; }
+                if (pattern.children.size() == 1)
+                {
+                    return fmt::format("Frame[{}]", scalar_pattern_to_string(pattern.children[0]));
+                }
+                return fmt::format("Frame[{}, {}]", scalar_pattern_to_string(pattern.children[0]),
+                                   scalar_pattern_to_string(pattern.children[1]));
             case ScalarPattern::Kind::Array:
             {
                 std::vector<std::string> dimensions;

--- a/tests/cpp/test_data_frame_operators.cpp
+++ b/tests/cpp/test_data_frame_operators.cpp
@@ -1,7 +1,9 @@
 #include <hgraph/lib/std/std_operators.h>
+#include <hgraph/lib/std/operators/impl/data_frame_impl.h>
 #include <hgraph/lib/testing/check_output.h>
 #include <hgraph/lib/testing/eval_node.h>
 #include <hgraph/types/metadata/value_plan_factory.h>
+#include <hgraph/types/record_replay.h>
 #include <hgraph/types/static_schema.h>
 #include <hgraph/types/value/value_builder.h>
 
@@ -9,6 +11,7 @@
 
 #include <catch2/catch_test_macros.hpp>
 
+#include <chrono>
 #include <cstdint>
 #include <memory>
 #include <optional>
@@ -21,6 +24,11 @@ namespace
     using namespace hgraph::testing;
 
     using Row = Bundle<"tests.data_frame::Row", Field<"a", Int>, Field<"b", Int>>;
+    using FrameMetaDetails = Bundle<"tests.data_frame::FrameMetaDetails",
+                                    Field<"desk", Str>>;
+    using FrameMeta = Bundle<"tests.data_frame::FrameMeta",
+                             Field<"revision", Int>, Field<"as_of", DateTime>,
+                             Field<"source", Str>, Field<"details", FrameMetaDetails>>;
     using JoinedRow = Bundle<"tests.data_frame::JoinedRow", Field<"a", Int>,
                              Field<"b", Int>, Field<"b_right", Int>>;
     using PredicateTSB = UnNamedTSB<Field<"a", TS<Int>>, Field<"b", TS<Int>>>;
@@ -94,6 +102,30 @@ namespace
         return builder.build();
     }
 
+    [[nodiscard]] Value metadata_value(Int revision)
+    {
+        BundleBuilder details{
+            ValuePlanFactory::instance().type_for(
+                scalar_descriptor<FrameMetaDetails>::value_meta())};
+        details.set(0, Value{Str{"systematic"}});
+        BundleBuilder builder{
+            ValuePlanFactory::instance().type_for(scalar_descriptor<FrameMeta>::value_meta())};
+        builder.set(0, Value{revision});
+        builder.set(1, Value{DateTime{std::chrono::microseconds{123456}}});
+        builder.set(2, Value{Str{"fixture"}});
+        builder.set(3, details.build());
+        return builder.build();
+    }
+
+    [[nodiscard]] Frame metadata_frame(std::vector<std::int64_t> a,
+                                       std::vector<std::int64_t> b, Int revision)
+    {
+        Frame result = frame(std::move(a), std::move(b));
+        result.table = result.table->ReplaceSchemaMetadata(
+            arrow::key_value_metadata({"external.owner"}, {"research"}));
+        return with_frame_metadata(std::move(result), metadata_value(revision));
+    }
+
     [[nodiscard]] Frame keyed_frame(std::vector<std::int64_t> a,
                                     std::vector<std::int64_t> b,
                                     std::vector<std::string> keys)
@@ -135,6 +167,18 @@ namespace
                                               Scalar<"descending", Bool> descending)
         {
             return wire<stdlib::sorted_>(w, ts, by, descending).as<TS<FrameOf<Row>>>();
+        }
+    };
+
+    struct SortMetadataFrameGraph
+    {
+        static constexpr auto name = "sort_metadata_frame_graph";
+        static Port<TS<FrameOf<Row, FrameMeta>>> compose(
+            Wiring &w, Port<TS<FrameOf<Row, FrameMeta>>> ts,
+            Scalar<"by", Str> by, Scalar<"descending", Bool> descending)
+        {
+            return wire<stdlib::sorted_>(w, ts, by, descending)
+                .as<TS<FrameOf<Row, FrameMeta>>>();
         }
     };
 
@@ -277,6 +321,83 @@ TEST_CASE("data frame operators: sorted_ orders rows through the native wiring p
     REQUIRE(result.size() == 1);
     REQUIRE(result[0].has_value());
     CHECK(equals(*result[0], expected));
+}
+
+TEST_CASE("data frame operators: Arrow schema metadata survives row-preserving operations")
+{
+    stdlib::register_standard_operators();
+    const Frame input = metadata_frame({2, 1}, {20, 10}, 7);
+    const auto &arrow_metadata = input.table->schema()->metadata();
+    REQUIRE(arrow_metadata != nullptr);
+    CHECK(*arrow_metadata->Get(frame_metadata_schema_key) ==
+          std::string{scalar_descriptor<FrameMeta>::value_meta()->name()});
+    CHECK(*arrow_metadata->Get(frame_metadata_version_key) == "1");
+    CHECK(*arrow_metadata->Get("hgraph.metadata.field.revision") == "7");
+    CHECK(*arrow_metadata->Get("hgraph.metadata.field.as_of") ==
+          "1970-01-01 00:00:00.123456");
+    CHECK(*arrow_metadata->Get("hgraph.metadata.field.source") == "fixture");
+    CHECK(*arrow_metadata->Get("hgraph.metadata.field.details") ==
+          R"({"desk": "systematic"})");
+    CHECK(frame_metadata(input, scalar_descriptor<FrameMeta>::value_meta()) ==
+          metadata_value(7));
+    CHECK(frame_metadata(input) == metadata_value(7));
+
+    Frame markerless = input;
+    auto markerless_metadata = markerless.table->schema()->metadata()->Copy();
+    for (std::int64_t index = markerless_metadata->size(); index-- > 0;)
+    {
+        if (markerless_metadata->key(index) != frame_metadata_schema_key) { continue; }
+        REQUIRE(markerless_metadata->Delete(index).ok());
+    }
+    markerless.table = markerless.table->ReplaceSchemaMetadata(
+        std::move(markerless_metadata));
+    CHECK(markerless.has_metadata());
+    CHECK(frame_metadata(markerless, scalar_descriptor<FrameMeta>::value_meta()) ==
+          metadata_value(7));
+    CHECK_THROWS_AS(frame_metadata(markerless), std::invalid_argument);
+    CHECK(frame_metadata_equal(markerless, input));
+
+    Frame unknown_field = input;
+    auto unknown_field_metadata =
+        unknown_field.table->schema()->metadata()->Copy();
+    unknown_field_metadata->Append("hgraph.metadata.field.unknown", "value");
+    unknown_field.table = unknown_field.table->ReplaceSchemaMetadata(
+        std::move(unknown_field_metadata));
+    CHECK_THROWS_AS(
+        frame_metadata(unknown_field, scalar_descriptor<FrameMeta>::value_meta()),
+        std::invalid_argument);
+
+    const auto result = eval_node<SortMetadataFrameGraph>(
+        values<Frame>(input), Str{"a"}, Bool{false});
+    REQUIRE(result.size() == 1);
+    REQUIRE(result[0]);
+    REQUIRE(result[0]->has_metadata());
+    CHECK(frame_metadata_equal(*result[0], input));
+    CHECK(result[0]->table->Equals(*frame({1, 2}, {10, 20}).table));
+
+    const Frame same_revision = metadata_frame({3}, {30}, 7);
+    const Frame combined = stdlib::data_frame_detail::concat_frames(input, same_revision);
+    CHECK(frame_metadata_equal(combined, input));
+    CHECK(frame_rows(combined) == 3);
+    const Frame markerless_combined =
+        stdlib::data_frame_detail::concat_frames(markerless, same_revision);
+    CHECK(frame_metadata_equal(markerless_combined, input));
+    CHECK(frame_rows(markerless_combined) == 3);
+
+    record_replay::store_write("tests.data_frame.metadata", markerless);
+    const Frame stored =
+        record_replay::store_read("tests.data_frame.metadata");
+    CHECK(frame_metadata_equal(stored, markerless));
+    CHECK(frame_metadata(stored, scalar_descriptor<FrameMeta>::value_meta()) ==
+          metadata_value(7));
+
+    const Frame other_revision = metadata_frame({3}, {30}, 8);
+    CHECK_THROWS_AS(stdlib::data_frame_detail::concat_frames(input, other_revision),
+                    std::invalid_argument);
+    const Frame stripped = without_frame_metadata(input);
+    CHECK_FALSE(stripped.has_metadata());
+    REQUIRE(stripped.table->schema()->metadata() != nullptr);
+    CHECK(*stripped.table->schema()->metadata()->Get("external.owner") == "research");
 }
 
 TEST_CASE("data frame operators: concat appends rows through the native wiring path")

--- a/tests/cpp/test_operators.cpp
+++ b/tests/cpp/test_operators.cpp
@@ -1051,6 +1051,19 @@ TEST_CASE("operators: typed Series and Frame patterns preserve their scalar stru
     CHECK(scalar_type<SeriesOf<Int>>() == registry.series(integer));
     CHECK(scalar_type<FrameOf<Bundle<"tests.pattern::Row", Field<"value", Int>>>>() ==
           registry.frame(registry.bundle("tests.pattern::Row", {{"value", integer}})));
+
+    const auto *metadata = registry.bundle("tests.pattern::Metadata", {{"version", integer}});
+    const ScalarPattern metadata_frame_pattern =
+        to_scalar_pattern<FrameOf<ScalarVar<"ROWS">, ScalarVar<"META">>>();
+    ResolutionMap metadata_frame_map;
+    const auto *typed_frame = registry.frame(row, metadata);
+    REQUIRE(scalar_pattern_match(metadata_frame_pattern, typed_frame, metadata_frame_map));
+    CHECK(metadata_frame_map.find_scalar("ROWS") == row);
+    CHECK(metadata_frame_map.find_scalar("META") == metadata);
+    CHECK(scalar_pattern_resolve(metadata_frame_pattern, metadata_frame_map) == typed_frame);
+    CHECK(scalar_pattern_to_string(metadata_frame_pattern) == "Frame[~ROWS, ~META]");
+    CHECK_FALSE(scalar_pattern_match(frame_pattern, typed_frame, frame_map));
+    CHECK_THROWS_AS(registry.frame(row, integer), std::invalid_argument);
 }
 
 TEST_CASE("operators: shaped Array patterns resolve element and dimension variables")

--- a/tests/install_consumer/main.cpp
+++ b/tests/install_consumer/main.cpp
@@ -1,7 +1,14 @@
+#include <hgraph/lib/std/standard_types.h>
+#include <hgraph/types/frame.h>
+#include <hgraph/types/static_schema.h>
+#include <hgraph/types/type_resolution.h>
 #include <hgraph/types/metadata/type_record.h>
 #include <hgraph/types/metadata/type_registry.h>
 #include <hgraph/types/type_pointer.h>
 #include <hgraph/types/value/value.h>
+#include <hgraph/types/value/value_builder.h>
+
+#include <arrow/api.h>
 
 #include <cstdint>
 #include <stdexcept>
@@ -33,6 +40,38 @@ int main()
     if (value.view().checked_as<std::int32_t>() != 73)
     {
         throw std::runtime_error("installed target mutation round-trip failed");
+    }
+
+    static_cast<void>(stdlib::register_standard_types(registry));
+
+    using TypedFrame = FrameOf<Bundle<"consumer::Row", Field<"value", Int>>,
+                               Bundle<"consumer::Metadata", Field<"revision", Int>>>;
+    const auto *typed_frame = scalar_type<TypedFrame>();
+    if (typed_frame == nullptr || typed_frame->key_type == nullptr)
+    {
+        throw std::runtime_error("installed typed frame metadata schema is unusable");
+    }
+
+    arrow::Int64Builder values;
+    if (!values.Append(42).ok())
+    {
+        throw std::runtime_error("installed Arrow builder is unusable");
+    }
+    std::shared_ptr<arrow::Array> array;
+    if (!values.Finish(&array).ok())
+    {
+        throw std::runtime_error("installed Arrow array construction failed");
+    }
+    Frame frame{arrow::Table::Make(
+        arrow::schema({arrow::field("value", arrow::int64())}),
+        {std::move(array)})};
+    BundleBuilder metadata{ValuePlanFactory::instance().type_for(typed_frame->key_type)};
+    metadata.set(0, Value{Int{7}});
+    frame = with_frame_metadata(std::move(frame), metadata.build());
+    if (!frame.has_metadata() ||
+        frame_metadata(frame, typed_frame->key_type).as_bundle().at(0).checked_as<Int>() != 7)
+    {
+        throw std::runtime_error("installed Arrow frame metadata codec is unusable");
     }
 
     return 0;

--- a/tests/python_extension_consumer/check.py
+++ b/tests/python_extension_consumer/check.py
@@ -54,12 +54,60 @@ import importlib
 import sys
 
 import _hgraph  # Load the wheel's shared runtime first.
+import hgraph
+from hgraph import TS, pass_through, register_native_scalar_type
+from hgraph.reflection import scalar_type
+from hgraph.test import eval_node
 
 sys.path.insert(0, sys.argv[1])
 consumer = importlib.import_module("_hgraph_consumer")
 address = consumer.registry_address()
 if not isinstance(address, int) or address == 0:
     raise RuntimeError("downstream extension returned an invalid registry address")
+
+# The extension registered its Python class and native scalar through public
+# installed C++ headers. Python annotations and reverse reflection use that
+# same process-wide association.
+assert repr(TS[consumer.ConsumerScalar].handle) == (
+    "TS[hgraph.test.consumer_scalar]"
+)
+assert scalar_type(TS[consumer.ConsumerScalar]) is consumer.ConsumerScalar
+
+value = consumer.ConsumerScalar(42)
+result = eval_node(
+    pass_through,
+    [value],
+    resolution_dict={"ts": TS[consumer.ConsumerScalar]},
+)
+assert result == [value]
+
+# Repeating the same pair is harmless. Conflicts on either side fail.
+register_native_scalar_type(
+    consumer.ConsumerScalar, "hgraph.test.consumer_scalar"
+)
+class OtherConsumerScalar:
+    pass
+try:
+    register_native_scalar_type(consumer.ConsumerScalar, "int")
+except ValueError:
+    pass
+else:
+    raise RuntimeError("conflicting Python-class registration was accepted")
+try:
+    register_native_scalar_type(
+        OtherConsumerScalar, "hgraph.test.consumer_scalar"
+    )
+except ValueError:
+    pass
+else:
+    raise RuntimeError("conflicting native-schema registration was accepted")
+try:
+    register_native_scalar_type(OtherConsumerScalar, "int")
+except ValueError:
+    pass
+else:
+    raise RuntimeError("built-in native-schema registration was replaced")
+
 print(f"installed Python extension consumer passed: registry={address:#x}")
 """,
                 str(module_dir),

--- a/tests/python_extension_consumer/module.cpp
+++ b/tests/python_extension_consumer/module.cpp
@@ -1,3 +1,4 @@
+#include <hgraph/python/native_scalar_registration.h>
 #include <hgraph/types/metadata/type_registry.h>
 
 #include <nanobind/nanobind.h>
@@ -6,8 +7,46 @@
 
 namespace nb = nanobind;
 
+namespace
+{
+    struct ConsumerScalar
+    {
+        std::int64_t value{};
+
+        friend bool operator==(const ConsumerScalar &,
+                               const ConsumerScalar &) = default;
+    };
+}
+
+namespace hgraph
+{
+    template <>
+    struct python_conversion_traits<ConsumerScalar>
+    {
+        static nb::object to_python(const ConsumerScalar &value)
+        {
+            return nb::cast(value);
+        }
+
+        static ConsumerScalar from_python(nb::handle source)
+        {
+            return nb::cast<ConsumerScalar>(source);
+        }
+    };
+}  // namespace hgraph
+
 NB_MODULE(_hgraph_consumer, module)
 {
+    auto consumer_scalar =
+        nb::class_<ConsumerScalar>(module, "ConsumerScalar")
+            .def(nb::init<std::int64_t>())
+            .def_ro("value", &ConsumerScalar::value)
+            .def("__eq__", [](const ConsumerScalar &lhs,
+                              const ConsumerScalar &rhs) { return lhs == rhs; });
+
+    hgraph::python_bridge::register_native_scalar_type<ConsumerScalar>(
+        consumer_scalar, "hgraph.test.consumer_scalar");
+
     module.def("registry_address", [] {
         return reinterpret_cast<std::uintptr_t>(&hgraph::TypeRegistry::instance());
     });


### PR DESCRIPTION
## Summary

- implement RFC 0001 with `Frame[Row, Metadata]` / `FrameOf<Row, Metadata>`, Arrow schema-metadata encoding and decoding, markerless explicit-schema reads, metadata propagation rules, and Python/C++ boundary validation
- implement RFC 0003 with an installed public C++ native-scalar registration API, Python registration/reflection support, conflict protection, and an external extension-consumer round trip
- update the RFC implementation records plus user/developer documentation and parity tables
- merge current `main`, including PR #21's opt-in immediate-cycle recursion guard

The RFCs remain `Proposed` until this implementation is accepted for merge, at which point their status is changed to `Accepted` in this PR as required by the RFC process.

## CI portability fixes

- avoid retaining a `Frame` reference through a temporary `ValueView`, resolving GCC's `-Wdangling-reference` failure
- export `Frame::has_metadata()` across the Windows DLL boundary, resolving the wheel's `LNK2019`

## Validation

- fresh macOS C++ warnings-as-errors build: 1,226/1,226 tests passed
- Python 3.14 non-WIP suite against the rebuilt stable-ABI wheel: 1,548 passed, 10 skipped
- Ubuntu/GCC warnings-as-errors wheel build: passed
- Ubuntu installed Frame tests: 2 passed
- Ubuntu full Python suite: 1,548 passed, 10 skipped
- installed external Python extension consumer: passed on macOS and Ubuntu
- stable-ABI wheel audit: passed (428 files)
- installed C++ consumer: passed
- strict Sphinx build (`-W`): passed
- `git diff --check`: passed