### PR TITLE
Fix Python dataclass runtime integration

### DIFF
--- a/docs/source/developer_guide/python_integration.rst
+++ b/docs/source/developer_guide/python_integration.rst
@@ -439,7 +439,10 @@ Recorded divergences / gaps (the morning-summary list):
   frame-local resolution), and a ``CONTEXT[TS[X]] = None`` parameter on a
   user node resolves by type/name — ``REQUIRED`` / ``REQUIRED["name"]`` /
   a call-site ``context="name"`` override, ``WiringError`` on failure; the
-  resolved context VALUE is entered (context-manager protocol) around each
+  type-based compatibility check normalises parameterised Python aliases to
+  their origin class, so a published ``TSB[Price[float]]`` satisfies a context
+  requested through a non-generic base class of ``Price``; the resolved
+  context VALUE is entered (context-manager protocol) around each
   eval, exactly hgraph's semantics. The C++-design-record API also stands:
   ``with hg.context("name", port)`` + ``hg.context.get/has`` over the
   string-keyed scope stack. Underpinning both: **arbitrary python objects

--- a/docs/source/rfc/rfc_0004_python_owned_structured_scalars.rst
+++ b/docs/source/rfc/rfc_0004_python_owned_structured_scalars.rst
@@ -777,7 +777,12 @@ binding. Its complete read-only ``IndexedValueOps`` surface projects declared
 attributes lazily, so ``BundleView`` and generic Bundle operators do not need
 to know which storage policy owns the value. ``TSB`` continues to hold the
 anonymous structural field representation and constructs the Python object
-only when converted to the scalar form.
+only when converted to the scalar form. Realised ``TSB`` output storage keeps
+that structural field layout even when the owning binding is a non-composite
+closed polymorphic union. The projection is recursive, so named Python-owned
+bundles nested inside anonymous structural bundles keep the same layout
+contract. This applies equally to standalone bundles and bundles held in
+``TSD`` slots.
 
 One representation-neutral capability was added to erased value operations:
 an owning binding may decide whether a partially valid indexed source contains

--- a/include/hgraph/types/metadata/ts_data_plan_factory_detail.h
+++ b/include/hgraph/types/metadata/ts_data_plan_factory_detail.h
@@ -27,6 +27,9 @@ namespace hgraph::ts_data_plan_factory_detail
     [[nodiscard]] const MemoryUtils::StoragePlan &ts_data_aux_plan(const TSValueTypeMetaData &schema);
     [[nodiscard]] const MemoryUtils::StoragePlan &ts_data_aux_plan(const TSValueTypeMetaData &schema,
                                                                   TypeRole role);
+    [[nodiscard]] ValueTypeRef fixed_value_storage_binding(
+        const TSValueTypeMetaData &schema,
+        ValueTypeRef value_binding);
     [[nodiscard]] const MemoryUtils::StoragePlan *synthesise_fixed_plan(const TSValueTypeMetaData &schema);
     [[nodiscard]] const MemoryUtils::StoragePlan *synthesise_dynamic_list_plan(const TSValueTypeMetaData &schema);
     [[nodiscard]] const MemoryUtils::StoragePlan *synthesise_window_plan(const TSValueTypeMetaData &schema);

--- a/include/hgraph/types/metadata/value_plan_factory.h
+++ b/include/hgraph/types/metadata/value_plan_factory.h
@@ -116,6 +116,16 @@ namespace hgraph
             const ValueTypeMetaData *schema,
             std::span<const ValueTypeRef> field_bindings);
 
+        /**
+         * Build a structural Tuple/Bundle projection from explicit field
+         * bindings while retaining ``schema`` as the binding's nominal
+         * identity. Unlike ``realized_composite_type_for``, this accepts
+         * Owned schemas whose canonical storage is non-composite.
+         */
+        [[nodiscard]] ValueTypeRef projected_composite_type_for(
+            const ValueTypeMetaData *schema,
+            std::span<const ValueTypeRef> field_bindings);
+
         /** Binding lookup only; never synthesises. Returns ``nullptr`` when missing. */
         [[nodiscard]] ValueTypeRef find_type(const ValueTypeMetaData *schema) const;
 

