### PR TITLE
Preserve nested TSD deltas across switch feedback

### DIFF
--- a/docs/source/developer_guide/data_structures/plans_and_ops/time_series.rst
+++ b/docs/source/developer_guide/data_structures/plans_and_ops/time_series.rst
@@ -1448,12 +1448,28 @@ The split of responsibility is deliberate:
 There is **no end-of-cycle cleanup sweep**. Physical reclamation is lazy and
 happens on the structure's **next mutation**: the slot-store ``prepare_delta``
 resets a collection's ``added`` / ``removed`` / ``modified`` bitsets and erases
-pending-removed keys the first time it is touched at a new ``delta_time_``
-(the ``delta_time_ != t`` guard, which is also the per-collection optimisation
-that skips re-clearing a delta already reset at ``t``). Because reads are
-cycle-gated, a stale delta is never observable in the window between the cycle
-it was produced and the producer's next mutation, so no eager reclamation pass
-is required. There is deliberately **no** ``cleanup_delta`` ops entry on
+pending-removed keys the first time it is touched at a **newer**
+``delta_time_`` (the ``modified_time <= delta_time_`` no-op guard, which is
+also the per-collection optimisation that skips re-clearing a delta already
+reset at ``t``). Because reads are cycle-gated, a stale delta is never
+observable in the window between the cycle it was produced and the producer's
+next mutation, so no eager reclamation pass is required.
+
+Delta clocks and delta windows are **monotonic**. A record that carries an
+*older* time than the current window — the canonical producer is a freshly
+bound link replaying its source's historical timestamp (plain ``bind``
+semantics), e.g. a re-homed child terminal aliasing an already-ticked source —
+**joins the current window instead of rebasing it**: ``prepare_delta`` treats
+``modified_time <= delta_time_`` as the current window, and
+``TSDataTracking::record_modified`` ignores older-than-recorded times (no
+rewind, no stale re-notification of observers). Rebasing on a stale record
+would erase sibling marks already recorded this cycle — the failure mode
+behind issue #38, where a switch branch-flip's sampled structural transition
+and a sibling key's added/modified marks were wiped by exactly such a replay,
+losing the delta downstream (dedup saw "no change") while the value read
+correctly. The dynamic-TSL modified ring drops stale records instead of
+joining (re-appending an already-linked entry would corrupt the ring); the
+``TSDProxy`` updated-window roll follows the same newer-only rule. There is deliberately **no** ``cleanup_delta`` ops entry on
 ``TSDataView`` / ``TSOutput`` / ``NodeView`` and **no** ``TSOutput::dirty_``
 flag: the earlier eager-sweep apparatus has been removed in favour of this
 read-gated, mutation-driven model.

--- a/include/hgraph/types/time_series/ts_data/types.h
+++ b/include/hgraph/types/time_series/ts_data/types.h
@@ -287,7 +287,8 @@ namespace hgraph
         /**
          * Record the first modification for ``modified_time`` and notify local
          * observers once. Returns false when this level was already marked for
-         * the same evaluation time.
+         * the same or a later evaluation time — delta clocks are monotonic, so
+         * a record replaying an older source timestamp never rewinds state.
          */
         [[nodiscard]] bool record_modified(DateTime modified_time);
 

