### PR TITLE
Accept python-owned dataclass payloads in Stream

### DIFF
--- a/python/hgraph/stream/stream.py
+++ b/python/hgraph/stream/stream.py
@@ -1,7 +1,7 @@
 import re
 import types
 import typing
-from dataclasses import dataclass, fields
+from dataclasses import dataclass, fields, is_dataclass
 from datetime import datetime
 from enum import Enum
 from itertools import chain
@@ -72,10 +72,18 @@ class Stream:
         is_ts_schema = (
             isinstance(origin, type) and issubclass(origin, TimeSeriesSchema)
         )
-        if not is_open_compound and not is_compound and not is_ts_schema:
+        # RFC 0004 python-owned structured scalars: a plain (frozen)
+        # dataclass is a structured payload too; its fields resolve through
+        # the public reflection layer exactly like a CompoundScalar's.
+        is_python_owned = (
+            not is_compound and not is_ts_schema
+            and isinstance(origin, type) and is_dataclass(origin)
+        )
+        if (not is_open_compound and not is_compound and not is_ts_schema
+                and not is_python_owned):
             raise TypeError(
-                "Stream[...] requires a CompoundScalar or TimeSeriesSchema "
-                f"payload, got {payload!r}"
+                "Stream[...] requires a CompoundScalar, TimeSeriesSchema, or "
+                f"structured dataclass payload, got {payload!r}"
             )
         parameters = tuple(getattr(origin, "__parameters__", ())) if not is_open_compound else ()
         arguments = tuple(typing.get_args(payload))
@@ -96,7 +104,7 @@ class Stream:
                     _substitute_typevars(
                         resolved_annotations.get(item.name, item.type), substitutions)
                 ]
-        elif is_ts_schema:
+        elif is_ts_schema or is_python_owned:
             from hgraph.reflection import fields as reflected_fields
 
             annotations.update(reflected_fields(TSB[payload]))

--- a/python/tests/stream/test_stream.py
+++ b/python/tests/stream/test_stream.py
@@ -98,3 +98,44 @@ def test_reduce_stream_statuses_and_messages_use_current_tsd_state():
         _reduce_message_dict,
         [{1: "failed a", 2: "failed b"}, {1: hg.REMOVE}],
     ) == ["failed a; failed b", "failed b"]
+
+
+def test_stream_accepts_python_owned_dataclass_payload():
+    # Issue #36: a frozen python-owned dataclass is a structured payload and
+    # flattens exactly like a CompoundScalar payload.
+    from dataclasses import dataclass
+
+    from hgraph.reflection import fields
+
+    @dataclass(frozen=True)
+    class Payload:
+        value: int
+
+    assert fields(TSB[Stream[Payload]]) == {
+        "value": TS[int],
+        "status": TS[StreamStatus],
+        "status_msg": TS[str],
+    }
+
+    stream_type = TSB[Stream[Payload]]
+
+    @graph
+    def make_stream(value: TS[int]) -> stream_type:
+        return combine[stream_type](
+            status=StreamStatus.OK,
+            status_msg="",
+            value=value,
+        )
+
+    assert eval_node(make_stream, [7]) == [{
+        "status": StreamStatus.OK,
+        "status_msg": "",
+        "value": 7,
+    }]
+
+
+def test_stream_still_rejects_unstructured_payloads():
+    import pytest
+
+    with pytest.raises(TypeError, match="structured dataclass"):
+        Stream[int]


### PR DESCRIPTION
## Summary

Fixes #36: `hgraph.stream.Stream[Payload]` rejected RFC 0004 python-owned frozen dataclasses even though public reflection and `TSB` already resolve their fields, forcing downstream packages (hhenson/hg_oap#137) to carry a local `Stream` adapter.

`Stream.__class_getitem__` now recognizes a structured dataclass payload (a plain dataclass that is neither `CompoundScalar` nor `TimeSeriesSchema`) and flattens it through the **public reflection layer** — the new branch reuses the existing `ts_schema` path's `fields(TSB[payload])`, per the issue's constraint of no new metadata hierarchy and no private implementation access. Generic/parameterized dataclass payloads ride the same path since `TSB[payload]` carries the type arguments. The rejection message for unstructured payloads now names all three accepted kinds.

The issue's exact expectation holds:

```python
fields(TSB[Stream[Payload]]) == {"value": TS[int], "status": TS[StreamStatus], "status_msg": TS[str]}
```

## Test plan

- New tests in `python/tests/stream/test_stream.py`: the reflection expectation from the issue plus a wiring-level round trip (`combine[TSB[Stream[Payload]]]` evaluated via `eval_node`), and a guard that unstructured payloads (`Stream[int]`) still raise `TypeError`.
- Full Python suite on a freshly rebuilt bridge: **1605 passed, 10 skipped** (includes the new dataclass-runtime teardown tests from current `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)