### PR TITLE
Document downstream extension governance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,29 @@ C++. A feature exposed to Python must also have an equivalent, first-class C++
 wiring path and comparable C++ tests. Python should adapt Python values and
 callables to that path rather than become a second runtime implementation.
 
+## Downstream Extensions And Promotion
+
+- Treat downstream libraries as the normal incubation boundary for
+  domain-specific types, nodes, graphs, policies, and adapters. Generality of
+  an algorithm alone is not evidence that its current API belongs in hgraph.
+- Add a facility to `hg_cpp` only when it is useful across domains or is
+  required to let independently built extensions participate safely in the
+  shared runtime.
+- A capability promoted from a downstream library requires implementation
+  experience, a numbered core RFC, a first-class public C++ contract, matching
+  Python exposure where applicable, performance evidence for hot paths, and an
+  installed-SDK consumer test.
+- Promotion is a migration, not duplication. The linked downstream change
+  removes or delegates the former implementation, documents compatibility,
+  and coordinates the dependency and release transition.
+- Core code must never import, link against, or otherwise depend on a
+  downstream package. Public core documentation must not disclose a private
+  downstream design; describe the generic requirement and evidence instead.
+- Wiring-time scalar policies should select concrete overloads. Use a
+  graph-level switch for a genuinely dynamic policy. Do not add per-tick
+  strings or policy branches to a generic node without an accepted RFC and
+  measured justification.
+
 ## Working Method
 
 - Read the relevant implementation, tests, and nearby documentation before

--- a/docs/source/developer_guide/build_system.rst
+++ b/docs/source/developer_guide/build_system.rst
@@ -110,4 +110,5 @@ Open Design Items
 - Decide when to split runtime, system nodes, schema, and Python bridge into separate targets.
 - Decide whether tests should use a bundled test framework or depend on system packages.
 - Decide whether the shared extension ABI needs an explicit compatibility
-  version independent of the Python distribution version.
+  version independent of the Python distribution version; this is assessed in
+  :doc:`extension_policy`.