--- a/python/tests/test_switch_tsd_delta.py
+++ b/python/tests/test_switch_tsd_delta.py
@@ -1,0 +1,200 @@
+"""Regression tests for GitHub issue #38: a nested TSD update was lost
+through switch_/feedback when a sibling TSD removed a key.
+
+Root cause (two layers, both delta-clock monotonicity violations):
+
+- ``TSDataTracking::record_modified`` accepted an OLDER time than the one
+  already recorded, rewinding a link/output delta clock mid-cycle. A
+  freshly re-homed child terminal replaying its source's historical
+  timestamp (plain ``bind`` semantics) regressed the parent chain and
+  erased the sampled structural transition installed by the switch's
+  branch-flip rebind.
+- The TSD/TSS slot-store ``prepare_delta`` rebased the whole delta window
+  on ANY differing time, so the same stale replay record wiped the
+  added/modified marks of sibling keys created earlier in the same cycle
+  (map_'s freshly instantiated output keys), producing an empty or
+  partial delta while the value read correctly.
+
+Delta clocks and delta windows are monotonic: an older record joins the
+current window; only a newer one rolls it.
+"""
+
+from frozendict import frozendict
+
+from hgraph import (
+    TS, TSB, TSD, TimeSeriesSchema, combine, compute_node, const, dedup,
+    default, feedback, graph, lag, map_, sample, switch_,
+)
+from hgraph.test import eval_node
+
+
+@compute_node
+def _observe(tsd: TSD[str, TS[float]]) -> TS[str]:
+    mods = tuple(sorted((str(k), v.value) for k, v in tsd.modified_items()))
+    rems = tuple(sorted(str(k) for k in tsd.removed_keys()))
+    return repr((mods, rems))
+
+
+def test_switch_flip_to_const_branch_publishes_sampled_delta():
+    """Baseline: retargeting onto an already-valid const output presents the
+    full sampled delta (new keys modified, vanished keys removed)."""
+
+    @graph
+    def probe(roll: TS[bool], current: TSD[str, TS[float]]) -> TS[str]:
+        out = switch_(
+            roll,
+            {True: lambda current: const(frozendict({"next": 20.0}), TSD[str, TS[float]]),
+             False: lambda current: current},
+            current,
+        )
+        return _observe(out)
+
+    result = eval_node(probe, roll=[False, True],
+                       current=[{"old": 10.0, "next": 10.0}, None])
+    assert result == [
+        "((('next', 10.0), ('old', 10.0)), ())",
+        "((('next', 20.0),), ('old',))",
+    ]
+
+
+def test_switch_flip_to_map_branch_publishes_sampled_delta():
+    """Issue #38 kernel: the new branch's terminal is a map_-owned TSD that
+    only becomes valid after the sampled rebind. The stale replay record
+    from the re-homed per-key terminal must not erase the transition."""
+
+    @graph
+    def probe(roll: TS[bool], current: TSD[str, TS[float]],
+              prices: TSD[str, TS[float]]) -> TS[str]:
+        out = switch_(
+            roll,
+            {True: lambda current, prices: map_(lambda p: p, prices),
+             False: lambda current, prices: current},
+            current, prices,
+        )
+        return _observe(out)
+
+    result = eval_node(probe, roll=[False, True],
+                       current=[{"old": 10.0, "next": 10.0}, None],
+                       prices=[{"next": 20.0}, None])
+    assert result == [
+        "((('next', 10.0), ('old', 10.0)), ())",
+        "((('next', 20.0),), ('old',))",
+    ]
+
+
+def test_switch_flip_multi_multiplexed_map_branch_delta():
+    """Two multiplexed TSDs: the union key created from the sampled boundary
+    (with a stale source timestamp) must not wipe the sibling key's marks."""
+
+    @graph
+    def probe(roll: TS[bool], units: TSD[str, TS[float]],
+              prices: TSD[str, TS[float]]) -> TS[str]:
+        out = switch_(
+            roll,
+            {True: lambda units, prices: map_(lambda u, p: p, units, prices),
+             False: lambda units, prices: prices},
+            units, prices,
+        )
+        return _observe(out)
+
+    result = eval_node(probe, roll=[False, True],
+                       units=[{"next": 1.0}, None],
+                       prices=[{"old": 10.0, "next": 10.0}, {"next": 20.0}])
+    assert result == [
+        "((('next', 10.0), ('old', 10.0)), ())",
+        "((('next', 20.0), ('old', 10.0)), ())",
+    ]
+
+
+class _Pos(TimeSeriesSchema):
+    units: TSD[str, TS[float]]
+    unit_values: TSD[str, TS[float]]
+
+
+def test_switch_flip_tsb_materialized_branch_delta():
+    """TSB-shaped branches route through the owned-output/materialize path
+    (capture_delta over map_'s raw dict marks) rather than the forwarding
+    transition wrapper — the raw marks themselves must survive the cycle."""
+
+    @graph
+    def branch_true(current: TSB[_Pos], prices: TSD[str, TS[float]]) -> TSB[_Pos]:
+        units = const(frozendict({"next": 1.0}), TSD[str, TS[float]])
+        return combine[TSB[_Pos]](
+            units=units,
+            unit_values=map_(lambda unit, price: price, units, prices))
+
+    @graph
+    def probe(roll: TS[bool], prices: TSD[str, TS[float]], current: TSB[_Pos]) -> TS[str]:
+        out = switch_(roll, {True: branch_true,
+                             False: lambda current, prices: current}, current, prices)
+        return _observe(out.unit_values)
+
+    result = eval_node(
+        probe,
+        roll=[False, True],
+        prices=[{"old": 10.0, "next": 10.0}, {"next": 20.0}],
+        current=[{"units": frozendict({"old": 0.5, "next": 0.5}),
+                  "unit_values": frozendict({"old": 10.0, "next": 10.0})}, None],
+    )
+    assert result == [
+        "((('next', 10.0), ('old', 10.0)), ())",
+        "((('next', 20.0), ('old', 10.0)), ())",
+    ]
+
+
+class _FeedbackPosition(TimeSeriesSchema):
+    units: TSD[str, TS[float]]
+    unit_values: TSD[str, TS[float]]
+
+
+def test_issue_38_nested_tsd_update_through_switch_feedback():
+    """The full issue #38 reproducer: the rolled position's new unit value
+    must survive the dedup/feedback round-trip after the switch flip."""
+
+    @graph
+    def update_position(
+        current: TSB[_FeedbackPosition],
+        prices: TSD[str, TS[float]],
+    ) -> TSB[_FeedbackPosition]:
+        units = const(frozendict({"next": 1.0}), TSD[str, TS[float]])
+        return combine[TSB[_FeedbackPosition]](
+            units=units,
+            unit_values=map_(lambda unit, price: price, units, prices),
+        )
+
+    @graph
+    def position_feedback_graph(
+        roll: TS[bool],
+        prices: TSD[str, TS[float]],
+        trigger: TS[int],
+    ) -> TS[float]:
+        position_feedback = feedback(TSB[_FeedbackPosition])
+        initial_position = combine[TSB[_FeedbackPosition]](
+            units=const(frozendict({"old": 0.5, "next": 0.5}), TSD[str, TS[float]]),
+            unit_values=const(frozendict({"old": 10.0, "next": 10.0}), TSD[str, TS[float]]),
+        )
+        position = dedup(default(lag(position_feedback(), 1, trigger), initial_position))
+        output = switch_(
+            roll,
+            {
+                True: update_position,
+                False: lambda current, prices: dedup(current),
+            },
+            position,
+            prices,
+        )
+        position_feedback(dedup(output))
+        return sample(trigger, position.unit_values["next"])
+
+    result = eval_node(
+        position_feedback_graph,
+        roll=[False, True, False, False],
+        prices=[
+            {"old": 10.0, "next": 10.0},
+            {"next": 20.0},
+            None,
+            None,
+        ],
+        trigger=[0, 1, 2, 3],
+    )
+    assert result == [10.0, 10.0, 10.0, 20.0]

