### PR TITLE
Add resettable time-series windows

### DIFF
--- a/docs/source/rfc/index.rst
+++ b/docs/source/rfc/index.rst
@@ -19,3 +19,5 @@ workflow are defined by :doc:`rfc_0000`.
    rfc_0003_extension_scalar_registration
    rfc_0004_python_owned_structured_scalars
    rfc_0005_hgraph_1_0_api
+   rfc_0006_tsw_reset_and_clear
+   rfc_0007_scheduled_duration_tsw_eviction

--- a/docs/source/rfc/rfc_0006_tsw_reset_and_clear.rst
+++ b/docs/source/rfc/rfc_0006_tsw_reset_and_clear.rst
@@ -1,0 +1,195 @@
+RFC 0006: TSW Reset and Clear
+=============================
+
+:Status: Proposed
+:Author: Howard Henson
+:Created: 2026-07-25
+:Target: TSW mutation and ``to_window``
+:Related: RFC 0007
+
+Summary
+-------
+
+Add an explicit clear operation to a time-series window and an optional reset
+signal to ``to_window``.  A reset clears the retained observations before any
+source tick delivered in the same evaluation cycle.  The operation is visible
+as a TSW modification even when the window was already empty.
+
+This RFC deliberately does not redesign the TSW delta or record/replay format.
+Until that work is completed, a clear-only TSW tick cannot be represented by
+the existing scalar-addition delta.  RFC 0007 specifies the follow-on design
+work for duration eviction, multi-value removal deltas, and recovery.
+
+Motivation
+----------
+
+``TSW`` is the graph-level owner of observations retained by a window.  Window
+consumers should not reproduce that history in private node state merely to
+support a logical reset.  Rolling calculations instead compose:
+
+.. code-block:: text
+
+   source -> admission/lag -> to_window -> private calculation node
+
+The private node may retain derived computational state, but the TSW remains
+the authoritative tick history.  Reset and invalidation policies therefore
+need a standard way to clear the TSW rather than replacing it with a
+node-specific queue.
+
+Ownership boundary
+------------------
+
+The mutation primitive and ``to_window`` overload are domain-independent core
+facilities.  Policies deciding *when* to reset, whether another output is
+invalidated, and how a statistic reacts remain graph or downstream concerns.
+
+C++ contract
+------------
+
+``TSWDataMutationView`` gains:
+
+.. code-block:: cpp
+
+   void clear();
+
+``clear``:
+
+* destroys all retained value and timestamp elements;
+* retains the configured period and allocated capacity;
+* marks the TSW modified at the mutation scope's evaluation time, including
+  when it was already empty;
+* produces an empty current window value;
+* does not report the cleared values through the legacy singular
+  ``removed_value`` surface; and
+* may be followed by exactly one ``push`` through the same mutation scope.
+
+A push followed by clear, two pushes, two clears, or a clear followed by a push
+through a different mutation scope at the same evaluation time is rejected.
+The permitted clear-then-push sequence provides the atomic ordering required by
+``to_window`` when reset and source tick together.
+
+The typed static-node output convenience ``Out<TSW<...>>::clear()`` delegates to
+the same mutation operation.
+
+Operator contract
+-----------------
+
+``to_window`` retains its existing forms and adds an optional signal:
+
+.. code-block:: text
+
+   to_window(ts, period, min_window_period=period)
+   to_window(ts, period, min_window_period=period, reset=signal)
+
+Both tick-count and duration-valued periods support the reset form.  ``reset``
+is a ``SIGNAL``: any reset tick clears the window; a boolean value carried by a
+``TS[bool]`` bound as a signal is not interpreted.
+
+Evaluation ordering is:
+
+1. if reset ticked, clear the TSW;
+2. if ``ts`` supplied a valid tick, append that tick; and
+3. publish the resulting TSW modification.
+
+Consequently, simultaneous reset and source ticks produce a one-element window
+containing the current source value.  A reset-only cycle produces an observable
+empty-window tick.  Window readiness is recalculated from the cleared contents;
+the next source tick starts warm-up again.
+
+The reset input is an optional overload input rather than a per-tick scalar
+policy.  Existing calls and their resolved output schemas remain unchanged.
+
+Python contract
+---------------
+
+Python wiring exposes the same named input:
+
+.. code-block:: python
+
+   values = to_window(ts, 20, min_window_period=5, reset=reset)
+
+Python user nodes observe the same empty value and modification semantics as
+C++ nodes.  There is no independent Python reset implementation.
+
+Representation and performance
+------------------------------
+
+Clear destroys the live cyclic-buffer or duration-queue elements in place and
+retains allocation.  Its cost is ``O(size)`` because element destructors must
+run; it performs no additional allocation.  The ordinary push path remains
+unchanged.  A boolean carried by the short-lived mutation view records whether
+that scope performed the permitted clear-before-push sequence.  The storage
+reuses the existing last-eviction timestamp with an absent evicted value to
+mark the most recent clear.  This lets legacy delta capture reject
+clear-plus-push as well as clear-only ticks without allocation or changing the
+TSW physical layout.
+
+Compatibility and persistence restriction
+-----------------------------------------
+
+Existing source-only ``to_window`` calls are source- and behaviour-compatible.
+The TSW current value can already represent an empty list, but the canonical
+TSW delta is currently only the newly appended scalar.  It cannot distinguish:
+
+* no TSW tick;
+* a clear-only TSW tick; and
+* a scheduler-driven removal-only TSW tick.
+
+Therefore phase-one resettable TSWs are not delta-record/recover safe.  A
+recorder asked to capture any TSW tick containing a clear, whether clear-only
+or clear followed by push, must fail explicitly rather than silently omit the
+clear.  Full-current-value inspection remains valid.  RFC 0007 will define a
+versioned structured delta and the associated migration.
+
+This restriction is intentional: clear is needed to establish correct graph
+and node ownership now, while inventing a partial persistence encoding would
+make the later duration-eviction migration harder.
+
+Alternatives considered
+-----------------------
+
+Private queues in every rolling node
+   Rejected.  They duplicate TSW semantics, prevent standard composition, and
+   make recovery dependent on each consumer.
+
+Rebuild a switched nested graph for each reset
+   Rejected as the primitive contract.  Branch construction samples held
+   inputs and introduces lifecycle and allocation semantics unrelated to
+   clearing a window.
+
+Replace the TSW from an erased empty list
+   Possible internally, but unsuitable as the public authoring API and unable
+   to express the permitted atomic clear-then-push sequence clearly.
+
+Acceptance criteria
+-------------------
+
+* Fixed and duration TSW mutation tests cover non-empty clear, empty clear,
+  retained capacity, rejection of invalid same-cycle operations, and an atomic
+  clear followed by push.
+* Native C++ wiring tests cover reset-only, source-only, and simultaneous
+  reset/source cycles for tick and duration periods.
+* Python wiring tests prove the same behaviours through the native operator.
+* Existing ``to_window`` and TSW tests remain unchanged and pass.
+* Unsupported clear-only and clear-plus-push delta capture are tested as
+  explicit errors.
+* The complete native and non-WIP Python compatibility suites pass.
+
+Implementation status
+---------------------
+
+Implemented on the proposal branch, pending review and acceptance:
+
+* fixed- and duration-window storage implement observable, capacity-retaining
+  clear;
+* typed and erased mutation APIs expose clear;
+* ``to_window`` has reset-aware tick-count and duration overloads in C++ and
+  Python wiring; and
+* native and Python tests cover reset ordering and the explicit legacy-delta
+  limitation.
+
+References
+----------
+
+* :doc:`rfc_0000`
+* :doc:`rfc_0007_scheduled_duration_tsw_eviction`

--- a/docs/source/rfc/rfc_0007_scheduled_duration_tsw_eviction.rst
+++ b/docs/source/rfc/rfc_0007_scheduled_duration_tsw_eviction.rst
@@ -12,13 +12,14 @@ Summary
 
 Define the implementation plan for duration-based time-series windows to evict
 expired observations at their actual expiry time, even when the source remains
-silent.  Scheduler interaction belongs to the node producing the duration
-``TSW``, or to a reusable producer-side facility acting on that node's behalf;
-it does not belong to the output or storage object.  ``to_window`` is the first
-producer to use this mechanism, not its exclusive owner.  The work also
-replaces the singular removal surface and scalar-only TSW delta with
-representations capable of describing multiple evictions, reset-only ticks,
-and removal-only scheduled ticks.
+silent.  A graph containing one or more owned duration ``TSW`` outputs receives
+one graph-local pull source.  Duration windows subscribe to that source, which
+schedules the earliest expiry and mutates every due window when evaluated.
+This covers ``to_window`` and any other node whose output is, or contains, a
+duration TSW without giving each producer its own scheduling implementation.
+The work also replaces the singular removal surface and scalar-only TSW delta
+with representations capable of describing multiple evictions, reset-only
+ticks, and removal-only scheduled ticks.
 
 This RFC is a design plan.  No scheduler-driven eviction or persistence-format
 change is supplied with RFC 0006.
@@ -41,42 +42,63 @@ they expired earlier.  At ``t=20s`` several values leave together, while the
 current C++ surface preserves only the last removed element.  Incremental
 consumers cannot update correctly from that delta.
 
-Scheduler ownership
--------------------
+Graph-local expiry source
+-------------------------
 
 TSW value storage remains independent of graph execution and scheduling.  It
 must be usable in values, tests, record/replay materialisation, and extension
-code without owning a node or graph.
+code without requiring a graph.  A standalone duration window continues to
+prune on explicit mutation; scheduled eviction is an execution-layer service.
 