--- a/python/hgraph/_wiring/_core.py
+++ b/python/hgraph/_wiring/_core.py
@@ -427,6 +427,8 @@ def _resolve_context(ctx_expr, name=None, resolution_scope=None):
     Generic annotations bind through the caller's native ResolutionScope so
     repeated uses of one type variable remain consistent.
     """
+    import typing
+
     from .._types import (
         _GenericTsExpr,
         _TSB_SCHEMA_CLASSES,
@@ -456,6 +458,8 @@ def _resolve_context(ctx_expr, name=None, resolution_scope=None):
                     _hgraph.tsb_value_vt(candidate))
                 if published_class is None:
                     published_class = _TSB_SCHEMA_CLASSES.get(candidate)
+            requested_class = typing.get_origin(requested_class) or requested_class
+            published_class = typing.get_origin(published_class) or published_class
             matches = (
                 isinstance(requested_class, type)
                 and isinstance(published_class, type)

--- a/python/tests/ported/_wiring/test_context.py
+++ b/python/tests/ported/_wiring/test_context.py
@@ -1,9 +1,13 @@
 from dataclasses import dataclass
+from typing import Generic, TypeVar
 
 import pytest
 
 import hgraph as hg
 from hgraph.test import eval_node
+
+
+T = TypeVar("T")
 
 
 class _TestContext:
@@ -204,3 +208,82 @@ def test_compound_context_selects_a_compatible_base_type():
             return read_context(trigger)
 
     assert eval_node(app, [True, None, False]) == ["bundle", None, "bundle"]
+
+
+def test_parameterized_dataclass_context_selects_a_compatible_base_type():
+    @dataclass(frozen=True)
+    class ContextValue(_TestContext, Generic[T]):
+        value: T
+        msg: str = "generic bundle"
+
+    @hg.compute_node(valid=("trigger", "context"))
+    def read_context(
+        trigger: hg.TS[bool], context: hg.CONTEXT[_TestContext] = None,
+    ) -> hg.TS[str]:
+        return _TestContext.instance().msg
+
+    @hg.graph
+    def app(trigger: hg.TS[bool]) -> hg.TS[str]:
+        with hg.combine[hg.TSB[ContextValue[int]]](
+            value=1, msg="generic bundle"
+        ):
+            return hg.switch_(
+                trigger,
+                {
+                    True: lambda selected: read_context(selected),
+                    False: lambda selected: hg.format_(
+                        "{} false", read_context(selected)
+                    ),
+                },
+                trigger,
+            )
+
+    assert eval_node(app, [True, None, False]) == [
+        "generic bundle",
+        None,
+        "generic bundle false",
+    ]
+
+
+def test_parameterized_dataclass_context_from_service_crosses_switch_boundary():
+    @dataclass(frozen=True)
+    class ContextValue(_TestContext, Generic[T]):
+        value: T
+        msg: str
+
+    @hg.subscription_service
+    def lookup(key: hg.TS[str]) -> hg.TSB[ContextValue[int]]: ...
+
+    @hg.service_impl(interfaces=lookup)
+    def lookup_impl(keys: hg.TSS[str]) -> hg.TSD[str, hg.TSB[ContextValue[int]]]:
+        return hg.map_(
+            lambda key: hg.TSB[ContextValue[int]].from_ts(value=1, msg=key),
+            __keys__=keys,
+        )
+
+    @hg.compute_node(valid=("trigger", "context"))
+    def read_context(
+        trigger: hg.TS[bool], context: hg.CONTEXT[_TestContext] = None,
+    ) -> hg.TS[str]:
+        return _TestContext.instance().msg
+
+    @hg.graph
+    def app(trigger: hg.TS[bool], key: hg.TS[str]) -> hg.TS[str]:
+        hg.register_service(hg.default_path, lookup_impl)
+        with lookup(key):
+            return hg.switch_(
+                trigger,
+                {
+                    True: lambda selected: read_context(selected),
+                    False: lambda selected: hg.format_(
+                        "{} false", read_context(selected)
+                    ),
+                },
+                trigger,
+            )
+
+    assert eval_node(app, [True, None, False], ["context"]) == [
+        None,
+        "context",
+        "context false",
+    ]

--- a/python/tests/test_python_owned_structured_scalar.py
+++ b/python/tests/test_python_owned_structured_scalar.py
@@ -14,6 +14,7 @@ from hgraph import (
     TimeSeriesSchema,
     combine,
     compute_node,
+    const,
     convert,
     dispatch_,
     drop_dups,
@@ -211,6 +212,10 @@ def test_tsb_round_trip_preserves_a_python_owned_polymorphic_field():
         expiry: str
 
     @dataclass(frozen=True)
+    class Cash(Instrument):
+        currency: str
+
+    @dataclass(frozen=True)
     class Envelope:
         instrument: Instrument
 
@@ -223,6 +228,69 @@ def test_tsb_round_trip_preserves_a_python_owned_polymorphic_field():
     result = eval_node(round_trip, [future])
     assert result == [Envelope(future)]
     assert type(result[0].instrument) is Future
+
+    cash = Cash("USD", "USD")
+    assert eval_node(round_trip, [future, cash, future]) == [
+        Envelope(future),
+        Envelope(cash),
+        Envelope(future),
+    ]
+
+
+def test_tsd_of_generic_python_dataclass_bundles_tears_down_cleanly():
+    T = TypeVar("T")
+
+    @dataclass(frozen=True)
+    class Unit:
+        name: str
+
+    @dataclass(frozen=True)
+    class PrimaryUnit(Unit):
+        dimension: str
+
+    @dataclass(frozen=True)
+    class Price(Generic[T]):
+        qty: T
+        currency_unit: Unit
+        unit: Unit
+
+    @dataclass(frozen=True)
+    class Submission:
+        instrument: str
+        price: Price[float]
+
+    @graph
+    def ignore(values: TSD[str, TSB[Price[float]]]) -> TS[int]:
+        return const(1)
+
+    @graph
+    def ignore_nested(values: TSD[int, TSB[Submission]]) -> TS[int]:
+        return const(1)
+
+    gbp_usd = Price(
+        1.25,
+        PrimaryUnit("USD", "currency"),
+        PrimaryUnit("GBP", "currency"),
+    )
+    usd_gbp = Price(
+        0.8,
+        PrimaryUnit("GBP", "currency"),
+        PrimaryUnit("USD", "currency"),
+    )
+    assert eval_node(
+        ignore,
+        [
+            None,
+            {
+                "GBPUSD": gbp_usd,
+                "USDGBP": usd_gbp,
+            },
+        ],
+    ) == [1, None]
+    assert eval_node(
+        ignore_nested,
+        [None, {1: Submission("GBPUSD", gbp_usd)}],
+    ) == [1, None]
 
 
 def test_combine_and_tsb_round_trip_use_the_python_constructor():

--- a/src/hgraph/types/metadata/ts_data_fixed_structured_plan.cpp
+++ b/src/hgraph/types/metadata/ts_data_fixed_structured_plan.cpp
@@ -34,41 +34,8 @@ namespace hgraph::ts_data_plan_factory_detail
 
         [[nodiscard]] ValueTypeRef fixed_value_storage_binding(const TSValueTypeMetaData &schema)
         {
-            auto binding = realized_value_binding(schema.value_schema);
-            if (schema.kind != TSTypeKind::TSB || !binding || binding.checked_plan().is_composite())
-            {
-                return binding;
-            }
-
-            // A TSB always stores its children independently. A named Bundle
-            // may nevertheless have a canonical non-composite representation
-            // (for example a Python-owned object projected through
-            // IndexedValueOps). Use the schema's anonymous structural twin for
-            // the TSB's internal field storage; its public value surface will
-            // materialise the canonical owning representation through erased
-            // Bundle operations.
-            const auto *value_schema = schema.value_schema;
-            if (value_schema == nullptr || value_schema->wrapped_un_named == nullptr)
-            {
-                throw std::logic_error(
-                    "TSDataPlanFactory: non-composite TSB value has no structural twin");
-            }
-            const auto *indexed = checked_value_ops<IndexedValueOps>(
-                binding, "TSDataPlanFactory: non-composite TSB value");
-            std::vector<ValueTypeRef> fields;
-            fields.reserve(value_schema->field_count);
-            for (std::size_t index = 0; index < value_schema->field_count; ++index)
-            {
-                const auto field = indexed->element_binding(indexed->context, nullptr, index);
-                if (!field)
-                {
-                    throw std::logic_error(
-                        "TSDataPlanFactory: non-composite TSB field binding is unresolved");
-                }
-                fields.push_back(field);
-            }
-            return ValuePlanFactory::instance().realized_composite_type_for(
-                value_schema->wrapped_un_named, fields);
+            return ts_data_plan_factory_detail::fixed_value_storage_binding(
+                schema, realized_value_binding(schema.value_schema));
         }
 
         [[nodiscard]] TSRoleTypeRef realized_output_type(const TSValueTypeMetaData &schema)
@@ -212,6 +179,61 @@ namespace hgraph::ts_data_plan_factory_detail
             builder.add_field("tracking", MemoryUtils::plan_for<TSDataTracking>());
             return builder.build();
         }
+    }
+
+    ValueTypeRef fixed_value_storage_binding(
+        const TSValueTypeMetaData &schema,
+        ValueTypeRef value_binding)
+    {
+        if (schema.kind != TSTypeKind::TSB || !value_binding)
+        {
+            return value_binding;
+        }
+
+        // A TSB always stores its children independently. A named Bundle may
+        // nevertheless have a non-composite owning representation, including
+        // a Python-owned object or a closed polymorphic union. Project every
+        // nested TSB field recursively so an anonymous outer Bundle cannot
+        // embed a child's owning representation in storage that the child
+        // treats as structural.
+        const auto *value_schema = schema.value_schema;
+        if (value_schema == nullptr)
+        {
+            throw std::logic_error(
+                "TSDataPlanFactory: TSB value schema is unresolved");
+        }
+        const auto *indexed = checked_value_ops<IndexedValueOps>(
+            value_binding, "TSDataPlanFactory: TSB value");
+        std::vector<ValueTypeRef> fields;
+        fields.reserve(value_schema->field_count);
+        bool requires_projection = !value_binding.checked_plan().is_composite();
+        for (std::size_t index = 0; index < value_schema->field_count; ++index)
+        {
+            auto field =
+                indexed->element_binding(indexed->context, nullptr, index);
+            if (!field)
+            {
+                throw std::logic_error(
+                    "TSDataPlanFactory: TSB field binding is unresolved");
+            }
+            const auto *child_schema = fixed_element_schema(schema, index);
+            if (child_schema == nullptr)
+            {
+                throw std::logic_error(
+                    "TSDataPlanFactory: TSB field schema is unresolved");
+            }
+            const auto projected =
+                fixed_value_storage_binding(*child_schema, field);
+            requires_projection = requires_projection || projected != field;
+            field = projected;
+            fields.push_back(field);
+        }
+        if (!requires_projection)
+        {
+            return value_binding;
+        }
+        return ValuePlanFactory::instance().projected_composite_type_for(
+            value_schema, fields);
     }
 
     [[nodiscard]] std::string field_component_name(std::size_t index)

--- a/src/hgraph/types/metadata/ts_data_plan_factory.cpp
+++ b/src/hgraph/types/metadata/ts_data_plan_factory.cpp
@@ -359,9 +359,12 @@ namespace hgraph
             }
         }
 
+        const auto storage_binding =
+            fixed ? plan_detail::fixed_value_storage_binding(*schema, value_binding)
+                  : value_binding;
         auto builder = MemoryUtils::named_tuple();
         builder.reserve(2);
-        builder.add_field("value", value_binding.checked_plan());
+        builder.add_field("value", storage_binding.checked_plan());
         if (scalar) { builder.add_field("tracking", MemoryUtils::plan_for<TSDataTracking>()); }
         else
         {

--- a/src/hgraph/types/metadata/value_plan_factory.cpp
+++ b/src/hgraph/types/metadata/value_plan_factory.cpp
@@ -1975,6 +1975,36 @@ ValueTypeRef ValuePlanFactory::realized_composite_type_for(
   return realized_composite_cache().get(*schema, std::move(fields));
 }
 
+ValueTypeRef ValuePlanFactory::projected_composite_type_for(
+    const ValueTypeMetaData *schema,
+    std::span<const ValueTypeRef> field_bindings) {
+  if (schema == nullptr ||
+      (schema->value_kind() != ValueTypeKind::Tuple &&
+       schema->value_kind() != ValueTypeKind::Bundle)) {
+    throw std::invalid_argument(
+        "projected_composite_type_for requires a Tuple or Bundle schema");
+  }
+  if (field_bindings.size() != schema->field_count) {
+    throw std::invalid_argument(
+        "projected_composite_type_for field count does not match its schema");
+  }
+  std::vector<ValueTypeRef> fields{field_bindings.begin(),
+                                   field_bindings.end()};
+  for (std::size_t index = 0; index < fields.size(); ++index) {
+    const auto *field_schema = fields[index] ? fields[index].schema() : nullptr;
+    const auto *declared = schema->fields[index].type;
+    const bool cycle_owner = field_schema != nullptr &&
+                             field_schema->is_owned() &&
+                             field_schema->element_type == declared;
+    if (field_schema != declared && !cycle_owner) {
+      throw std::invalid_argument(
+          "projected_composite_type_for received an incompatible field "
+          "binding");
+    }
+  }
+  return realized_composite_cache().get(*schema, std::move(fields));
+}
+
 void ValuePlanFactory::reset() noexcept {
   std::lock_guard<std::mutex> lock(mutex_);
   cache_.clear();

--- a/tests/cpp/test_plan_factories.cpp
+++ b/tests/cpp/test_plan_factories.cpp
@@ -287,6 +287,32 @@ TEST_CASE("ValuePlanFactory: tuple synthesis matches MemoryUtils::tuple_plan")
     REQUIRE(&plan->component(2).plan->array_element_plan() == &MemoryUtils::plan_for<std::uint64_t>());
 }
 
+TEST_CASE("ValuePlanFactory projects an Owned Bundle onto structural storage")
+{
+    using namespace hgraph;
+
+    auto       &registry = TypeRegistry::instance();
+    auto       &factory  = ValuePlanFactory::instance();
+    const auto *integer = registry.value_type("int");
+    REQUIRE(integer != nullptr);
+    const auto *bundle =
+        registry.bundle("tests.plan", "ProjectedBundle", {{"value", integer}});
+    const auto *owned = registry.owned(bundle);
+    const auto integer_binding = factory.type_for(integer);
+
+    const std::array fields{integer_binding};
+    const auto projected = factory.projected_composite_type_for(owned, fields);
+
+    REQUIRE(projected.schema() == owned);
+    REQUIRE(projected.checked_plan().is_composite());
+    REQUIRE(projected.checked_plan().component_count() == 2);
+    const auto *indexed = checked_value_ops<IndexedValueOps>(
+        projected, "projected Owned Bundle");
+    REQUIRE(indexed->size(indexed->context, nullptr) == 1);
+    REQUIRE(indexed->element_binding(indexed->context, nullptr, 0) ==
+            integer_binding);
+}
+
 TEST_CASE("ValuePlanFactory: bundle synthesis preserves field names and shape")
 {
     using namespace hgraph;


### PR DESCRIPTION
## Summary

- normalize parameterized Python aliases before context compatibility checks
- recursively project Python-owned and polymorphic bundle fields onto structural `TSB` storage
- preserve the projected layout for bundles stored in `TSD` slots
- add C++ and Python regression coverage and document the storage contract

## Root cause

Parameterized dataclass aliases were treated as runtime classes during context selection, so compatible generic dataclass bundles could fail matching. Separately, nested `TSB` values could retain a non-composite owning binding inside storage that the child bundle interpreted structurally, leading to invalid teardown and polymorphic-value behavior.

## Impact

Downstream packages can use ordinary Python dataclasses—including generic and polymorphic dataclasses—as bundle scalar values and contexts without inheriting compound-scalar behavior.

Related downstream change: hhenson/hg_oap#137.

## Validation

- macOS native C++ suite: 1,258 passed
- macOS CPython 3.14 stable-ABI suite: 1,603 passed, 10 skipped
- `hg-linux` GCC 15 native suite: 1,258 passed
- `hg-linux` CPython 3.14 stable-ABI suite: 1,603 passed, 10 skipped
- Ubuntu/OrbStack native and Python ASan suites passed