### PR TITLE
Deliver due wall-clock alarms instead of dropping them

### DIFF
--- a/docs/source/developer_guide/services.rst
+++ b/docs/source/developer_guide/services.rst
@@ -122,6 +122,16 @@ on_wall_clock=true)`` is enabled only for real-time graph executors, where
 engine time is wall-clock-aligned; simulation rejects wall-clock alarms because
 simulated time cannot be advanced by host time.
 
+A wall-clock alarm that is already **due** when ``schedule`` runs — the wall
+clock crossed the requested time between the caller computing it and the
+scheduler re-reading the clock, which a polling node makes arbitrarily likely
+— is delivered on the next evaluatable cycle
+(``max(evaluation_time + MIN_TD, wall now)``, the authoritative Python alarm
+sweep's fire time), never dropped. Dropping it would silently kill a
+self-rescheduling alarm chain: an evaluation-time ``schedule`` at or before
+``now`` stays a no-op, because there the caller is scheduling from within the
+cycle that already satisfies the request.
+
 
 Wiring surface
 --------------

--- a/include/hgraph/runtime/node_scheduler.h
+++ b/include/hgraph/runtime/node_scheduler.h
@@ -186,13 +186,25 @@ namespace hgraph
             require_state("schedule");
             const DateTime reference_now = scheduling_reference_time(on_wall_clock);
             // Started: only the future. Not yet started: the start cycle onward.
+            // A wall-clock alarm that is already due is delivered on the next
+            // evaluatable cycle rather than dropped: the wall clock may cross
+            // the requested time between the caller computing it and this
+            // guard re-reading the clock, and dropping the alarm silently
+            // kills a self-rescheduling chain (services.rst, wall-clock
+            // alarms; matches the Python alarm sweep's max(now, eval + MIN_TD)
+            // fire time).
             if (started_)
             {
-                if (when <= reference_now) { return; }
+                if (when <= reference_now)
+                {
+                    if (!on_wall_clock) { return; }
+                    when = std::max(now_ + MIN_TD, reference_now);
+                }
             }
             else if (when < reference_now)
             {
-                return;
+                if (!on_wall_clock) { return; }
+                when = reference_now;
             }
 
             const bool        tagged    = tag.has_value() && !tag->empty();

--- a/tests/cpp/test_realtime_execution.cpp
+++ b/tests/cpp/test_realtime_execution.cpp
@@ -188,6 +188,66 @@ TEST_CASE("real-time NodeScheduler supports wall-clock alarms")
     CHECK(graph.node_at(0).output(evaluation_time).value().checked_as<Int>() == Int{1});
 }
 
+TEST_CASE("real-time NodeScheduler delivers a wall-clock alarm that became due while scheduling")
+{
+    using namespace hgraph;
+
+    // A polling node computes its next wall-clock boundary and then calls
+    // schedule(); the wall clock may cross that boundary in between (the
+    // boundary distance is arbitrarily small for interval polls). A due
+    // alarm must deliver on the next evaluatable cycle — dropping it kills
+    // the self-rescheduling chain (observed as the intermittent
+    // test_sql_subscription_polling_reissues_rendered_request CI failure).
+    constexpr int target_evaluations = 3;
+
+    std::atomic_int eval_count{0};
+
+    auto       &registry = TypeRegistry::instance();
+    const auto *int_meta = registry.register_scalar<Int>("int");
+    const auto *ts_int   = registry.ts(int_meta);
+
+    NodeTypeMetaData schema;
+    schema.display_name      = "due_wall_alarm_source";
+    schema.output_schema     = ts_int;
+    schema.node_kind         = NodeKind::PullSource;
+    schema.schedule_on_start = true;
+    schema.uses_scheduler    = true;
+
+    NodeCallbacks callbacks;
+    callbacks.evaluate = [&eval_count](const NodeView &view, DateTime evaluation_time) {
+        ++eval_count;
+        testing::set_output_value(view, evaluation_time, Int{eval_count.load()});
+        if (eval_count.load() >= target_evaluations) { return; }
+        const NodeScheduler scheduler{view.scheduler_state(), view.graph_value(),
+                                      view.node_index(), evaluation_time,
+                                      view.started(), view.evaluation_clock(),
+                                      /*supports_wall_clock=*/true};
+        // Aim just past now, then let the wall clock overtake the target
+        // before schedule() re-reads it.
+        const DateTime target = hgraph::testing::wall_now() + TimeDelta{200};
+        std::this_thread::sleep_for(std::chrono::milliseconds{2});
+        scheduler.schedule(target, "wall", /*on_wall_clock=*/true);
+    };
+
+    GraphBuilder graph_builder;
+    graph_builder.add_node(NodeBuilder::native(std::move(schema), std::move(callbacks)));
+
+    const DateTime start_time = hgraph::testing::wall_now();
+
+    GraphExecutorBuilder executor_builder;
+    executor_builder.graph_builder(std::move(graph_builder))
+        .mode(GraphExecutorMode::RealTime)
+        .start_time(start_time)
+        .end_time(start_time + TimeDelta{5'000'000});
+
+    GraphExecutorValue executor = executor_builder.make_executor();
+    executor.view().run();
+
+    CHECK(eval_count.load() == target_evaluations);
+    // The chain never waits for end_time: each due alarm fires next cycle.
+    CHECK(hgraph::testing::wall_now() - start_time < TimeDelta{4'000'000});
+}
+
 TEST_CASE("real-time executor stop request wakes a sleeping executor")
 {
     using namespace hgraph;


### PR DESCRIPTION
## Summary

Root-causes the intermittent `test_sql_subscription_polling_reissues_rendered_request` CI failure (seen on windows-latest before #27 and on macos-26 on the #28 branch **after** the #27 window widening — proving #27 treated a symptom).

`NodeScheduler::schedule` silently returns when a started node's target is not strictly after the reference clock. For evaluation-time scheduling that's the correct contract. For `on_wall_clock` alarms the reference is the **live wall clock**, and a polling node computes its next interval boundary — which can be arbitrarily close — before calling `schedule`. If the wall clock crosses the boundary in between, the alarm was silently dropped and the self-rescheduling poll chain died; the graph then sat idle to `end_time` with one capture missing. Per-poll probability ≈ P(boundary distance < scheduling overhead), which is why it's rare, platform-noisy, and always passes on rerun.

The fix: a due wall-clock alarm is delivered on the next evaluatable cycle, `max(evaluation_time + MIN_TD, wall now)` — exactly the fire time of the authoritative Python runtime's alarm sweep (which never drops due alarms). Evaluation-time scheduling keeps the strict future-only contract; the unstarted-node start-cycle pattern is preserved. Design record updated in `services.rst`.

## Test plan

- New failing-first test: a node computes a near wall target, sleeps past it, then schedules — deterministically hits the drop. Unfixed: 1 of 3 evaluations (chain dead). Fixed: 3 of 3, returning well before `end_time`.
- Previously-flaky subscriber file: 30/30 repetition runs green post-fix.
- Full ctest suite green; full Python suite 1580 passed / 10 skipped, including the ported wall-clock scheduler parity tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)