-A node producing a duration ``TSW`` is the execution-layer owner that can bring
-together the required parties:
+During graph assembly, core recursively inspects resolved, owned output
+schemas.  If at least one output is, or contains, a duration TSW, it adds
+exactly one special pull source to that runtime graph.  This must apply to both
+normal ``Wiring`` construction and the supported direct C++ graph-builder path.
+Layout-only dependencies rank the source before every node owning such an
+output.  It is the first normal-rank source, after the root graph's mandatory
+push-source phase.  Each dynamically instantiated nested graph has its own
+expiry source because rank, evaluation time, and scheduling are graph-local.
 
-* the duration and closure rule;
-* the output TSW;
-* the current evaluation time; and
-* its injected ``NodeScheduler``.
+When an owning node starts, the framework attaches each duration TSW in its
+output tree to the graph's expiry source.  The relationship is subscription
+based:
 
-This applies to ``to_window`` and to any other node that constructs a duration
-TSW.  It would be incorrect to hard-code expiry scheduling as a special
-property of ``to_window``: a custom adaptor, replay source, aggregation node, or
-extension node can also be a TSW producer and must be able to provide the same
-time-range guarantee.
+* the TSW output retains an opaque subscription/callback to the source through
+  the existing execution-time notification machinery;
+* the source retains a stable handle to the TSW and its next expiry;
+* a TSW mutation notifies the source, which inserts, updates, or removes that
+  window's expiry entry; and
+* source invalidation or graph stop removes the subscription before either
+  endpoint is destroyed.
 
-Core should therefore provide a reusable producer-side expiry facility.  The
-exact C++ shape is subject to implementation review; it may be a small
-controller, node policy, or shared eval utility.  It must:
+The source is shared by ``to_window``, custom adaptors, replay sources,
+aggregation nodes, and extension nodes.  Producers neither inject
+``NodeScheduler`` for this purpose nor implement expiry callbacks themselves.
 
-* operate on an explicitly supplied duration TSW output and ``NodeScheduler``;
-* provide due-expiry processing plus cancel/re-arm operations after mutation;
-* keep any alarm identity and lifecycle state with the producer node;
-* support a distinct alarm for each duration TSW output when one node produces
-  several windows; and
-* be usable by installed C++ extensions without depending on ``to_window``.
+Rank order also gives the required lifecycle order.  The expiry source starts
+before producer nodes, so it is available when their outputs attach.  Stop runs
+in reverse rank while all node storage remains alive, so producers complete
+their stop hooks before the source releases its remaining subscriptions.  The
+source must release every subscription before graph storage destruction.
 
-The duration ``to_window`` overload will inject ``NodeScheduler`` and use this
-facility for its output.  Other producers use the same contract.  The output
-view will not retain a scheduler or producer pointer and will not call back
-into its owning node.
+Output-tree coverage
+--------------------
+
+The subscription pass must cover owned duration TSWs at any fixed path,
+including fields beneath ``TSB`` and fixed ``TSL`` outputs.  A node with several
+duration windows creates several subscriptions to the same pull source.
+
+Dynamic output trees require incremental attachment.  When a duration TSW is
+created beneath a dynamic ``TSL`` or ``TSD``, the output-tree lifecycle attaches
+it before or as part of publishing that structural change.  Erasure detaches it
+before its storage is destroyed.  This should reuse the existing slot-observer
+and source-invalidation patterns rather than rescan the complete output tree on
+every tick.
+
+Forwarding outputs and ``REF`` values do not create a second subscription to an
+upstream window: only the output that owns the duration TSW storage registers
+it.  Alternative views over the same storage likewise resolve to one
+subscription identity.
 
 Proposed execution algorithm
 ----------------------------
@@ -89,18 +111,41 @@ The storage/view layer will provide operations equivalent to:
    TSWRemovalView evict_expired(DateTime now);
 
 The exact names and return representation are subject to implementation review.
-For ``to_window``, the producer algorithm is:
+The graph-level algorithm is:
 
-1. On reset, cancel ``"expiry"`` and clear the window.
-2. On a due ``"expiry"`` alarm, evict every value outside the time range.
-3. On a valid source tick, append it after reset/expiry processing.
-4. If the window is non-empty, schedule ``"expiry"`` for the oldest retained
-   value's expiry time; otherwise leave the tag unscheduled.
-5. Mark the TSW modified once when any clear, removal, or append occurred.
+1. Graph assembly creates one expiry pull source when the graph owns at least
+   one duration TSW and ranks it before all corresponding producer nodes.
+2. Start-time attachment registers each live window.  Registration reads its
+   current oldest timestamp, so a restored or pre-seeded window is armed
+   without persisting an alarm handle.
+3. After a push, clear, restore, or removal, the TSW subscription reports its
+   new ``next_expiry_time``.  An empty window removes its entry.
+4. The source maintains all entries and schedules its node for the earliest
+   expiry across the graph.  Updating one window does not create another pull
+   source or poll the other windows.
+5. When evaluated, the source visits every entry due at or before the current
+   evaluation time, calls ``evict_expired(now)``, and marks each changed TSW
+   modified.  Normal output notification then schedules downstream consumers.
+6. The resulting mutation notification supplies the window's next expiry, and
+   the source arms itself for the new global minimum.
 
-When an input and alarm coincide, expiry is processed before append.  This
-gives one deterministic TSW delta for the evaluation cycle and avoids
-transiently exceeding the duration contract.
+The source's queue should use a stable subscription identifier plus a
+generation to reject stale entries after reschedule, reset, dynamic erasure, or
+address reuse.
+
+Eviction marks the TSW modified and therefore notifies its expiry subscription
+while the source is itself evaluating.  Queue updates must be re-entrant safe:
+the entry being processed is identified by subscription and generation, and
+the callback records its replacement deadline without invalidating the due-set
+iteration.
+
+When a producer tick and expiry coincide, graph rank evaluates the expiry
+source first.  The producer can then append or clear-and-append in the same
+cycle, and downstream consumers observe one final window value and one
+structured delta containing all removals and additions.  Stage 1 must therefore
+allow scheduler removal followed by an owner mutation through separate mutation
+scopes at the same evaluation time; the present singular-delta guard is not
+sufficient.
 
 Window closure
 --------------
@@ -175,11 +220,13 @@ A checkpoint for a duration TSW must preserve retained values and their
 original evaluation timestamps.  Replaying values without timestamps changes
 their future expiry and is not recovery.
 
-Scheduled alarm handles are not persisted.  Recovery restores the TSW current
-state and then derives the next alarm from the oldest value.  The implementation
-must verify graph-start ordering so re-arming occurs after output seeding.  If
-the existing lifecycle cannot guarantee that ordering, add an explicit
-post-recovery/re-arm hook rather than persisting scheduler internals.
+The expiry-source queue, subscription generations, and graph alarm are derived
+execution state and are not persisted.  Start-time subscription reads the
+restored TSW and derives its next alarm from the oldest value.  If recovery
+seeding occurs during the owning node's start hook, attachment must happen
+first so the seed mutation updates the source.  A start-completion invariant
+check must prove that every non-empty owned duration TSW has one live source
+entry.
 
 Recovery conformance is defined by comparing uninterrupted and recovered runs:
 they must emit the same append, reset, and scheduled-removal cycles at the same
@@ -188,13 +235,18 @@ evaluation times.
 Runtime and performance goals
 -----------------------------
 
-* Maintain at most one pending expiry alarm per live duration TSW output.
+* Create at most one expiry pull source per runtime graph and one subscription
+  per live, owned duration TSW.
+* Keep one graph alarm for the earliest window expiry; the source owns the
+  remaining per-window deadlines.
 * Perform no polling ticks while the window is empty.
-* Make each alarm ``O(k)`` for the ``k`` values actually evicted, plus ``O(1)``
-  rescheduling.
+* For ``w`` live windows, update a deadline in ``O(log w)`` without scanning
+  unrelated windows.  Evicting ``r`` observations from ``d`` due windows should
+  cost ``O(r + d log w)``.
 * Keep ordinary fixed-count TSW push and singular eviction allocation-free.
-* Avoid an output-to-node pointer, scheduler pointer in TSW storage, or
-  process-global scheduler registry.
+* Add no scheduler state to producer nodes and no process-global scheduler
+  registry.  Standalone TSW value storage remains usable without a source
+  subscription.
 * Bound transient removal storage by the number of values evicted in the
   current evaluation cycle and release it after observers have run.
 
@@ -203,24 +255,24 @@ Implementation stages
 
 Stage 1: delta and mutation semantics
    Specify and implement the structured delta, multi-value removal storage,
-   clear capture/apply, legacy scalar reads, and direct native tests.  Do not
-   schedule expiry yet.
+   clear capture/apply, legacy scalar reads, and same-cycle removal followed by
+   owner mutation.  Add direct native tests.  Do not schedule expiry yet.
 
-Stage 2: node scheduling
-   Define the reusable producer-side expiry facility, integrate it with
-   duration ``to_window``, and exercise it from a second test producer to prove
-   that the mechanism is not tied to ``to_window``.  Implement expiry-only and
-   coincident input/expiry cycles in simulation; retain existing fixed-window
-   behaviour.
+Stage 2: graph-local expiry source
+   Add automatic source creation, rank dependencies, static output-tree
+   subscriptions, deadline management, and due eviction.  Exercise direct TSW
+   output, a TSW nested in a bundle, multiple producers, and coincident
+   producer/expiry cycles.  Retain existing fixed-window behaviour.
 
 Stage 3: recording and recovery
    Version the Arrow/JSON recording representation, preserve timestamps in
-   checkpoints, restore TSW state, re-arm the derived alarm, and compare
-   uninterrupted with recovered execution.
+   checkpoints, restore TSW state, rebuild source subscriptions and deadlines,
+   and compare uninterrupted with recovered execution.
 
