### PR TITLE
Support Python-owned structured scalars

### DIFF
--- a/benchmarks/scenarios.py
+++ b/benchmarks/scenarios.py
@@ -119,6 +119,15 @@ class BenchCS(CompoundScalar):
     label: str
 
 
+@dataclass(frozen=True)
+class BenchPythonRecord:
+    """Python-owned counterpart to ``BenchCS`` for storage-policy benches."""
+
+    ident: int
+    price: float
+    label: str
+
+
 class BenchBundle(TimeSeriesSchema):
     fast: TS[int]
     medium: TS[int]
@@ -130,6 +139,40 @@ def _cs_pulse(cycles: int) -> TS[BenchCS]:
     values = [BenchCS(ident=i, price=i * 1.5, label=f"cs-{i:04d}") for i in range(64)]
     for i in range(cycles):
         yield MIN_TD, values[i & 63]
+
+
+@generator
+def _python_record_pulse(cycles: int) -> TS[BenchPythonRecord]:
+    values = [
+        BenchPythonRecord(ident=i, price=i * 1.5, label=f"record-{i:04d}")
+        for i in range(64)
+    ]
+    for i in range(cycles):
+        yield MIN_TD, values[i & 63]
+
+
+@generator
+def _cs_equal_pair_pulse(cycles: int) -> TS[BenchCS]:
+    values = [
+        BenchCS(ident=i // 2, price=(i // 2) * 1.5, label=f"cs-{i // 2:04d}")
+        for i in range(128)
+    ]
+    for i in range(cycles):
+        yield MIN_TD, values[i & 127]
+
+
+@generator
+def _python_record_equal_pair_pulse(cycles: int) -> TS[BenchPythonRecord]:
+    values = [
+        BenchPythonRecord(
+            ident=i // 2,
+            price=(i // 2) * 1.5,
+            label=f"record-{i // 2:04d}",
+        )
+        for i in range(128)
+    ]
+    for i in range(cycles):
+        yield MIN_TD, values[i & 127]
 
 
 @generator
@@ -479,6 +522,124 @@ def type_cs_py(scale: float):
         x = _cs_pulse(cycles)
         x = _cs_work_py(_cs_work_py(x))
         null_sink(x.price)
+
+    return g, cycles
+
+
+def python_owned_pass_through_native(scale: float):
+    """Whole-value storage traffic for a native-layout structured scalar."""
+    cycles = int(20_000 * scale)
+
+    @graph
+    def g():
+        null_sink(_cs_pulse(cycles))
+
+    return g, cycles
+
+
+def python_owned_pass_through_python(scale: float):
+    """Whole-value storage traffic for a Python-owned structured scalar."""
+    cycles = int(20_000 * scale)
+
+    @graph
+    def g():
+        null_sink(_python_record_pulse(cycles))
+
+    return g, cycles
+
+
+def python_owned_project_one_native(scale: float):
+    cycles = int(20_000 * scale)
+
+    @graph
+    def g():
+        null_sink(_cs_pulse(cycles).price)
+
+    return g, cycles
+
+
+def python_owned_project_one_python(scale: float):
+    cycles = int(20_000 * scale)
+
+    @graph
+    def g():
+        null_sink(_python_record_pulse(cycles).price)
+
+    return g, cycles
+
+
+def python_owned_project_several_native(scale: float):
+    cycles = int(20_000 * scale)
+
+    @graph
+    def g():
+        value = _cs_pulse(cycles)
+        null_sink(value.ident)
+        null_sink(value.price)
+        null_sink(value.label)
+
+    return g, cycles
+
+
+def python_owned_project_several_python(scale: float):
+    cycles = int(20_000 * scale)
+
+    @graph
+    def g():
+        value = _python_record_pulse(cycles)
+        null_sink(value.ident)
+        null_sink(value.price)
+        null_sink(value.label)
+
+    return g, cycles
+
+
+def python_owned_construct_native(scale: float):
+    cycles = int(20_000 * scale)
+
+    @graph
+    def g():
+        ident = _int_pulse(cycles)
+        null_sink(hg.combine[TS[BenchCS]](
+            ident=ident,
+            price=ident * 1.5,
+            label=hg.convert[TS[str]](ident),
+        ))
+
+    return g, cycles
+
+
+def python_owned_construct_python(scale: float):
+    cycles = int(20_000 * scale)
+
+    @graph
+    def g():
+        ident = _int_pulse(cycles)
+        null_sink(hg.combine[TS[BenchPythonRecord]](
+            ident=ident,
+            price=ident * 1.5,
+            label=hg.convert[TS[str]](ident),
+        ))
+
+    return g, cycles
+
+
+def python_owned_dedup_native(scale: float):
+    cycles = int(20_000 * scale)
+
+    @graph
+    def g():
+        null_sink(hg.drop_dups(_cs_equal_pair_pulse(cycles)))
+
+    return g, cycles
+
+
+def python_owned_dedup_python(scale: float):
+    cycles = int(20_000 * scale)
+
+    @graph
+    def g():
+        null_sink(hg.drop_dups(_python_record_equal_pair_pulse(cycles)))
 
     return g, cycles
 
@@ -1291,6 +1452,56 @@ SCENARIOS = {
         type_cs_std),
     "type_cs_py": _scenario(
         "Value types", "CompoundScalar crossing Python nodes", type_cs_py),
+    "python_owned_pass_through_native": _scenario(
+        "Python-owned structured scalars",
+        "Whole-object pass-through - native layout",
+        python_owned_pass_through_native,
+        suite="diagnostic", modes=HG_CPP_ONLY),
+    "python_owned_pass_through_python": _scenario(
+        "Python-owned structured scalars",
+        "Whole-object pass-through - Python-owned",
+        python_owned_pass_through_python,
+        suite="diagnostic", modes=HG_CPP_ONLY),
+    "python_owned_project_one_native": _scenario(
+        "Python-owned structured scalars",
+        "One field projection - native layout",
+        python_owned_project_one_native,
+        suite="diagnostic", modes=HG_CPP_ONLY),
+    "python_owned_project_one_python": _scenario(
+        "Python-owned structured scalars",
+        "One field projection - Python-owned",
+        python_owned_project_one_python,
+        suite="diagnostic", modes=HG_CPP_ONLY),
+    "python_owned_project_several_native": _scenario(
+        "Python-owned structured scalars",
+        "Three field projections - native layout",
+        python_owned_project_several_native,
+        suite="diagnostic", modes=HG_CPP_ONLY),
+    "python_owned_project_several_python": _scenario(
+        "Python-owned structured scalars",
+        "Three field projections - Python-owned",
+        python_owned_project_several_python,
+        suite="diagnostic", modes=HG_CPP_ONLY),
+    "python_owned_construct_native": _scenario(
+        "Python-owned structured scalars",
+        "Construction from fields - native layout",
+        python_owned_construct_native,
+        suite="diagnostic", modes=HG_CPP_ONLY),
+    "python_owned_construct_python": _scenario(
+        "Python-owned structured scalars",
+        "Construction from fields - Python-owned",
+        python_owned_construct_python,
+        suite="diagnostic", modes=HG_CPP_ONLY),
+    "python_owned_dedup_native": _scenario(
+        "Python-owned structured scalars",
+        "Equality and deduplication - native layout",
+        python_owned_dedup_native,
+        suite="diagnostic", modes=HG_CPP_ONLY),
+    "python_owned_dedup_python": _scenario(
+        "Python-owned structured scalars",
+        "Equality and deduplication - Python-owned",
+        python_owned_dedup_python,
+        suite="diagnostic", modes=HG_CPP_ONLY),
     "type_tsb_partial_fields_std": _scenario(
         "Value types", "Bundle with partial field updates",
         type_tsb_partial_fields_std, suite="diagnostic"),

--- a/docs/source/developer_guide/data_structures/schemas/scalar.rst
+++ b/docs/source/developer_guide/data_structures/schemas/scalar.rst
@@ -73,13 +73,24 @@ A scalar schema has one of nine kinds, recorded on its
     ``Quote``) keep nominal identity even when their fields happen
     to coincide.
 
-    *Python correspondence.* The Python ``CompoundScalar`` class maps onto
-    the C++ ``Bundle`` kind. A dataclass subclass is a qualified nominal
-    Bundle; its default namespace is the defining module plus enclosing
-    scope. ``class Quote(CompoundScalar, namespace="feed", abstract=True,
+    *Python correspondence.* Both native ``CompoundScalar`` classes and
+    Python-owned structured scalars map onto the C++ ``Bundle`` kind. A
+    dataclass subclass of ``CompoundScalar`` is a qualified nominal Bundle
+    with offset-backed native storage; its default namespace is the defining
+    module plus enclosing scope.
+    ``class Quote(CompoundScalar, namespace="feed", abstract=True,
     discriminator="kind")`` overrides the namespace, construction policy,
     and external type marker. Anonymous compounds produced by
     ``compound_scalar(**kwargs)`` remain structural.
+
+    A plain standard-library dataclass, or an explicitly registered annotated
+    Python class, is also a qualified nominal Bundle but uses a Python-owned
+    binding. That binding retains the exact object and implements complete
+    read-only ``IndexedValueOps`` by lazy attribute projection. Consequently
+    ``ValueView::as_bundle()`` returns the same representation-erased
+    ``BundleView`` for either storage policy. Generic code must select by
+    Bundle/indexed capability and must not assume field offsets merely because
+    the schema kind is ``Bundle``.
 
     Named Bundle metadata records immediate parents and children. Multiple
     inheritance is allowed, but a child must contain every inherited field
@@ -143,10 +154,12 @@ C++ code can request an owner with ``TypeRegistry::owned(target)``. A
 self-recursive nominal schema is declared atomically with
 ``TypeRegistry::recursive_bundle(...)``; a null field-schema entry denotes
 ``Owned<Self>``. Python recognises direct self references, including
-``Optional[Self]``, on a dataclass ``CompoundScalar`` and uses the same path.
-Mutually recursive Python classes are intentionally not inferred yet: they
-need a future batch declaration API so neither class publishes a partial
-schema.
+``Optional[Self]``, on a dataclass ``CompoundScalar`` and uses the same native
+owned path. Python-owned dataclasses may also describe direct or mutual
+recursion because their annotations do not imply recursive inline native
+storage; their bridge registration resolves the class graph before publishing
+the concrete bindings. A recursive native ``CompoundScalar`` still requires
+the ``Owned[T]`` representation described above.
 
 ``List``
     Ordered sequence of one element type. May be ``fixed_size`` or dynamic.

--- a/docs/source/developer_guide/python_bridge.rst
+++ b/docs/source/developer_guide/python_bridge.rst
@@ -185,6 +185,46 @@ scopes move verbatim** — when relocating code, never widen or narrow an
 acquire/release, and keep the ruling comments attached to
 ``PyWiring::run`` and the sender.
 
+Python-owned Bundle bindings
+----------------------------
+
+RFC 0004 adds a second owning representation for named Bundles without adding
+a value kind. ``src/hgraph/python/bridge_state.cpp`` owns the bridge-only
+``PythonBundleValue`` and its binding registry. A value retains the exact
+``PyObject *``, its active concrete schema, its realised binding, and a lazy
+cache of projected fields. The public C++ surface remains
+``ValueTypeRef``/``BundleView``; neither ``PyObject`` nor the carrier layout is
+part of the SDK.
+
+The binding is deliberately non-composite but supplies complete read-only
+``IndexedValueOps``. ``element_at`` performs normal Python attribute lookup
+under the GIL and converts only the requested field into its declared realised
+binding. Generic Bundle code therefore selects on indexed capability, not on
+Python ownership. Whole-object copy, move, conversion, equality, hashing,
+formatting, and destruction acquire the GIL where Python is involved.
+
+The named Bundle's anonymous structural twin remains the assembly format.
+``TSB[PythonClass]`` stores that field-expanded shape, while
+``BundleBuilder`` and ``as_scalar_ts`` erase the source and ask the owning
+binding to construct the Python class. The optional
+``ValueOps::can_materialize_source`` policy permits construction when every
+required constructor field is valid, even if defaulted or ``init=False``
+fields are absent. Bindings without that capability keep the normal
+all-fields-valid rule.
+
+Python-side schema extraction and generic specialisation live in
+``hgraph._types``. Class identity, not rendered name or field shape, is the
+registration key. A concrete generic alias is retained beside its shared
+Python origin so ``Box[int]`` and ``Box[str]`` have distinct nominal schemas
+and dispatcher tags. Runtime conversion first uses exact class/specialisation
+information, then MRO and field-schema matching; ambiguous inference is an
+error.
+
+Registration records and owning bindings follow the bridge's immortality
+rule. ``reset_registries`` clears the lookup maps and invalidates Python-side
+generation-keyed caches, but already-published binding objects are never
+destroyed during interpreter teardown.
+
 The single-threaded wiring model
 --------------------------------
 

--- a/docs/source/rfc/rfc_0004_python_owned_structured_scalars.rst
+++ b/docs/source/rfc/rfc_0004_python_owned_structured_scalars.rst
@@ -1,7 +1,7 @@
 RFC 0004: Python-Owned Structured Scalars
 =========================================
 
-:Status: Proposed
+:Status: Accepted
 :Author: Howard Henson
 :Created: 2026-07-23
 :Target: Next ``hg_cpp`` minor release
@@ -768,10 +768,30 @@ Semantics and robustness
 Implementation status
 ---------------------
 
-No implementation is included with this proposal. The RFC remains
-``Proposed`` until its implementation and conformance tests are accepted for
-merge. The implementation PR must update this section with any contract changes
-and change the status to ``Accepted`` only when the code is accepted.
+The RFC was accepted on 2026-07-23. Its implementation is included in the
+corresponding implementation PR.
+
+The implementation keeps the accepted representation boundary: a Python-owned
+structured scalar is a normal named ``Bundle`` with a non-composite owning
+binding. Its complete read-only ``IndexedValueOps`` surface projects declared
+attributes lazily, so ``BundleView`` and generic Bundle operators do not need
+to know which storage policy owns the value. ``TSB`` continues to hold the
+anonymous structural field representation and constructs the Python object
+only when converted to the scalar form.
+
+One representation-neutral capability was added to erased value operations:
+an owning binding may decide whether a partially valid indexed source contains
+enough fields to construct it. Python-owned bindings use this to distinguish
+required constructor fields from defaults and ``init=False`` fields; ordinary
+composite Bundles retain the existing all-fields-valid rule.
+
+The public Python surface consists of lazy recognition of standard-library
+dataclasses and ``register_python_object_type`` for explicit classes. The
+implementation includes nominal and generic registration, inheritance and
+closed-union dispatch, recursive fields, constructor/default handling,
+``TS``/``TSB`` conversion, reflection, Python equality and hashing, key
+capability validation, focused native and Python conformance tests, and paired
+diagnostic benchmark scenarios for the workloads in `Performance and memory`_.
 
 References
 ----------

--- a/docs/source/user_guide/python_compatibility.rst
+++ b/docs/source/user_guide/python_compatibility.rst
@@ -132,6 +132,74 @@ hgraph representation retain their concrete type record, so native conversion
 and ``type_`` dispatch remain available. An arbitrary Python object is retained
 as an opaque bridge value only when no native representation exists.
 
+Python-owned structured scalars
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+A standard-library dataclass may be used directly as a nominal scalar schema:
+
+.. code-block:: python
+
+   from dataclasses import dataclass
+   from hgraph import TS, combine, graph
+
+   @dataclass(frozen=True)
+   class Quote:
+       instrument: str
+       bid: float
+       ask: float = 0.0
+
+   @graph
+   def spread(quote: TS[Quote]) -> TS[float]:
+       return quote.ask - quote.bid
+
+   @graph
+   def make_quote(bid: TS[float]) -> TS[Quote]:
+       return combine[TS[Quote]](instrument="ABC", bid=bid)
+
+The value held by ``TS[Quote]`` is the exact Python object that was emitted.
+Its ordered annotations provide a nominal Bundle schema for wiring,
+reflection, field access, generic resolution, and dispatch. Attribute
+projection is lazy: assigning the whole object does not recursively validate
+its fields, while reading a declared field converts that attribute to the
+declared output type and reports an error if it is incompatible.
+
+``TSB[Quote]`` is the field-expanded time-series form. ``as_scalar_ts()``
+constructs ``Quote`` using keyword arguments and honours dataclass defaults,
+default factories, keyword-only fields, ``init=False``, and ``__post_init__``.
+Generic dataclasses such as ``Box[int]`` retain their concrete specialisation
+through storage, Bundle conversion, and runtime dispatch.
+
+An annotated non-dataclass class must opt in:
+
+.. code-block:: python
+
+   from hgraph import register_python_object_type
+
+   @register_python_object_type
+   class LegacyQuote:
+       instrument: str
+       price: float
+
+       def __init__(self, price: float, instrument: str = "ABC"):
+           self.instrument = instrument
+           self.price = price
+
+``register_python_object_type`` also accepts an ordered ``fields`` mapping.
+Constructor parameters used to reconstruct a value must be keyword-capable;
+required constructor parameters not represented in the schema are rejected.
+
+Use native ``CompoundScalar`` for records that need native field layout,
+Python-free execution, or repeated low-cost field access in C++. Use a plain
+dataclass or registered class when preserving Python constructors,
+descriptors, identity, permissive values, or custom equality is the priority.
+Both forms are Bundles and therefore share the storage-independent
+``BundleView`` and graph-operator contract.
+
+Python-owned values have snapshot-by-emission semantics. Mutating an object in
+place does not create a tick; emit a new object to publish a change. Equality
+and hashing follow the class's Python methods. An unhashable class can be a
+``TS`` value but is rejected as a ``TSS`` or ``TSD`` key.
+
 Native ``DateTime`` is a timezone-naive UTC value. Python timezone-aware
 ``datetime`` values are normalized to UTC and then made naive on ingress;
 naive values are already interpreted as UTC. Timezone-aware standalone

--- a/include/hgraph/lib/std/operators/impl/collection_impl.h
+++ b/include/hgraph/lib/std/operators/impl/collection_impl.h
@@ -3298,9 +3298,15 @@ namespace hgraph::stdlib
         {
             const auto *target = erased.schema()->value_schema;
             const auto *snapshot = active_type_realization();
-            BundleBuilder builder{snapshot != nullptr
-                                      ? snapshot->exact_type_for(target)
-                                      : ValuePlanFactory::instance().type_for(target)};
+            const auto target_binding = snapshot != nullptr
+                                            ? snapshot->exact_type_for(target)
+                                            : ValuePlanFactory::instance().type_for(target);
+            const bool policy_materialization =
+                target_binding.ops_ref().has_source_materialization_policy();
+            const auto assembly_binding = policy_materialization
+                                              ? BundleBuilder::assembly_type(target_binding)
+                                              : target_binding;
+            BundleBuilder builder{assembly_binding};
 
             const auto *input_schema = fields.schema();
             for (std::size_t index = 0; index < input_schema->field_count(); ++index)
@@ -3324,7 +3330,25 @@ namespace hgraph::stdlib
                     }
                 }
             }
-            Value bundle = builder.build();
+            Value source = builder.build();
+            if (policy_materialization &&
+                !target_binding.ops_ref().can_materialize_source(source.binding(), source.view().data()))
+            {
+                return;
+            }
+
+            Value bundle;
+            if (assembly_binding == target_binding)
+            {
+                bundle = std::move(source);
+            }
+            else
+            {
+                bundle = Value{target_binding};
+                target_binding.ops_ref().move_assign_from(
+                    target_binding, const_cast<void *>(bundle.view().data()),
+                    source.binding(), const_cast<void *>(source.view().data()));
+            }
             if (erased.data_view().has_current_value() && erased.value().equals(bundle.view())) { return; }
             auto mutation = erased.data_view().begin_mutation(erased.evaluation_time());
             static_cast<void>(mutation.move_value_from(std::move(bundle)));