--- a/docs/source/developer_guide/extension_policy.rst
+++ b/docs/source/developer_guide/extension_policy.rst
@@ -1,0 +1,179 @@
+Downstream Extension Policy
+===========================
+
+Status
+------
+
+This page records the core ownership and promotion rules applied to
+independently built hgraph extensions. It also inventories extension facilities
+and candidate gaps as of 24 July 2026. Candidate entries are an assessment, not
+approved feature RFCs.
+
+Ownership boundary
+------------------
+
+``hg_cpp`` owns the C++ runtime, type and operator systems, graph execution,
+generic persistence contracts, and the public facilities required for another
+library to join the same process-wide runtime safely.
+
+A downstream extension owns its domain values, policies, algorithms, reusable
+graphs, adapters, and optional Python facade. Domain-specific work should
+incubate there until use demonstrates a stable, efficient, domain-independent
+contract. Mathematical generality does not by itself establish core ownership.
+
+The dependency direction is one way:
+
+.. code-block:: text
+
+   application -> downstream extension -> hg_cpp
+
+Core hgraph code must not import, link against, or name a private downstream
+package. A requirement originating in a private extension is stated in generic
+terms before it enters a public core RFC.
+
+Extension implementation rules
+------------------------------
+
+An extension follows the same C++-first model as the core:
+
+* Native values, nodes, graph overloads, and adapters are implemented in C++.
+* Pure C++ applications can use the public extension without embedding Python.
+* Python exposes public native values and wiring; it does not contain a second
+  implementation of runtime semantics.
+* The extension links the installed shared hgraph targets and shared nanobind
+  runtime. It must not statically embed another hgraph registry universe.
+* Static scalar policies select overloads during wiring. A genuinely dynamic
+  policy composes a graph-level switch.
+* Public hot paths avoid repeated string policy checks, reflection, allocation,
+  and Python calls.
+* C++ and Python behaviour tests use the same cases and expected results.
+
+Incubation and promotion
+------------------------
+
+A downstream feature is promoted only through the RFC process in
+:doc:`../rfc/rfc_0000`. The proposal supplies real implementation evidence,
+separates generic mechanics from domain policy, states representation and
+performance goals, and proves the public surface with an installed-SDK
+extension.
+
+Promotion does not leave two authoritative implementations. Separate linked
+pull requests:
+
+#. add the accepted generic contract to ``hg_cpp``;
+#. remove, delegate, or explicitly deprecate the downstream implementation;
+#. update compatibility and serialization paths; and
+#. coordinate minimum dependency versions and releases.
+
+Existing extension facilities
+-----------------------------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 28 18 54
+
+   * - Facility
+     - State
+     - Evidence and boundary
+   * - Shared native runtime and SDK
+     - Available
+     - Exported shared CMake targets and ``hgraph_add_python_module`` keep
+       process-wide registries and the nanobind runtime unique.
+   * - Native scalar/Python facade registration
+     - Available
+     - :doc:`../rfc/rfc_0003_extension_scalar_registration` proves a separately
+       built scalar extension and bidirectional Python reflection.
+   * - Typed Frame metadata
+     - Available
+     - :doc:`../rfc/rfc_0001_typed_frame_metadata` supplies one Arrow-backed
+       ``Frame[Rows, Metadata]`` representation and schema-directed metadata.
+   * - Temporal values, zones, and ranges
+     - Available
+     - :doc:`../rfc/rfc_0002_temporal_types` supplies native/Python values,
+       range algebra, fixed-time iteration, named-zone resolution, and codecs.
+   * - Python-owned structured scalar compatibility
+     - Available
+     - :doc:`../rfc/rfc_0004_python_owned_structured_scalars` presents declared
+       Python objects through the normal Bundle contract. It is a Python
+       compatibility facility, not a substitute for native extension values.
+   * - Services, adapters, and record/replay composition
+     - Available foundation
+     - Native interfaces, graph-selected implementations, ``GlobalState``
+       configuration, and component record/replay support environment-specific
+       bindings without changing decision graphs.
+
+Core RFC candidates
+-------------------
+
+The following gaps are sufficiently generic to justify focused RFC
+investigation. Their ordering reflects current downstream impact.
+
+Extension scalar codecs
+~~~~~~~~~~~~~~~~~~~~~~~
+
+**Priority: high.** A native extension scalar can register its schema and
+Python facade, but the JSON and Arrow codec builders still recognize a closed
+set of core atomic types. An otherwise valid extension scalar is rejected by
+generic JSON, Frame metadata, table, and record/replay paths.
+
+A proposal should define public, conflict-detecting registration of:
+
+* schema-directed JSON encode/decode operations;
+* an Arrow physical type plus scalar/array encode/decode operations;
+* deterministic codec identity and versioning;
+* converter-plan caching so evaluation does not perform registry lookup;
+* registry-reset and extension lifetime rules; and
+* an installed pure-C++ and Python extension round trip.
+
+The core owns the registry and invocation contract. The extension owns its
+wire representation, conversion functions, and migrations.
+
+Explicit extension ABI identity
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+**Priority: high.** The installed SDK currently constrains package, Arrow, and
+nanobind versions, but it does not publish an independent hgraph C++ extension
+ABI identifier or perform a load-time compatibility check.
+
+A proposal should define the compatibility identifier, which headers and
+shared-library surfaces it covers, compile-time and load-time diagnostics, and
+the release rules for compatible and breaking changes. It should avoid
+promising a stable ABI for templates or private implementation types.
+
+Serializable graph and binding manifest
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+**Priority: medium.** Graph traits, type reflection, inspectors,
+``GlobalState``, services/adapters, and record/replay configuration provide the
+ingredients for environment substitution, but there is no one stable manifest
+that identifies the graph contract, extension versions, selected
+implementations, source/sink bindings, and reproducibility inputs for a run.
+
+A proposal must distinguish a stable public manifest from diagnostic dumps and
+must not serialize credentials or live resource handles.
+
+Durable checkpoint and store contract
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+**Priority: medium.** The core has typed record/replay and in-memory/Arrow
+foundations, but long-running applications still need a generic durable store
+and checkpoint/recovery contract. Any proposal must define consistency
+boundaries, schema/version migration, idempotency, and the relation between
+recorded inputs, node state, and external effects.
+
+Capabilities that remain downstream
+-----------------------------------
+
+The following may use generic mathematics but do not yet justify core
+ownership:
+
+* policy-rich streaming statistics and mergeable estimators;
+* event-time, explicitly keyed, late-data, or revision-aware window policy;
+* dimensional units and domain conversion catalogues;
+* dynamic cross-sectional analytics;
+* business calendars, sessions, settlement, and lifecycle rules; and
+* domain order, position, risk, market-data, and execution models.
+
+These capabilities should continue to gain API, dispatch, serialization, and
+performance experience downstream. A later proposal applies the promotion gate
+without copying domain policy into hgraph.

--- a/docs/source/developer_guide/index.rst
+++ b/docs/source/developer_guide/index.rst
@@ -7,6 +7,7 @@ The developer guide describes the internal design of the C++ implementation. The
    :maxdepth: 2
 
    build_system
+   extension_policy
    debugging
    documentation_conventions
    roadmap

--- a/docs/source/rfc/rfc_0000.rst
+++ b/docs/source/rfc/rfc_0000.rst
@@ -1,7 +1,7 @@
 RFC 0000: RFC Process
 =====================
 
-:Status: Proposed
+:Status: Accepted
 :Author: Howard Henson
 :Created: 2026-07-23
 :Target: Project governance
@@ -36,6 +36,37 @@ requirement that may need a generic hgraph facility is first explored in its
 own repository. Once proposed for the core, its core RFC is placed here and the
 downstream document links to it rather than maintaining a second normative
 specification.