-Stage 4: real-time and nested lifecycle
-   Exercise wall-clock lateness, graph stop/start boundaries, nested graph
-   teardown, reset cancellation, and no callbacks after node destruction.
+Stage 4: dynamic, real-time, and nested lifecycle
+   Add dynamic-child attachment and detachment.  Exercise wall-clock lateness,
+   graph stop/start boundaries, nested graph teardown, reset cancellation, and
+   no callbacks after node destruction.
 
 Test plan
 ---------
@@ -231,6 +283,10 @@ Native and Python tests must cover:
 * exact closed-left boundary behaviour;
 * multiple and duplicate-timestamp evictions;
 * input, reset, and expiry coinciding in one cycle;
+* one expiry source shared by multiple producer nodes and multiple TSW fields;
+* a direct TSW output, a bundle-contained TSW, and dynamically created TSW
+  children;
+* source rank before producers and downstream same-cycle notification order;
 * incremental sum/mean consumers using ``removed_values``;
 * old scalar-delta recordings read by the new implementation;
 * clear-only and removal-only delta record/replay;
@@ -238,8 +294,8 @@ Native and Python tests must cover:
 * recovery with an already-overdue oldest value;
 * simulation, real-time, nested graph stop, and teardown;
 * no scheduler or transient-removal allocation on fixed-count push; and
-* installed C++ extension use of both the producer-side expiry facility and
-  the new removal surface.
+* an installed C++ extension node whose output contains a duration TSW, without
+  depending on ``to_window``.
 
 Unresolved questions
 --------------------
@@ -248,7 +304,10 @@ Unresolved questions
 * The exact structured value schema used for zero-or-one ``added``.
 * Whether the delta migration belongs in the next major wire version or can be
   introduced under a TSW-specific metadata version.
-* Which lifecycle hook should re-arm derived alarms after recovery seeding.
+* Whether the expiry source should use an indexed heap or a lazy heap with
+  subscription generations.
+* The exact output-tree hook used to attach dynamic duration TSW children
+  without a full-tree scan.
 * Whether scheduler lateness should expose the scheduled expiry time in
   addition to the actual evaluation time.
 

--- a/docs/source/rfc/rfc_0007_scheduled_duration_tsw_eviction.rst
+++ b/docs/source/rfc/rfc_0007_scheduled_duration_tsw_eviction.rst
@@ -12,14 +12,16 @@ Summary
 
 Define the implementation plan for duration-based time-series windows to evict
 expired observations at their actual expiry time, even when the source remains
-silent.  A graph containing one or more owned duration ``TSW`` outputs receives
-one graph-local pull source.  Duration windows subscribe to that source, which
-schedules the earliest expiry and mutates every due window when evaluated.
-This covers ``to_window`` and any other node whose output is, or contains, a
-duration TSW without giving each producer its own scheduling implementation.
-The work also replaces the singular removal surface and scalar-only TSW delta
-with representations capable of describing multiple evictions, reset-only
-ticks, and removal-only scheduled ticks.
+silent.  A root graph containing one or more owned duration ``TSW`` outputs,
+including outputs inside nested graph instances, receives one root-owned pull
+source.  A runtime-only forward reference to that source is published in the
+root ``GlobalState`` shared by every nested graph.  Duration windows subscribe
+to the source, which schedules the earliest expiry and mutates every due window
+when evaluated.  This covers ``to_window`` and any other node whose output is,
+or contains, a duration TSW without giving each producer or nested graph its
+own scheduling implementation.  The work also replaces the singular removal
+surface and scalar-only TSW delta with representations capable of describing
+multiple evictions, reset-only ticks, and removal-only scheduled ticks.
 
 This RFC is a design plan.  No scheduler-driven eviction or persistence-format
 change is supplied with RFC 0006.
@@ -42,26 +44,38 @@ they expired earlier.  At ``t=20s`` several values leave together, while the
 current C++ surface preserves only the last removed element.  Incremental
 consumers cannot update correctly from that delta.
 
-Graph-local expiry source
--------------------------
+Root-graph expiry source
+------------------------
 
 TSW value storage remains independent of graph execution and scheduling.  It
 must be usable in values, tests, record/replay materialisation, and extension
 code without requiring a graph.  A standalone duration window continues to
 prune on explicit mutation; scheduled eviction is an execution-layer service.
 
-During graph assembly, core recursively inspects resolved, owned output
-schemas.  If at least one output is, or contains, a duration TSW, it adds
-exactly one special pull source to that runtime graph.  This must apply to both
-normal ``Wiring`` construction and the supported direct C++ graph-builder path.
-Layout-only dependencies rank the source before every node owning such an
-output.  It is the first normal-rank source, after the root graph's mandatory
-push-source phase.  Each dynamically instantiated nested graph has its own
-expiry source because rank, evaluation time, and scheduling are graph-local.
+During root graph assembly, core recursively inspects resolved, owned output
+schemas, including the output requirements of nested graph definitions.  If at
+least one output is, or contains, a duration TSW, it adds exactly one special
+pull source to the root graph.  This must apply to both normal ``Wiring``
+construction and the supported direct C++ graph-builder path.
+
+The root source publishes a typed, runtime-only forward reference under a
+reserved internal ``GlobalState`` key.  Nested ``GraphView::global_state()``
+already resolves to the root store, so a TSW at any nesting depth finds the
+same source.  The concrete representation should follow the existing
+type-erasure pattern: a reference to a private control output resolves its
+owning node, and that node exposes a typed expiry-source view.  It must not
+expose or persist a raw ``NodePtr``.  Root construction binds the forward
+reference after node storage is attached and before any node start hook; root
+stop removes it.
+
+Layout-only dependencies place the source before every normal root node that
+can own or host a duration TSW.  It is the first normal-rank source, after the
+root graph's mandatory push-source phase.  A nested graph does not create
+another expiry source.
 
 When an owning node starts, the framework attaches each duration TSW in its
-output tree to the graph's expiry source.  The relationship is subscription
-based:
+output tree to the root expiry source resolved from ``GlobalState``.  The
+relationship is subscription based:
 
 * the TSW output retains an opaque subscription/callback to the source through
   the existing execution-time notification machinery;
@@ -71,15 +85,17 @@ based:
 * source invalidation or graph stop removes the subscription before either
   endpoint is destroyed.
 
-The source is shared by ``to_window``, custom adaptors, replay sources,
-aggregation nodes, and extension nodes.  Producers neither inject
-``NodeScheduler`` for this purpose nor implement expiry callbacks themselves.
+The root source is shared by ``to_window``, custom adaptors, replay sources,
+aggregation nodes, extension nodes, and dynamically created nested graph
+instances.  Producers neither inject ``NodeScheduler`` for this purpose nor
+implement expiry callbacks themselves.
 
-Rank order also gives the required lifecycle order.  The expiry source starts
-before producer nodes, so it is available when their outputs attach.  Stop runs
-in reverse rank while all node storage remains alive, so producers complete
-their stop hooks before the source releases its remaining subscriptions.  The
-source must release every subscription before graph storage destruction.
+The forward reference is bound before start, so even a root push-source output
+can attach although push-source start hooks precede normal nodes.  Nested
+producers start later through their root parent and resolve the same reference.
+Stop and dynamic graph teardown detach subscriptions while both endpoints are
+alive.  The root source must release every remaining subscription and erase the
+reserved ``GlobalState`` entry before root graph storage destruction.
 
 Output-tree coverage
 --------------------
@@ -111,22 +127,29 @@ The storage/view layer will provide operations equivalent to:
    TSWRemovalView evict_expired(DateTime now);
 
 The exact names and return representation are subject to implementation review.
-The graph-level algorithm is:
+The root-level algorithm is:
 
-1. Graph assembly creates one expiry pull source when the graph owns at least
-   one duration TSW and ranks it before all corresponding producer nodes.
-2. Start-time attachment registers each live window.  Registration reads its
-   current oldest timestamp, so a restored or pre-seeded window is armed
-   without persisting an alarm handle.
-3. After a push, clear, restore, or removal, the TSW subscription reports its
+1. Root graph assembly creates one expiry pull source when the complete graph
+   can own at least one duration TSW and ranks it before corresponding normal
+   root producers and nested-graph host nodes.
+2. Root construction binds the source's typed forward reference into the
+   reserved ``GlobalState`` entry before start.
+3. Start-time attachment at any graph depth resolves that reference and
+   registers each live window.  Registration reads its current oldest
+   timestamp, so a restored or pre-seeded window is armed without persisting an
+   alarm handle.
+4. After a push, clear, restore, or removal, the TSW subscription reports its
    new ``next_expiry_time``.  An empty window removes its entry.
-4. The source maintains all entries and schedules its node for the earliest
-   expiry across the graph.  Updating one window does not create another pull
-   source or poll the other windows.
-5. When evaluated, the source visits every entry due at or before the current
+5. The root source maintains all entries and schedules itself for the earliest
+   expiry across the complete graph.  Updating one window does not create
+   another source or poll the other windows.
+6. When evaluated, the source visits every entry due at or before the current
    evaluation time, calls ``evict_expired(now)``, and marks each changed TSW
-   modified.  Normal output notification then schedules downstream consumers.
-6. The resulting mutation notification supplies the window's next expiry, and
+   modified.
+7. For a nested TSW, normal output notification schedules local consumers; the
+   existing nested schedule propagation wakes each parent until the
+   later-ranked root host node is scheduled in the same cycle.
+8. The resulting mutation notification supplies the window's next expiry, and
    the source arms itself for the new global minimum.
 
 The source's queue should use a stable subscription identifier plus a
@@ -139,13 +162,15 @@ the entry being processed is identified by subscription and generation, and
 the callback records its replacement deadline without invalidating the due-set
 iteration.
 