@@ -3437,8 +3461,11 @@ namespace hgraph::stdlib
             }
         };
 
-        /** convert[TS[CS]](tsb): the whole-bundle VALUE of a TSB (strict:
-            every field valid; None until then - hgraph parity). */
+        /** convert[TS[CS]](tsb): the whole-bundle VALUE of a TSB. Ordinary
+            composite Bundles remain all-fields-valid. An erased owning
+            representation may declare that an incomplete indexed source is
+            constructible (for example a Python dataclass with defaults or
+            init=False fields). */
         struct convert_tsb_to_cs_impl
         {
             static constexpr auto name = "convert_tsb_to_cs";
@@ -3456,13 +3483,22 @@ namespace hgraph::stdlib
                 return bundle_value != nullptr && bundle_value->value_kind() == ValueTypeKind::Bundle;
             }
 
-            static void eval(In<"ts", TsVar<"S">, InputValidity::AllValid> ts, Out<TsVar<"__out__">> out)
+            static void eval(In<"ts", TsVar<"S">, InputValidity::Unchecked> ts, Out<TsVar<"__out__">> out)
             {
                 const auto &erased = static_cast<const TSOutputView &>(out);
                 const auto  value  = ts.base().value();
-                if (erased.data_view().has_current_value() && erased.value().equals(value)) { return; }
+                if (!ts.base().all_valid())
+                {
+                    const auto target = erased.data_view().layout().value_binding;
+                    if (!target || !target.ops_ref().can_materialize_source(value.binding(), value.data()))
+                    {
+                        return;
+                    }
+                }
+                Value materialized{value};
+                if (erased.data_view().has_current_value() && erased.value().equals(materialized.view())) { return; }
                 auto mutation = erased.data_view().begin_mutation(erased.evaluation_time());
-                static_cast<void>(mutation.copy_value_from(value));
+                static_cast<void>(mutation.move_value_from(std::move(materialized)));
             }
         };
 
@@ -3481,9 +3517,10 @@ namespace hgraph::stdlib
             {
                 const auto &erased = static_cast<const TSOutputView &>(out);
                 const auto  value  = ts.base().value();
-                if (erased.data_view().has_current_value() && erased.value().equals(value)) { return; }
+                Value materialized{value};
+                if (erased.data_view().has_current_value() && erased.value().equals(materialized.view())) { return; }
                 auto mutation = erased.data_view().begin_mutation(erased.evaluation_time());
-                static_cast<void>(mutation.copy_value_from(value));
+                static_cast<void>(mutation.move_value_from(std::move(materialized)));
             }
         };
 

--- a/include/hgraph/python/bridge_state.h
+++ b/include/hgraph/python/bridge_state.h
@@ -7,8 +7,14 @@
 
 #include <nanobind/nanobind.h>
 
+#include <span>
 #include <unordered_map>
 #include <vector>
+
+namespace hgraph {
+struct ValueTypeMetaData;
+class ValueTypeRef;
+} // namespace hgraph
 
 /**
  * Shared python-bridge STATE consulted by type-erased conversion impls
@@ -59,18 +65,21 @@ struct HGRAPH_LOCAL PyBundleClassInfo {
   using Allocator = PyObject *(*)(PyTypeObject *, Py_ssize_t);
 
   nb::object type{};
+  nb::object specialization{};
   Allocator allocator{nullptr};
   std::vector<nb::str> field_names{};
   std::vector<nb::object> field_overrides{};
   std::vector<bool> constructor_fields{};
+  std::vector<bool> defaulted_constructor_fields{};
   bool requires_constructor{false};
 };
 
 /** Schema-addressed companion to ``bundle_class_registry`` for hot value
     conversion. It retains interned field-name objects so conversion does
     not recreate and hash every field name on every node evaluation. */
-[[nodiscard]] HGRAPH_EXPORT std::unordered_map<const void *, PyBundleClassInfo> &
-bundle_class_info_registry();
+[[nodiscard]] HGRAPH_EXPORT
+    std::unordered_map<const void *, PyBundleClassInfo> &
+    bundle_class_info_registry();
 
 /** Structural ``TSB[CompoundScalar]`` schema -> its scalar Bundle schema.
  * The TS runtime remains structural; this bridge-only association restores the
@@ -78,6 +87,32 @@ bundle_class_info_registry();
  */
 [[nodiscard]] HGRAPH_EXPORT std::unordered_map<const void *, const void *> &
 tsb_compound_value_registry();
+
+/**
+ * Install a Python-owned canonical binding for a nominal Bundle schema.
+ *
+ * The class reconstruction metadata must already be present in
+ * ``bundle_class_info_registry``. The resulting binding retains the Python
+ * object as-is and projects declared fields lazily through ``BundleView``.
+ */
+HGRAPH_EXPORT void
+register_python_bundle_binding(const ValueTypeMetaData *schema);
+
+/** True when ``schema`` has a Python-owned Bundle storage policy. */
+[[nodiscard]] HGRAPH_EXPORT bool
+is_python_bundle_schema(const ValueTypeMetaData *schema) noexcept;
+
+/**
+ * Return the Python-owned binding for ``schema`` with the supplied realized
+ * field bindings. Used by graph snapshots when a declared field contains a
+ * closed Bundle hierarchy. Returns an unbound reference for non-Python schemas.
+ */
+[[nodiscard]] HGRAPH_EXPORT ValueTypeRef
+python_bundle_binding_for(const ValueTypeMetaData *schema,
+                          std::span<const ValueTypeRef> field_bindings);
+
+/** Test/reset lifecycle hook; retained binding contexts remain immortal. */
+HGRAPH_EXPORT void clear_python_bundle_bindings() noexcept;
 } // namespace hgraph::python_bridge
 
 #endif // HGRAPH_ENABLE_PYTHON_USER_NODES

--- a/include/hgraph/types/value/value.h
+++ b/include/hgraph/types/value/value.h
@@ -253,11 +253,11 @@ namespace hgraph
 
         // -- generic ops --
         [[nodiscard]] std::size_t hash() const { return view().hash(); }
-        [[nodiscard]] bool equals(const Value &other) const noexcept
+        [[nodiscard]] bool equals(const Value &other) const
         {
             return view().equals(other.view());
         }
-        [[nodiscard]] bool equals(const ValueView &other) const noexcept
+        [[nodiscard]] bool equals(const ValueView &other) const
         {
             return view().equals(other);
         }
@@ -269,7 +269,7 @@ namespace hgraph
         {
             return view().compare(other);
         }
-        [[nodiscard]] bool operator==(const Value &other) const noexcept { return equals(other); }
+        [[nodiscard]] bool operator==(const Value &other) const { return equals(other); }
         [[nodiscard]] std::partial_ordering operator<=>(const Value &other) const noexcept
         {
             return compare(other);

--- a/include/hgraph/types/value/value_builder.h
+++ b/include/hgraph/types/value/value_builder.h
@@ -17,6 +17,7 @@
 #include <stdexcept>
 #include <string_view>
 #include <utility>
+#include <vector>
 
 namespace hgraph
 {
@@ -724,12 +725,17 @@ namespace hgraph
     class BundleBuilder
     {
       public:
-        explicit BundleBuilder(const ValueTypeRef &bundle_binding) : binding_{bundle_binding}, value_{bundle_binding}
+        explicit BundleBuilder(const ValueTypeRef &bundle_binding)
+            : target_binding_{bundle_binding},
+              binding_{assembly_binding(bundle_binding)},
+              value_{binding_}
         {
-            if (!bundle_binding.checked_plan().is_composite())
-            {
-                throw std::logic_error("BundleBuilder requires a composite (bundle/tuple) binding");
-            }
+        }
+
+        /** Return the composite field-assembly binding for ``target``. */
+        [[nodiscard]] static ValueTypeRef assembly_type(ValueTypeRef target)
+        {
+            return assembly_binding(target);
         }
 
         /** Set field ``index`` to a copy of ``field`` (whole-value copy-assign). */
@@ -797,10 +803,58 @@ namespace hgraph
         {
             ensure_not_built();
             built_ = true;
-            return std::move(value_);
+            if (target_binding_ == binding_) { return std::move(value_); }
+
+            Value result{target_binding_};
+            target_binding_.ops_ref().move_assign_from(
+                target_binding_,
+                const_cast<void *>(result.view().data()),
+                binding_,
+                const_cast<void *>(value_.view().data()));
+            return result;
         }
 
       private:
+        [[nodiscard]] static ValueTypeRef assembly_binding(ValueTypeRef target)
+        {
+            if (!target)
+            {
+                throw std::invalid_argument("BundleBuilder requires a bound target");
+            }
+            if (target.checked_plan().is_composite()) { return target; }
+            const auto *schema = target.schema();
+            if (schema == nullptr || schema->try_value_kind() != ValueTypeKind::Bundle ||
+                schema->wrapped_un_named == nullptr)
+            {
+                throw std::logic_error(
+                    "BundleBuilder requires composite storage or a named Bundle with a structural twin");
+            }
+            const auto *indexed =
+                checked_value_ops<IndexedValueOps>(target, "BundleBuilder target");
+            std::vector<ValueTypeRef> fields;
+            fields.reserve(schema->field_count);
+            for (std::size_t index = 0; index < schema->field_count; ++index)
+            {
+                const auto field =
+                    indexed->element_binding(indexed->context, nullptr, index);
+                if (!field)
+                {
+                    throw std::logic_error(
+                        "BundleBuilder target has an unresolved field binding");
+                }
+                fields.push_back(field);
+            }
+            const auto structural =
+                ValuePlanFactory::instance().realized_composite_type_for(
+                    schema->wrapped_un_named, fields);
+            if (!structural || !structural.checked_plan().is_composite())
+            {
+                throw std::logic_error(
+                    "BundleBuilder structural assembly binding is unavailable");
+            }
+            return structural;
+        }
+
         [[nodiscard]] const MemoryUtils::CompositeState &state() const
         {
             const auto *s =
@@ -854,6 +908,7 @@ namespace hgraph
             if (built_) { throw std::logic_error("BundleBuilder is single-use"); }
         }
 
+        ValueTypeRef target_binding_{nullptr};
         ValueTypeRef binding_{nullptr};
         Value                   value_{};
         bool                    built_{false};

--- a/include/hgraph/types/value/value_ops.h
+++ b/include/hgraph/types/value/value_ops.h
@@ -117,7 +117,7 @@ namespace hgraph
         const void *context{nullptr};
         bool        allows_mutation{false};
         std::size_t (*hash_impl)(const void *context, const void *memory) = nullptr;
-        bool (*equals_impl)(const void *context, const void *lhs, const void *rhs) noexcept = nullptr;
+        bool (*equals_impl)(const void *context, const void *lhs, const void *rhs) = nullptr;
         std::partial_ordering (*compare_impl)(const void *context, const void *lhs,
                                               const void *rhs) noexcept = nullptr;
         std::string (*to_string_impl)(const void *context, const void *memory) = nullptr;
@@ -144,6 +144,9 @@ namespace hgraph
         const void *(*concrete_memory_impl)(const void *context, const void *memory) noexcept = nullptr;
         void *(*mutable_concrete_memory_impl)(const void *context, void *memory) noexcept = nullptr;
         std::string (*format_string_impl)(const void *context, const void *memory) = nullptr;
+        bool (*can_materialize_source_impl)(const void *context,
+                                            ValueTypeRef source,
+                                            const void *memory) = nullptr;
 
         [[nodiscard]] std::size_t hash(const void *memory) const
         {
@@ -157,7 +160,7 @@ namespace hgraph
 
         [[nodiscard]] bool can_begin_mutation() const noexcept { return allows_mutation; }
 
-        [[nodiscard]] bool equals(const void *lhs, const void *rhs) const noexcept
+        [[nodiscard]] bool equals(const void *lhs, const void *rhs) const
         {
             return equals_impl != nullptr ? equals_impl(context, lhs, rhs) : lhs == rhs;
         }
@@ -267,6 +270,24 @@ namespace hgraph
         {
             if (accepts_source_impl != nullptr) { return accepts_source_impl(context, binding, source); }
             return binding && source && binding.plan() == source.plan();
+        }
+
+        /**
+         * Whether an incomplete indexed source contains enough fields to
+         * construct this owning representation. The default is deliberately
+         * false: ordinary composite Bundles retain all-fields-valid
+         * materialisation semantics.
+         */
+        [[nodiscard]] bool can_materialize_source(ValueTypeRef source,
+                                                  const void *memory) const
+        {
+            return can_materialize_source_impl != nullptr &&
+                   can_materialize_source_impl(context, source, memory);
+        }
+
+        [[nodiscard]] bool has_source_materialization_policy() const noexcept
+        {
+            return can_materialize_source_impl != nullptr;
         }
 
         void copy_assign_from(ValueTypeRef binding, void *dst, ValueTypeRef source, const void *src) const
@@ -409,7 +430,7 @@ namespace hgraph
             }
             else
             {
-                return static_cast<bool (*)(const void *, const void *, const void *) noexcept>(nullptr);
+                return static_cast<bool (*)(const void *, const void *, const void *)>(nullptr);
             }
         }
 

--- a/include/hgraph/types/value/value_view.h
+++ b/include/hgraph/types/value/value_view.h
@@ -339,9 +339,9 @@ namespace hgraph
             if (!valid()) { throw std::logic_error("ValueView::hash requires a non-empty view"); }
             return type().ops_ref().hash(data());
         }
-        [[nodiscard]] bool equals(const ValueView &other) const noexcept;
+        [[nodiscard]] bool equals(const ValueView &other) const;
         [[nodiscard]] std::partial_ordering compare(const ValueView &other) const noexcept;
-        [[nodiscard]] bool operator==(const ValueView &other) const noexcept { return equals(other); }
+        [[nodiscard]] bool operator==(const ValueView &other) const { return equals(other); }
         [[nodiscard]] std::partial_ordering operator<=>(const ValueView &other) const noexcept
         {
             return compare(other);

--- a/python/hgraph/__init__.py
+++ b/python/hgraph/__init__.py
@@ -68,7 +68,8 @@ from ._wiring import _Combine as _CombineClass
 combine = _CombineClass()
 
 from ._types import (Frame, TABLE, COMPOUND_SCALAR, COMPOUND_SCALAR_1,
-                     compound_scalar, register_native_scalar_type)
+                     compound_scalar, register_native_scalar_type,
+                     register_python_object_type)
 from ._frame import (frame_metadata, has_frame_metadata, without_frame_metadata,
                      with_frame_metadata)
 from ._table import (ToTableMode, TableSchema, make_table_schema, table_schema,
@@ -107,7 +108,7 @@ __all__ = [
     "utc_now", "get_recorded_value", "get_recorder_api", "get_recording_label", "set_recorder_api", "set_recording_label", "EvaluationClock", "TSW_OUT", "get_context", "equal_lambdas", "is_feature_enabled",
     "GlobalContext", "GlobalState", "set_as_of", "set_table_schema_date_key", "set_table_schema_as_of_key",
     "set_record_replay_config", "frame_store_contains", "frame_store_read", "evaluate_const",
-    "Frame", "with_frame_metadata", "frame_metadata", "has_frame_metadata", "without_frame_metadata", "register_native_scalar_type", "TABLE", "COMPOUND_SCALAR", "COMPOUND_SCALAR_1", "ToTableMode", "TableSchema", "make_table_schema", "table_schema",
+    "Frame", "with_frame_metadata", "frame_metadata", "has_frame_metadata", "without_frame_metadata", "register_native_scalar_type", "register_python_object_type", "TABLE", "COMPOUND_SCALAR", "COMPOUND_SCALAR_1", "ToTableMode", "TableSchema", "make_table_schema", "table_schema",
     "table_shape", "table_shape_from_schema", "shape_of_table_type", "drop_dups",
     "get_table_schema_date_key", "get_table_schema_as_of_key",
     "ParseError", "IncorrectTypeBinding", "RequirementsNotMetWiringError",

--- a/python/hgraph/_types.py
+++ b/python/hgraph/_types.py
@@ -18,6 +18,9 @@ _SCALAR_NAMES = {
 }
 
 _COMPOUND_TYPE_CACHE = {}
+_PYTHON_OBJECT_TYPE_CACHE = {}
+_PYTHON_OBJECT_REGISTRATIONS = {}
+_PYTHON_OBJECT_CLASSES = []
 _TSB_SCHEMA_CLASSES = {}
 
 
@@ -37,8 +40,72 @@ def register_native_scalar_type(python_type, native_value_type):
     _hgraph.register_native_scalar_type(python_type, native_value_type)
 
 
-def _register_bundle_class(meta, scalar):
+def register_python_object_type(cls=None, *, fields=None):
+    """Register a Python class for Python-owned structured scalar semantics.
+
+    Standard-library dataclasses are recognised automatically. This function
+    opts other application classes into the same nominal Bundle contract. An
+    ordered ``fields`` mapping may be supplied when annotations do not fully
+    describe the public schema. The class is returned so the function can be
+    used as a decorator.
+    """
+    from collections.abc import Mapping
+
+    def register(target):
+        from ._compat import CompoundScalar
+
+        if not isinstance(target, type):
+            raise TypeError("register_python_object_type expects a Python class")
+        if issubclass(target, CompoundScalar):
+            raise TypeError(
+                "CompoundScalar classes already use native Bundle storage")
+        if fields is not None and not isinstance(fields, Mapping):
+            raise TypeError("fields must be an ordered mapping of field names to types")
+        normalized = None if fields is None else tuple(fields.items())
+        if normalized is not None:
+            if any(not isinstance(name, str) or not name for name, _ in normalized):
+                raise TypeError("registered field names must be non-empty strings")
+            if len({name for name, _ in normalized}) != len(normalized):
+                raise TypeError("registered field names must be unique")
+        previous = _PYTHON_OBJECT_REGISTRATIONS.get(target, ...)
+        if previous is not ... and previous != normalized:
+            raise TypeError(
+                f"{target.__module__}.{target.__qualname__} is already registered "
+                "with a different field schema")
+        _PYTHON_OBJECT_REGISTRATIONS[target] = normalized
+        if target not in _PYTHON_OBJECT_CLASSES:
+            _PYTHON_OBJECT_CLASSES.append(target)
+        return target
+
+    return register if cls is None else register(cls)
+
+
+def _is_python_object_class(cls):
+    """Whether ``cls`` has Python-owned structured scalar semantics."""
+    import dataclasses
+
+    from ._compat import CompoundScalar
+
+    time_series_schema = globals().get("TimeSeriesSchema")
+    return (
+        isinstance(cls, type)
+        and not issubclass(cls, CompoundScalar)
+        and not (
+            isinstance(time_series_schema, type)
+            and issubclass(cls, time_series_schema)
+        )
+        and (
+            dataclasses.is_dataclass(cls)
+            or cls in _PYTHON_OBJECT_REGISTRATIONS
+        )
+    )
+
+
+def _register_bundle_class(
+    meta, scalar, *, python_owned=False, specialization=None
+):
     """Register reconstruction policy without exposing it as runtime semantics."""
+    import dataclasses
     import inspect
     import types
 
@@ -49,18 +116,77 @@ def _register_bundle_class(meta, scalar):
             (types.MemberDescriptorType, types.GetSetDescriptorType),
         )
     )
+    try:
+        defaulted_constructor_fields = {
+            field.name
+            for field in dataclasses.fields(scalar)
+            if field.init and (
+                field.default is not dataclasses.MISSING
+                or field.default_factory is not dataclasses.MISSING
+            )
+        }
+    except TypeError:
+        defaulted_constructor_fields = set()
 
     try:
         signature = inspect.signature(scalar)
     except (TypeError, ValueError):
         signature = None
     if signature is None:
-        _hgraph.register_bundle_class(meta, scalar, (), True, raw_descriptor_fields,
-                                      scalar.__new__ is not object.__new__)
+        _hgraph.register_bundle_class(
+            meta,
+            scalar,
+            specialization,
+            (),
+            True,
+            raw_descriptor_fields,
+            tuple(defaulted_constructor_fields),
+            scalar.__new__ is not object.__new__,
+        )
+        if python_owned:
+            _hgraph.register_python_bundle_binding(meta)
         return
+    schema_fields = {name for name, _ in meta.fields}
+    if python_owned:
+        positional_only = tuple(
+            name
+            for name, parameter in signature.parameters.items()
+            if parameter.kind is inspect.Parameter.POSITIONAL_ONLY
+            and name in schema_fields
+        )
+        if positional_only:
+            raise TypeError(
+                f"{scalar.__module__}.{scalar.__qualname__} cannot be "
+                "reconstructed from Bundle fields because constructor "
+                f"parameter(s) {positional_only!r} are positional-only")
+        required_non_fields = tuple(
+            name
+            for name, parameter in signature.parameters.items()
+            if parameter.default is inspect.Parameter.empty
+            and parameter.kind in (
+                inspect.Parameter.POSITIONAL_ONLY,
+                inspect.Parameter.POSITIONAL_OR_KEYWORD,
+                inspect.Parameter.KEYWORD_ONLY,
+            )
+            and name not in schema_fields
+        )
+        if required_non_fields:
+            raise TypeError(
+                f"{scalar.__module__}.{scalar.__qualname__} cannot be "
+                "reconstructed from its Bundle schema because required "
+                f"constructor parameter(s) {required_non_fields!r} are not fields")
     accepts_kwargs = any(
         parameter.kind is inspect.Parameter.VAR_KEYWORD
         for parameter in signature.parameters.values()
+    )
+    defaulted_constructor_fields.update(
+        name
+        for name, parameter in signature.parameters.items()
+        if parameter.default is not inspect.Parameter.empty
+        and parameter.kind not in (
+            inspect.Parameter.VAR_POSITIONAL,
+            inspect.Parameter.VAR_KEYWORD,
+        )
     )
     constructor_fields = () if accepts_kwargs else tuple(
         name for name, parameter in signature.parameters.items()
@@ -70,22 +196,68 @@ def _register_bundle_class(meta, scalar):
             inspect.Parameter.KEYWORD_ONLY,
         )
     )
