### PR TITLE
Widen the subscriber-scheduling safety-net window

### DIFF
--- a/python/tests/adaptors/data_catalogue/test_subscriber_scheduling.py
+++ b/python/tests/adaptors/data_catalogue/test_subscriber_scheduling.py
@@ -17,7 +17,12 @@ _DELAY = timedelta(milliseconds=10)
 
 
 def _end_time():
-    return datetime.now(timezone.utc).replace(tzinfo=None) + timedelta(seconds=2)
+    # Safety net only: every test stops its own engine once it has captured
+    # what it asserts on, so the width costs nothing on the happy path. A
+    # shared CI runner stalling longer than the remainder of the window
+    # after a capture drops the next wall-clock poll and fails the test
+    # (observed on windows-latest with the previous 2s window).
+    return datetime.now(timezone.utc).replace(tzinfo=None) + timedelta(seconds=15)
 
 
 def test_delta_subscription_polling_reissues_rendered_request():


### PR DESCRIPTION
## Summary

`Test windows-latest / Python 3.13` on `main` (run 30017270758) failed `test_sql_subscription_polling_reissues_rendered_request` with 2 of 3 expected captures — an intermittent, not a scheduling bug.

Mechanism: the poll re-schedules itself as a wall-clock alarm ~10 ms out, and the test run is capped at `now + 2s` as a safety net. The graph stops its own engine after the third capture, normally well inside the window — but when a shared runner stalls longer than the window remainder after a capture (VM steal / AV scans on windows-latest; same runner pathology the ported scheduler tests document), the pending alarm is still undelivered when the wall clock passes `end_time`, the run ends, and the third capture never happens.

Fix: widen `_end_time()` from 2 s to 15 s. Every test using it stops its own engine once it has captured what it asserts on, so the width costs nothing on the happy path — it only extends the safety net a stalled runner falls back on. The success-feedback negative test keeps its own deliberately tight `3 * _DELAY` window since it must run to `end_time` by design.

## Test plan

- All 10 `python/tests/adaptors/data_catalogue` tests pass locally against a fresh build of current `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)