-When a producer tick and expiry coincide, graph rank evaluates the expiry
-source first.  The producer can then append or clear-and-append in the same
-cycle, and downstream consumers observe one final window value and one
-structured delta containing all removals and additions.  Stage 1 must therefore
-allow scheduler removal followed by an owner mutation through separate mutation
-scopes at the same evaluation time; the present singular-delta guard is not
-sufficient.
+When a normal producer tick and expiry coincide, root or nested rank evaluates
+the expiry effect before the producer.  The producer can then append or
+clear-and-append in the same cycle, and downstream consumers observe one final
+window value and one structured delta containing all removals and additions.
+Stage 1 must therefore allow scheduler removal followed by an owner mutation
+through separate mutation scopes at the same evaluation time; the present
+singular-delta guard is not sufficient.  A direct root push-source TSW producer
+runs in the mandatory push phase before the expiry source; its structured delta
+must normalize push/removal into the same final per-cycle result.
 
 Window closure
 --------------
@@ -235,9 +260,9 @@ evaluation times.
 Runtime and performance goals
 -----------------------------
 
-* Create at most one expiry pull source per runtime graph and one subscription
-  per live, owned duration TSW.
-* Keep one graph alarm for the earliest window expiry; the source owns the
+* Create at most one expiry pull source per root graph execution and one
+  subscription per live, owned duration TSW across all nested graphs.
+* Keep one root graph alarm for the earliest window expiry; the source owns the
   remaining per-window deadlines.
 * Perform no polling ticks while the window is empty.
 * For ``w`` live windows, update a deadline in ``O(log w)`` without scanning
@@ -258,11 +283,12 @@ Stage 1: delta and mutation semantics
    clear capture/apply, legacy scalar reads, and same-cycle removal followed by
    owner mutation.  Add direct native tests.  Do not schedule expiry yet.
 
-Stage 2: graph-local expiry source
-   Add automatic source creation, rank dependencies, static output-tree
-   subscriptions, deadline management, and due eviction.  Exercise direct TSW
-   output, a TSW nested in a bundle, multiple producers, and coincident
-   producer/expiry cycles.  Retain existing fixed-window behaviour.
+Stage 2: root-graph expiry source
+   Add automatic root source creation, the reserved ``GlobalState`` forward
+   reference, rank dependencies, static output-tree subscriptions, deadline
+   management, and due eviction.  Exercise direct TSW output, a TSW nested in a
+   bundle, root and nested producers, and coincident producer/expiry cycles.
+   Retain existing fixed-window behaviour.
 
 Stage 3: recording and recovery
    Version the Arrow/JSON recording representation, preserve timestamps in
@@ -283,10 +309,12 @@ Native and Python tests must cover:
 * exact closed-left boundary behaviour;
 * multiple and duplicate-timestamp evictions;
 * input, reset, and expiry coinciding in one cycle;
-* one expiry source shared by multiple producer nodes and multiple TSW fields;
+* one root expiry source shared by multiple producer nodes, nested graph
+  instances, and multiple TSW fields;
 * a direct TSW output, a bundle-contained TSW, and dynamically created TSW
   children;
-* source rank before producers and downstream same-cycle notification order;
+* root-source rank, nested schedule propagation, and downstream same-cycle
+  notification order;
 * incremental sum/mean consumers using ``removed_values``;
 * old scalar-delta recordings read by the new implementation;
 * clear-only and removal-only delta record/replay;

--- a/docs/source/rfc/rfc_0007_scheduled_duration_tsw_eviction.rst
+++ b/docs/source/rfc/rfc_0007_scheduled_duration_tsw_eviction.rst
@@ -12,10 +12,13 @@ Summary
 
 Define the implementation plan for duration-based time-series windows to evict
 expired observations at their actual expiry time, even when the source remains
-silent.  The ``to_window`` node, not the output or storage object, owns the
-scheduler interaction.  The work also replaces the singular removal surface
-and scalar-only TSW delta with representations capable of describing multiple
-evictions, reset-only ticks, and removal-only scheduled ticks.
+silent.  Scheduler interaction belongs to the node producing the duration
+``TSW``, or to a reusable producer-side facility acting on that node's behalf;
+it does not belong to the output or storage object.  ``to_window`` is the first
+producer to use this mechanism, not its exclusive owner.  The work also
+replaces the singular removal surface and scalar-only TSW delta with
+representations capable of describing multiple evictions, reset-only ticks,
+and removal-only scheduled ticks.
 
 This RFC is a design plan.  No scheduler-driven eviction or persistence-format
 change is supplied with RFC 0006.
@@ -45,16 +48,35 @@ TSW value storage remains independent of graph execution and scheduling.  It
 must be usable in values, tests, record/replay materialisation, and extension
 code without owning a node or graph.
 
-``to_window`` is the node that knows all required parties:
+A node producing a duration ``TSW`` is the execution-layer owner that can bring
+together the required parties:
 
 * the duration and closure rule;
 * the output TSW;
 * the current evaluation time; and
 * its injected ``NodeScheduler``.
 
-The duration overload will therefore inject ``NodeScheduler`` and manage one
-tagged ``"expiry"`` alarm.  The output view will not retain a scheduler pointer
-or call back into its owning node.
+This applies to ``to_window`` and to any other node that constructs a duration
+TSW.  It would be incorrect to hard-code expiry scheduling as a special
+property of ``to_window``: a custom adaptor, replay source, aggregation node, or
+extension node can also be a TSW producer and must be able to provide the same
+time-range guarantee.
+
+Core should therefore provide a reusable producer-side expiry facility.  The
+exact C++ shape is subject to implementation review; it may be a small
+controller, node policy, or shared eval utility.  It must:
+
+* operate on an explicitly supplied duration TSW output and ``NodeScheduler``;
+* provide due-expiry processing plus cancel/re-arm operations after mutation;
+* keep any alarm identity and lifecycle state with the producer node;
+* support a distinct alarm for each duration TSW output when one node produces
+  several windows; and
+* be usable by installed C++ extensions without depending on ``to_window``.
+
+The duration ``to_window`` overload will inject ``NodeScheduler`` and use this
+facility for its output.  Other producers use the same contract.  The output
+view will not retain a scheduler or producer pointer and will not call back
+into its owning node.
 
 Proposed execution algorithm
 ----------------------------
@@ -67,7 +89,7 @@ The storage/view layer will provide operations equivalent to:
    TSWRemovalView evict_expired(DateTime now);
 
 The exact names and return representation are subject to implementation review.
-The node algorithm is:
+For ``to_window``, the producer algorithm is:
 
 1. On reset, cancel ``"expiry"`` and clear the window.
 2. On a due ``"expiry"`` alarm, evict every value outside the time range.
@@ -166,7 +188,7 @@ evaluation times.
 Runtime and performance goals
 -----------------------------
 
-* Maintain at most one pending expiry alarm per duration ``to_window`` node.
+* Maintain at most one pending expiry alarm per live duration TSW output.
 * Perform no polling ticks while the window is empty.
 * Make each alarm ``O(k)`` for the ``k`` values actually evicted, plus ``O(1)``
   rescheduling.
@@ -185,7 +207,9 @@ Stage 1: delta and mutation semantics
    schedule expiry yet.
 
 Stage 2: node scheduling
-   Add the tagged scheduler to duration ``to_window``; implement expiry-only and
+   Define the reusable producer-side expiry facility, integrate it with
+   duration ``to_window``, and exercise it from a second test producer to prove
+   that the mechanism is not tied to ``to_window``.  Implement expiry-only and
    coincident input/expiry cycles in simulation; retain existing fixed-window
    behaviour.
 
@@ -214,7 +238,8 @@ Native and Python tests must cover:
 * recovery with an already-overdue oldest value;
 * simulation, real-time, nested graph stop, and teardown;
 * no scheduler or transient-removal allocation on fixed-count push; and
-* installed C++ extension use of the new removal surface.
+* installed C++ extension use of both the producer-side expiry facility and
+  the new removal surface.
 
 Unresolved questions
 --------------------