+    if (
+        python_owned
+        and not dataclasses.is_dataclass(scalar)
+        and not accepts_kwargs
+        and not any(name in schema_fields for name in constructor_fields)
+        and schema_fields
+    ):
+        # A default object constructor cannot consume field-wise data. Mark
+        # each declared field as an attempted keyword so reconstruction fails
+        # explicitly instead of returning an object with missing attributes.
+        # Whole-object storage remains available.
+        constructor_fields = tuple(name for name, _ in meta.fields)
     _hgraph.register_bundle_class(
         meta,
         scalar,
+        specialization,
         constructor_fields,
         accepts_kwargs,
         raw_descriptor_fields,
+        tuple(defaulted_constructor_fields),
         scalar.__new__ is not object.__new__,
     )
+    if python_owned:
+        _hgraph.register_python_bundle_binding(meta)
+
+
+def _python_object_required_constructor_fields(scalar):
+    """Schema fields that must be supplied to reconstruct ``scalar``."""
+    import inspect
+
+    try:
+        signature = inspect.signature(scalar)
+    except (TypeError, ValueError):
+        return ()
+    ordered_schema_fields = tuple(_python_object_python_field_types(scalar))
+    schema_fields = set(ordered_schema_fields)
+    required = tuple(
+        name
+        for name, parameter in signature.parameters.items()
+        if name in schema_fields
+        and parameter.default is inspect.Parameter.empty
+        and parameter.kind in (
+            inspect.Parameter.POSITIONAL_OR_KEYWORD,
+            inspect.Parameter.KEYWORD_ONLY,
+        )
+    )
+    if (
+        scalar in _PYTHON_OBJECT_REGISTRATIONS
+        and not required
+        and not any(name in schema_fields for name in signature.parameters)
+    ):
+        return ordered_schema_fields
+    return required
 
 
 def _finalize_compound_scalar_types():
     """Register every visible concrete descendant of materialized bundles.
 
-    CompoundScalar classes can be imported after a base schema was first used.
-    Wiring closes the hierarchy immediately before the C++ graph snapshot, so
-    the snapshot sees the complete subclass set visible to that wiring run.
+    Structured scalar classes can be imported after a base schema was first
+    used. Wiring closes each hierarchy immediately before the C++ graph
+    snapshot, so the snapshot sees the complete subclass set visible to that
+    wiring run.
     """
     from ._compat import CompoundScalar
 
@@ -112,6 +284,29 @@ def _finalize_compound_scalar_types():
 
     for root in roots:
         visit(root)
+
+    python_roots = {
+        scalar
+        for cached_generation, scalar, arguments in tuple(_PYTHON_OBJECT_TYPE_CACHE)
+        if cached_generation == generation and not arguments
+        and _is_python_object_class(scalar)
+    }
+    python_seen = set()
+
+    def visit_python(parent):
+        if parent in python_seen:
+            return
+        python_seen.add(parent)
+        for child in parent.__subclasses__():
+            if not _is_python_object_class(child):
+                continue
+            if getattr(child, "__parameters__", ()):
+                continue
+            _python_object_value_type(child)
+            visit_python(child)
+
+    for root in python_roots:
+        visit_python(root)
 
 
 def _substitute_typevars(tp, substitutions):
@@ -151,6 +346,15 @@ def _compound_specialization_token(tp):
         args = ",".join(_compound_specialization_token(arg) for arg in typing.get_args(tp))
         return f"{origin.__name__}[{args}]"
     return getattr(tp, "__name__", repr(tp))
+
+
+def _specialization_alias(scalar, type_args):
+    if not type_args:
+        return None
+    try:
+        return scalar[type_args[0] if len(type_args) == 1 else tuple(type_args)]
+    except TypeError:
+        return None
 
 
 def _is_self_recursive_annotation(annotation, scalar, substitutions):
@@ -415,6 +619,419 @@ def _compound_python_field_types(scalar):
     return result
 
 
+def _python_object_python_field_types(scalar):
+    """Ordered Python annotations for a Python-owned structured scalar."""
+    import dataclasses
+    import typing
+
+    explicit = _PYTHON_OBJECT_REGISTRATIONS.get(scalar, ...)
+    if explicit is not ... and explicit is not None:
+        return dict(explicit)
+
+    try:
+        resolved_annotations = typing.get_type_hints(scalar)
+    except (NameError, TypeError):
+        resolved_annotations = {}
+
+    if dataclasses.is_dataclass(scalar):
+        return {
+            field.name: resolved_annotations.get(field.name, field.type)
+            for field in dataclasses.fields(scalar)
+        }
+
+    result = {}
+    for base in reversed(scalar.__mro__):
+        if base is object:
+            continue
+        local = _locally_declared_annotations(base)
+        for name, annotation in local.items():
+            result[name] = resolved_annotations.get(name, annotation)
+    if not result:
+        raise TypeError(
+            f"{scalar.__module__}.{scalar.__qualname__} has no registered fields "
+            "or annotated instance fields")
+    return result
+
+
+def _structured_python_field_types(scalar):
+    """Ordered logical annotations for either structured storage policy."""
+    from ._compat import CompoundScalar
+
+    if isinstance(scalar, type) and issubclass(scalar, CompoundScalar):
+        return _compound_python_field_types(scalar)
+    if _is_python_object_class(scalar):
+        return _python_object_python_field_types(scalar)
+    raise TypeError(f"{scalar!r} is not a structured scalar class")
+
+
+def _structured_specialized_field_types(schema):
+    """Logical annotations with a parameterized class's TypeVars resolved."""
+    import typing
+
+    origin = typing.get_origin(schema) or schema
+    parameters = tuple(getattr(origin, "__parameters__", ()))
+    substitutions = dict(zip(parameters, typing.get_args(schema)))
+    return {
+        name: _substitute_typevars(annotation, substitutions)
+        for name, annotation in _structured_python_field_types(origin).items()
+    }
+
+
+def _python_object_forward_target(annotation, scalar, substitutions):
+    """Resolve a Python structured scalar reference in its defining scope."""
+    import gc
+    import types
+    import typing
+
+    annotation = _substitute_typevars(annotation, substitutions)
+    origin = typing.get_origin(annotation)
+    candidate = origin or annotation
+    if _is_python_object_class(candidate):
+        return candidate
+    if isinstance(annotation, typing.ForwardRef):
+        annotation = annotation.__forward_arg__
+    if origin in (typing.Union, types.UnionType):
+        members = tuple(
+            value for value in typing.get_args(annotation)
+            if value is not type(None)
+        )
+        return (
+            _python_object_forward_target(members[0], scalar, substitutions)
+            if len(members) == 1 else None
+        )
+    if not isinstance(annotation, str):
+        return None
+
+    token = annotation.strip().replace(" ", "").replace("'", "").replace('"', "")
+    for prefix in ("typing.Optional[", "Optional["):
+        if token.startswith(prefix) and token.endswith("]"):
+            token = token[len(prefix):-1]
+    if token.endswith("|None"):
+        token = token[:-5]
+    elif token.startswith("None|"):
+        token = token[5:]
+
+    scope = scalar.__qualname__.rsplit(".", 1)[0]
+    candidates = [
+        candidate for candidate in reversed(_PYTHON_OBJECT_CLASSES)
+        if candidate.__module__ == scalar.__module__
+        and token in (candidate.__name__, candidate.__qualname__)
+    ]
+    if not candidates:
+        module = __import__(scalar.__module__, fromlist=("*",))
+        visible = getattr(module, token, None)
+        if _is_python_object_class(visible):
+            candidates.append(visible)
+    if not candidates:
+        # Function-local dataclasses have no module-global name and no
+        # __init_subclass__ hook. A bounded GC lookup is needed only while
+        # resolving an otherwise-unresolved local forward reference.
+        candidates = [
+            candidate for candidate in gc.get_objects()
+            if isinstance(candidate, type)
+            and candidate.__module__ == scalar.__module__
+            and token in (candidate.__name__, candidate.__qualname__)
+            and _is_python_object_class(candidate)
+        ]
+    selected = next(
+        (
+            candidate for candidate in candidates
+            if candidate.__qualname__.rsplit(".", 1)[0] == scope
+        ),
+        candidates[0] if candidates else None,
+    )
+    if selected is not None and selected not in _PYTHON_OBJECT_CLASSES:
+        _PYTHON_OBJECT_CLASSES.append(selected)
+    return selected
+
+
+def _python_object_field_value_type(annotation, scalar, substitutions):
+    """Resolve a Python-backed Bundle field without validating its value."""
+    import collections.abc as abc
+    import types
+    import typing
+
+    annotation = _substitute_typevars(annotation, substitutions)
+    if (
+        annotation in (typing.Callable, abc.Callable)
+        or typing.get_origin(annotation) is abc.Callable
+    ):
+        return _hgraph.value_type("callable")
+    target = _python_object_forward_target(annotation, scalar, substitutions)
+    if target is not None:
+        if target is scalar:
+            raise TypeError(
+                "self-recursive Python structured scalar containers require "
+                "a recursive value recipe")
+        if issubclass(scalar, target):
+            return _hgraph.owned_vt(_python_object_value_type(target))
+        return _value_type(annotation)
+
+    origin = typing.get_origin(annotation)
+    if origin in (typing.Union, types.UnionType):
+        members = tuple(
+            arg for arg in typing.get_args(annotation) if arg is not type(None)
+        )
+        if len(members) == 1:
+            return _python_object_field_value_type(
+                members[0], scalar, substitutions)
+        return _value_type(annotation)
+    if origin is tuple:
+        args = typing.get_args(annotation)
+        if len(args) == 2 and args[1] is Ellipsis:
+            return _hgraph.tuple_vt(
+                _python_object_field_value_type(args[0], scalar, substitutions))
+        return _hgraph.fixed_tuple_vt([
+            _python_object_field_value_type(arg, scalar, substitutions)
+            for arg in args
+        ])
+    if origin in (frozenset, set):
+        return _hgraph.set_vt(_python_object_field_value_type(
+            typing.get_args(annotation)[0], scalar, substitutions))
+    if origin is dict or getattr(origin, "__name__", "") in (
+        "frozendict", "Mapping", "MutableMapping"
+    ):
+        key, value = typing.get_args(annotation)
+        return _hgraph.map_vt(
+            _python_object_field_value_type(key, scalar, substitutions),
+            _python_object_field_value_type(value, scalar, substitutions),
+        )
+    return _value_type(annotation)
+
+
+def _python_object_namespace(scalar):
+    """Stable nominal namespace, including a local class's defining scope."""
+    qualname = scalar.__qualname__
+    if "<locals>" not in qualname:
+        return scalar.__module__
+    return f"{scalar.__module__}.{qualname.rsplit('.', 1)[0]}"
+
+
+def _python_mutual_recursive_component(scalar):
+    graph = {}
+
+    def visit(current):
+        if current in graph:
+            return
+        edges = {
+            target
+            for annotation in _python_object_python_field_types(current).values()
+            if (target := _python_object_forward_target(
+                annotation, current, {})) is not None
+        }
+        graph[current] = edges
+        for target in edges:
+            visit(target)
+
+    visit(scalar)
+
+    def reaches(start, target, seen=None):
+        if start is target:
+            return True
+        seen = set() if seen is None else seen
+        if start in seen:
+            return False
+        seen.add(start)
+        return any(
+            reaches(child, target, seen) for child in graph.get(start, ()))
+
+    return tuple(
+        candidate for candidate in graph
+        if candidate is not scalar and reaches(candidate, scalar)
+    ) + (scalar,)
+
+
+def _register_python_mutual_recursive_component(component):
+    generation = _hgraph._registry_generation()
+    unique = tuple(dict.fromkeys(component))
+    indices = {scalar: index for index, scalar in enumerate(unique)}
+    definitions = []
+
+    for scalar in unique:
+        parents = [
+            _python_object_value_type(base)
+            for base in scalar.__bases__
+            if _is_python_object_class(base) and base not in indices
+        ]
+        fields = []
+        for name, annotation in _python_object_python_field_types(scalar).items():
+            target = _python_object_forward_target(annotation, scalar, {})
+            if target in indices:
+                fields.append((name, indices[target]))
+            else:
+                fields.append((
+                    name,
+                    _python_object_field_value_type(annotation, scalar, {}),
+                ))
+        definitions.append((
+            _python_object_namespace(scalar),
+            scalar.__name__,
+            fields,
+            parents,
+            False,
+            "__type__",
+            [],
+        ))
+
+    metas = _hgraph.recursive_bundles_vt(definitions)
+    for scalar, meta in zip(unique, metas):
+        if scalar not in _PYTHON_OBJECT_CLASSES:
+            _PYTHON_OBJECT_CLASSES.append(scalar)
+        _register_bundle_class(meta, scalar, python_owned=True)
+        _PYTHON_OBJECT_TYPE_CACHE[(generation, scalar, ())] = meta
+
+
+def _python_object_value_type(scalar, type_args=()):
+    """Return the nominal Bundle schema for a Python-owned object class."""
+    import typing
+
+    cache_key = (_hgraph._registry_generation(), scalar, tuple(type_args))
+    if cache_key in _PYTHON_OBJECT_TYPE_CACHE:
+        return _PYTHON_OBJECT_TYPE_CACHE[cache_key]
+    if not _is_python_object_class(scalar):
+        raise TypeError(f"{scalar!r} is not a registered Python object type")
+    if scalar not in _PYTHON_OBJECT_CLASSES:
+        _PYTHON_OBJECT_CLASSES.append(scalar)
+
+    parameters = tuple(getattr(scalar, "__parameters__", ()))
+    if type_args and len(type_args) != len(parameters):
+        raise TypeError(
+            f"Python structured scalar {scalar.__qualname__} expects "
+            f"{len(parameters)} generic arguments, got {len(type_args)}")
+    substitutions = dict(zip(parameters, type_args))
+
+    if not type_args:
+        component = _python_mutual_recursive_component(scalar)
+        if len(component) > 1:
+            _register_python_mutual_recursive_component(component)
+            return _PYTHON_OBJECT_TYPE_CACHE[cache_key]
+
+    if type_args:
+        argument_patterns = []
+        generic = False
+        for argument in type_args:
+            try:
+                argument_patterns.append(
+                    _hgraph.scalar_pattern_value(_value_type(argument)))
+            except _GenericType as error:
+                if error.pattern is None:
+                    raise TypeError(
+                        f"generic Python object argument {argument!r} "
+                        "has no C++ pattern") from error
+                generic = True
+                argument_patterns.append(error.pattern)
+        if generic:
+            namespace = _python_object_namespace(scalar)
+            qualified_origin = (
+                f"{namespace}::{scalar.__name__}"
+                if namespace else scalar.__name__
+            )
+            raise _GenericType(
+                repr(scalar),
+                _hgraph.scalar_pattern_bundle_generic(
+                    f"__bundle__{qualified_origin}",
+                    qualified_origin,
+                    argument_patterns,
+                ),
+            )
+
+    parent_metas = []
+    inherited_annotations = {}
+    consumed = set()
+    for original_base in scalar.__dict__.get("__orig_bases__", ()):
+        base_origin = typing.get_origin(original_base)
+        if not _is_python_object_class(base_origin):
+            continue
+        base_args = tuple(
+            _substitute_typevars(arg, substitutions)
+            for arg in typing.get_args(original_base)
+        )
+        parent_metas.append(_python_object_value_type(base_origin, base_args))
+        base_substitutions = dict(
+            zip(getattr(base_origin, "__parameters__", ()), base_args))
+        inherited_annotations.update({
+            name: _substitute_typevars(annotation, base_substitutions)
+            for name, annotation
+            in _python_object_python_field_types(base_origin).items()
+        })
+        consumed.add(base_origin)
+    for base in scalar.__bases__:
+        if _is_python_object_class(base) and base not in consumed:
+            parent_metas.append(_python_object_value_type(base))
+            inherited_annotations.update(
+                _python_object_python_field_types(base))
+
+    inherited_fields = {}
+    for parent in parent_metas:
+        for field_name, field_type in parent.fields:
+            previous = inherited_fields.setdefault(field_name, field_type)
+            if previous != field_type:
+                raise TypeError(
+                    f"Python structured scalar {scalar.__qualname__} inherits "
+                    f"incompatible field {field_name!r}")
+
+    annotations = _python_object_python_field_types(scalar)
+    local_annotations = _locally_declared_annotations(scalar)
+    fields = []
+    has_self_recursion = False
+    for field_name, field_type in annotations.items():
+        field_type = _substitute_typevars(field_type, substitutions)
+        if field_name in inherited_fields and field_name not in local_annotations:
+            fields.append((field_name, inherited_fields[field_name]))
+            continue
+        if _is_self_recursive_annotation(field_type, scalar, substitutions):
+            fields.append((field_name, None))
+            has_self_recursion = True
+        else:
+            fields.append((
+                field_name,
+                _python_object_field_value_type(
+                    field_type, scalar, substitutions),
+            ))
+
+    local_name = scalar.__name__
+    if type_args:
+        local_name += "[" + ",".join(
+            _compound_specialization_token(arg) for arg in type_args) + "]"
+    generic_arguments = [_value_type(argument) for argument in type_args]
+    register = (
+        _hgraph.recursive_bundle_vt
+        if has_self_recursion else _hgraph.qualified_bundle_vt
+    )
+    meta = register(
+        _python_object_namespace(scalar),
+        local_name,
+        fields,
+        parent_metas,
+        False,
+        "__type__",
+        generic_arguments,
+    )
+    _register_bundle_class(
+        meta,
+        scalar,
+        python_owned=True,
+        specialization=_specialization_alias(scalar, type_args),
+    )
+    _PYTHON_OBJECT_TYPE_CACHE[cache_key] = meta
+
+    for child in scalar.__subclasses__():
+        if not _is_python_object_class(child):
+            continue
+        if getattr(child, "__parameters__", ()):
+            continue
+        if type_args:
+            matches_specialization = any(
+                typing.get_origin(base) is scalar
+                and tuple(typing.get_args(base)) == tuple(type_args)
+                for base in child.__dict__.get("__orig_bases__", ())
+            )
+            if not matches_specialization:
+                continue
+        _python_object_value_type(child)
+    return meta
+
+
 def _compound_field_value_type(annotation, scalar, substitutions):
     """Resolve a field type, inserting Owned at recursive ancestry edges.
 
@@ -648,7 +1265,11 @@ def _compound_value_type(scalar, type_args=()):
     # Python erases generic arguments on ``instance.__class__``. The runtime
     # schema still carries invariant arguments, while class matching must use
     # the concrete origin class.
-    _register_bundle_class(meta, scalar)
+    _register_bundle_class(
+        meta,
+        scalar,
+        specialization=_specialization_alias(scalar, type_args),
+    )
     _COMPOUND_TYPE_CACHE[cache_key] = meta
 
     # Close the Python-visible subclass set while wiring is still allowed to
@@ -747,6 +1368,8 @@ def _value_type(scalar):
         from ._compat import CompoundScalar
         if isinstance(origin, type) and issubclass(origin, CompoundScalar):
             return _compound_value_type(origin, args)
+        if _is_python_object_class(origin):
+            return _python_object_value_type(origin, args)
         is_mapping_origin = (
             origin is dict
             or getattr(origin, "__name__", "") == "frozendict"
@@ -850,6 +1473,8 @@ def _value_type(scalar):
             # C++-first ruling (2026-07-06): a CompoundScalar IS a C++
             # Bundle value - the schema maps to a named bundle schema.
             return _compound_value_type(scalar)
+        if _is_python_object_class(scalar):
+            return _python_object_value_type(scalar)
     if name is None and isinstance(scalar, type) and issubclass(scalar, _enum.Enum):
         # A python Enum is a FIRST-CLASS enum scalar (nominal identity by
         # class name; the member table interns with the meta and the class
@@ -933,15 +1558,36 @@ class _TsExpr:
             cs_class = getattr(self, "_cs_class", None)
             field_types = {}
             if cs_class is not None:
-                # hgraph parity: UNSUPPLIED fields take their dataclass
+                field_types.update(_structured_specialized_field_types(
+                    getattr(self, "_structured_schema", cs_class)))
+                # hgraph parity: UNSUPPLIED dataclass fields take their
                 # defaults (supplied-but-invalid stays None in non-strict).
                 import dataclasses
 
-                for field in dataclasses.fields(cs_class):
-                    field_types[field.name] = field.type
+                try:
+                    dataclass_fields = dataclasses.fields(cs_class)
+                except TypeError:
+                    dataclass_fields = ()
+                for field in dataclass_fields:
                     if (field.name not in call and field.default is not dataclasses.MISSING
                             and field.default is not None):
                         call[field.name] = field.default
+                if _is_python_object_class(cs_class):
+                    unknown = tuple(name for name in call if name not in field_types)
+                    if unknown:
+                        raise TypeError(
+                            f"combine[{self!r}] received unknown field(s) "
+                            f"{unknown!r}")
+                    missing = tuple(
+                        name
+                        for name in _python_object_required_constructor_fields(
+                            cs_class)
+                        if name not in call
+                    )
+                    if missing:
+                        raise TypeError(
+                            f"combine[{self!r}] requires constructor field(s) "
+                            f"{missing!r}")
             lifted = {}
             for name, value in call.items():
                 unwrapped = _unwrap(value)
@@ -1052,7 +1698,16 @@ class _TsExpr:
 
     """A resolved time-series type: wraps the C++ TsType handle."""
 
-    __slots__ = ("handle", "_label", "is_ref", "_bare_map", "_json", "_cs_class", "_py_class")
+    __slots__ = (
+        "handle",
+        "_label",
+        "is_ref",
+        "_bare_map",
+        "_json",
+        "_cs_class",
+        "_py_class",
+        "_structured_schema",
+    )
 
     def __init__(self, handle, label):
         self.handle = handle
@@ -1165,8 +1820,19 @@ class _TSMeta(type):
             return _GenericTsExpr(f"TS[{scalar!r}]", pattern=_hgraph.type_pattern_ts(e.pattern))
         from ._compat import CompoundScalar as _CS
 
-        if isinstance(scalar, type) and issubclass(scalar, _CS):
-            expr._cs_class = scalar   # combine fills dataclass defaults at wiring
+        structured_origin = typing.get_origin(scalar) or scalar
+        if (
+            isinstance(structured_origin, type)
+            and (
+                issubclass(structured_origin, _CS)
+                or _is_python_object_class(structured_origin)
+            )
+        ):
+            # ``_cs_class`` is the established storage-independent Bundle
+            # marker used by combine/reflection. It deliberately names the
+            # origin because Python aliases are not runtime classes.
+            expr._cs_class = structured_origin
+            expr._structured_schema = scalar
         if isinstance(scalar, type):
             expr._py_class = scalar   # dispatch reads the DECLARED class
         # BARE frozendict (combine[TS[frozendict]](...)): the key/value
@@ -1191,7 +1857,11 @@ class TS(metaclass=_TSMeta):
 class _TSSMeta(type):
     def __getitem__(cls, scalar):
         try:
-            return _TsExpr(_hgraph.tss(_value_type(scalar)), f"TSS[{getattr(scalar, '__name__', scalar)}]")
+            value_type = _value_type(scalar)
+            if not value_type.is_hashable or not value_type.is_equatable:
+                raise TypeError(
+                    f"TSS element type {scalar!r} must be hashable and equatable")
+            return _TsExpr(_hgraph.tss(value_type), f"TSS[{getattr(scalar, '__name__', scalar)}]")
         except _GenericType:
             return _GenericTsExpr(f"TSS[{scalar!r}]", pattern=_hgraph.type_pattern_tss(_scalar_pattern(scalar)))
 
@@ -1219,7 +1889,11 @@ class _TSDMeta(type):
         try:
             if isinstance(value, (_GenericTsExpr, _TypeVarSentinel)):
                 raise _GenericType()
-            return _TsExpr(_hgraph.tsd(_value_type(key), _resolve(value)), f"TSD[{key!r}, {value!r}]")
+            key_type = _value_type(key)
+            if not key_type.is_hashable or not key_type.is_equatable:
+                raise TypeError(
+                    f"TSD key type {key!r} must be hashable and equatable")
+            return _TsExpr(_hgraph.tsd(key_type, _resolve(value)), f"TSD[{key!r}, {value!r}]")
         except _GenericType:
             return _GenericTsExpr(
                 f"TSD[{key!r}, {value!r}]",
@@ -1400,7 +2074,7 @@ class TimeSeriesSchema:
 
     @staticmethod
     def from_scalar_schema(schema):
-        """Lift every logical CompoundScalar field to a ``TS`` field.
+        """Lift every logical structured scalar field to a ``TS`` field.
 
         The generated class is cached on the scalar schema, matching the
         upstream API and preserving nominal identity across repeated calls.
@@ -1409,16 +2083,27 @@ class TimeSeriesSchema:
 
         if schema is CompoundScalar:
             return TimeSeriesSchema
-        if not isinstance(schema, type) or not issubclass(schema, CompoundScalar):
+        if (
+            not isinstance(schema, type)
+            or not (
+                issubclass(schema, CompoundScalar)
+                or _is_python_object_class(schema)
+            )
+        ):
             raise TypeError(
-                f"Can only create bundle schema from CompoundScalar classes, not {schema!r}")
+                "Can only create bundle schema from structured scalar "
+                f"classes, not {schema!r}")
         cached = schema.__dict__.get("__bundle_type__")
         if cached is not None:
             return cached
 
         annotations = {
             name: TS[annotation]
-            for name, annotation in _compound_python_field_types(schema).items()
+            for name, annotation in (
+                _compound_python_field_types(schema)
+                if issubclass(schema, CompoundScalar)
+                else _python_object_python_field_types(schema)
+            ).items()
         }
         bundle = type(
             f"{schema.__name__}Bundle",
@@ -1491,21 +2176,26 @@ class _TSBMeta(type):
         for klass in reversed(origin.__mro__):
             annotations.update(getattr(klass, "__annotations__", {}))
         is_cs = issubclass(origin, _CS)
+        is_python_object = _is_python_object_class(origin)
         compound_meta = None
-        if is_cs:
-            # TSB[CompoundScalar]: scalar annotations LIFT to TS fields; the
-            # bundle keeps the CS NAME (and registers the class) so its
-            # value side IS the CS bundle and reads back as the dataclass.
+        if is_cs or is_python_object:
+            # TSB[structured scalar]: scalar annotations LIFT to TS fields;
+            # the bundle keeps the scalar Bundle name so conversion uses the
+            # registered native or Python-owned construction policy.
             try:
                 compound_meta = _value_type(schema)
             except _GenericType:
-                # Keep an unspecialized CompoundScalar as a C++ type pattern;
-                # its nominal Bundle is created after scalar resolution.
+                # Keep an unspecialized structured scalar as a C++ type
+                # pattern; its nominal Bundle is created after resolution.
                 compound_meta = None
             substitutions = dict(zip(parameters, type_args))
             annotations = {
                 name: TS[_substitute_typevars(tp, substitutions)]
-                for name, tp in _compound_python_field_types(origin).items()
+                for name, tp in (
+                    _compound_python_field_types(origin)
+                    if is_cs
+                    else _python_object_python_field_types(origin)
+                ).items()
             }
 
         field_names = []

--- a/python/hgraph/_wiring/_operator.py
+++ b/python/hgraph/_wiring/_operator.py
@@ -355,7 +355,9 @@ def _register_overload(target, impl, requires=None):
 # ---------------------------------------------------------------------------
 
 def _dispatch_specificity(cls):
-    return len(cls.__mro__)
+    import typing
+
+    return len((typing.get_origin(cls) or cls).__mro__)
 
 
 def _dispatch_key_node():
@@ -422,10 +424,10 @@ def _declared_dispatch_class(annotation):
     expression carries the class AND the value schema decides the kind;
     atomic scalars like TS[int] are not dispatch subjects)."""
     cls = getattr(annotation, "_py_class", None)