--- a/src/hgraph/types/metadata/ts_data_dynamic_list_ops.cpp
+++ b/src/hgraph/types/metadata/ts_data_dynamic_list_ops.cpp
@@ -94,7 +94,14 @@ namespace hgraph::ts_data_plan_factory_detail
             void record_child_modified(std::size_t index, DateTime modified_time)
             {
                 auto &header = ordinal_keys_.front();
-                if (DateTime{std::chrono::microseconds{header.ordinal_key}} != modified_time)
+                const DateTime window{std::chrono::microseconds{header.ordinal_key}};
+                // Monotonic delta window: a record carrying an older time (a
+                // freshly bound link replaying source history) must not
+                // rebase the ring and erase sibling marks recorded this
+                // cycle. It cannot join the ring either (re-appending an
+                // already-linked entry would corrupt it), so it is dropped.
+                if (modified_time < window) { return; }
+                if (modified_time != window)
                 {
                     header.ordinal_key = modified_time.time_since_epoch().count();
                     header.next_modified = 0;

--- a/src/hgraph/types/metadata/ts_data_slot_ops.cpp
+++ b/src/hgraph/types/metadata/ts_data_slot_ops.cpp
@@ -281,7 +281,12 @@ namespace hgraph::ts_data_plan_factory_detail
 
             void prepare_delta(DateTime modified_time)
             {
-                if (delta_time_ == modified_time)
+                // Delta windows are monotonic: only a NEWER time rolls the
+                // window. A record carrying an older time (a freshly bound
+                // link replaying its source's history) joins the current
+                // window — rebasing on it would erase sibling marks already
+                // recorded this cycle.
+                if (modified_time <= delta_time_)
                 {
                     ensure_delta_capacity();
                     return;
@@ -584,7 +589,8 @@ namespace hgraph::ts_data_plan_factory_detail
 
             void prepare_delta(DateTime modified_time)
             {
-                if (delta_time_ == modified_time)
+                // Monotonic delta window — see the slot-set variant above.
+                if (modified_time <= delta_time_)
                 {
                     ensure_delta_capacity();
                     return;

--- a/src/hgraph/types/time_series/ts_data/proxy.cpp
+++ b/src/hgraph/types/time_series/ts_data/proxy.cpp
@@ -1938,9 +1938,11 @@ namespace hgraph
     {
         if (!has_child(slot) || !source_available()) { return; }
         // LAZY delta-window roll: updated bits describe the CURRENT window
-        // only - a record at a new time clears the previous window's bits
-        // (they otherwise over-report the Modified surface forever).
-        if (modified_time != MIN_DT && modified_time != updated_window_)
+        // only - a record at a NEWER time clears the previous window's bits
+        // (they otherwise over-report the Modified surface forever). Older
+        // times (replayed source history on a fresh bind) join the current
+        // window instead of rebasing it.
+        if (modified_time != MIN_DT && modified_time > updated_window_)
         {
             for (std::size_t index = 0; index < built_times_.size(); ++index)
             {

--- a/src/hgraph/types/time_series/ts_data/types.cpp
+++ b/src/hgraph/types/time_series/ts_data/types.cpp
@@ -291,7 +291,11 @@ namespace hgraph
     bool TSDataTracking::record_modified(DateTime modified_time)
     {
         if (modified_time == MIN_DT) { throw std::invalid_argument("TSDataTracking requires a concrete evaluation time"); }
-        if (last_modified_time == modified_time) { return false; }
+        // Delta clocks are monotonic. A record carrying an older time (e.g. a
+        // freshly bound link replaying its source's historical timestamp)
+        // must not rewind state already recorded this cycle, nor re-notify
+        // observers with a stale time.
+        if (modified_time <= last_modified_time) { return false; }
 
         last_modified_time = modified_time;
         observers.notify(modified_time);

--- a/tests/cpp/test_plan_factories.cpp
+++ b/tests/cpp/test_plan_factories.cpp
@@ -1578,6 +1578,44 @@ TEST_CASE("TSDataPlanFactory: TSS uses slot storage with added and removed delta
     REQUIRE(view.last_modified_time() == t3);
 }
 
+TEST_CASE("TSDataPlanFactory: TSS stale mutations join the current delta window")
+{
+    using namespace hgraph;
+
+    auto       &registry = TypeRegistry::instance();
+    const auto *int_meta = registry.register_scalar<std::int32_t>("int32");
+    const auto *tss      = registry.tss(int_meta);
+    const auto  type     = TSDataPlanFactory::instance().data_type_for(tss);
+
+    TSData data{type};
+    auto   view = data.view();
+    auto   set  = view.as_set();
+    const auto t1 = MIN_ST;
+    const auto t2 = t1 + TimeDelta{1};
+    Value      one{1};
+    Value      two{2};
+    Value      three{3};
+
+    {
+        auto mutation = set.begin_mutation(t2);
+        REQUIRE(mutation.add(one.view()));
+        REQUIRE(mutation.add(two.view()));
+    }
+    {
+        auto mutation = set.begin_mutation(t1);
+        REQUIRE(mutation.add(three.view()));
+    }
+
+    REQUIRE(view.last_modified_time() == t2);
+    REQUIRE(view.modified(t2));
+    auto delta = view.delta_value(t2).as_bundle();
+    auto added = delta.at("added").as_set();
+    REQUIRE(added.contains(one.view()));
+    REQUIRE(added.contains(two.view()));
+    REQUIRE(added.contains(three.view()));
+    REQUIRE(delta.at("removed").as_set().empty());
+}
+
 TEST_CASE("TSDataPlanFactory: TSD uses slot storage with key-set and modified deltas")
 {
     using namespace hgraph;
@@ -1884,6 +1922,42 @@ TEST_CASE("TSDataPlanFactory: dynamic TSL stores grow-only child TSData")
     }
     REQUIRE_FALSE(view.modified(t3));
     REQUIRE(view.as_list().size() == 3);
+}
+
+TEST_CASE("TSDataPlanFactory: dynamic TSL stale child records preserve the current modified ring")
+{
+    using namespace hgraph;
+
+    auto       &registry = TypeRegistry::instance();
+    const auto *int_meta = registry.register_scalar<std::int32_t>("int32");
+    const auto *tsl      = registry.tsl(registry.ts(int_meta), 0);
+    const auto  type     = TSDataPlanFactory::instance().data_type_for(tsl);
+
+    TSData data{type};
+    auto   view = data.view();
+    const auto t1 = MIN_ST;
+    const auto t2 = t1 + TimeDelta{1};
+    {
+        auto source = stdlib::make_list<std::int32_t>({11, 22});
+        auto mutation = view.begin_mutation(t2);
+        REQUIRE(mutation.copy_value_from(source.view()));
+    }
+
+    auto list = view.as_list();
+    REQUIRE(std::vector<std::size_t>(list.modified_indices().begin(), list.modified_indices().end()) ==
+            std::vector<std::size_t>{0, 1});
+
+    const auto &table = *view.storage_type().ops();
+    table.record_child_modified_impl(table.context, const_cast<void *>(view.data()), 0, t1);
+
+    REQUIRE(view.last_modified_time() == t2);
+    REQUIRE(std::vector<std::size_t>(list.modified_indices().begin(), list.modified_indices().end()) ==
+            std::vector<std::size_t>{0, 1});
+    Value key_zero{std::int64_t{0}};
+    Value key_one{std::int64_t{1}};
+    auto  delta = view.delta_value(t2).as_map();
+    REQUIRE(delta.contains(key_zero.view()));
+    REQUIRE(delta.contains(key_one.view()));
 }
 
 TEST_CASE("TSDataPlanFactory: failed first dynamic TSL growth restores unbound element identity")

--- a/tests/cpp/test_switch.cpp
+++ b/tests/cpp/test_switch.cpp
@@ -11,6 +11,7 @@
 
 #include <hgraph/lib/std/std_operators.h>
 #include <hgraph/lib/std/std_nodes.h>
+#include <hgraph/lib/std/value_util.h>
 #include <hgraph/lib/testing/check_output.h>
 #include <hgraph/lib/testing/eval_node.h>
 #include <hgraph/lib/testing/record_replay.h>
@@ -486,6 +487,80 @@ namespace
         static_cast<void>(w.add_node(std::type_index(typeid(SwitchStorageRecorderTag)),
                                      std::move(builder), inputs, Value{}));
     }
+
+    using Issue38Dict = TSD<Str, TS<Int>>;
+    using Issue38Position =
+        TSB<"Issue38Position", Field<"units", Issue38Dict>, Field<"unit_values", Issue38Dict>>;
+
+    struct Issue38SelectPrice
+    {
+        static constexpr auto name = "issue_38_select_price";
+
+        static Port<TS<Int>> compose(Wiring &, Port<TS<Int>>, Port<TS<Int>> price)
+        {
+            return price;
+        }
+    };
+
+    struct Issue38UpdatePosition
+    {
+        static constexpr auto name = "issue_38_update_position";
+
+        static Port<Issue38Position> compose(Wiring &w, Port<Issue38Position>, Port<Issue38Dict> prices)
+        {
+            auto units = wire<stdlib::const_, Issue38Dict>(
+                w, stdlib::make_map<Str, Int>({{Str{"next"}, Int{1}}}));
+            auto unit_values = wire<stdlib::map_>(w, fn<Issue38SelectPrice>(), units, prices).as<Issue38Dict>();
+            auto position = stdlib::to_tsb<Issue38Position>(w, units, unit_values);
+            return wire<stdlib::pass_through_node>(w, position).as<Issue38Position>();
+        }
+    };
+
+    struct Issue38KeepPosition
+    {
+        static constexpr auto name = "issue_38_keep_position";
+
+        static Port<Issue38Position> compose(Wiring &w, Port<Issue38Position> current, Port<Issue38Dict>)
+        {
+            auto deduplicated = wire<stdlib::dedup>(w, current).as<Issue38Position>();
+            return wire<stdlib::pass_through_node>(w, deduplicated).as<Issue38Position>();
+        }
+    };
+
+    struct Issue38FeedbackGraph
+    {
+        static constexpr auto name = "issue_38_feedback_graph";
+
+        static Port<TS<Int>> compose(Wiring &w, Port<TS<Bool>> roll, Port<Issue38Dict> prices,
+                                     Port<TS<Int>> trigger)
+        {
+            auto position_feedback = stdlib::feedback<Issue38Position>(w);
+            auto lagged = wire<stdlib::lag>(w, position_feedback(), Int{1}, trigger).as<Issue38Position>();
+
+            auto initial_units = wire<stdlib::const_, Issue38Dict>(
+                w, stdlib::make_map<Str, Int>({{Str{"old"}, Int{1}}, {Str{"next"}, Int{1}}}));
+            auto initial_values = wire<stdlib::const_, Issue38Dict>(
+                w, stdlib::make_map<Str, Int>({{Str{"old"}, Int{10}}, {Str{"next"}, Int{10}}}));
+            auto initial_position = stdlib::to_tsb<Issue38Position>(w, initial_units, initial_values);
+            auto position = wire<stdlib::dedup>(
+                                w, wire<stdlib::default_>(w, lagged, initial_position))
+                                .as<Issue38Position>();
+
+            auto output = wire<stdlib::switch_, Issue38Position>(
+                              w, roll,
+                              stdlib::switch_cases(
+                                  {{Value{Bool{true}}, fn<Issue38UpdatePosition>()},
+                                   {Value{Bool{false}}, fn<Issue38KeepPosition>()}}),
+                              position, prices)
+                              .as<Issue38Position>();
+            position_feedback(wire<stdlib::dedup>(w, output).as<Issue38Position>());
+
+            auto unit_values =
+                wire<stdlib::getitem_>(w, position, Str{"unit_values"}).as<Issue38Dict>();
+            auto next = wire<stdlib::getitem_>(w, unit_values, Str{"next"}).as<TS<Int>>();
+            return wire<stdlib::sample>(w, trigger, next).as<TS<Int>>();
+        }
+    };
 }  // namespace
 
 TEST_CASE("switch_: the key selects the branch and a swap samples the held input")
@@ -607,6 +682,23 @@ TEST_CASE("switch_: a direct structural branch samples held list values on activ
                                list_delta<TS<Int>>({20, -20}),
                                list_delta<TS<Int>>({1, 2}),
                                list_delta<TS<Int>>({40, -40})));
+}
+
+TEST_CASE("switch_: nested TSD update survives the feedback round-trip")
+{
+    using namespace hgraph;
+    using namespace hgraph::testing;
+    using namespace std::string_literals;
+
+    stdlib::register_standard_operators();
+
+    CHECK_OUTPUT(
+        eval_node<Issue38FeedbackGraph>(
+            values<Bool>(false, true, false, false),
+            values<Value>(dict_delta<Str, TS<Int>>({{"old"s, Int{10}}, {"next"s, Int{10}}}),
+                          dict_delta<Str, TS<Int>>({{"next"s, Int{20}}}), none, none),
+            values<Int>(0, 1, 2, 3)),
+        values<Int>(10, 10, 10, 20));
 }
 
 TEST_CASE("switch_: a branch may consume the key as its first argument (mixed arities)")

--- a/tests/cpp/test_ts_output.cpp
+++ b/tests/cpp/test_ts_output.cpp
@@ -1468,3 +1468,68 @@ TEST_CASE("TSOutputView delegates window all_valid through TSData ops")
     REQUIRE(range_count(time_values) == 2);
     REQUIRE(range_count(value_times) == 2);
 }
+
+// Delta clocks are monotonic (GitHub issue #38): a record carrying an older
+// time — a freshly bound link replaying its source's historical timestamp —
+// must neither rewind tracking state nor rebase a slot store's delta window
+// (that would erase sibling marks already recorded this cycle).
+TEST_CASE("TSDataTracking ignores records older than the current time")
+{
+    using namespace hgraph;
+
+    TSDataTracking tracking{};
+    const auto t1 = MIN_ST;
+    const auto t2 = t1 + TimeDelta{1};
+
+    REQUIRE(tracking.record_modified(t2));
+    REQUIRE(tracking.last_modified_time == t2);
+    REQUIRE_FALSE(tracking.record_modified(t1));
+    REQUIRE(tracking.last_modified_time == t2);
+    REQUIRE_FALSE(tracking.record_modified(t2));
+}
+
+TEST_CASE("TSD delta window survives a stale child record within the cycle")
+{
+    using namespace hgraph;
+
+    auto       &registry = TypeRegistry::instance();
+    const auto *key_meta = registry.register_scalar<std::int32_t>("int32");
+    const auto *ts_int   = registry.ts(key_meta);
+    const auto *tsd_meta = registry.tsd(key_meta, ts_int);
+
+    const auto t1 = MIN_ST;
+    const auto t2 = t1 + TimeDelta{1};
+
+    TSOutput output{*tsd_meta};
+    Value    key_a{10};
+    Value    key_b{20};
+    Value    one{1};
+    Value    two{2};
+    {
+        auto output_view = output.view(t2);
+        auto dict = output_view.as_dict();
+        auto mutation = dict.begin_mutation(t2);
+        mutation.set(key_a.view(), one.view());
+        mutation.set(key_b.view(), two.view());
+    }
+
+    auto data = output.data_view();
+    auto dict = data.as_dict();
+    const auto slot_a = dict.find_slot(key_a.view());
+    const auto slot_b = dict.find_slot(key_b.view());
+    REQUIRE(dict.slot_added(slot_a));
+    REQUIRE(dict.slot_added(slot_b));
+    REQUIRE(dict.slot_modified(slot_a));
+    REQUIRE(dict.slot_modified(slot_b));
+
+    // Replay a stale (t1) child record into the t2 window — the pre-fix
+    // behaviour rebased the delta window and wiped the sibling marks.
+    const auto &table = *data.storage_type().ops();
+    table.record_child_modified_impl(table.context, const_cast<void *>(data.data()), slot_a, t1);
+
+    REQUIRE(dict.slot_added(slot_a));
+    REQUIRE(dict.slot_added(slot_b));
+    REQUIRE(dict.slot_modified(slot_a));
+    REQUIRE(dict.slot_modified(slot_b));
+    REQUIRE(data.modified(t2));
+}

--- a/tests/cpp/test_tsd_proxy.cpp
+++ b/tests/cpp/test_tsd_proxy.cpp
@@ -646,6 +646,56 @@ TEST_CASE("TSDProxy same-time identity reconciliation builds once and repeat rea
     REQUIRE(counts.matches == matches_after_reconcile + 2);
 }
 
+TEST_CASE("TSDProxy stale child records join the current updated window")
+{
+    using namespace hgraph;
+
+    auto       &registry = TypeRegistry::instance();
+    const auto *integer  = registry.register_scalar<std::int32_t>("int32");
+    const auto *ts       = registry.ts(integer);
+    const auto *tsd      = registry.tsd(integer, ts);
+    const auto  source_type = TSDataPlanFactory::instance().data_type_for(tsd);
+    const auto  element_type = TSDataPlanFactory::instance().data_type_for(ts);
+
+    TSData source{source_type};
+    TSData proxy{tsd_proxy_data_type_for(*tsd, TSRoleTypeRef{element_type.as_role()})};
+    Value key_one{1};
+    Value key_two{2};
+    Value value_one{11};
+    Value value_two{22};
+    const auto t1 = MIN_ST;
+    const auto t2 = t1 + TimeDelta{1};
+    {
+        auto source_view = source.view();
+        auto mutation = source_view.as_dict().begin_mutation(t1);
+        mutation.set(key_one.view(), value_one.view());
+        mutation.set(key_two.view(), value_two.view());
+    }
+
+    auto proxy_view = proxy.view();
+    auto source_view = source.view();
+    bind_tsd_proxy(proxy_view, source_view.as_dict(), &key_value_ops, nullptr, t1);
+
+    proxy_view = proxy.view();
+    auto proxy_dict = proxy_view.as_dict();
+    const auto slot_one = proxy_dict.find_slot(key_one.view());
+    const auto slot_two = proxy_dict.find_slot(key_two.view());
+    REQUIRE(slot_one != TS_DATA_NO_CHILD_ID);
+    REQUIRE(slot_two != TS_DATA_NO_CHILD_ID);
+
+    auto &storage = *static_cast<TSDProxy *>(const_cast<void *>(proxy_view.data()));
+    storage.record_child_modified(slot_one, t2);
+    REQUIRE(storage.tracking().record_modified(t2));
+    REQUIRE(storage.child_updated(slot_one));
+    REQUIRE_FALSE(storage.child_updated(slot_two));
+
+    storage.record_child_modified(slot_two, t1);
+    REQUIRE_FALSE(storage.tracking().record_modified(t1));
+    REQUIRE(storage.tracking().last_modified_time == t2);
+    REQUIRE(storage.child_updated(slot_one));
+    REQUIRE(storage.child_updated(slot_two));
+}
+
 TEST_CASE("TSDProxy announced insertion retries a failed build without a second insert")
 {
     using namespace hgraph;


### PR DESCRIPTION
## Summary

- make TSData clocks and delta windows monotonic so stale bind replay cannot erase current-cycle sibling deltas
- preserve the active TSS/TSD slot-store, dynamic TSL, and TSDProxy delta windows
- add equivalent public-wiring C++ and Python regressions for the full switch/map/feedback failure, plus focused lower-level coverage
- document the monotonic delta-window contract
- update `ext/main` to `6bfd9a667853d60974a5109f6730d6236b0724a0`

## Root cause

Freshly rebound child links can replay historical timestamps. `TSDataTracking` accepted those older times and TSS/TSD slot stores rolled their delta windows on any different time, clearing current-cycle added/modified marks. Through `switch_`, `map_`, and feedback this left the current value correct but its delta empty, so `dedup` suppressed the update.

The fix only advances clocks and rolls windows for newer timestamps. Older records either join the current window or, for the dynamic TSL ring where re-appending would corrupt linkage, are ignored.

## Validation

- native C++ acceptance preset: **1266/1266 passed**
- Python 3.14 non-WIP compatibility suite from a fresh stable-ABI wheel: **1613 passed, 10 skipped**
- focused issue #38 C++ and Python regressions passed

Fixes #38