--- a/docs/source/rfc/rfc_0007_scheduled_duration_tsw_eviction.rst
+++ b/docs/source/rfc/rfc_0007_scheduled_duration_tsw_eviction.rst
@@ -1,0 +1,241 @@
+RFC 0007: Scheduler-Driven Duration TSW Eviction
+================================================
+
+:Status: Proposed
+:Author: Howard Henson
+:Created: 2026-07-25
+:Target: Duration TSW scheduling, deltas, recording, and recovery
+:Related: RFC 0006
+
+Summary
+-------
+
+Define the implementation plan for duration-based time-series windows to evict
+expired observations at their actual expiry time, even when the source remains
+silent.  The ``to_window`` node, not the output or storage object, owns the
+scheduler interaction.  The work also replaces the singular removal surface
+and scalar-only TSW delta with representations capable of describing multiple
+evictions, reset-only ticks, and removal-only scheduled ticks.
+
+This RFC is a design plan.  No scheduler-driven eviction or persistence-format
+change is supplied with RFC 0006.
+
+Problem statement
+-----------------
+
+The present duration TSW prunes old values only while pushing a new source
+value.  Given a ten-second range:
+
+.. code-block:: text
+
+   t=0s   1
+   t=1s   2
+   t=2s   3
+   t=20s  4
+
+the values ``1``, ``2``, and ``3`` remain visible until ``t=20s`` even though
+they expired earlier.  At ``t=20s`` several values leave together, while the
+current C++ surface preserves only the last removed element.  Incremental
+consumers cannot update correctly from that delta.
+
+Scheduler ownership
+-------------------
+
+TSW value storage remains independent of graph execution and scheduling.  It
+must be usable in values, tests, record/replay materialisation, and extension
+code without owning a node or graph.
+
+``to_window`` is the node that knows all required parties:
+
+* the duration and closure rule;
+* the output TSW;
+* the current evaluation time; and
+* its injected ``NodeScheduler``.
+
+The duration overload will therefore inject ``NodeScheduler`` and manage one
+tagged ``"expiry"`` alarm.  The output view will not retain a scheduler pointer
+or call back into its owning node.
+
+Proposed execution algorithm
+----------------------------
+
+The storage/view layer will provide operations equivalent to:
+
+.. code-block:: cpp
+
+   DateTime next_expiry_time() const;
+   TSWRemovalView evict_expired(DateTime now);
+
+The exact names and return representation are subject to implementation review.
+The node algorithm is:
+
+1. On reset, cancel ``"expiry"`` and clear the window.
+2. On a due ``"expiry"`` alarm, evict every value outside the time range.
+3. On a valid source tick, append it after reset/expiry processing.
+4. If the window is non-empty, schedule ``"expiry"`` for the oldest retained
+   value's expiry time; otherwise leave the tag unscheduled.
+5. Mark the TSW modified once when any clear, removal, or append occurred.
+
+When an input and alarm coincide, expiry is processed before append.  This
+gives one deterministic TSW delta for the evaluation cycle and avoids
+transiently exceeding the duration contract.
+
+Window closure
+--------------
+
+The current implementation removes values whose timestamp is strictly less
+than ``now - range``.  It therefore represents the closed interval
+``[now-range, now]``.  With microsecond-resolution ``DateTime``, a value at
+``t`` first becomes invalid at ``t + range + MIN_TD``.
+
+The implementation should initially preserve this boundary for compatibility
+and schedule that first invalid instant.  Tests must cover the exact boundary,
+one microsecond after it, duplicate timestamps, and several values sharing one
+expiry.  A different closure policy would require an explicit operator policy
+and separate RFC review.
+
+Removal surface
+---------------
+
+The C++ TSW surface will gain a per-evaluation range:
+
+.. code-block:: cpp
+
+   Range<ValueView> removed_values() const;
+
+For a fixed-count TSW the range contains zero or one value.  For a duration TSW
+it may contain any number.  The existing singular ``removed_value`` may remain
+as a fixed-window convenience, but duration consumers must not silently receive
+only the final removal.
+
+The storage representation should own removed values only until the end of the
+evaluation cycle.  The plan must establish stable borrowed-view lifetime,
+destruction, and after-evaluation cleanup without allocating on the
+single-removal fixed-window hot path.
+
+Structured TSW delta
+--------------------
+
+The existing scalar TSW delta cannot represent clear or removal-only events.
+A versioned structured delta is required before scheduled eviction can ship.
+The candidate logical shape is:
+
+.. code-block:: text
+
+   TSWDelta<T>:
+       cleared: bool
+       added:   zero-or-one T
+       removed: zero-or-more T
+
+The implementation review must choose concrete value schemas that preserve
+type erasure and avoid optional-value ambiguity.  A zero-or-one list for
+``added`` is preferable to assigning sentinel meaning to a default ``T``.
+
+``removed`` includes every value removed by expiry or fixed-window overflow.
+On clear it includes the formerly retained values and ``cleared`` remains true,
+including for an already-empty window.  This lets incremental consumers remove
+their derived state while preserving the semantically important empty clear.
+
+The review must decide whether removal timestamps are part of the public delta
+or remain accessible only through a richer transient view.  This decision
+requires examples using time-weighted and event-time algorithms before the
+schema is accepted.
+
+Recording and migration
+-----------------------
+
+The structured delta is a wire-format change and requires its own version
+marker.  Readers must continue accepting legacy scalar TSW deltas, interpreting
+each as ``cleared=false, added=[value], removed=[]``.  Writers emit only the new
+format after migration.
+
+A checkpoint for a duration TSW must preserve retained values and their
+original evaluation timestamps.  Replaying values without timestamps changes
+their future expiry and is not recovery.
+
+Scheduled alarm handles are not persisted.  Recovery restores the TSW current
+state and then derives the next alarm from the oldest value.  The implementation
+must verify graph-start ordering so re-arming occurs after output seeding.  If
+the existing lifecycle cannot guarantee that ordering, add an explicit
+post-recovery/re-arm hook rather than persisting scheduler internals.
+
+Recovery conformance is defined by comparing uninterrupted and recovered runs:
+they must emit the same append, reset, and scheduled-removal cycles at the same
+evaluation times.
+
+Runtime and performance goals
+-----------------------------
+
+* Maintain at most one pending expiry alarm per duration ``to_window`` node.
+* Perform no polling ticks while the window is empty.
+* Make each alarm ``O(k)`` for the ``k`` values actually evicted, plus ``O(1)``
+  rescheduling.
+* Keep ordinary fixed-count TSW push and singular eviction allocation-free.
+* Avoid an output-to-node pointer, scheduler pointer in TSW storage, or
+  process-global scheduler registry.
+* Bound transient removal storage by the number of values evicted in the
+  current evaluation cycle and release it after observers have run.
+
+Implementation stages
+---------------------
+
+Stage 1: delta and mutation semantics
+   Specify and implement the structured delta, multi-value removal storage,
+   clear capture/apply, legacy scalar reads, and direct native tests.  Do not
+   schedule expiry yet.
+
+Stage 2: node scheduling
+   Add the tagged scheduler to duration ``to_window``; implement expiry-only and
+   coincident input/expiry cycles in simulation; retain existing fixed-window
+   behaviour.
+
+Stage 3: recording and recovery
+   Version the Arrow/JSON recording representation, preserve timestamps in
+   checkpoints, restore TSW state, re-arm the derived alarm, and compare
+   uninterrupted with recovered execution.
+
+Stage 4: real-time and nested lifecycle
+   Exercise wall-clock lateness, graph stop/start boundaries, nested graph
+   teardown, reset cancellation, and no callbacks after node destruction.
+
+Test plan
+---------
+
+Native and Python tests must cover:
+
+* source silence beyond one or several expiry boundaries;
+* exact closed-left boundary behaviour;
+* multiple and duplicate-timestamp evictions;
+* input, reset, and expiry coinciding in one cycle;
+* incremental sum/mean consumers using ``removed_values``;
+* old scalar-delta recordings read by the new implementation;
+* clear-only and removal-only delta record/replay;
+* checkpoint recovery during warm-up and immediately before expiry;
+* recovery with an already-overdue oldest value;
+* simulation, real-time, nested graph stop, and teardown;
+* no scheduler or transient-removal allocation on fixed-count push; and
+* installed C++ extension use of the new removal surface.
+
+Unresolved questions
+--------------------
+
+* Whether public removal deltas require original timestamps as well as values.
+* The exact structured value schema used for zero-or-one ``added``.
+* Whether the delta migration belongs in the next major wire version or can be
+  introduced under a TSW-specific metadata version.
+* Which lifecycle hook should re-arm derived alarms after recovery seeding.
+* Whether scheduler lateness should expose the scheduled expiry time in
+  addition to the actual evaluation time.
+
+Acceptance criteria
+-------------------
+
+This RFC may move to ``Accepted`` only when all four implementation stages,
+versioned migration tests, native/Python parity, installed-SDK coverage, and the
+complete acceptance suites pass.
+
+References
+----------
+
+* :doc:`rfc_0000`
+* :doc:`rfc_0006_tsw_reset_and_clear`

--- a/include/hgraph/lib/std/operators/impl/stream_impl.h
+++ b/include/hgraph/lib/std/operators/impl/stream_impl.h
@@ -78,6 +78,28 @@ namespace hgraph::stdlib
             }
         };
 
+        /**
+         * Resettable tick-count TSW. Reset is processed before a simultaneous
+         * source tick, so the resulting window begins with the current value.
+         */
+        struct to_window_reset_impl : to_window_impl
+        {
+            static constexpr auto name = "to_window_reset";
+
+            static void eval(In<"ts", TS<ScalarVar<"T">>, InputValidity::Unchecked> ts,
+                             Scalar<"period", Int>,
+                             Scalar<"min_window_period", Int>,
+                             In<"reset", SIGNAL, InputValidity::Unchecked> reset,
+                             Out<TsVar<"__out__">> out)
+            {
+                const auto &erased   = static_cast<const TSOutputView &>(out);
+                auto        window   = erased.as_window();
+                auto        mutation = window.begin_mutation(erased.evaluation_time());
+                if (reset.modified()) { mutation.clear(); }
+                if (ts.modified() && ts.valid()) { mutation.push(ts.base().value()); }
+            }
+        };
+
         /** Window readiness: size windows need min_period elements, duration
             windows need the newest-oldest span to reach min_time_range
             (mirrors the data layer's all_valid). */
@@ -128,6 +150,25 @@ namespace hgraph::stdlib
                 auto        window   = erased.as_window();
                 auto        mutation = window.begin_mutation(erased.evaluation_time());
                 mutation.push(ts.base().value());
+            }
+        };
+
+        /** Resettable duration TSW with the same reset-before-source ordering. */
+        struct to_window_duration_reset_impl : to_window_duration_impl
+        {
+            static constexpr auto name = "to_window_duration_reset";
+
+            static void eval(In<"ts", TS<ScalarVar<"T">>, InputValidity::Unchecked> ts,
+                             Scalar<"period", TimeDelta>,
+                             Scalar<"min_window_period", TimeDelta>,
+                             In<"reset", SIGNAL, InputValidity::Unchecked> reset,
+                             Out<TsVar<"__out__">> out)
+            {
+                const auto &erased   = static_cast<const TSOutputView &>(out);
+                auto        window   = erased.as_window();
+                auto        mutation = window.begin_mutation(erased.evaluation_time());
+                if (reset.modified()) { mutation.clear(); }
+                if (ts.modified() && ts.valid()) { mutation.push(ts.base().value()); }
             }
         };
 