+    if getattr(annotation, "_cs_class", None) is not None:
+        return getattr(annotation, "_structured_schema", None) or cls
     if cls is None:
         return None
-    if getattr(annotation, "_cs_class", None) is not None:
-        return cls
     handle = getattr(annotation, "handle", None)
     if handle is not None and handle.is_ts and _is_object_vt(_hgraph.ts_value_vt(handle)):
         return cls
@@ -491,7 +493,10 @@ def _dispatch_branch(op, impl, root_signature, branch_signature, scalar_argument
         )
         return callable_(*bound.args, **bound.kwargs)
 
-    suffix = "_".join(cls.__name__ for cls in dispatch_types.values())
+    suffix = "_".join(
+        getattr(cls, "__name__", repr(cls)).replace(".", "_")
+        for cls in dispatch_types.values()
+    )
     invoke.__name__ = f"__dispatch_{op.__name__}_{suffix}"
     invoke.__signature__ = branch_signature
     return _GraphFn(invoke)
@@ -565,10 +570,13 @@ def dispatch_(overloaded, *args, __on__=None, __output_type=None, **kwargs):
                     f"{impl.__name__}: dispatch parameter '{name}' must be a "
                     "TS[class] or a union of TS[class] annotations"
                 )
-            if not all(issubclass(cls, dispatch_params[name]) for cls in classes):
+            import typing
+            base = typing.get_origin(dispatch_params[name]) or dispatch_params[name]
+            if not all(issubclass(typing.get_origin(cls) or cls, base)
+                       for cls in classes):
                 raise WiringError(
                     f"{impl.__name__}: dispatch parameter '{name}' is outside "
-                    f"{dispatch_params[name].__name__}"
+                    f"{getattr(dispatch_params[name], '__name__', dispatch_params[name])}"
                 )
             class_options.append(classes)
         from itertools import product

--- a/python/hgraph/reflection.py
+++ b/python/hgraph/reflection.py
@@ -37,7 +37,13 @@ from datetime import date, datetime, time, timedelta
 
 import _hgraph as _m
 