+
+Core promotion is a migration rather than a copy. The downstream
+implementation is removed, deprecated in favour of the core, or reduced to a
+domain composition over the new core contract. The core never imports or links
+against the downstream package. A public core RFC describes the generic
+requirement and evidence without disclosing private downstream designs.
+
+Promotion gate
+--------------
+
+An algorithm being mathematically general is not enough to establish core
+ownership. A capability promoted from a downstream extension must provide:
+
+* implementation experience from at least one real downstream use;
+* a domain-independent contract with domain policy kept outside the core;
+* one native C++ implementation and first-class C++ value, node, or graph
+  authoring as appropriate;
+* matching Python exposure and behavioural tests when the feature is visible
+  to Python;
+* wiring-time overload selection for static policies, or a graph composition
+  for a demonstrated dynamic policy;
+* representation, allocation, and latency evidence for any per-tick path;
+* an installed-SDK fixture proving use from a separately built extension;
+* compatibility, serialization, ABI, and migration rules; and
+* linked core and downstream pull requests with an explicit dependency and
+  release transition.
+
+The generic core change and the downstream migration use separate branches and
+pull requests. The downstream document may remain as motivation and
+domain-specific guidance, but it links to the accepted core RFC rather than
+retaining a second normative definition.
 
 Numbering and filenames
 -----------------------
@@ -96,6 +127,9 @@ Each feature RFC contains, as applicable:
 * runtime representation and operator/dispatch semantics;
 * compatibility, migration, and serialization consequences;
 * performance and memory considerations;
+* downstream incubation evidence and the promotion/removal plan, when
+  applicable;
+* installed-extension and ABI consequences for extension facilities;
 * alternatives considered and unresolved questions;
 * acceptance criteria and test plan;
 * implementation status after work begins; and

--- a/docs/source/rfc/rfc_0001_typed_frame_metadata.rst
+++ b/docs/source/rfc/rfc_0001_typed_frame_metadata.rst
@@ -1,7 +1,7 @@
 RFC 0001: Typed Frame Metadata
 ==============================
 
-:Status: Proposed
+:Status: Accepted
 :Author: Howard Henson
 :Created: 2026-07-23
 :Target: Next ``hg_cpp`` minor release
@@ -112,12 +112,11 @@ Acceptance criteria
 Implementation status
 ---------------------
 
-The implementation is complete on its implementation PR. It covers the
+The accepted implementation covers the
 two-parameter C++ and Python Frame type, field-wise Arrow schema codec,
 marker-bearing and markerless decoding, Python conversion validation,
 metadata-aware table overloads, installed-SDK use, and C++/Python conformance
-tests. The RFC remains ``Proposed`` until that implementation is accepted for
-merge, at which point this status changes to ``Accepted`` in the same PR.
+tests.
 
 Versioned-dataset proof
 -----------------------

--- a/docs/source/rfc/rfc_0003_extension_scalar_registration.rst
+++ b/docs/source/rfc/rfc_0003_extension_scalar_registration.rst
@@ -1,7 +1,7 @@
 RFC 0003: Downstream Python Scalar Registration
 ================================================
 
-:Status: Proposed
+:Status: Accepted
 :Author: Howard Henson
 :Created: 2026-07-23
 :Target: Unscheduled
@@ -97,10 +97,8 @@ Acceptance criteria
 Implementation status
 ---------------------
 
-The implementation is complete on its implementation PR. A separately built
-test extension uses only the installed SDK to register a custom native scalar,
-resolve ``TS[ExtensionType]``, reflect its Python class, and round-trip a value
-through a Python-authored graph. It also verifies harmless duplicate
-registration and deterministic conflicts on both sides. This RFC remains
-``Proposed`` until the implementation is accepted for merge, when it changes
-to ``Accepted`` in the same PR.
+The accepted implementation includes a separately built test extension that
+uses only the installed SDK to register a custom native scalar, resolve
+``TS[ExtensionType]``, reflect its Python class, and round-trip a value through
+a Python-authored graph. It also verifies harmless duplicate registration and
+deterministic conflicts on both sides.


### PR DESCRIPTION
## Summary

- codify the ownership boundary between `hg_cpp` and independently built downstream extensions
- define the evidence and migration gates for promoting downstream capabilities into core
- document the current extension facilities and prioritize candidate core gaps
- record extension-scalar codecs and explicit ABI identity as the highest-priority RFC candidates
- mark RFC 0000, RFC 0001, and RFC 0003 accepted to match the implemented and merged state

## Why

The shared runtime now provides several extension facilities, but the rules for incubation, promotion, dependency direction, C++/Python parity, installed-SDK validation, and avoiding duplicate implementations were spread across prior design work. This change makes those rules explicit and provides a current audit of what remains appropriately downstream versus what warrants a focused core RFC.

## Impact

Documentation and contributor policy only. This PR does not change runtime behavior or public APIs, and it does not approve the candidate RFCs listed in the audit.

## Validation

- `git diff --check`
- `/Users/hhenson/CLionProjects/hg_cpp/.venv/bin/sphinx-build -W --keep-going -b html docs/source /tmp/hg_cpp-extension-governance-docs-pr`