--- a/include/hgraph/lib/std/operators/stream.h
+++ b/include/hgraph/lib/std/operators/stream.h
@@ -97,7 +97,9 @@ namespace hgraph::stdlib
     };
 
     /** ``to_window`` — convert ``ts`` into a ``TSW`` time-series window of
-        ``period`` ticks, valid once ``min_window_period`` ticks arrived. */
+        ``period`` ticks, valid once ``min_window_period`` ticks arrived.
+        An optional ``reset`` SIGNAL overload clears retained ticks before
+        admitting a source tick from the same evaluation cycle. */
     struct to_window : Operator<"to_window", In<"ts", TsVar<"S">>, Scalar<"period", Int>,
                                 Scalar<"min_window_period", Int>, Out<TsVar<"O">>>
     {

--- a/include/hgraph/types/static_node.h
+++ b/include/hgraph/types/static_node.h
@@ -1520,6 +1520,8 @@ namespace hgraph
             TSWOutputView::begin_mutation(evaluation_time()).push(wrapped.view());
         }
 
+        void clear() const { TSWOutputView::begin_mutation(evaluation_time()).clear(); }
+
         void apply(const ValueView &value) const { TSWOutputView::begin_mutation(evaluation_time()).push(value); }
     };
 

--- a/include/hgraph/types/time_series/ts_data/ops.h
+++ b/include/hgraph/types/time_series/ts_data/ops.h
@@ -333,6 +333,8 @@ namespace hgraph
         bool (*full_impl)(const void *context, const void *memory) = nullptr;
         void (*push_impl)(const void *context, void *memory, const ValueView &source,
                           DateTime modified_time) = nullptr;
+        void (*clear_impl)(const void *context, void *memory, DateTime modified_time) = nullptr;
+        DateTime (*cleared_time_impl)(const void *context, const void *memory) = nullptr;
         // The element most recently EVICTED by a push (hgraph's
         // removed_value): the time it fell out plus its value memory
         // (nullptr when nothing has been evicted yet).

--- a/include/hgraph/types/time_series/ts_data/window_view.h
+++ b/include/hgraph/types/time_series/ts_data/window_view.h
@@ -131,7 +131,12 @@ namespace hgraph
          */
         void clear();
 
-        /** Replace the window from a value-layer window/list representation. */
+        /**
+         * Replace the window from a value-layer window/list representation.
+         *
+         * A replacement is rejected after clear has participated in the same
+         * evaluation cycle, including through a different mutation view.
+         */
         [[nodiscard]] bool copy_value_from(const ValueView &source);
 
       private:

--- a/include/hgraph/types/time_series/ts_data/window_view.h
+++ b/include/hgraph/types/time_series/ts_data/window_view.h
@@ -61,6 +61,9 @@ namespace hgraph
         [[nodiscard]] bool has_removed_value(DateTime evaluation_time) const;
         [[nodiscard]] ValueView removed_value(DateTime evaluation_time) const;
 
+        /** True when clear participated in the supplied evaluation cycle. */
+        [[nodiscard]] bool cleared(DateTime evaluation_time) const;
+
         /** Time associated with the oldest element, or ``MIN_DT`` when empty. */
         [[nodiscard]] DateTime first_modified_time() const;
 
@@ -119,6 +122,15 @@ namespace hgraph
         /** Append one window tick. Only one tick is accepted per evaluation time. */
         void push(const ValueView &source);
 
+        /**
+         * Remove every retained tick and mark the window modified.
+         *
+         * One push may follow through this same mutation scope, allowing
+         * reset-before-current-value semantics without exposing an
+         * intermediate window state.
+         */
+        void clear();
+
         /** Replace the window from a value-layer window/list representation. */
         [[nodiscard]] bool copy_value_from(const ValueView &source);
 
@@ -128,6 +140,7 @@ namespace hgraph
         TSWDataMutationView(TSWDataStorageRef storage, DateTime evaluation_time, TrustedStorageTag);
 
         TSDataMutationView mutation_;
+        bool               cleared_{false};
     };
 }  // namespace hgraph
 

--- a/python/tests/test_tsw_reset.py
+++ b/python/tests/test_tsw_reset.py
@@ -1,0 +1,42 @@
+from datetime import timedelta
+
+from hgraph import SIGNAL, TS, TSW, WINDOW_SIZE, WINDOW_SIZE_MIN, compute_node, eval_node, graph, to_window
+
+
+@compute_node
+def _snapshot(window: TSW[int, WINDOW_SIZE, WINDOW_SIZE_MIN]) -> TS[tuple[int, ...]]:
+    return tuple(window.value)
+
+
+@graph
+def _tick_window(ts: TS[int], reset: SIGNAL) -> TS[tuple[int, ...]]:
+    return _snapshot(to_window(ts, 3, 1, reset=reset))
+
+
+@graph
+def _duration_window(ts: TS[int], reset: SIGNAL) -> TS[tuple[int, ...]]:
+    return _snapshot(to_window(ts, timedelta(microseconds=10), timedelta(microseconds=1), reset=reset))
+
+
+def test_tick_window_reset_clears_before_a_later_source_tick():
+    assert eval_node(
+        _tick_window,
+        [1, 2, None, 3, 4],
+        [None, None, True, None, None],
+    ) == [(1,), (1, 2), (), (3,), (3, 4)]
+
+
+def test_tick_window_reset_clears_before_a_simultaneous_source_tick():
+    assert eval_node(
+        _tick_window,
+        [1, 2, 3],
+        [None, True, None],
+    ) == [(1,), (2,), (2, 3)]
+
+
+def test_duration_window_supports_the_same_reset_contract():
+    assert eval_node(
+        _duration_window,
+        [1, 2, None, 3],
+        [None, None, True, None],
+    ) == [(1,), (1, 2), (), (3,)]

--- a/src/hgraph/lib/std/operators/stream_impl.cpp
+++ b/src/hgraph/lib/std/operators/stream_impl.cpp
@@ -29,7 +29,9 @@ namespace hgraph::stdlib
         register_graph_overload<freeze, freeze_fn_compose>();
         register_overload<gate, gate_impl>();
         register_overload<to_window, stream_impl_detail::to_window_impl>();
+        register_overload<to_window, stream_impl_detail::to_window_reset_impl>();
         register_overload<to_window, stream_impl_detail::to_window_duration_impl>();
+        register_overload<to_window, stream_impl_detail::to_window_duration_reset_impl>();
         register_overload<abs_, stream_impl_detail::abs_tsw_impl<Int>>();
         register_overload<abs_, stream_impl_detail::abs_tsw_impl<Float>>();
         register_overload<sum_, stream_impl_detail::tsw_numeric_aggregate_impl<false, Int>>();

--- a/src/hgraph/types/metadata/ts_data_window_ops.cpp
+++ b/src/hgraph/types/metadata/ts_data_window_ops.cpp
@@ -120,6 +120,18 @@ namespace hgraph::ts_data_plan_factory_detail
                 removed_value) and the evaluation time it fell out. */
             [[nodiscard]] const Value &evicted_element() const noexcept { return evicted_; }
             [[nodiscard]] DateTime evicted_time() const noexcept { return evicted_time_; }
+            [[nodiscard]] DateTime cleared_time() const noexcept
+            {
+                return evicted_.has_value() ? MIN_DT : evicted_time_;
+            }
+
+            /** Clear the logical window while retaining its allocation. */
+            void clear_values(DateTime modified_time) noexcept
+            {
+                clear();
+                evicted_.reset();
+                evicted_time_ = modified_time;
+            }
 
             [[nodiscard]] const void *element_at(std::size_t index) const
             {
@@ -819,6 +831,8 @@ namespace hgraph::ts_data_plan_factory_detail
                 ops.capacity_impl    = nullptr;
                 ops.full_impl        = nullptr;
                 ops.push_impl        = &window_push;
+                ops.clear_impl       = &window_clear;
+                ops.cleared_time_impl = &window_cleared_time;
                 ops.evicted_time_impl    = &window_evicted_time;
                 ops.evicted_element_impl = &window_evicted_element;
             }
@@ -826,6 +840,11 @@ namespace hgraph::ts_data_plan_factory_detail
             [[nodiscard]] static DateTime window_evicted_time(const void *context, const void *memory) noexcept
             {
                 return storage<Storage>(window_value_memory(context, memory)).evicted_time();
+            }
+
+            [[nodiscard]] static DateTime window_cleared_time(const void *context, const void *memory) noexcept
+            {
+                return storage<Storage>(window_value_memory(context, memory)).cleared_time();
             }
 
             [[nodiscard]] static const void *window_evicted_element(const void *context, const void *memory) noexcept
@@ -950,6 +969,11 @@ namespace hgraph::ts_data_plan_factory_detail
                                     DateTime modified_time)
             {
                 storage<Storage>(window_mutable_value_memory(context, memory)).push(source, modified_time);
+            }
+
+            static void window_clear(const void *context, void *memory, DateTime modified_time)
+            {
+                storage<Storage>(window_mutable_value_memory(context, memory)).clear_values(modified_time);
             }
 
             [[nodiscard]] static bool window_copy_value_from(const void *context, void *memory,

--- a/src/hgraph/types/time_series/ts_data/window_view.cpp
+++ b/src/hgraph/types/time_series/ts_data/window_view.cpp
@@ -162,6 +162,13 @@ namespace hgraph
         return ValueView{data_layout.element_binding, ops.evicted_element_impl(ops.context, memory)};
     }
 