-from ._types import _TsExpr, _compound_python_field_types, _value_type
+from ._types import (
+    _TsExpr,
+    _is_python_object_class,
+    _structured_specialized_field_types,
+    _structured_python_field_types,
+    _value_type,
+)
 
 __all__ = (
     "scalar_type",
@@ -133,6 +139,9 @@ def scalar_type(t):
     if h.is_tss:
         return _vt_to_py(_m.vt_element(_m.ts_value_vt(h)))
     if h.is_ts:
+        structured_schema = getattr(t, "_structured_schema", None)
+        if structured_schema is not None:
+            return structured_schema
         cs = getattr(t, "_cs_class", None)
         if cs is not None:
             return cs
@@ -189,9 +198,16 @@ def fields(t):
     """
     if isinstance(t, Mapping):
         return {name: resolved_type(value) for name, value in t.items()}
-    # A compound-scalar class (dataclass) passed directly: its scalar fields.
-    if isinstance(t, type) and dataclasses.is_dataclass(t):
-        return dict(_compound_python_field_types(t))
+    import typing
+
+    origin = typing.get_origin(t)
+    if _is_python_object_class(origin):
+        return dict(_structured_specialized_field_types(t))
+    # A structured scalar class passed directly: its scalar fields.
+    if isinstance(t, type) and (
+        dataclasses.is_dataclass(t) or _is_python_object_class(t)
+    ):
+        return dict(_structured_python_field_types(t))
     if isinstance(t, _m.ValueType):
         python_type = _m.python_type_for_value(t)
         if python_type is not t and isinstance(python_type, type):
@@ -208,7 +224,8 @@ def fields(t):
         return {name: _wrap(field) for name, field in _m.ts_field_types(h)}
     cs = getattr(t, "_cs_class", None)
     if cs is not None:
-        return dict(_compound_python_field_types(cs))
+        schema = getattr(t, "_structured_schema", cs)
+        return dict(_structured_specialized_field_types(schema))
     raise TypeError(f"fields expects a TSB or compound-scalar type, got {t!r}")
 
 
@@ -254,7 +271,7 @@ def is_bundle(t):
 
 
 def is_compound_scalar(t):
-    """``True`` if ``t`` is a ``TS`` over a compound scalar."""
+    """``True`` if ``t`` is a ``TS`` over either structured scalar policy."""
     return _handle(t).is_ts and getattr(t, "_cs_class", None) is not None
 
 

--- a/python/module.cpp
+++ b/python/module.cpp
@@ -166,6 +166,7 @@ NB_MODULE(_hgraph, m)
         python_bridge::bundle_class_registry().clear();
         python_bridge::bundle_class_info_registry().clear();
         python_bridge::tsb_compound_value_registry().clear();
+        python_bridge::clear_python_bundle_bindings();
         python_bridge::clear_native_scalar_types();
         reset_all_registries();
         ++python_registry_generation;

--- a/python/py_ports.cpp
+++ b/python/py_ports.cpp
@@ -352,11 +352,33 @@ void bind_ports(nb::module_ &m) {
   });
   m.def(
       "register_bundle_class",
-      [](PyValueType type, nb::object cls, nb::tuple constructor_fields,
-         bool constructor_accepts_kwargs, nb::tuple raw_descriptor_fields,
-         bool force_constructor) {
+      [](PyValueType type, nb::object cls, nb::object specialization,
+         nb::tuple constructor_fields, bool constructor_accepts_kwargs,
+         nb::tuple raw_descriptor_fields,
+         nb::tuple defaulted_constructor_fields, bool force_constructor) {
         auto &info = bundle_class_info_registry()[type.meta];
+        if (info.type.is_valid() && !info.type.is(cls)) {
+          throw nb::type_error("Bundle schema is already registered to a "
+                               "different Python class");
+        }
+        const bool has_specialization =
+            specialization.is_valid() && !specialization.is_none();
+        if (info.specialization.is_valid() != has_specialization ||
+            (has_specialization &&
+             PyObject_RichCompareBool(info.specialization.ptr(),
+                                      specialization.ptr(), Py_EQ) != 1)) {
+          if (info.type.is_valid()) {
+            if (PyErr_Occurred() != nullptr) {
+              nb::raise_python_error();
+            }
+            throw nb::type_error(
+                "Bundle schema is already registered with a different "
+                "Python specialization");
+          }
+        }
         info.type = cls;
+        info.specialization =
+            has_specialization ? specialization : nb::object{};
         info.allocator =
             reinterpret_cast<PyBundleClassInfo::Allocator>(PyType_GetSlot(
                 reinterpret_cast<PyTypeObject *>(cls.ptr()), Py_tp_alloc));
@@ -369,6 +391,7 @@ void bind_ports(nb::module_ &m) {
         info.field_overrides.reserve(type.meta->field_count);
         info.constructor_fields.assign(type.meta->field_count,
                                        constructor_accepts_kwargs);
+        info.defaulted_constructor_fields.assign(type.meta->field_count, false);
         info.requires_constructor = force_constructor;
         std::vector<bool> raw_descriptors(type.meta->field_count, false);
         for (nb::handle constructor_field : constructor_fields) {
@@ -387,6 +410,16 @@ void bind_ports(nb::module_ &m) {
             const char *field_name = type.meta->fields[index].name;
             if (field_name != nullptr && name == field_name) {
               raw_descriptors[index] = true;
+              break;
+            }
+          }
+        }
+        for (nb::handle defaulted_field : defaulted_constructor_fields) {
+          const std::string name = nb::cast<std::string>(defaulted_field);
+          for (std::size_t index = 0; index < type.meta->field_count; ++index) {
+            const char *field_name = type.meta->fields[index].name;
+            if (field_name != nullptr && name == field_name) {
+              info.defaulted_constructor_fields[index] = true;
               break;
             }
           }
@@ -441,21 +474,25 @@ void bind_ports(nb::module_ &m) {
         bundle_class_registry()[nb::int_(
             reinterpret_cast<std::uintptr_t>(type.meta))] = std::move(cls);
       },
-      nb::arg("type"), nb::arg("cls"),
+      nb::arg("type"), nb::arg("cls"), nb::arg("specialization") = nb::none(),
       nb::arg("constructor_fields") = nb::tuple(),
       nb::arg("constructor_accepts_kwargs") = false,
       nb::arg("raw_descriptor_fields") = nb::tuple(),
+      nb::arg("defaulted_constructor_fields") = nb::tuple(),
       nb::arg("force_constructor") = false);
-  m.def("register_tsb_compound_class",
-        [](PyTsType tsb, PyValueType value) {
-          if (tsb.meta == nullptr || tsb.meta->kind != TSTypeKind::TSB ||
-              value.meta == nullptr ||
-              value.meta->value_kind() != ValueTypeKind::Bundle) {
-            throw nb::type_error(
-                "register_tsb_compound_class requires TSB and Bundle schemas");
-          }
-          tsb_compound_value_registry()[tsb.meta] = value.meta;
-        });
+  m.def(
+      "register_python_bundle_binding",
+      [](PyValueType type) { register_python_bundle_binding(type.meta); },
+      nb::arg("type"));
+  m.def("register_tsb_compound_class", [](PyTsType tsb, PyValueType value) {
+    if (tsb.meta == nullptr || tsb.meta->kind != TSTypeKind::TSB ||
+        value.meta == nullptr ||
+        value.meta->value_kind() != ValueTypeKind::Bundle) {
+      throw nb::type_error(
+          "register_tsb_compound_class requires TSB and Bundle schemas");
+    }
+    tsb_compound_value_registry()[tsb.meta] = value.meta;
+  });
 
   m.def("tsl_element", [](const PyPort &port, std::size_t index) {
     // Fixed-TSL scalar indexing: the structural element projection

--- a/python/py_type_system.cpp
+++ b/python/py_type_system.cpp
@@ -164,6 +164,15 @@ namespace hgraph::python_bridge
         .def_prop_ro("local_name", [](const PyValueType &self) {
             return self.meta != nullptr ? std::string{self.meta->bundle_local_name()} : std::string{};
         })
+        .def_prop_ro("is_hashable", [](const PyValueType &self) {
+            return self.meta != nullptr && self.meta->is_hashable();
+        })
+        .def_prop_ro("is_equatable", [](const PyValueType &self) {
+            return self.meta != nullptr && self.meta->is_equatable();
+        })
+        .def_prop_ro("is_comparable", [](const PyValueType &self) {
+            return self.meta != nullptr && self.meta->is_comparable();
+        })
         .def_prop_ro("fields", [](const PyValueType &self) {
             nb::list result;
             if (self.meta == nullptr) { return result; }
@@ -199,7 +208,9 @@ namespace hgraph::python_bridge
         const auto bundle = bundle_class_info_registry().find(value.meta);
         if (bundle != bundle_class_info_registry().end() && bundle->second.type.is_valid())
         {
-            return bundle->second.type;
+            return bundle->second.specialization.is_valid()
+                       ? bundle->second.specialization
+                       : bundle->second.type;
         }
         const auto enumeration = enum_class_registry().find(value.meta);
         if (enumeration != enum_class_registry().end()) { return enumeration->second; }

--- a/python/tests/test_python_owned_structured_scalar.py
+++ b/python/tests/test_python_owned_structured_scalar.py
@@ -1,0 +1,592 @@
+import json
+from dataclasses import dataclass, field
+from typing import Generic, Optional, TypeVar
+
+import pytest
+
+from hgraph import (
+    MIN_TD,
+    SCALAR,
+    TS,
+    TSB,
+    TSD,
+    TSS,
+    TimeSeriesSchema,
+    combine,
+    compute_node,
+    convert,
+    dispatch_,
+    drop_dups,
+    eq_,
+    from_json_builder,
+    generator,
+    getattr_,
+    graph,
+    operator,
+    register_python_object_type,
+    to_json_builder,
+)
+from hgraph._types import _value_type
+from hgraph.reflection import fields, is_compound_scalar, scalar_type
+from hgraph.test import eval_node
+
+
+def test_plain_dataclass_is_a_nominal_python_owned_bundle():
+    @dataclass(frozen=True)
+    class Quote:
+        instrument: str
+        bid: float
+        ask: float
+
+    meta = _value_type(Quote)
+    quote = Quote("ABC", 100.0, 101.0)
+
+    @compute_node
+    def identity(value: TS[Quote]) -> TS[Quote]:
+        return value.value
+
+    @graph
+    def bid(value: TS[Quote]) -> TS[float]:
+        return value.bid
+
+    result = eval_node(identity, [quote])
+    assert result[0] is quote
+    assert eval_node(bid, [quote]) == [100.0]
+    assert meta.name.endswith("::Quote")
+    assert fields(Quote) == {
+        "instrument": str,
+        "bid": float,
+        "ask": float,
+    }
+    assert fields(TS[Quote]) == fields(Quote)
+    assert scalar_type(TS[Quote]) is Quote
+    assert is_compound_scalar(TS[Quote])
+
+
+def test_python_owned_assignment_is_lenient_until_a_field_is_extracted():
+    @dataclass(frozen=True)
+    class Descriptive:
+        number: int
+
+    value = Descriptive("accepted by Python")
+
+    @compute_node
+    def identity(source: TS[Descriptive]) -> TS[Descriptive]:
+        return source.value
+
+    @graph
+    def number(source: TS[Descriptive]) -> TS[int]:
+        return source.number
+
+    assert eval_node(identity, [value])[0] is value
+    with pytest.raises(Exception, match="int"):
+        eval_node(number, [value])
+
+
+def test_explicit_registration_supports_annotated_application_classes():
+    @register_python_object_type
+    class LegacyQuote:
+        instrument: str
+        price: float
+
+        def __init__(self, price, instrument="ABC"):
+            self.instrument = instrument
+            self.price = price
+
+    value = LegacyQuote(42.0)
+
+    @compute_node
+    def identity(source: TS[LegacyQuote]) -> TS[LegacyQuote]:
+        return source.value
+
+    @graph
+    def from_bundle(price: TS[float]) -> TS[LegacyQuote]:
+        return combine[TSB[LegacyQuote]](price=price).as_scalar_ts()
+
+    assert register_python_object_type(LegacyQuote) is LegacyQuote
+    assert fields(LegacyQuote) == {"instrument": str, "price": float}
+    assert eval_node(identity, [value])[0] is value
+    reconstructed = eval_node(from_bundle, [42.0])[0]
+    assert reconstructed.instrument == "ABC"
+    assert reconstructed.price == 42.0
+
+
+def test_explicit_registration_accepts_an_ordered_field_mapping():
+    class Legacy:
+        def __init__(self, left, right):
+            self.left = left
+            self.right = right
+
+    register_python_object_type(
+        Legacy, fields={"left": int, "right": str})
+
+    assert fields(Legacy) == {"left": int, "right": str}
+    with pytest.raises(TypeError, match="different field schema"):
+        register_python_object_type(
+            Legacy, fields={"left": str, "right": str})
+
+
+def test_explicit_class_without_a_field_constructor_is_not_silently_rebuilt():
+    @register_python_object_type
+    class SchemaOnly:
+        value: int
+
+    source = SchemaOnly()
+    source.value = 3
+
+    @compute_node
+    def identity(value: TS[SchemaOnly]) -> TS[SchemaOnly]:
+        return value.value
+
+    assert eval_node(identity, [source])[0] is source
+    encoded = to_json_builder(SchemaOnly)(source)
+    with pytest.raises(Exception, match="argument|keyword|constructor"):
+        from_json_builder(SchemaOnly)(encoded)
+
+
+def test_parameterized_dataclasses_resolve_invariant_field_schemas():
+    value_type = TypeVar("value_type")
+
+    @dataclass(frozen=True)
+    class Box(Generic[value_type]):
+        value: value_type
+
+    integer_box = _value_type(Box[int])
+    string_box = _value_type(Box[str])
+    value = Box[int](7)
+
+    @compute_node
+    def identity(source: TS[Box[int]]) -> TS[Box[int]]:
+        return source.value
+
+    @graph
+    def from_bundle(value: TS[int]) -> TS[Box[int]]:
+        return combine[TSB[Box[int]]](value=value).as_scalar_ts()
+
+    assert integer_box != string_box
+    assert integer_box.local_name == "Box[int]"
+    assert string_box.local_name == "Box[str]"
+    assert fields(Box[int]) == {"value": int}
+    assert fields(TS[Box[str]]) == {"value": str}
+    assert scalar_type(TS[Box[int]]) == Box[int]
+    assert eval_node(identity, [value])[0] is value
+    assert eval_node(from_bundle, [7]) == [Box[int](7)]
+
+
+def test_parameterized_dataclass_inheritance_preserves_the_active_child():
+    value_type = TypeVar("value_type")
+
+    @dataclass(frozen=True)
+    class Base(Generic[value_type]):
+        value: value_type
+
+    @dataclass(frozen=True)
+    class IntegerValue(Base[int]):
+        label: str
+
+    @compute_node
+    def upcast(value: TS[IntegerValue]) -> TS[Base[int]]:
+        return value.value
+
+    @compute_node
+    def is_child(value: TS[Base[int]]) -> TS[bool]:
+        return isinstance(value.value, IntegerValue)
+
+    @graph
+    def app(value: TS[IntegerValue]) -> TS[bool]:
+        return is_child(upcast(value))
+
+    assert fields(TS[Base[int]]) == {"value": int}
+    assert eval_node(
+        app, [IntegerValue(value=1, label="one")]) == [True]
+
+
+def test_tsb_round_trip_preserves_a_python_owned_polymorphic_field():
+    @dataclass(frozen=True)
+    class Instrument:
+        symbol: str
+
+    @dataclass(frozen=True)
+    class Future(Instrument):
+        expiry: str
+
+    @dataclass(frozen=True)
+    class Envelope:
+        instrument: Instrument
+
+    @graph
+    def round_trip(instrument: TS[Instrument]) -> TS[Envelope]:
+        return combine[TSB[Envelope]](
+            instrument=instrument).as_scalar_ts()
+
+    future = Future("ES", "2026-09")
+    result = eval_node(round_trip, [future])
+    assert result == [Envelope(future)]
+    assert type(result[0].instrument) is Future
+
+
+def test_combine_and_tsb_round_trip_use_the_python_constructor():
+    initialized = []
+
+    @dataclass(frozen=True, kw_only=True)
+    class Quote:
+        instrument: str
+        bid: float
+        ask: float = 0.0
+        tags: tuple[str, ...] = field(default_factory=tuple)
+        spread: float = field(init=False)
+
+        def __post_init__(self):
+            object.__setattr__(self, "spread", self.ask - self.bid)
+            initialized.append(self.instrument)
+
+    @graph
+    def build(bid: TS[float]) -> TS[Quote]:
+        return combine[TS[Quote]](instrument="ABC", bid=bid)
+
+    @graph
+    def from_bundle(bid: TS[float], ask: TS[float]) -> TS[Quote]:
+        bundle = combine[TSB[Quote]](
+            instrument="ABC", bid=bid, ask=ask)
+        return bundle.as_scalar_ts()
+
+    assert eval_node(build, [100.0]) == [
+        Quote(instrument="ABC", bid=100.0)]
+    assert eval_node(from_bundle, [100.0], [101.5]) == [
+        Quote(instrument="ABC", bid=100.0, ask=101.5)]
+    assert eval_node(from_bundle, [None, 100.0], [101.5, None]) == [
+        None, Quote(instrument="ABC", bid=100.0, ask=101.5)]
+
+    @graph
+    def missing_required(bid: TS[float]) -> TS[Quote]:
+        return combine[TS[Quote]](bid=bid)
+
+    @graph
+    def unknown_field(bid: TS[float]) -> TS[Quote]:
+        return combine[TS[Quote]](instrument="ABC", bid=bid, typo=1)
+
+    with pytest.raises(TypeError, match="instrument"):
+        eval_node(missing_required, [100.0])
+    with pytest.raises(TypeError, match="unknown field"):
+        eval_node(unknown_field, [100.0])
+    assert initialized.count("ABC") >= 4
+
+
+def test_declared_and_computed_attribute_projection_uses_python_lookup():
+    @dataclass(frozen=True)
+    class Quote:
+        bid: float
+        ask: float
+
+        @property
+        def mid(self):
+            return (self.bid + self.ask) / 2.0
+
+    @graph
+    def declared(value: TS[Quote]) -> TS[float]:
+        return value.ask
+
+    @graph
+    def computed(value: TS[Quote]) -> TS[float]:
+        return getattr_[SCALAR: float](value, "mid")
+
+    values = [Quote(100.0, 102.0)]
+    assert eval_node(declared, values) == [102.0]
+    assert eval_node(computed, values) == [101.0]
+
+
+def test_python_owned_hierarchy_uses_native_bundle_dispatch():
+    @dataclass(frozen=True)
+    class Animal:
+        name: str
+
+    @dataclass(frozen=True)
+    class Dog(Animal):
+        volume: int
+
+    @dataclass(frozen=True)
+    class Puppy(Dog):
+        cute: bool = True
+
+    @operator
+    def sound(animal: TS[Animal]) -> TS[str]: ...
+
+    @compute_node(overloads=sound)
+    def dog_sound(animal: TS[Dog]) -> TS[str]:
+        return type(animal.value).__name__
+
+    @graph
+    def app(animal: TS[Animal]) -> TS[str]:
+        return dispatch_(sound, animal)
+
+    assert eval_node(
+        app,
+        [Dog("dog", 1), Puppy("puppy", 2)],
+    ) == ["Dog", "Puppy"]
+
+
+def test_dispatch_distinguishes_python_generic_specializations():
+    value_type = TypeVar("value_type")
+
+    @dataclass(frozen=True)
+    class Value:
+        name: str
+
+    @dataclass(frozen=True)
+    class Box(Value, Generic[value_type]):
+        item: value_type
+
+    @operator
+    def describe(value: TS[Value]) -> TS[str]: ...
+
+    @compute_node(overloads=describe)
+    def describe_int(value: TS[Box[int]]) -> TS[str]:
+        return f"int:{value.value.item}"
+
+    @compute_node(overloads=describe)
+    def describe_str(value: TS[Box[str]]) -> TS[str]:
+        return f"str:{value.value.item}"
+
+    @graph
+    def app(value: TS[Value]) -> TS[str]:
+        return dispatch_(describe, value)
+
+    assert eval_node(
+        app,
+        [Box[int]("one", 1), Box[str]("two", "two")],
+    ) == ["int:1", "str:two"]
+
+
+def test_python_equality_hashing_and_deduplication_are_preserved():
+    @dataclass(frozen=True, eq=False)
+    class Key:
+        value: int
+
+        def __eq__(self, other):
+            return isinstance(other, Key) and self.value % 2 == other.value % 2
+
+        def __hash__(self):
+            return hash(self.value % 2)
+
+    @graph
+    def same(lhs: TS[Key], rhs: TS[Key]) -> TS[bool]:
+        return eq_(lhs, rhs)
+
+    first = Key(1)
+    equal = Key(3)
+    different = Key(2)
+    assert eval_node(same, [first, first], [equal, different]) == [
+        True, False]
+    assert eval_node(drop_dups, [first, equal, different],
+                     resolution_dict={"ts": TS[Key]}) == [
+        first, None, different]
+    assert TSS[Key].handle.is_tss
+    assert TSD[Key, TS[int]].handle.is_tsd
+
+    @dataclass
+    class Unhashable:
+        value: int
+
+    with pytest.raises(TypeError, match="hashable"):
+        TSS[Unhashable]
+    with pytest.raises(TypeError, match="hashable"):
+        TSD[Unhashable, TS[int]]
+
+
+def test_python_equality_exceptions_cross_the_bridge():
+    @dataclass(frozen=True, eq=False)
+    class Explosive:
+        value: int
+
+        def __eq__(self, other):
+            raise ValueError("equality exploded")
+
+    @graph
+    def same(lhs: TS[Explosive], rhs: TS[Explosive]) -> TS[bool]:
+        return eq_(lhs, rhs)
+
+    with pytest.raises(Exception, match="equality exploded"):
+        eval_node(same, [Explosive(1)], [Explosive(1)])
+
+
+def test_recursive_python_owned_dataclass_preserves_nested_objects():
+    @dataclass(frozen=True)
+    class Recursive:
+        value: int
+        next: Optional["Recursive"] = None
+
+    @compute_node
+    def child_value(value: TS[Recursive]) -> TS[int]:
+        child = value.value.next
+        return -1 if child is None else child.value
+
+    source = Recursive(1, Recursive(2))
+    assert eval_node(child_value, [source, Recursive(3)]) == [2, -1]
+
+
+def test_time_series_schema_can_be_lifted_from_python_owned_dataclass():
+    @dataclass(frozen=True)
+    class Quote:
+        bid: float
+        ask: float
+
+    schema = TimeSeriesSchema.from_scalar_schema(Quote)
+
+    assert schema.scalar_type() is Quote
+    assert schema.__annotations__ == {"bid": TS[float], "ask": TS[float]}
+    assert TSB[schema].handle.is_tsb
+
+
+def test_generic_typevar_resolution_and_nested_container_substitution():
+    value_type = TypeVar("value_type")
+
+    @dataclass(frozen=True)
+    class Box(Generic[value_type]):
+        value: value_type
+
+    @dataclass(frozen=True)
+    class Batch(Generic[value_type]):
+        values: tuple[Box[value_type], ...]
+
+    @compute_node
+    def unbox(value: TS[Box[value_type]]) -> TS[value_type]:
+        return value.value.value
+
+    assert fields(Batch[int]) == {"values": tuple[Box[int], ...]}
+    assert eval_node(
+        unbox,
+        [Box[int](1), Box[int](2)],
+        resolution_dict={"value": TS[Box[int]]},
+    ) == [1, 2]
+
+
+def test_bundle_conversion_and_json_codec_reconstruct_the_python_class():
+    @dataclass(frozen=True)
+    class Quote:
+        bid: float
+        ask: float
+
+    @graph
+    def as_bundle(value: TS[Quote]) -> TSB[Quote]:
+        return convert[TSB](value)
+
+    quote = Quote(100.0, 101.0)
+    assert eval_node(as_bundle, [quote]) == [
+        {"bid": 100.0, "ask": 101.0}]
+
+    encoded = to_json_builder(Quote)(quote)
+    decoded = from_json_builder(Quote)(encoded)
+    assert json.loads(encoded) == {"bid": 100.0, "ask": 101.0}
+    assert decoded == quote
+    assert type(decoded) is Quote
+
+
+def test_none_missing_and_descriptor_errors_follow_python_attribute_semantics():
+    @dataclass(frozen=True)
+    class Maybe:
+        value: int
+
+    @graph
+    def value_or_default(source: TS[Maybe]) -> TS[int]:
+        return getattr_(source, "value", 7)
+
+    assert eval_node(value_or_default, [Maybe(None), Maybe(2)]) == [7, 2]
+
+    @register_python_object_type
+    class Explosive:
+        value: int
+
+        def __init__(self, value=0):
+            self._value = value
+
+        @property
+        def value(self):
+            raise ValueError("descriptor exploded")
+
+    @graph
+    def projected(source: TS[Explosive]) -> TS[int]:
+        return source.value
+
+    with pytest.raises(
+        Exception,
+        match=r"Explosive.*field 'value'|field 'value'.*Explosive",
+    ):
+        eval_node(projected, [Explosive()])
+
+
+def test_mutually_recursive_python_owned_classes_are_schema_only_recursion():
+    @dataclass(frozen=True)
+    class Left:
+        value: int
+        right: Optional["Right"] = None
+
+    @dataclass(frozen=True)
+    class Right:
+        value: int
+        left: Optional[Left] = None
+
+    @compute_node
+    def nested_value(value: TS[Left]) -> TS[int]:
+        return value.value.right.left.value
+
+    source = Left(1, Right(2, Left(3)))
+    assert eval_node(nested_value, [source]) == [3]
+
+
+def test_in_place_mutation_does_not_create_a_new_value_tick():
+    @dataclass
+    class Mutable:
+        number: int
+
+    @generator
+    def values() -> TS[Mutable]:
+        value = Mutable(1)
+        yield MIN_TD, value
+        value.number = 2
+        yield MIN_TD, value
+        yield MIN_TD, Mutable(3)
+
+    @graph
+    def app() -> TS[int]:
+        return drop_dups(values()).number
+
+    # The generator resumes and mutates the retained object before the
+    # downstream projection, so the first read may already observe 2. The
+    # repeated object itself creates no second tick; the new object does.
+    assert eval_node(app) == [None, 2, None, 3]
+
+
+def test_multiple_inheritance_dispatch_reports_ambiguity():
+    @dataclass(frozen=True)
+    class Root:
+        value: int
+
+    @dataclass(frozen=True)
+    class Left(Root):
+        left: int
+
+    @dataclass(frozen=True)
+    class Right(Root):
+        right: int
+
+    @dataclass(frozen=True)
+    class Hybrid(Left, Right):
+        hybrid: int
+
+    @operator
+    def describe(value: TS[Root]) -> TS[str]: ...
+
+    @graph(overloads=describe)
+    def describe_left(value: TS[Left]) -> TS[str]:
+        return "left"
+
+    @graph(overloads=describe)
+    def describe_right(value: TS[Right]) -> TS[str]:
+        return "right"
+
+    @graph
+    def app(value: TS[Root]) -> TS[str]:
+        return dispatch_(describe, value)
+
+    with pytest.raises(RuntimeError, match="Ambiguous dispatch"):
+        eval_node(app, [Hybrid(value=1, left=2, right=3, hybrid=4)])

--- a/python/value_conversion.cpp
+++ b/python/value_conversion.cpp
@@ -14,9 +14,11 @@
 
 #include <chrono>
 #include <cstdint>
+#include <limits>
 #include <memory>
 #include <optional>
 #include <ranges>
+#include <span>
 #include <stdexcept>
 #include <string>
 #include <string_view>
@@ -207,24 +209,69 @@ namespace hgraph::python_bridge
             return box_any(Value{PyObj{nb::borrow<nb::object>(object)}});
         }
 
-        [[nodiscard]] std::optional<Value> try_python_bundle_value(nb::handle object)
+        [[nodiscard]] std::size_t python_mro_distance(nb::handle source_class,
+                                                      nb::handle registered_class)
+        {
+            nb::tuple mro = nb::cast<nb::tuple>(nb::getattr(source_class, "__mro__"));
+            for (std::size_t index = 0; index < mro.size(); ++index)
+            {
+                if (mro[index].is(registered_class)) { return index; }
+            }
+            return std::numeric_limits<std::size_t>::max();
+        }
+
+        [[nodiscard]] const ValueTypeMetaData *select_python_bundle_schema(
+            nb::handle object, std::span<const ValueTypeMetaData *const> permitted)
         {
             const nb::object source_class = nb::getattr(object, "__class__");
             std::vector<const ValueTypeMetaData *> candidates;
-            for (const auto &[schema, info] : bundle_class_info_registry())
+            std::size_t best_distance = std::numeric_limits<std::size_t>::max();
+            for (const auto *schema : permitted)
             {
-                if (info.type.is_valid() && source_class.is(info.type))
+                const auto found = bundle_class_info_registry().find(schema);
+                if (found == bundle_class_info_registry().end() ||
+                    !found->second.type.is_valid() ||
+                    !nb::isinstance(object, found->second.type))
                 {
-                    candidates.push_back(static_cast<const ValueTypeMetaData *>(schema));
+                    continue;
                 }
+                const auto distance = python_mro_distance(source_class, found->second.type);
+                if (distance < best_distance)
+                {
+                    best_distance = distance;
+                    candidates.clear();
+                }
+                if (distance == best_distance) { candidates.push_back(schema); }
             }
-            if (candidates.empty()) { return std::nullopt; }
-            if (candidates.size() == 1) { return py_to_value_as(object, candidates.front()); }
+            if (candidates.empty()) { return nullptr; }
+            if (candidates.size() == 1) { return candidates.front(); }
 
-            // Frozen dataclass generics cannot retain ``__orig_class__``. Rank
-            // their registered specialisations by exact field-value schemas;
-            // a tie remains opaque so overload resolution cannot depend on
-            // unordered registry iteration.
+            // A non-frozen generic instance normally retains its alias.
+            if (nb::hasattr(object, "__orig_class__"))
+            {
+                nb::object alias = nb::getattr(object, "__orig_class__");
+                const ValueTypeMetaData *matched = nullptr;
+                for (const auto *candidate : candidates)
+                {
+                    const auto &info = bundle_class_info_registry().at(candidate);
+                    if (!info.specialization.is_valid()) { continue; }
+                    const int equal = PyObject_RichCompareBool(
+                        alias.ptr(), info.specialization.ptr(), Py_EQ);
+                    if (equal < 0) { nb::raise_python_error(); }
+                    if (equal == 0) { continue; }
+                    if (matched != nullptr)
+                    {
+                        throw std::invalid_argument(
+                            "Python structured scalar specialization is ambiguous");
+                    }
+                    matched = candidate;
+                }
+                if (matched != nullptr) { return matched; }
+            }
+
+            // Frozen dataclass generics cannot retain ``__orig_class__``.
+            // Infer only at this schema-free boundary by comparing declared
+            // fields with independently inferred value schemas.
             const ValueTypeMetaData *best = nullptr;
             std::size_t best_score = 0;
             bool ambiguous = false;
@@ -261,8 +308,29 @@ namespace hgraph::python_bridge
                     ambiguous = true;
                 }
             }
-            if (ambiguous) { return std::nullopt; }
-            return py_to_value_as(object, best);
+            if (ambiguous)
+            {
+                throw std::invalid_argument(
+                    "Python structured scalar schema inference is ambiguous");
+            }
+            return best;
+        }
+
+        [[nodiscard]] std::optional<Value> try_python_bundle_value(nb::handle object)
+        {
+            std::vector<const ValueTypeMetaData *> registered;
+            registered.reserve(bundle_class_info_registry().size());
+            for (const auto &[schema, info] : bundle_class_info_registry())
+            {
+                if (info.type.is_valid())
+                {
+                    registered.push_back(static_cast<const ValueTypeMetaData *>(schema));
+                }
+            }
+            const auto *selected = select_python_bundle_schema(object, registered);
+            return selected != nullptr
+                       ? std::optional<Value>{py_to_value_as(object, selected)}
+                       : std::nullopt;
         }
 
         [[nodiscard]] Value py_container_to_value(nb::handle object)
@@ -605,12 +673,9 @@ namespace hgraph::python_bridge
             return match;
         }
 
-        const nb::object source_class = nb::getattr(source, "__class__");
-        auto &classes = bundle_class_registry();
-        for (const auto *alternative : alternatives)
+        if (const auto *selected = select_python_bundle_schema(source, alternatives))
         {
-            nb::int_ key{reinterpret_cast<std::uintptr_t>(alternative)};
-            if (classes.contains(key) && source_class.is(classes[key])) { return alternative; }
+            return selected;
         }
         throw std::invalid_argument("value is not an instance of a closed Bundle alternative");
     }

--- a/src/hgraph/python/bridge_state.cpp
+++ b/src/hgraph/python/bridge_state.cpp
@@ -4,13 +4,29 @@
 #if HGRAPH_ENABLE_PYTHON_USER_NODES
 
 #include <hgraph/types/frame.h>
+#include <hgraph/types/metadata/type_registry.h>
+#include <hgraph/types/metadata/value_plan_factory.h>
 #include <hgraph/types/series.h>
 #include <hgraph/types/time_series_reference.h>
+#include <hgraph/types/value/specialized_views.h>
+#include <hgraph/types/value/value.h>
 #include <hgraph/types/value_callable.h>
 #include <hgraph/types/wired_fn.h>
 
+#include <algorithm>
+#include <compare>
+#include <cstddef>
+#include <cstdint>
+#include <exception>
+#include <memory>
+#include <mutex>
+#include <ranges>
 #include <stdexcept>
+#include <string>
+#include <string_view>
 #include <unordered_map>
+#include <utility>
+#include <vector>
 
 namespace hgraph::python_bridge {
 namespace {
@@ -24,6 +40,512 @@ struct NativeScalarRegistrations {
 NativeScalarRegistrations &native_scalar_registrations() {
   static auto *registrations = new NativeScalarRegistrations{};
   return *registrations;
+}
+
+struct PythonBundleValue {
+  PyObject *object{nullptr};
+  const ValueTypeMetaData *active_schema{nullptr};
+  ValueTypeRef active_binding{};
+  mutable std::vector<Value> projected_fields{};
+
+  PythonBundleValue() noexcept = default;
+
+  PythonBundleValue(const PythonBundleValue &other)
+      : object(other.object), active_schema(other.active_schema),
+        active_binding(other.active_binding) {
+    if (object != nullptr) {
+      nb::gil_scoped_acquire gil;
+      Py_INCREF(object);
+    }
+  }
+
+  PythonBundleValue(PythonBundleValue &&other) noexcept
+      : object(std::exchange(other.object, nullptr)),
+        active_schema(std::exchange(other.active_schema, nullptr)),
+        active_binding(std::move(other.active_binding)),
+        projected_fields(std::move(other.projected_fields)) {}
+
+  PythonBundleValue &operator=(const PythonBundleValue &other) {
+    if (this == &other) {
+      return *this;
+    }
+    PythonBundleValue replacement{other};
+    swap(replacement);
+    return *this;
+  }
+
+  PythonBundleValue &operator=(PythonBundleValue &&other) noexcept {
+    if (this == &other) {
+      return *this;
+    }
+    PythonBundleValue replacement{std::move(other)};
+    swap(replacement);
+    return *this;
+  }
+
+  ~PythonBundleValue() {
+    projected_fields.clear();
+    if (object != nullptr) {
+      nb::gil_scoped_acquire gil;
+      Py_DECREF(object);
+    }
+  }
+
+  void swap(PythonBundleValue &other) noexcept {
+    std::swap(object, other.object);
+    std::swap(active_schema, other.active_schema);
+    std::swap(active_binding, other.active_binding);
+    projected_fields.swap(other.projected_fields);
+  }
+
+  void set(nb::handle source, const ValueTypeMetaData *schema,
+           ValueTypeRef binding) {
+    if (!source.is_valid() || source.is_none()) {
+      throw nb::type_error("Python-backed Bundle requires a non-None object");
+    }
+    PyObject *replacement = source.ptr();
+    Py_INCREF(replacement);
+    PyObject *previous = object;
+    object = replacement;
+    active_schema = schema;
+    active_binding = binding;
+    projected_fields.clear();
+    Py_XDECREF(previous);
+  }
+};
+
+struct PythonBundleBindingEntry {
+  const ValueTypeMetaData *schema{nullptr};
+  std::vector<ValueTypeRef> field_bindings{};
+  IndexedValueOps ops{};
+  ValueTypeRef binding{};
+
+  PythonBundleBindingEntry(const ValueTypeMetaData *value_schema,
+                           std::vector<ValueTypeRef> realized_fields)
+      : schema(value_schema), field_bindings(std::move(realized_fields)) {
+    if (schema == nullptr || !schema->is_named_bundle()) {
+      throw std::invalid_argument(
+          "Python-owned value binding requires a named Bundle schema");
+    }
+    if (field_bindings.size() != schema->field_count) {
+      throw std::invalid_argument(
+          "Python-owned Bundle field binding count does not match its schema");
+    }
+
+    ops.kind = ValueOpsKind::Indexed;
+    ops.context = this;
+    ops.allows_mutation = false;
+    ops.hash_impl = schema->is_hashable() ? &hash : nullptr;
+    ops.equals_impl = &equals;
+    // Python objects do not gain ordering merely because their declared
+    // fields are ordered.
+    ops.compare_impl = nullptr;
+    ops.to_string_impl = &to_string;
+    ops.to_python_impl = &to_python;
+    ops.from_python_impl = &from_python;
+    ops.accepts_source_impl = &accepts_source;
+    ops.copy_assign_from_impl = &copy_assign_from;
+    ops.move_assign_from_impl = &move_assign_from;
+    ops.concrete_type_impl = &concrete_type;
+    ops.concrete_memory_impl = &concrete_memory;
+    ops.can_materialize_source_impl = &can_materialize_source;
+    ops.size = &size;
+    ops.element_at = &element_at;
+    ops.element_binding = &element_binding;
+    ops.make_range = &make_range;
+
+    binding = intern_value_type(
+        *schema, MemoryUtils::plan_for<PythonBundleValue>(), ops);
+  }
+
+  [[nodiscard]] static const PythonBundleBindingEntry &
+  entry(const void *context) noexcept {
+    return *static_cast<const PythonBundleBindingEntry *>(context);
+  }
+
+  [[nodiscard]] static PythonBundleValue &value(void *memory) {
+    if (memory == nullptr) {
+      throw std::logic_error(
+          "Python-owned Bundle operation requires live value memory");
+    }
+    return *static_cast<PythonBundleValue *>(memory);
+  }
+
+  [[nodiscard]] static const PythonBundleValue &value(const void *memory) {
+    if (memory == nullptr) {
+      throw std::logic_error(
+          "Python-owned Bundle operation requires live value memory");
+    }
+    return *static_cast<const PythonBundleValue *>(memory);
+  }
+
+  [[nodiscard]] const PyBundleClassInfo &class_info() const {
+    const auto found = bundle_class_info_registry().find(schema);
+    if (found == bundle_class_info_registry().end() ||
+        !found->second.type.is_valid()) {
+      throw std::logic_error(
+          "Python-owned Bundle class registration is incomplete");
+    }
+    return found->second;
+  }
+
+  [[nodiscard]] static bool
+  structurally_compatible(const ValueTypeMetaData *target,
+                          const ValueTypeMetaData *source) noexcept {
+    if (target == nullptr || source == nullptr ||
+        source->try_value_kind() != ValueTypeKind::Bundle) {
+      return false;
+    }
+    if (target == source || source == target->wrapped_un_named) {
+      return true;
+    }
+    if (target->is_named_bundle() && source->is_named_bundle() &&
+        TypeRegistry::instance().bundle_is_a(source, target)) {
+      return true;
+    }
+    if (target->field_count != source->field_count) {
+      return false;
+    }
+    for (std::size_t index = 0; index < target->field_count; ++index) {
+      const auto &lhs = target->fields[index];
+      const auto &rhs = source->fields[index];
+      if (lhs.type != rhs.type) {
+        return false;
+      }
+      const std::string_view lhs_name =
+          lhs.name != nullptr ? std::string_view{lhs.name} : std::string_view{};
+      const std::string_view rhs_name =
+          rhs.name != nullptr ? std::string_view{rhs.name} : std::string_view{};
+      if (lhs_name != rhs_name) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  static std::size_t hash(const void *, const void *memory) {
+    const auto &stored = value(memory);
+    if (stored.object == nullptr) {
+      throw std::logic_error("cannot hash an empty Python-owned Bundle");
+    }
+    nb::gil_scoped_acquire gil;
+    const Py_hash_t result = PyObject_Hash(stored.object);
+    if (result == -1) {
+      throw nb::python_error();
+    }
+    return static_cast<std::size_t>(result);
+  }
+
+  static bool equals(const void *, const void *lhs, const void *rhs) {
+    const auto &left = *static_cast<const PythonBundleValue *>(lhs);
+    const auto &right = *static_cast<const PythonBundleValue *>(rhs);
+    if (left.object == right.object) {
+      return true;
+    }
+    if (left.object == nullptr || right.object == nullptr) {
+      return false;
+    }
+    nb::gil_scoped_acquire gil;
+    const int result =
+        PyObject_RichCompareBool(left.object, right.object, Py_EQ);
+    if (result < 0) {
+      throw nb::python_error();
+    }
+    return result == 1;
+  }
+
+  static std::string to_string(const void *, const void *memory) {
+    const auto &stored = value(memory);
+    if (stored.object == nullptr) {
+      return "<empty Python-owned Bundle>";
+    }
+    nb::gil_scoped_acquire gil;
+    nb::object text = nb::steal(PyObject_Str(stored.object));
+    if (!text.is_valid()) {
+      throw nb::python_error();
+    }
+    return nb::cast<std::string>(text);
+  }
+
+  static nb::object to_python(const void *, const void *memory) {
+    const auto &stored = value(memory);
+    return stored.object != nullptr ? nb::borrow<nb::object>(stored.object)
+                                    : nb::none();
+  }
+
+  static void from_python(const void *context, const ValueTypeRef &binding,
+                          void *memory, nb::handle source) {
+    const auto &self = entry(context);
+    const auto &info = self.class_info();
+    if (!source.is_valid() || source.is_none() ||
+        !nb::isinstance(source, info.type)) {
+      throw nb::type_error(
+          ("value is not an instance of Python-backed Bundle '" +
+           std::string{self.schema->name()} + "'")
+              .c_str());
+    }
+    value(memory).set(source, self.schema, binding);
+  }
+
+  static bool accepts_source(const void *context, ValueTypeRef binding,
+                             ValueTypeRef source) noexcept {
+    const auto &self = entry(context);
+    return binding == self.binding && source &&
+           structurally_compatible(self.schema, source.schema());
+  }
+
+  [[nodiscard]] static nb::object
+  construct_from_indexed(const PythonBundleBindingEntry &self,
+                         ValueTypeRef source, const void *source_memory) {
+    const auto concrete = source.ops_ref().concrete_type(source, source_memory);
+    const auto *concrete_memory =
+        source.ops_ref().concrete_memory(source_memory);
+    if (!concrete || concrete_memory == nullptr) {
+      throw std::invalid_argument(
+          "Python-owned Bundle source has no concrete value");
+    }
+
+    if (is_python_bundle_schema(concrete.schema()) &&
+        concrete.plan() == &MemoryUtils::plan_for<PythonBundleValue>()) {
+      nb::object object = concrete.ops_ref().to_python(concrete_memory);
+      if (nb::isinstance(object, self.class_info().type)) {
+        return object;
+      }
+    }
+
+    const auto *indexed = checked_value_ops<IndexedValueOps>(
+        concrete, "Python-owned Bundle construction source");
+    if (indexed->size == nullptr || indexed->element_at == nullptr ||
+        indexed->element_binding == nullptr ||
+        indexed->size(indexed->context, concrete_memory) !=
+            self.schema->field_count) {
+      throw std::invalid_argument(
+          "Python-owned Bundle source has an incompatible field shape");
+    }
+
+    const auto &info = self.class_info();
+    nb::dict arguments;
+    for (std::size_t index = 0; index < self.schema->field_count; ++index) {
+      if (index >= info.constructor_fields.size() ||
+          !info.constructor_fields[index]) {
+        continue;
+      }
+      const void *field_memory =
+          indexed->element_at(indexed->context, concrete_memory, index);
+      if (field_memory == nullptr &&
+          index < info.defaulted_constructor_fields.size() &&
+          info.defaulted_constructor_fields[index]) {
+        continue;
+      }
+      if (field_memory == nullptr) {
+        throw std::invalid_argument(
+            "Python-backed Bundle '" + std::string{self.schema->name()} +
+            "' cannot be constructed because required field '" +
+            std::string{self.schema->fields[index].name} + "' is unset");
+      }
+      nb::object field_value =
+          indexed->element_binding(indexed->context, concrete_memory, index)
+              .ops_ref()
+              .to_python(field_memory);
+      arguments[info.field_names[index]] = std::move(field_value);
+    }
+
+    nb::tuple positional = nb::steal<nb::tuple>(PyTuple_New(0));
+    nb::object result = nb::steal(
+        PyObject_Call(info.type.ptr(), positional.ptr(), arguments.ptr()));
+    if (!result.is_valid()) {
+      throw nb::python_error();
+    }
+    return result;
+  }
+
+  static void copy_assign_from(const void *context, ValueTypeRef, void *dst,
+                               ValueTypeRef source, const void *src) {
+    const auto &self = entry(context);
+    nb::gil_scoped_acquire gil;
+    const auto concrete = source.ops_ref().concrete_type(source, src);
+    const auto *concrete_memory = source.ops_ref().concrete_memory(src);
+    if (concrete && concrete_memory != nullptr &&
+        is_python_bundle_schema(concrete.schema()) &&
+        concrete.plan() == &MemoryUtils::plan_for<PythonBundleValue>()) {
+      const auto &stored =
+          *static_cast<const PythonBundleValue *>(concrete_memory);
+      if (stored.object != nullptr &&
+          nb::isinstance(nb::handle{stored.object}, self.class_info().type)) {
+        value(dst) = stored;
+        return;
+      }
+    }
+    nb::object object = construct_from_indexed(self, source, src);
+    value(dst).set(object, self.schema, self.binding);
+  }
+
+  static void move_assign_from(const void *context, ValueTypeRef binding,
+                               void *dst, ValueTypeRef source, void *src) {
+    copy_assign_from(context, binding, dst, source, src);
+  }
+
+  static ValueTypeRef concrete_type(const void *context, ValueTypeRef,
+                                    const void *memory) noexcept {
+    if (memory != nullptr) {
+      const auto &stored = *static_cast<const PythonBundleValue *>(memory);
+      if (stored.active_binding) {
+        return stored.active_binding;
+      }
+    }
+    return entry(context).binding;
+  }
+
+  static bool can_materialize_source(const void *context, ValueTypeRef source,
+                                     const void *source_memory) {
+    const auto &self = entry(context);
+    const auto concrete = source.ops_ref().concrete_type(source, source_memory);
+    const auto *concrete_memory =
+        source.ops_ref().concrete_memory(source_memory);
+    if (!concrete || concrete_memory == nullptr) {
+      return false;
+    }
+    const auto *indexed = checked_value_ops<IndexedValueOps>(
+        concrete, "Python-owned Bundle materialisation source");
+    if (indexed->size(indexed->context, concrete_memory) !=
+        self.schema->field_count) {
+      return false;
+    }
+
+    const auto &info = self.class_info();
+    for (std::size_t index = 0; index < self.schema->field_count; ++index) {
+      if (index >= info.constructor_fields.size() ||
+          !info.constructor_fields[index]) {
+        continue;
+      }
+      const bool has_default =
+          index < info.defaulted_constructor_fields.size() &&
+          info.defaulted_constructor_fields[index];
+      if (!has_default && indexed->element_at(indexed->context, concrete_memory,
+                                              index) == nullptr) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  static const void *concrete_memory(const void *,
+                                     const void *memory) noexcept {
+    return memory;
+  }
+
+  static std::size_t size(const void *context, const void *) noexcept {
+    return entry(context).field_bindings.size();
+  }
+
+  static ValueTypeRef element_binding(const void *context, const void *,
+                                      std::size_t index) noexcept {
+    const auto &self = entry(context);
+    return index < self.field_bindings.size() ? self.field_bindings[index]
+                                              : ValueTypeRef{};
+  }
+
+  static const void *element_at(const void *context, const void *memory,
+                                std::size_t index) {
+    const auto &self = entry(context);
+    const auto &stored = value(memory);
+    if (index >= self.field_bindings.size()) {
+      throw std::out_of_range(
+          "Python-owned Bundle field index is out of range");
+    }
+    if (stored.object == nullptr) {
+      return nullptr;
+    }
+
+    nb::gil_scoped_acquire gil;
+    const auto &info = self.class_info();
+    PyObject *raw =
+        PyObject_GetAttr(stored.object, info.field_names[index].ptr());
+    if (raw == nullptr) {
+      if (PyErr_ExceptionMatches(PyExc_AttributeError)) {
+        PyErr_Clear();
+        return nullptr;
+      }
+      try {
+        throw nb::python_error();
+      } catch (...) {
+        const char *field_name = self.schema->fields[index].name;
+        std::throw_with_nested(std::runtime_error(
+            "Python-backed Bundle '" + std::string{self.schema->name()} +
+            "' failed to read field '" +
+            std::string{field_name != nullptr ? field_name : "<unnamed>"} +
+            "'"));
+      }
+    }
+    nb::object attribute = nb::steal(raw);
+    if (attribute.is_none()) {
+      return nullptr;
+    }
+
+    auto &fields = stored.projected_fields;
+    if (fields.empty()) {
+      fields.resize(self.field_bindings.size());
+    }
+    if (!fields[index].binding()) {
+      fields[index] = Value{self.field_bindings[index]};
+    }
+    try {
+      fields[index].view().assign_from_python(attribute);
+    } catch (...) {
+      const auto *declared = self.schema->fields[index].type;
+      nb::object actual_type = nb::steal(PyObject_Type(attribute.ptr()));
+      std::string actual =
+          actual_type.is_valid()
+              ? nb::cast<std::string>(
+                    nb::getattr(actual_type, "__name__", nb::str{"<unknown>"}))
+              : std::string{"<unknown>"};
+      const char *field_name = self.schema->fields[index].name;
+      std::throw_with_nested(std::invalid_argument(
+          "Python-backed Bundle '" + std::string{self.schema->name()} +
+          "' field '" +
+          std::string{field_name != nullptr ? field_name : "<unnamed>"} +
+          "' declared as '" +
+          std::string{declared != nullptr ? declared->name() : "<unknown>"} +
+          "' cannot convert value of type '" + actual + "'"));
+    }
+    return fields[index].view().data();
+  }
+
+  static ValueView range_project(const void *context, const void *memory,
+                                 std::size_t index) {
+    return ValueView{element_binding(context, memory, index),
+                     element_at(context, memory, index)};
+  }
+
+  static Range<ValueView> make_range(const void *context, const void *memory) {
+    return Range<ValueView>{
+        .context = context,
+        .memory = memory,
+        .limit = size(context, memory),
+        .predicate = nullptr,
+        .projector = &range_project,
+    };
+  }
+};
+
+struct PythonBundleBindings {
+  std::recursive_mutex mutex{};
+  std::unordered_map<const ValueTypeMetaData *,
+                     std::vector<PythonBundleBindingEntry *>>
+      current{};
+  std::vector<std::unique_ptr<PythonBundleBindingEntry>> immortal{};
+};
+
+PythonBundleBindings &python_bundle_bindings() {
+  static auto *bindings = new PythonBundleBindings{};
+  return *bindings;
+}
+
+[[nodiscard]] bool
+same_field_bindings(const PythonBundleBindingEntry &entry,
+                    std::span<const ValueTypeRef> requested) noexcept {
+  return entry.field_bindings.size() == requested.size() &&
+         std::ranges::equal(entry.field_bindings, requested);
 }
 } // namespace
 
@@ -84,6 +606,97 @@ std::unordered_map<const void *, const void *> &tsb_compound_value_registry() {
   return *registry;
 }
 
+void register_python_bundle_binding(const ValueTypeMetaData *schema) {
+  if (schema == nullptr || !schema->is_named_bundle()) {
+    throw std::invalid_argument(
+        "register_python_bundle_binding requires a named Bundle schema");
+  }
+  const auto info = bundle_class_info_registry().find(schema);
+  if (info == bundle_class_info_registry().end() ||
+      !info->second.type.is_valid()) {
+    throw std::invalid_argument("register_python_bundle_binding requires "
+                                "registered Python class metadata");
+  }
+
+  PyObject *hash_method =
+      PyObject_GetAttrString(info->second.type.ptr(), "__hash__");
+  if (hash_method == nullptr) {
+    nb::raise_python_error();
+  }
+  const bool hashable = hash_method != Py_None;
+  Py_DECREF(hash_method);
+  auto *mutable_schema = const_cast<ValueTypeMetaData *>(schema);
+  mutable_schema->flags =
+      (mutable_schema->flags | ValueTypeFlags::Equatable) &
+      ~(ValueTypeFlags::TriviallyConstructible |
+        ValueTypeFlags::TriviallyDestructible |
+        ValueTypeFlags::TriviallyCopyable | ValueTypeFlags::BufferCompatible |
+        ValueTypeFlags::Comparable | ValueTypeFlags::Hashable);
+  if (hashable) {
+    mutable_schema->flags |= ValueTypeFlags::Hashable;
+  }
+
+  auto &bindings = python_bundle_bindings();
+  {
+    std::lock_guard lock(bindings.mutex);
+    bindings.current.try_emplace(schema);
+  }
+  std::vector<ValueTypeRef> fields;
+  fields.reserve(schema->field_count);
+  for (std::size_t index = 0; index < schema->field_count; ++index) {
+    fields.push_back(
+        ValuePlanFactory::instance().type_for(schema->fields[index].type));
+  }
+  const auto binding = python_bundle_binding_for(schema, fields);
+  if (!binding) {
+    throw std::logic_error("failed to create Python-owned Bundle binding");
+  }
+  ValuePlanFactory::instance().register_type(binding);
+}
+
+bool is_python_bundle_schema(const ValueTypeMetaData *schema) noexcept {
+  if (schema == nullptr) {
+    return false;
+  }
+  auto &bindings = python_bundle_bindings();
+  std::lock_guard lock(bindings.mutex);
+  return bindings.current.contains(schema);
+}
+
+ValueTypeRef
+python_bundle_binding_for(const ValueTypeMetaData *schema,
+                          std::span<const ValueTypeRef> field_bindings) {
+  if (schema == nullptr) {
+    return {};
+  }
+  auto &bindings = python_bundle_bindings();
+  std::lock_guard lock(bindings.mutex);
+  const auto current = bindings.current.find(schema);
+  if (current == bindings.current.end()) {
+    // Only schemas explicitly installed through
+    // register_python_bundle_binding own Python objects.
+    return {};
+  }
+  for (const auto *entry : current->second) {
+    if (same_field_bindings(*entry, field_bindings)) {
+      return entry->binding;
+    }
+  }
+  auto created = std::make_unique<PythonBundleBindingEntry>(
+      schema,
+      std::vector<ValueTypeRef>{field_bindings.begin(), field_bindings.end()});
+  const auto result = created->binding;
+  current->second.push_back(created.get());
+  bindings.immortal.push_back(std::move(created));
+  return result;
+}
+
+void clear_python_bundle_bindings() noexcept {
+  auto &bindings = python_bundle_bindings();
+  std::lock_guard lock(bindings.mutex);
+  bindings.current.clear();
+}
+
 void register_native_scalar_type(nb::handle python_type,
                                  const ValueTypeMetaData *native_value_type) {
   if (PyType_Check(python_type.ptr()) == 0) {
@@ -119,8 +732,7 @@ void register_native_scalar_type(nb::handle python_type,
   registrations.by_native_type.emplace(native_value_type, std::move(retained));
 }
 
-const ValueTypeMetaData *
-native_scalar_type_for_python(nb::handle python_type) {
+const ValueTypeMetaData *native_scalar_type_for_python(nb::handle python_type) {
   const auto &registrations = native_scalar_registrations();
   const auto found = registrations.by_python_type.find(python_type.ptr());
   return found == registrations.by_python_type.end() ? nullptr

--- a/src/hgraph/types/metadata/ts_data_fixed_structured_ops.cpp
+++ b/src/hgraph/types/metadata/ts_data_fixed_structured_ops.cpp
@@ -150,6 +150,15 @@ namespace hgraph::ts_data_plan_factory_detail
             {
                 throw std::logic_error("TSDataPlanFactory: fixed TSData owning bindings are not resolved");
             }
+            if (schema->kind == TSTypeKind::TSB &&
+                !value_owning_binding.checked_plan().is_composite())
+            {
+                // The TSB's internal storage is field-expanded even when the
+                // scalar's owning representation is not. Present the existing
+                // projected Bundle surface and materialise the owning value
+                // only when a consumer requests one.
+                projected_value_surface = true;
+            }
             active_layout().value_binding =
                 projected_value_surface ? intern_value_type(*value_schema, *plan, value_indexed_ops)
                                         : value_owning_binding;
@@ -779,14 +788,8 @@ namespace hgraph::ts_data_plan_factory_detail
                 throw std::logic_error("fixed TSData value copy requires the canonical parent value schema");
             }
 
-            const auto &plan = binding.checked_plan();
-            auto       *bytes = static_cast<std::byte *>(dst);
             if (state->schema->kind == TSTypeKind::TSB)
             {
-                if (!plan.is_composite() || plan.component_count() < state->element_count())
-                {
-                    throw std::logic_error("fixed TSB value copy requires a matching structured plan");
-                }
                 BundleBuilder builder{binding};
                 for (std::size_t index = 0; index < state->element_count(); ++index)
                 {
@@ -796,10 +799,12 @@ namespace hgraph::ts_data_plan_factory_detail
                     builder.set(index, child.view());
                 }
                 Value bundle = builder.build();
-                plan.copy_assign(dst, bundle.view().data());
+                binding.checked_plan().copy_assign(dst, bundle.view().data());
                 return;
             }
 
+            const auto &plan = binding.checked_plan();
+            auto       *bytes = static_cast<std::byte *>(dst);
             if (!plan.is_array() || plan.array_count() != state->element_count())
             {
                 throw std::logic_error("fixed TSL value copy requires a matching array plan");

--- a/src/hgraph/types/metadata/ts_data_fixed_structured_plan.cpp
+++ b/src/hgraph/types/metadata/ts_data_fixed_structured_plan.cpp
@@ -3,6 +3,7 @@
 #include <hgraph/types/metadata/ts_data_plan_factory.h>
 #include <hgraph/types/metadata/type_realization.h>
 #include <hgraph/types/metadata/value_plan_factory.h>
+#include <hgraph/types/value/specialized_views.h>
 
 #include <fmt/format.h>
 
@@ -29,6 +30,45 @@ namespace hgraph::ts_data_plan_factory_detail
                 if (const auto realized = snapshot->type_for(schema)) { return realized; }
             }
             return ValuePlanFactory::instance().type_for(schema);
+        }
+
+        [[nodiscard]] ValueTypeRef fixed_value_storage_binding(const TSValueTypeMetaData &schema)
+        {
+            auto binding = realized_value_binding(schema.value_schema);
+            if (schema.kind != TSTypeKind::TSB || !binding || binding.checked_plan().is_composite())
+            {
+                return binding;
+            }
+
+            // A TSB always stores its children independently. A named Bundle
+            // may nevertheless have a canonical non-composite representation
+            // (for example a Python-owned object projected through
+            // IndexedValueOps). Use the schema's anonymous structural twin for
+            // the TSB's internal field storage; its public value surface will
+            // materialise the canonical owning representation through erased
+            // Bundle operations.
+            const auto *value_schema = schema.value_schema;
+            if (value_schema == nullptr || value_schema->wrapped_un_named == nullptr)
+            {
+                throw std::logic_error(
+                    "TSDataPlanFactory: non-composite TSB value has no structural twin");
+            }
+            const auto *indexed = checked_value_ops<IndexedValueOps>(
+                binding, "TSDataPlanFactory: non-composite TSB value");
+            std::vector<ValueTypeRef> fields;
+            fields.reserve(value_schema->field_count);
+            for (std::size_t index = 0; index < value_schema->field_count; ++index)
+            {
+                const auto field = indexed->element_binding(indexed->context, nullptr, index);
+                if (!field)
+                {
+                    throw std::logic_error(
+                        "TSDataPlanFactory: non-composite TSB field binding is unresolved");
+                }
+                fields.push_back(field);
+            }
+            return ValuePlanFactory::instance().realized_composite_type_for(
+                value_schema->wrapped_un_named, fields);
         }
 
         [[nodiscard]] TSRoleTypeRef realized_output_type(const TSValueTypeMetaData &schema)
@@ -449,7 +489,7 @@ namespace hgraph::ts_data_plan_factory_detail
                 schema, role, root_plan, ops, fixed_record_label(schema, role, false))};
         }
 
-        const auto value_type = realized_value_binding(schema.value_schema);
+        const auto value_type = fixed_value_storage_binding(schema);
         if (!value_type) throw std::logic_error("embedded fixed TSData value binding is not resolved");
 
         const auto &value_plan = value_type.checked_plan();
@@ -482,14 +522,14 @@ namespace hgraph::ts_data_plan_factory_detail
 
     [[nodiscard]] const MemoryUtils::StoragePlan *synthesise_fixed_plan(const TSValueTypeMetaData &schema)
     {
-        const auto value_plan = ValuePlanFactory::instance().plan_for(schema.value_schema);
-        if (value_plan == nullptr)
+        const auto value_binding = fixed_value_storage_binding(schema);
+        if (!value_binding)
         {
             throw std::logic_error("TSDataPlanFactory: fixed TSData value plan is not resolved");
         }
         auto builder = MemoryUtils::named_tuple();
         builder.reserve(2);
-        builder.add_field("value", *value_plan);
+        builder.add_field("value", value_binding.checked_plan());
         builder.add_field("aux", ts_data_aux_plan(schema));
         return &builder.build();
     }

--- a/src/hgraph/types/metadata/type_realization.cpp
+++ b/src/hgraph/types/metadata/type_realization.cpp
@@ -10,6 +10,7 @@
 #include <hgraph/types/value/compact_container_ops.h>
 #include <hgraph/types/value/container_ops.h>
 #include <hgraph/types/value/mutable_container_ops.h>
+#include <hgraph/types/value/value.h>
 #include <hgraph/types/value/value_range.h>
 #include <hgraph/util/scope.h>
 
@@ -17,6 +18,7 @@
 #include <compare>
 #include <cstddef>
 #include <cstdint>
+#include <limits>
 #include <memory>
 #include <mutex>
 #include <new>
@@ -500,13 +502,112 @@ struct TypeRealizationSnapshot::Impl {
 
     [[nodiscard]] ValueTypeRef python_source_type(nb::handle source) const {
       nb::object object = nb::borrow<nb::object>(source);
-      auto &classes = python_bridge::bundle_class_registry();
       const nb::object source_class = nb::getattr(object, "__class__");
+      std::vector<ValueTypeRef> class_matches;
+      std::size_t best_distance = std::numeric_limits<std::size_t>::max();
       for (const auto alternative : alternatives) {
-        nb::int_ key{reinterpret_cast<std::uintptr_t>(alternative.schema())};
-        if (classes.contains(key) && source_class.is(classes[key])) {
-          return alternative;
+        const auto found = python_bridge::bundle_class_info_registry().find(
+            alternative.schema());
+        if (found == python_bridge::bundle_class_info_registry().end() ||
+            !found->second.type.is_valid() ||
+            !nb::isinstance(object, found->second.type)) {
+          continue;
         }
+        const auto mro =
+            nb::cast<nb::tuple>(nb::getattr(source_class, "__mro__"));
+        std::size_t distance = std::numeric_limits<std::size_t>::max();
+        for (std::size_t index = 0; index < mro.size(); ++index) {
+          if (mro[index].is(found->second.type)) {
+            distance = index;
+            break;
+          }
+        }
+        if (distance < best_distance) {
+          best_distance = distance;
+          class_matches.clear();
+        }
+        if (distance == best_distance) {
+          class_matches.push_back(alternative);
+        }
+      }
+      if (class_matches.size() == 1) {
+        return class_matches.front();
+      }
+      if (!class_matches.empty() && nb::hasattr(object, "__orig_class__")) {
+        const auto alias = nb::getattr(object, "__orig_class__");
+        ValueTypeRef matched{};
+        for (const auto candidate : class_matches) {
+          const auto &info = python_bridge::bundle_class_info_registry().at(
+              candidate.schema());
+          if (!info.specialization.is_valid()) {
+            continue;
+          }
+          const int equal = PyObject_RichCompareBool(
+              alias.ptr(), info.specialization.ptr(), Py_EQ);
+          if (equal < 0) {
+            nb::raise_python_error();
+          }
+          if (equal == 0) {
+            continue;
+          }
+          if (matched) {
+            throw std::invalid_argument(
+                "Python structured scalar specialization is ambiguous");
+          }
+          matched = candidate;
+        }
+        if (matched) {
+          return matched;
+        }
+      }
+      if (class_matches.size() > 1) {
+        using InferValueFn = Value (*)(nb::handle);
+        const auto infer = reinterpret_cast<InferValueFn>(
+            python_bridge::py_infer_value_slot());
+        if (infer == nullptr) {
+          throw std::logic_error(
+              "Python Bundle inference hook is not installed");
+        }
+        ValueTypeRef best{};
+        std::size_t best_score = 0;
+        bool ambiguous = false;
+        for (const auto candidate : class_matches) {
+          std::size_t score = 0;
+          for (std::size_t index = 0; index < candidate.schema()->field_count;
+               ++index) {
+            const auto &field = candidate.schema()->fields[index];
+            if (field.name == nullptr || !nb::hasattr(object, field.name)) {
+              continue;
+            }
+            const auto field_value = nb::getattr(object, field.name);
+            if (field_value.is_none() || field_value.ptr() == object.ptr()) {
+              continue;
+            }
+            const Value inferred = infer(field_value);
+            if (inferred.schema() == field.type) {
+              score += 2;
+            } else if (inferred.schema() != nullptr && field.type != nullptr &&
+                       inferred.schema()->value_kind() ==
+                           ValueTypeKind::Bundle &&
+                       field.type->value_kind() == ValueTypeKind::Bundle &&
+                       TypeRegistry::instance().bundle_is_a(inferred.schema(),
+                                                            field.type)) {
+              ++score;
+            }
+          }
+          if (!best || score > best_score) {
+            best = candidate;
+            best_score = score;
+            ambiguous = false;
+          } else if (score == best_score) {
+            ambiguous = true;
+          }
+        }
+        if (!ambiguous) {
+          return best;
+        }
+        throw std::invalid_argument(
+            "Python structured scalar schema inference is ambiguous");
       }
 
       if (nb::isinstance<nb::dict>(object)) {
@@ -538,9 +639,9 @@ struct TypeRealizationSnapshot::Impl {
       const nb::object source_module = nb::getattr(source_class, "__module__");
       const nb::object source_qualname =
           nb::getattr(source_class, "__qualname__");
-      const std::string source_name =
-          nb::cast<std::string>(source_module) + "." +
-          nb::cast<std::string>(source_qualname);
+      const std::string source_name = nb::cast<std::string>(source_module) +
+                                      "." +
+                                      nb::cast<std::string>(source_qualname);
       throw std::invalid_argument("value of Python type '" + source_name +
                                   "' is not an instance of closed Bundle '" +
                                   std::string{declared->name()} + "'");
@@ -729,7 +830,15 @@ struct TypeRealizationSnapshot::Impl {
             changed || child != factory.type_for(schema->fields[index].type);
       }
       if (changed) {
-        result = factory.realized_composite_type_for(schema, fields);
+#if HGRAPH_ENABLE_PYTHON_USER_NODES
+        if (const auto python =
+                python_bridge::python_bundle_binding_for(schema, fields)) {
+          result = python;
+        } else
+#endif
+        {
+          result = factory.realized_composite_type_for(schema, fields);
+        }
       }
       break;
     }

--- a/src/hgraph/types/metadata/type_registry.cpp
+++ b/src/hgraph/types/metadata/type_registry.cpp
@@ -1540,6 +1540,10 @@ namespace hgraph
 
     const TSValueTypeMetaData *TypeRegistry::tss(const ValueTypeMetaData *element_type)
     {
+        if (element_type != nullptr && (!element_type->is_hashable() || !element_type->is_equatable()))
+        {
+            throw std::invalid_argument("TSS element type must be hashable and equatable");
+        }
         const std::lock_guard lock(mutex_);
         const TSValueTypeMetaData &meta = tss_cache_.intern(element_type, [&]() {
             TSValueTypeMetaData m(TSTypeKind::TSS, element_type ? set(element_type) : nullptr,
@@ -1552,6 +1556,10 @@ namespace hgraph
 
     const TSValueTypeMetaData *TypeRegistry::tsd(const ValueTypeMetaData *key_type, const TSValueTypeMetaData *value_ts)
     {
+        if (key_type != nullptr && (!key_type->is_hashable() || !key_type->is_equatable()))
+        {
+            throw std::invalid_argument("TSD key type must be hashable and equatable");
+        }
         const std::lock_guard lock(mutex_);
         const TSDictKey key{key_type, value_ts};
         const TSValueTypeMetaData &meta = tsd_cache_.intern(key, [&]() {

--- a/src/hgraph/types/metadata/value_plan_factory.cpp
+++ b/src/hgraph/types/metadata/value_plan_factory.cpp
@@ -1838,6 +1838,38 @@ void ValuePlanFactory::register_type(ValueTypeRef type) {
     return;
   }
   const auto *schema = type.schema();
+  if (schema != nullptr && schema->try_value_kind() == ValueTypeKind::Bundle) {
+    const auto *indexed = try_value_ops<IndexedValueOps>(type);
+    if (indexed == nullptr || indexed->size == nullptr ||
+        indexed->element_at == nullptr || indexed->element_binding == nullptr ||
+        indexed->make_range == nullptr) {
+      throw std::invalid_argument(
+          "ValuePlanFactory: Bundle binding must expose complete read-only "
+          "IndexedValueOps");
+    }
+    if (indexed->size(indexed->context, nullptr) != schema->field_count) {
+      throw std::invalid_argument(
+          "ValuePlanFactory: Bundle binding field count does not match its "
+          "schema");
+    }
+    for (std::size_t index = 0; index < schema->field_count; ++index) {
+      const auto field =
+          indexed->element_binding(indexed->context, nullptr, index);
+      if (!field || field.schema() != schema->fields[index].type) {
+        throw std::invalid_argument(
+            "ValuePlanFactory: Bundle binding field schema does not match "
+            "its declared schema");
+      }
+    }
+    if (!type.checked_plan().is_composite() &&
+        (type.ops_ref().accepts_source_impl == nullptr ||
+         (type.ops_ref().copy_assign_from_impl == nullptr &&
+          type.ops_ref().move_assign_from_impl == nullptr))) {
+      throw std::invalid_argument(
+          "ValuePlanFactory: non-composite Bundle binding must support "
+          "erased assignment");
+    }
+  }
 
   std::lock_guard<std::mutex> lock(mutex_);
   if (const auto it = type_cache_.find(schema); it != type_cache_.end()) {

--- a/src/hgraph/types/value/value_view.cpp
+++ b/src/hgraph/types/value/value_view.cpp
@@ -268,7 +268,7 @@ namespace hgraph
         return true;
     }
 
-    bool ValueView::equals(const ValueView &other) const noexcept
+    bool ValueView::equals(const ValueView &other) const
     {
         const auto bound       = binding();
         const auto other_bound = other.binding();
@@ -282,18 +282,16 @@ namespace hgraph
             return bound == other_bound || value_schema_equivalent(schema(), other.schema());
         }
 
-        return fallback_on_exception(false, [&] {
-            if (bound == other_bound) { return bound.ops_ref().equals(data(), other.data()); }
+        if (bound == other_bound) { return bound.ops_ref().equals(data(), other.data()); }
 
-            auto lhs_concrete = concrete();
-            auto rhs_concrete = other.concrete();
-            if (lhs_concrete.binding() != bound || rhs_concrete.binding() != other_bound)
-            {
-                return lhs_concrete.equals(rhs_concrete);
-            }
-            if (!value_schema_equivalent(schema(), other.schema())) { return false; }
-            return semantic_equals(*this, other);
-        });
+        auto lhs_concrete = concrete();
+        auto rhs_concrete = other.concrete();
+        if (lhs_concrete.binding() != bound || rhs_concrete.binding() != other_bound)
+        {
+            return lhs_concrete.equals(rhs_concrete);
+        }
+        if (!value_schema_equivalent(schema(), other.schema())) { return false; }
+        return semantic_equals(*this, other);
     }
 
     std::partial_ordering ValueView::compare(const ValueView &other) const noexcept

--- a/tests/cpp/test_bundle_builder.cpp
+++ b/tests/cpp/test_bundle_builder.cpp
@@ -7,12 +7,14 @@
 #include <catch2/catch_test_macros.hpp>
 
 #include <cstdint>
+#include <ranges>
 #include <utility>
 
 #include <hgraph/lib/std/value_util.h>
 #include <hgraph/types/metadata/type_registry.h>
 #include <hgraph/types/metadata/value_plan_factory.h>
 #include <hgraph/types/primitive_types.h>
+#include <hgraph/types/value/specialized_views.h>
 #include <hgraph/types/value/value.h>
 #include <hgraph/types/value/value_builder.h>
 
@@ -52,6 +54,119 @@ namespace
     {
         BundleMoveCountingScalar::copy_constructs = 0;
         BundleMoveCountingScalar::copy_assigns    = 0;
+    }
+
+    struct ProjectedBundleStorage
+    {
+        std::int32_t count{0};
+        Str          label{};
+
+        bool operator==(const ProjectedBundleStorage &) const = default;
+    };
+
+    struct ProjectedBundleContext
+    {
+        ValueTypeRef binding{};
+        ValueTypeRef count_binding{};
+        ValueTypeRef label_binding{};
+    };
+
+    std::size_t projected_bundle_size(const void *, const void *) noexcept { return 2; }
+
+    ValueTypeRef projected_bundle_element_binding(const void *context, const void *,
+                                                  std::size_t index) noexcept
+    {
+        const auto &self = *static_cast<const ProjectedBundleContext *>(context);
+        if (index == 0) { return self.count_binding; }
+        if (index == 1) { return self.label_binding; }
+        return {};
+    }
+
+    const void *projected_bundle_element_at(const void *, const void *memory, std::size_t index)
+    {
+        if (memory == nullptr) { return nullptr; }
+        const auto &value = *static_cast<const ProjectedBundleStorage *>(memory);
+        if (index == 0) { return std::addressof(value.count); }
+        if (index == 1) { return std::addressof(value.label); }
+        throw std::out_of_range("projected Bundle field index");
+    }
+
+    ValueView projected_bundle_project(const void *context, const void *memory,
+                                       std::size_t index)
+    {
+        return ValueView{
+            projected_bundle_element_binding(context, memory, index),
+            projected_bundle_element_at(context, memory, index),
+        };
+    }
+
+    Range<ValueView> projected_bundle_range(const void *context, const void *memory)
+    {
+        return Range<ValueView>{
+            .context = context,
+            .memory = memory,
+            .limit = 2,
+            .predicate = nullptr,
+            .projector = &projected_bundle_project,
+        };
+    }
+
+    std::size_t projected_bundle_hash(const void *, const void *memory)
+    {
+        const auto &value = *static_cast<const ProjectedBundleStorage *>(memory);
+        return std::hash<std::int32_t>{}(value.count) ^
+               (std::hash<Str>{}(value.label) << 1U);
+    }
+
+    std::partial_ordering projected_bundle_compare(
+        const void *, const void *lhs, const void *rhs) noexcept
+    {
+        const auto &left = *static_cast<const ProjectedBundleStorage *>(lhs);
+        const auto &right = *static_cast<const ProjectedBundleStorage *>(rhs);
+        if (left.count < right.count) { return std::partial_ordering::less; }
+        if (left.count > right.count) { return std::partial_ordering::greater; }
+        if (left.label < right.label) { return std::partial_ordering::less; }
+        if (left.label > right.label) { return std::partial_ordering::greater; }
+        return std::partial_ordering::equivalent;
+    }
+
+    bool projected_bundle_accepts(const void *, ValueTypeRef binding,
+                                  ValueTypeRef source) noexcept
+    {
+        const auto *target = binding.schema();
+        const auto *candidate = source.schema();
+        if (target == nullptr || candidate == nullptr ||
+            candidate->try_value_kind() != ValueTypeKind::Bundle ||
+            target->field_count != candidate->field_count)
+        {
+            return false;
+        }
+        for (std::size_t index = 0; index < target->field_count; ++index)
+        {
+            if (target->fields[index].type != candidate->fields[index].type)
+            {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    void projected_bundle_assign(const void *, ValueTypeRef, void *destination,
+                                 ValueTypeRef source, const void *source_memory)
+    {
+        const auto concrete = source.ops_ref().concrete_type(source, source_memory);
+        const auto *memory = source.ops_ref().concrete_memory(source_memory);
+        const auto *indexed = checked_value_ops<IndexedValueOps>(
+            concrete, "projected Bundle assignment");
+        auto &result = *static_cast<ProjectedBundleStorage *>(destination);
+        result.count = ValueView{
+            indexed->element_binding(indexed->context, memory, 0),
+            indexed->element_at(indexed->context, memory, 0),
+        }.checked_as<std::int32_t>();
+        result.label = ValueView{
+            indexed->element_binding(indexed->context, memory, 1),
+            indexed->element_at(indexed->context, memory, 1),
+        }.checked_as<Str>();
     }
 
     // Build the canonical TSS-delta bundle: Bundle{added: Set<std::int32_t>, removed: Set<std::int32_t>}.
@@ -170,4 +285,61 @@ TEST_CASE("BundleBuilder: the built value matches the canonical un_named_bundle 
     // it compares (Value::equals) against a runtime-produced delta of the same shape.
     CHECK(bundle.schema() == bundle_schema);
     CHECK_FALSE(bundle.view().to_string().empty());
+}
+
+TEST_CASE("BundleBuilder: constructs a registered non-composite Bundle binding")
+{
+    using namespace hgraph;
+
+    auto &registry = TypeRegistry::instance();
+    auto &factory = ValuePlanFactory::instance();
+    const auto *count_meta = registry.register_scalar<std::int32_t>("int32");
+    const auto *label_meta = registry.register_scalar<Str>("str");
+    const auto *schema = registry.bundle(
+        "tests.bundle_binding",
+        "ProjectedBundle",
+        {{"count", count_meta}, {"label", label_meta}});
+
+    // The registered ops table is process-global, so its context must outlive
+    // this test case just as a production extension binding's context does.
+    auto *context = new ProjectedBundleContext{
+        .count_binding = factory.type_for(count_meta),
+        .label_binding = factory.type_for(label_meta),
+    };
+    IndexedValueOps ops{};
+    static_cast<ValueOps &>(ops) = ops_for<ProjectedBundleStorage>();
+    ops.kind = ValueOpsKind::Indexed;
+    ops.context = context;
+    ops.allows_mutation = false;
+    ops.hash_impl = &projected_bundle_hash;
+    ops.compare_impl = &projected_bundle_compare;
+    ops.accepts_source_impl = &projected_bundle_accepts;
+    ops.copy_assign_from_impl = &projected_bundle_assign;
+    ops.move_assign_from_impl =
+        [](const void *ops_context, ValueTypeRef binding, void *destination,
+           ValueTypeRef source, void *source_memory) {
+            projected_bundle_assign(
+                ops_context, binding, destination, source, source_memory);
+        };
+    ops.size = &projected_bundle_size;
+    ops.element_binding = &projected_bundle_element_binding;
+    ops.element_at = &projected_bundle_element_at;
+    ops.make_range = &projected_bundle_range;
+
+    context->binding = intern_value_type(
+        *schema, MemoryUtils::plan_for<ProjectedBundleStorage>(), ops);
+    factory.register_type(context->binding);
+    REQUIRE_FALSE(context->binding.checked_plan().is_composite());
+
+    BundleBuilder builder{context->binding};
+    builder.set("count", Value{std::int32_t{7}});
+    builder.set("label", Value{Str{"seven"}});
+    Value value = builder.build();
+
+    REQUIRE(value.binding() == context->binding);
+    const auto bundle = value.as_bundle();
+    REQUIRE(bundle.size() == 2);
+    CHECK(bundle.at("count").checked_as<std::int32_t>() == 7);
+    CHECK(bundle.at("label").checked_as<Str>() == "seven");
+    CHECK(std::ranges::distance(bundle) == 2);
 }


### PR DESCRIPTION
## Summary

Implements accepted RFC 0004 so ordinary Python dataclasses, and explicitly registered Python classes, can participate as nominal structured scalars while retaining their exact Python objects.

- represents Python-owned structured scalars as normal named `Bundle` schemas with non-composite owning bindings
- exposes fields through the existing read-only, type-erased `BundleView` contract
- supports generic specialisations, inheritance and dispatch, recursive fields, reflection, equality/hash semantics, and `TS`/`TSB` conversion
- preserves dataclass constructor behaviour including defaults, default factories, keyword-only fields, `init=False`, and `__post_init__`
- rejects unhashable structured schemas as `TSS` elements or `TSD` keys
- adds C++ and Python conformance coverage, paired diagnostic benchmark scenarios, and user/developer documentation
- records the implementation in accepted RFC 0004

## Why

The original Python hgraph kept `CompoundScalar` values as Python objects. Existing applications consequently rely on Python constructors, descriptors, subclassing, relaxed runtime values, equality/hash implementations, and object identity. Eagerly converting every field to native C++ storage changes those semantics. This implementation separates the logical Bundle schema and view from physical storage while keeping native `CompoundScalar` behaviour unchanged.

## User and developer impact

Standard-library dataclasses are recognised lazily when used as hgraph scalar annotations. Other application classes can opt in with `register_python_object_type`. Python consumers receive their original objects; generic C++ Bundle code sees the same `BundleView` abstraction used for native structured storage, without assuming a native field layout.

## Validation

Local validation:

- clean native configure/build with warnings as errors
- native C++ suite: 1,227 passed
- focused Python structured-scalar and compatibility suites: 98 passed
- CPython 3.12 stable-ABI wheel built successfully
- that exact wheel installed into a fresh CPython 3.14 environment: 1,570 passed, 10 skipped (`-m "not wip"`)
- Sphinx clean HTML build with `-W --keep-going`
- all new diagnostic benchmark scenarios wired and executed at reduced scale

GitHub Actions is fully green across:

- native C++ on Ubuntu and macOS, including Linux shared-library installation
- manylinux 2.28 / GCC 14, macOS, and Windows wheel builds
- installed-wheel tests on Linux, macOS, and Windows with Python 3.12, 3.13, and 3.14
- source distribution and release-metadata validation

A direct build on the dedicated `hg-linux` server could not be started: the host now resolves and accepts TCP on port 22, but its SSH daemon does not emit a protocol banner and times out after 60 seconds.