### PR TITLE
Package the shared-library SDK for Conan

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ benchmarks/.venv-hg-cpp*/
 /reports/
 
 python/_hgraph.abi3.so
+test_package/build/
+test_package/CMakeUserPresets.json

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -459,8 +459,18 @@ for path in (root, root / "include", arrow_link, compute_link, acero_link,
         "Directory containing pyarrow's bundled Arrow libraries" FORCE)
 else()
     find_package(Arrow CONFIG REQUIRED)
-    find_package(ArrowCompute CONFIG REQUIRED)  # Arrow 24 splits compute into its own lib
-    find_package(ArrowAcero CONFIG REQUIRED)
+    # Arrow 24 splits compute/acero into their own CMake packages; some
+    # packagers (Conan's Arrow recipe) define all three target namespaces
+    # from the single Arrow config, in which case the separate packages do
+    # not exist and must not be required.
+    if(NOT TARGET ArrowCompute::arrow_compute_shared AND
+       NOT TARGET ArrowCompute::arrow_compute_static)
+        find_package(ArrowCompute CONFIG REQUIRED)
+    endif()
+    if(NOT TARGET ArrowAcero::arrow_acero_shared AND
+       NOT TARGET ArrowAcero::arrow_acero_static)
+        find_package(ArrowAcero CONFIG REQUIRED)
+    endif()
 endif()
 if(HGRAPH_BUILD_SHARED AND HGRAPH_BUILD_PYTHON_BINDINGS)
     target_link_libraries(hgraph_private_dependencies INTERFACE
@@ -768,8 +778,15 @@ if(NOT HGRAPH_BUILD_SHARED OR NOT HGRAPH_BUILD_PYTHON_BINDINGS)
     list(APPEND _hgraph_config_dependencies
         "find_dependency(fmt 11 CONFIG)\n"
         "find_dependency(Arrow CONFIG)\n"
-        "find_dependency(ArrowCompute CONFIG)\n"
-        "find_dependency(ArrowAcero CONFIG)\n"
+        # Some packagers (Conan's Arrow) define the compute/acero targets
+        # from the single Arrow config; only find the split packages when
+        # the targets are still missing, mirroring the build-side guard.
+        "if(NOT TARGET ArrowCompute::arrow_compute_shared AND NOT TARGET ArrowCompute::arrow_compute_static)\n"
+        "  find_dependency(ArrowCompute CONFIG)\n"
+        "endif()\n"
+        "if(NOT TARGET ArrowAcero::arrow_acero_shared AND NOT TARGET ArrowAcero::arrow_acero_static)\n"
+        "  find_dependency(ArrowAcero CONFIG)\n"
+        "endif()\n"
         "find_dependency(spdlog 1.15 CONFIG)\n"
         # Static consumers link these implementation dependencies. The
         # simdjson floor is explicit because its package version file uses

--- a/conanfile.py
+++ b/conanfile.py
@@ -1,0 +1,125 @@
+"""Conan recipe for the hgraph C++ shared-library SDK.
+
+Packages the native runtime exactly as the installed SDK ships it: the
+shared hgraph libraries, public headers, debugger support, and the
+project's own ``hgraphConfig.cmake`` (consumers use ``find_package(hgraph)``
+against that config — Conan does not generate a competing one). The Python
+bridge is out of scope here; wheels remain the Python distribution channel.
+
+Local development flow::
+
+    conan create . --build=missing
+
+Consumers add ``hgraph/<version>`` to their requires; the C++ API is
+source-provisional (see docs/source/developer_guide/release_readiness.rst),
+so native consumers pin the exact version and rebuild per release.
+"""
+
+import re
+import subprocess
+
+from conan import ConanFile
+from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
+
+
+class HgraphConan(ConanFile):
+    name = "hgraph"
+    package_type = "shared-library"
+    license = "MIT"
+    url = "https://github.com/hhenson/hg_cpp"
+    homepage = "https://github.com/hhenson/hg_cpp"
+    description = (
+        "C++-first hgraph runtime: forward-propagating graph engine with "
+        "time-series types, operator library, and extension SDK"
+    )
+    topics = ("reactive", "graph", "time-series", "frp")
+
+    settings = "os", "arch", "compiler", "build_type"
+
+    exports_sources = (
+        "CMakeLists.txt",
+        "include/*",
+        "src/*",
+        "tools/debugger/*",
+    )
+
+    def set_version(self):
+        if self.version:
+            return
+        # Git tags are the version authority (release_readiness.rst: tagged
+        # releases restamp metadata to the ``v_<version>`` tag). An exact tag
+        # yields that version; commits past the tag yield ``<tag>.dev<n>`` so
+        # a cache entry never impersonates a release. pyproject.toml is only
+        # the no-git fallback.
+        try:
+            described = subprocess.check_output(
+                ["git", "describe", "--tags", "--match", "v_*"],
+                cwd=self.recipe_folder, text=True,
+                stderr=subprocess.DEVNULL).strip()
+            match = re.fullmatch(r"v_(.+?)(?:-(\d+)-g[0-9a-f]+)?", described)
+            version, ahead = match.group(1), match.group(2)
+            self.version = f"{version}.dev{ahead}" if ahead else version
+        except (subprocess.CalledProcessError, FileNotFoundError):
+            pyproject = open(f"{self.recipe_folder}/pyproject.toml").read()
+            self.version = re.search(
+                r'^version\s*=\s*"([^"]+)"', pyproject, re.M).group(1)
+
+    def requirements(self):
+        # The floors match CMakeLists.txt; fmt is forced because spdlog's
+        # recipe carries its own fmt pin.
+        self.requires("fmt/11.2.0", force=True)
+        self.requires("spdlog/1.15.3")
+        self.requires("simdjson/4.6.3")
+        self.requires("date/3.0.4")
+        self.requires("arrow/24.0.0")
+
+    def configure(self):
+        # The SDK links Arrow's shared targets and needs compute + acero.
+        self.options["arrow"].shared = True
+        self.options["arrow"].compute = True
+        self.options["arrow"].acero = True
+        self.options["arrow"].parquet = False
+        # date/tz as a compiled library reading the OS TZDB, matching the
+        # project's FetchContent configuration.
+        self.options["date"].header_only = False
+        self.options["date"].use_system_tz_db = True
+        self.options["fmt"].shared = True
+        self.options["spdlog"].shared = True
+        self.options["simdjson"].shared = True
+
+    def layout(self):
+        cmake_layout(self)
+
+    def generate(self):
+        deps = CMakeDeps(self)
+        deps.generate()
+        tc = CMakeToolchain(self)
+        tc.cache_variables["HGRAPH_BUILD_SHARED"] = True
+        tc.cache_variables["HGRAPH_BUILD_PYTHON_BINDINGS"] = False
+        tc.cache_variables["HGRAPH_ENABLE_PYTHON_USER_NODES"] = False
+        tc.cache_variables["HGRAPH_ENABLE_IDE_PYTHON_HEADER_HINTS"] = False
+        tc.cache_variables["BUILD_TESTING"] = False
+        tc.cache_variables["HGRAPH_FETCH_SIMDJSON"] = False
+        tc.cache_variables["HGRAPH_FETCH_DATE"] = False
+        # Deterministic named-zone backend across platforms: the packaged
+        # SDK always uses date/tz rather than probing the standard library.
+        tc.cache_variables["HGRAPH_TIME_ZONE_BACKEND"] = "date"
+        tc.cache_variables["HGRAPH_ENABLE_COMPILER_CACHE"] = False
+        tc.generate()
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def package(self):
+        cmake = CMake(self)
+        cmake.install()
+
+    def package_info(self):
+        # Consumers use the project's installed hgraphConfig.cmake — the
+        # authoritative config carrying the SDK helpers
+        # (hgraph_add_python_module, exact-version machinery) — rather than
+        # a Conan-generated one.
+        self.cpp_info.set_property("cmake_find_mode", "none")
+        self.cpp_info.builddirs = ["lib/cmake/hgraph"]

--- a/docs/source/developer_guide/build_system.rst
+++ b/docs/source/developer_guide/build_system.rst
@@ -104,6 +104,39 @@ relative runtime search path to the wheel's platform-selected library directory
 (``lib`` or ``lib64``), using ``@loader_path`` on macOS and ``$ORIGIN`` on ELF
 systems.
 
+Conan package
+-------------
+
+``conanfile.py`` at the repository root packages the shared-library SDK for
+Conan 2 consumers: the shared hgraph libraries, public headers, debugger
+support, and the project's own ``hgraphConfig.cmake``. Conan does not
+generate a competing CMake config (``cmake_find_mode`` is ``none``);
+consumers call ``find_package(hgraph CONFIG)`` against the packaged config,
+so the SDK helpers (``hgraph_add_python_module``, dependency pinning)
+behave identically to a plain CMake install. Dependencies (fmt, spdlog,
+simdjson, date/tz, Arrow 24 with compute + acero, all shared) come from
+Conan Center; the named-zone backend is pinned to ``date`` for
+deterministic behaviour across platforms, and the Python bridge is out of
+scope — wheels remain the Python distribution channel.
+
+Build and test the package locally with::
+
+   CMAKE_POLICY_VERSION_MINIMUM=3.5 conan create . --build=missing \
+       -s "arrow/*:compiler.cppstd=gnu20" -s "&:compiler.cppstd=gnu23"
+
+The per-package standards matter: hgraph itself requires C++23, Arrow's
+recipe requires (and is only validated at) C++20, and the remaining
+dependencies build at the profile default. ``CMAKE_POLICY_VERSION_MINIMUM``
+works around transitive recipes (bzip2) whose ``cmake_minimum_required``
+predates CMake 4. The version is derived from the latest ``v_`` git tag
+(the version authority; commits past the tag get a ``.dev<n>`` suffix, and
+``pyproject.toml`` is only the no-git fallback); native consumers pin the
+exact version, per the compatibility policy in :doc:`release_readiness`. ``test_package/`` holds the consumer exercised by
+``conan create``. Both the build and the generated config guard the split
+``ArrowCompute``/``ArrowAcero`` packages behind target-existence checks
+because Conan's Arrow defines all three target namespaces from the single
+``Arrow`` config.
+
 Open Design Items
 -----------------
 

--- a/test_package/CMakeLists.txt
+++ b/test_package/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.25)
+
+project(hgraph_conan_consumer LANGUAGES CXX)
+
+find_package(hgraph CONFIG REQUIRED)
+
+add_executable(hgraph_conan_consumer main.cpp)
+target_link_libraries(hgraph_conan_consumer PRIVATE hgraph::core)

--- a/test_package/conanfile.py
+++ b/test_package/conanfile.py
@@ -1,0 +1,29 @@
+import os
+
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
+
+
+class HgraphTestPackage(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def layout(self):
+        cmake_layout(self)
+
+    def generate(self):
+        CMakeDeps(self).generate()
+        CMakeToolchain(self).generate()
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if can_run(self):
+            self.run(os.path.join(self.cpp.build.bindir, "hgraph_conan_consumer"),
+                     env="conanrun")

--- a/test_package/main.cpp
+++ b/test_package/main.cpp
@@ -1,0 +1,32 @@
+// Conan test-package consumer: exercises the installed SDK end to end —
+// registry, value layer, and a temporal value — through hgraph::core.
+#include <hgraph/types/metadata/type_registry.h>
+#include <hgraph/types/temporal.h>
+#include <hgraph/types/value/value.h>
+
+#include <cstdint>
+#include <cstdio>
+#include <stdexcept>
+
+int main()
+{
+    using namespace hgraph;
+
+    auto &registry = TypeRegistry::instance();
+    registry.register_scalar<std::int64_t>("int");
+
+    const Value value{std::int64_t{42}};
+    if (value.view().checked_as<std::int64_t>() != 42)
+    {
+        throw std::logic_error("value round trip failed");
+    }
+
+    const Duration day = checked_add(Duration{0}, Duration{86'400'000'000});
+    if (format_duration(day) != "86400000000us")
+    {
+        throw std::logic_error("temporal round trip failed");
+    }
+
+    std::puts("hgraph conan consumer ok");
+    return 0;
+}


### PR DESCRIPTION
## Summary

Makes the hg_cpp shared-library SDK consumable via Conan 2:

- **`conanfile.py`** — a real shared-library recipe: shared hgraph libraries, public headers, debugger support, and the project's own `hgraphConfig.cmake`. `cmake_find_mode` is `none`, so consumers call `find_package(hgraph CONFIG)` against the packaged config and the SDK helpers (`hgraph_add_python_module`, exact-version pinning) behave identically to a plain CMake install. Dependencies resolve from Conan Center — `fmt`, `spdlog`, `simdjson`, `date/3.0.4`, `arrow/24.0.0` with `compute`+`acero`, all shared. The named-zone backend is pinned to `date` for cross-platform determinism; the Python bridge is out of scope (wheels remain the Python channel).
- **Version from tags**: derived from the latest `v_` git tag (the version authority; commits past the tag get `.dev<n>`, so a cache entry never impersonates a release; `pyproject.toml` is only the no-git fallback). Current head packages as `hgraph/0.4.3.dev6`.
- **Arrow config guards** (build side and generated `hgraphConfig.cmake`): the split `ArrowCompute`/`ArrowAcero` packages are only sought when their targets aren't already defined — Conan's Arrow provides all three namespaces from the single `Arrow` config, and the unguarded `find_dependency` calls escaped to system Arrow installs (observed target clash with Homebrew Arrow). No-ops for system/pyarrow Arrow.
- **`test_package/`** — consumer exercising registry, value layer, and a temporal value through `hgraph::core`.
- **`build_system.rst`** — new Conan section documenting the invocation and its two non-obvious flags: `-s "arrow/*:compiler.cppstd=gnu20" -s "&:compiler.cppstd=gnu23"` (hgraph needs C++23; Arrow validates only at C++20 — C++23 trips a real acero source bug) and `CMAKE_POLICY_VERSION_MINIMUM=3.5` (transitive bzip2 recipe predates CMake 4).

This publishes to a local cache / private remote today; Conan Center publication would be a separate conan-center-index process if wanted.

## Test plan

- `conan create . --build=missing` (with the documented flags) green end-to-end on macOS arm64: 19 dependency packages built, hgraph packaged as `0.4.3.dev6`, test-package consumer built against the packaged `hgraphConfig.cmake` and ran.
- Local non-Conan path regression-checked: default configure (with `-DHGRAPH_FETCH_DATE=ON`) and full build clean — the Arrow guards are no-ops when the split configs exist.
- Sphinx `-W` docs build passes with the new section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)