+    bool TSWDataView::cleared(DateTime evaluation_time) const
+    {
+        const auto &ops = window_ops();
+        return evaluation_time != MIN_DT && ops.cleared_time_impl != nullptr &&
+               ops.cleared_time_impl(ops.context, storage_.data()) == evaluation_time;
+    }
+
     DateTime TSWDataView::first_modified_time() const
     {
         const auto &ops = window_ops();
@@ -341,7 +348,7 @@ namespace hgraph
     void TSWDataMutationView::push(const ValueView &source)
     {
         const auto &ops = window_ops();
-        if (mutation_.modified(ops, current_mutation_time()))
+        if (mutation_.modified(ops, current_mutation_time()) && !cleared_)
         {
             throw std::logic_error("TSWDataMutationView::push allows only one window tick per evaluation time");
         }
@@ -351,6 +358,23 @@ namespace hgraph
         }
         ops.push_impl(ops.context, mutation_.mutable_data(ops), source, current_mutation_time());
         mutation_.mark_modified(ops);
+        cleared_ = false;
+    }
+
+    void TSWDataMutationView::clear()
+    {
+        const auto &ops = window_ops();
+        if (mutation_.modified(ops, current_mutation_time()))
+        {
+            throw std::logic_error("TSWDataMutationView::clear allows only one reset per evaluation time");
+        }
+        if (ops.clear_impl == nullptr)
+        {
+            throw std::logic_error("TSWDataMutationView::clear is not supported by this TSW ops");
+        }
+        ops.clear_impl(ops.context, mutation_.mutable_data(ops), current_mutation_time());
+        mutation_.mark_modified(ops);
+        cleared_ = true;
     }
 
     bool TSWDataMutationView::copy_value_from(const ValueView &source)

--- a/src/hgraph/types/time_series/ts_data/window_view.cpp
+++ b/src/hgraph/types/time_series/ts_data/window_view.cpp
@@ -379,6 +379,11 @@ namespace hgraph
 
     bool TSWDataMutationView::copy_value_from(const ValueView &source)
     {
+        if (cleared(current_mutation_time()))
+        {
+            throw std::logic_error(
+                "TSWDataMutationView::copy_value_from cannot replace a window after clear in the same evaluation time");
+        }
         return mutation_.copy_value_from(source);
     }
 }  // namespace hgraph

--- a/src/hgraph/types/time_series/ts_delta.cpp
+++ b/src/hgraph/types/time_series/ts_delta.cpp
@@ -384,7 +384,18 @@ namespace hgraph
 
         Value capture_delta_tsw(const TSInputView &in)
         {
-            return Value{in.delta_value()};
+            if (in.data_view().as_window().cleared(in.evaluation_time()))
+            {
+                throw std::logic_error(
+                    "capture_delta: TSW clear ticks are not representable by the legacy scalar delta");
+            }
+            const ValueView delta = in.delta_value();
+            if (!delta.has_value())
+            {
+                throw std::logic_error(
+                    "capture_delta: TSW clear/removal-only ticks are not representable by the legacy scalar delta");
+            }
+            return Value{delta};
         }
 
         Value capture_delta_tss(const TSInputView &in)

--- a/tests/cpp/test_plan_factories.cpp
+++ b/tests/cpp/test_plan_factories.cpp
@@ -1218,6 +1218,49 @@ TEST_CASE("TSDataPlanFactory: tick TSW stores a fixed cyclic current window")
     auto  duplicate_mutation = window.begin_mutation(t4);
     REQUIRE_THROWS_AS(duplicate_mutation.push(duplicate.view()), std::logic_error);
 
+    const auto retained_capacity = window.capacity();
+    const auto t5 = t4 + TimeDelta{1};
+    Value five{5};
+    {
+        auto mutation = window.begin_mutation(t5);
+        mutation.clear();
+        REQUIRE(mutation.empty());
+        REQUIRE(mutation.modified(t5));
+        REQUIRE_FALSE(mutation.delta_value(t5).has_value());
+        REQUIRE_FALSE(mutation.has_removed_value(t5));
+
+        // Reset and a source tick in one node evaluation are atomic: clear
+        // first, then retain only the current source value.
+        mutation.push(five.view());
+        REQUIRE(mutation.size() == 1);
+        REQUIRE(mutation.back().checked_as<std::int32_t>() == 5);
+        REQUIRE_THROWS_AS(mutation.push(five.view()), std::logic_error);
+    }
+    REQUIRE(window.capacity() == retained_capacity);
+    REQUIRE(window.size() == 1);
+    REQUIRE(window.time_at(0) == t5);
+
+    const auto t6 = t5 + TimeDelta{1};
+    {
+        auto mutation = window.begin_mutation(t6);
+        mutation.clear();
+        REQUIRE(mutation.empty());
+        REQUIRE_THROWS_AS(mutation.clear(), std::logic_error);
+    }
+    REQUIRE(window.capacity() == retained_capacity);
+    REQUIRE(window.empty());
+    REQUIRE(window.modified(t6));
+    REQUIRE_FALSE(window.delta_value(t6).has_value());
+
+    const auto t7 = t6 + TimeDelta{1};
+    {
+        auto mutation = window.begin_mutation(t7);
+        mutation.clear();
+        REQUIRE(mutation.empty());
+    }
+    REQUIRE(window.modified(t7));
+    REQUIRE(window.capacity() == retained_capacity);
+
     const auto *move_assign_meta = registry.register_scalar<MoveAssignableOnlyScalar>("move_assign_only");
     const auto *move_assign_tsw  = registry.tsw(move_assign_meta, 1, 1);
     const auto move_type = factory.data_type_for(move_assign_tsw);
@@ -1321,6 +1364,45 @@ TEST_CASE("TSDataPlanFactory: duration TSW stores a timestamped queue current wi
     REQUIRE(window.removed_value(t3).checked_as<std::int32_t>() == 1);
     REQUIRE_FALSE(window.has_removed_value(t3 + TimeDelta{1}));
     REQUIRE_THROWS_AS(window.removed_value(t3 + TimeDelta{1}), std::logic_error);
+
+    const auto retained_capacity = window.capacity();
+    const auto t4 = t3 + TimeDelta{1};
+    Value four{4};
+    {
+        auto mutation = window.begin_mutation(t4);
+        mutation.clear();
+        REQUIRE(mutation.empty());
+        REQUIRE(mutation.modified(t4));
+        REQUIRE_FALSE(mutation.delta_value(t4).has_value());
+        REQUIRE_FALSE(mutation.has_removed_value(t4));
+
+        mutation.push(four.view());
+        REQUIRE(mutation.size() == 1);
+        REQUIRE(mutation.back().checked_as<std::int32_t>() == 4);
+        REQUIRE_THROWS_AS(mutation.push(four.view()), std::logic_error);
+    }
+    REQUIRE(window.capacity() == retained_capacity);
+    REQUIRE(window.size() == 1);
+    REQUIRE(window.time_at(0) == t4);
+
+    const auto t5 = t4 + TimeDelta{1};
+    {
+        auto mutation = window.begin_mutation(t5);
+        mutation.clear();
+        REQUIRE(mutation.empty());
+        REQUIRE_THROWS_AS(mutation.clear(), std::logic_error);
+    }
+    REQUIRE(window.modified(t5));
+    REQUIRE(window.capacity() == retained_capacity);
+
+    const auto t6 = t5 + TimeDelta{1};
+    {
+        auto mutation = window.begin_mutation(t6);
+        mutation.clear();
+        REQUIRE(mutation.empty());
+    }
+    REQUIRE(window.modified(t6));
+    REQUIRE(window.capacity() == retained_capacity);
 }
 
 TEST_CASE("TSDataPlanFactory: fixed structured TSData recursively embeds child layouts")

--- a/tests/cpp/test_plan_factories.cpp
+++ b/tests/cpp/test_plan_factories.cpp
@@ -1221,6 +1221,7 @@ TEST_CASE("TSDataPlanFactory: tick TSW stores a fixed cyclic current window")
     const auto retained_capacity = window.capacity();
     const auto t5 = t4 + TimeDelta{1};
     Value five{5};
+    auto  replacement = stdlib::make_list<std::int32_t>({7, 8});
     {
         auto mutation = window.begin_mutation(t5);
         mutation.clear();
@@ -1228,10 +1229,15 @@ TEST_CASE("TSDataPlanFactory: tick TSW stores a fixed cyclic current window")
         REQUIRE(mutation.modified(t5));
         REQUIRE_FALSE(mutation.delta_value(t5).has_value());
         REQUIRE_FALSE(mutation.has_removed_value(t5));
+        REQUIRE_THROWS_AS(mutation.copy_value_from(replacement.view()), std::logic_error);
+        REQUIRE(mutation.empty());
 
         // Reset and a source tick in one node evaluation are atomic: clear
         // first, then retain only the current source value.
         mutation.push(five.view());
+        REQUIRE(mutation.size() == 1);
+        REQUIRE(mutation.back().checked_as<std::int32_t>() == 5);
+        REQUIRE_THROWS_AS(mutation.copy_value_from(replacement.view()), std::logic_error);
         REQUIRE(mutation.size() == 1);
         REQUIRE(mutation.back().checked_as<std::int32_t>() == 5);
         REQUIRE_THROWS_AS(mutation.push(five.view()), std::logic_error);
@@ -1246,6 +1252,10 @@ TEST_CASE("TSDataPlanFactory: tick TSW stores a fixed cyclic current window")
         mutation.clear();
         REQUIRE(mutation.empty());
         REQUIRE_THROWS_AS(mutation.clear(), std::logic_error);
+    }
+    {
+        auto replacement_mutation = window.begin_mutation(t6);
+        REQUIRE_THROWS_AS(replacement_mutation.copy_value_from(replacement.view()), std::logic_error);
     }
     REQUIRE(window.capacity() == retained_capacity);
     REQUIRE(window.empty());
@@ -1368,6 +1378,7 @@ TEST_CASE("TSDataPlanFactory: duration TSW stores a timestamped queue current wi
     const auto retained_capacity = window.capacity();
     const auto t4 = t3 + TimeDelta{1};
     Value four{4};
+    auto  replacement = stdlib::make_list<std::int32_t>({7, 8});
     {
         auto mutation = window.begin_mutation(t4);
         mutation.clear();
@@ -1375,8 +1386,13 @@ TEST_CASE("TSDataPlanFactory: duration TSW stores a timestamped queue current wi
         REQUIRE(mutation.modified(t4));
         REQUIRE_FALSE(mutation.delta_value(t4).has_value());
         REQUIRE_FALSE(mutation.has_removed_value(t4));
+        REQUIRE_THROWS_AS(mutation.copy_value_from(replacement.view()), std::logic_error);
+        REQUIRE(mutation.empty());
 
         mutation.push(four.view());
+        REQUIRE(mutation.size() == 1);
+        REQUIRE(mutation.back().checked_as<std::int32_t>() == 4);
+        REQUIRE_THROWS_AS(mutation.copy_value_from(replacement.view()), std::logic_error);
         REQUIRE(mutation.size() == 1);
         REQUIRE(mutation.back().checked_as<std::int32_t>() == 4);
         REQUIRE_THROWS_AS(mutation.push(four.view()), std::logic_error);
@@ -1391,6 +1407,10 @@ TEST_CASE("TSDataPlanFactory: duration TSW stores a timestamped queue current wi
         mutation.clear();
         REQUIRE(mutation.empty());
         REQUIRE_THROWS_AS(mutation.clear(), std::logic_error);
+    }
+    {
+        auto replacement_mutation = window.begin_mutation(t5);
+        REQUIRE_THROWS_AS(replacement_mutation.copy_value_from(replacement.view()), std::logic_error);
     }
     REQUIRE(window.modified(t5));
     REQUIRE(window.capacity() == retained_capacity);

--- a/tests/cpp/test_std_operators.cpp
+++ b/tests/cpp/test_std_operators.cpp
@@ -183,6 +183,42 @@ namespace
         }
     };
 
+    struct WindowSnapshot
+    {
+        static constexpr auto name = "window_snapshot";
+
+        static void eval(In<"window", TsVar<"W">, InputValidity::Unchecked> input,
+                         Out<TS<Int>> out)
+        {
+            auto window = input.base().as_window();
+            Int  total  = 0;
+            for (const ValueView value : window.values()) { total += value.checked_as<Int>(); }
+            out.set(static_cast<Int>(window.size()) * 100 + total);
+        }
+    };
+
+    struct ResettableTickWindowGraph
+    {
+        static constexpr auto name = "resettable_tick_window_graph";
+
+        static Port<TS<Int>> compose(Wiring &w, Port<TS<Int>> ts, Port<SIGNAL> reset)
+        {
+            auto window = wire<stdlib::to_window>(w, ts, Int{3}, Int{1}, reset);
+            return wire<WindowSnapshot, TS<Int>>(w, window);
+        }
+    };
+
+    struct ResettableDurationWindowGraph
+    {
+        static constexpr auto name = "resettable_duration_window_graph";
+
+        static Port<TS<Int>> compose(Wiring &w, Port<TS<Int>> ts, Port<SIGNAL> reset)
+        {
+            auto window = wire<stdlib::to_window>(w, ts, MIN_TD * 10, MIN_TD, reset);
+            return wire<WindowSnapshot, TS<Int>>(w, window);
+        }
+    };
+
     // Scalar-container TS schemas are runtime metadata today. The wrapper graph
     // pins the output type expectation while eval_runtime_schema_graph supplies
     // the input schema at replay.
@@ -1882,6 +1918,18 @@ TEST_CASE("std operators: stream operators cover sampling filtering slicing and 
     CHECK_OUTPUT(eval_node<stdlib::to_window>(values<Int>(1, 2, 3, 4, 5), MIN_TD * 2),
                  values<Value>(Value{Int{1}}, Value{Int{2}}, Value{Int{3}},
                                Value{Int{4}}, Value{Int{5}}));
+    CHECK_OUTPUT(eval_node<ResettableTickWindowGraph>(
+                     values<Int>(1, 2, none, 3, 4),
+                     values<Bool>(none, none, true, none, none)),
+                 values<Int>(101, 203, 0, 103, 207));
+    CHECK_OUTPUT(eval_node<ResettableTickWindowGraph>(
+                     values<Int>(1, 2, 3),
+                     values<Bool>(none, true, none)),
+                 values<Int>(101, 102, 205));
+    CHECK_OUTPUT(eval_node<ResettableDurationWindowGraph>(
+                     values<Int>(1, 2, none, 3),
+                     values<Bool>(none, none, true, none)),
+                 values<Int>(101, 203, 0, 103));
 
     CHECK_OUTPUT(eval_node<stdlib::count>(values<Int>(3, none, 2, 1)), values<Int>(1, none, 2, 3));
     CHECK_OUTPUT(eval_node<stdlib::dedup>(values<Int>(1, 2, 2, 3, 3, 3, 4)),

--- a/tests/cpp/test_ts_delta.cpp
+++ b/tests/cpp/test_ts_delta.cpp
@@ -461,6 +461,62 @@ TEST_CASE("ts_delta: capture/apply round-trip a TSW scalar push delta") {
                {Value{Int{1}}, Value{Int{2}}, Value{Int{3}}});
 }
 
+TEST_CASE("ts_delta: legacy TSW delta capture rejects a clear-only tick") {
+  (void)TypeRegistry::instance().register_scalar<Int>("int");
+  const auto *schema = schema_descriptor<TSW<Int, 3, 1>>::ts_meta();
+  TSOutput output{schema};
+  TSInput input{TSInputBuilderFactory::checked_builder_for(
+      *schema, TSEndpointSchema::peered(schema))};
+
+  const auto t1 = MIN_ST;
+  const auto t2 = t1 + MIN_TD;
+  input.view(nullptr, t1).bind_output(output.view(t1));
+
+  {
+    auto data = output.data_view();
+    auto window = data.as_window();
+    auto mutation = window.begin_mutation(t1);
+    Value one{Int{1}};
+    mutation.push(one.view());
+  }
+  {
+    auto data = output.data_view();
+    auto window = data.as_window();
+    auto mutation = window.begin_mutation(t2);
+    mutation.clear();
+  }
+
+  auto cleared = input.view(nullptr, t2);
+  REQUIRE(cleared.modified());
+  REQUIRE_FALSE(cleared.delta_value().has_value());
+  REQUIRE_THROWS_AS(capture_delta(cleared), std::logic_error);
+}
+
+TEST_CASE("ts_delta: legacy TSW delta capture rejects clear followed by push") {
+  (void)TypeRegistry::instance().register_scalar<Int>("int");
+  const auto *schema = schema_descriptor<TSW<Int, 3, 1>>::ts_meta();
+  TSOutput output{schema};
+  TSInput input{TSInputBuilderFactory::checked_builder_for(
+      *schema, TSEndpointSchema::peered(schema))};
+
+  const auto t1 = MIN_ST;
+  input.view(nullptr, t1).bind_output(output.view(t1));
+
+  {
+    auto data = output.data_view();
+    auto window = data.as_window();
+    auto mutation = window.begin_mutation(t1);
+    Value one{Int{1}};
+    mutation.clear();
+    mutation.push(one.view());
+  }
+
+  auto reset_and_pushed = input.view(nullptr, t1);
+  REQUIRE(reset_and_pushed.modified());
+  REQUIRE(reset_and_pushed.delta_value().checked_as<Int>() == 1);
+  REQUIRE_THROWS_AS(capture_delta(reset_and_pushed), std::logic_error);
+}
+
 TEST_CASE("ts_delta: capture/apply round-trip a SIGNAL tick delta") {
   (void)TypeRegistry::instance().register_scalar<bool>("bool");
   const std::vector<std::optional<Value>> deltas{Value{true}, Value{true},


### PR DESCRIPTION
## Summary

- add an observable, capacity-retaining `clear()` operation to fixed-count and duration `TSW` storage
- add reset-aware `to_window` overloads for C++ and Python wiring, with reset-before-source ordering in the same evaluation cycle
- reject clear-only and clear-plus-push capture through the legacy scalar TSW delta so persistence cannot silently lose reset semantics
- document the implemented phase in RFC 0006 and the follow-on scheduler-driven duration eviction, structured delta, and recovery plan in RFC 0007
- add native storage/operator/delta tests and Python wiring coverage

## Motivation

Rolling computations should use `TSW` as the authoritative tick window instead of maintaining duplicate tick queues in private node state. The existing window API could append and evict through admission but could not express an explicit reset. Duration windows also need a separate, carefully designed follow-on for scheduled eviction during source silence and recoverable multi-removal deltas.

## User and developer impact

C++ and Python graphs can now wire an optional `reset` signal to `to_window`. A reset clears retained observations before admitting a simultaneous source tick, restarts warm-up, remains observable when the window is already empty, and retains the existing allocation. Existing source-only calls are unchanged.

Until the structured delta work described by RFC 0007 is implemented, recording a TSW cycle containing clear fails explicitly rather than producing an incomplete legacy delta.

## Validation

- rebased onto current `main` (`da7dab49`)
- hg-linux Release build with GNU 15.2 and 20 parallel jobs
- native CTest suite: 1,259/1,259 passed
- local native, Python compatibility, documentation, and Ubuntu GCC 13 validation completed before the final rebase
- `git diff --check`
