### PR TITLE
Fix nested TSD proxy lag rebinds

### DIFF
--- a/include/hgraph/lib/std/operators/impl/stream_impl.h
+++ b/include/hgraph/lib/std/operators/impl/stream_impl.h
@@ -839,8 +839,9 @@ namespace hgraph::stdlib
         }
     };
 
-    /** ``lag(ts, period, proxy)`` over a fixed TSL: per-element proxy lag
-        (map_'s wiring-time TSL expansion). */
+    /** ``lag(ts, period, proxy)`` over a fixed TSL: recursively dispatch lag
+        for every element so nested structural kinds retain their specialised
+        lifecycle semantics. */
     struct lag_proxy_tsl_compose
     {
         static constexpr auto name = "lag_proxy_tsl";
@@ -856,17 +857,29 @@ namespace hgraph::stdlib
             stream_impl_detail::bind_lag_proxy_output(resolution, context);
         }
 
-        static auto compose(Wiring &w, NamedPort<"ts", TSL<TsVar<"V">>> ts, Scalar<"period", Int> period,
-                            NamedPort<"proxy", SIGNAL> proxy)
+        static WiringPortRef compose(Wiring &w, NamedPort<"ts", TSL<TsVar<"V">>> ts,
+                                     Scalar<"period", Int> period,
+                                     NamedPort<"proxy", SIGNAL> proxy)
         {
-            auto ticks  = wire<count>(w, proxy);
-            auto lagged = wire<lag>(w, ticks, period.value());
-            return wire<map_>(w, fn<lag_proxy_node>(), ts, ticks, lagged);
+            WiringPortRef source = ts.erased();
+            const auto   *schema = source.schema;
+            std::vector<WiringPortRef> children;
+            children.reserve(schema->fixed_size());
+            for (std::size_t index = 0; index < schema->fixed_size(); ++index)
+            {
+                WiringPortRef element = subgraph_wiring_detail::tsl_element_ref(
+                    source, index, schema->element_ts());
+                Port<void> lagged_element = wire<lag>(
+                    w, Port<void>{w, std::move(element)}, period.value(), proxy);
+                children.push_back(lagged_element.erased());
+            }
+            return WiringPortRef::structural_source(schema, std::move(children));
         }
     };
 
-    /** ``lag(ts, period, proxy)`` over a TSB: per-field proxy lag assembled
-        back into the SAME named bundle shape (upstream's lag_proxy_tsb). */
+    /** ``lag(ts, period, proxy)`` over a TSB: recursively dispatch lag for
+        every field and assemble the SAME named bundle shape (upstream's
+        lag_proxy_tsb). */
     struct lag_proxy_tsb_compose
     {
         static constexpr auto name = "lag_proxy_tsb";
@@ -885,8 +898,6 @@ namespace hgraph::stdlib
         static WiringPortRef compose(Wiring &w, NamedPort<"ts", TsVar<"S">> ts, Scalar<"period", Int> period,
                                      NamedPort<"proxy", SIGNAL> proxy)
         {
-            auto ticks  = wire<count>(w, proxy);
-            auto lagged = wire<lag>(w, ticks, period.value());
             WiringPortRef source = ts.erased();
             const auto *schema = source.schema;
             std::vector<WiringPortRef> children;
@@ -896,7 +907,7 @@ namespace hgraph::stdlib
                 WiringPortRef field =
                     subgraph_wiring_detail::tsb_field_ref(source, index, schema->fields()[index].type);
                 Port<void> lagged_field =
-                    wire<lag_proxy_node>(w, Port<void>{w, std::move(field)}, ticks, lagged);
+                    wire<lag>(w, Port<void>{w, std::move(field)}, period.value(), proxy);
                 children.push_back(lagged_field.erased());
             }
             return WiringPortRef::structural_source(schema, std::move(children));

--- a/python/tests/test_switch_tsd_delta.py
+++ b/python/tests/test_switch_tsd_delta.py
@@ -1,5 +1,7 @@
-"""Regression tests for GitHub issue #38: a nested TSD update was lost
-through switch_/feedback when a sibling TSD removed a key.
+"""Regression tests for nested TSD deltas crossing structural references.
+
+GitHub issue #38 lost a nested TSD update through switch_/feedback when a
+sibling TSD removed a key.
 
 Root cause (two layers, both delta-clock monotonicity violations):
 
@@ -17,13 +19,17 @@ Root cause (two layers, both delta-clock monotonicity violations):
 
 Delta clocks and delta windows are monotonic: an older record joins the
 current window; only a newer one rolls it.
+
+GitHub issue #40 exposed a separate structural-lag bug: TSB and fixed TSL
+children bypassed kind-specific lag dispatch, so a nested TSD could lose its
+key during an ``if_then_else`` feedback rebind.
 """
 
 from frozendict import frozendict
 
 from hgraph import (
     TS, TSB, TSD, TimeSeriesSchema, combine, compute_node, const, dedup,
-    default, feedback, graph, lag, map_, sample, switch_,
+    default, feedback, graph, if_then_else, lag, map_, no_key, sample, switch_,
 )
 from hgraph.test import eval_node
 
@@ -198,3 +204,59 @@ def test_issue_38_nested_tsd_update_through_switch_feedback():
         trigger=[0, 1, 2, 3],
     )
     assert result == [10.0, 10.0, 10.0, 20.0]
+
+
+class _RebasedFeedbackState(TimeSeriesSchema):
+    unit_values: TSD[str, TS[float]]
+    target_units: TSD[str, TS[float]]
+
+
+def test_issue_40_feedback_preserves_no_key_map_after_if_then_else_rebind():
+    """Nested TSD lag keeps mapped keys alive across a reference rebind."""
+
+    @graph
+    def rebased_feedback_graph(
+        target: TSD[str, TS[float]],
+        rebase: TS[bool],
+        prices: TSD[str, TS[float]],
+        trigger: TS[int],
+    ) -> TS[float]:
+        state_feedback = feedback(TSB[_RebasedFeedbackState])
+        initial_state = combine[TSB[_RebasedFeedbackState]](
+            unit_values=const(frozendict(), TSD[str, TS[float]]),
+            target_units=const(frozendict(), TSD[str, TS[float]]),
+        )
+        state = default(
+            lag(state_feedback(), 1, trigger),
+            initial_state,
+        )
+        target_units = if_then_else(
+            rebase,
+            target,
+            state.target_units,
+        )
+        unit_values = map_(
+            lambda unit, price: price,
+            target_units,
+            no_key(prices),
+        )
+        state_feedback(
+            combine[TSB[_RebasedFeedbackState]](
+                unit_values=unit_values,
+                target_units=target_units,
+            )
+        )
+        return sample(
+            trigger,
+            default(state.unit_values["next"], -1.0),
+        )
+
+    result = eval_node(
+        rebased_feedback_graph,
+        target=[{"next": 1.0}, None, None, None],
+        rebase=[True, False, False, False],
+        prices=[{"next": 10.5}, None, None, None],
+        trigger=[0, 1, 2, 3],
+    )
+
+    assert result == [-1.0, -1.0, 10.5, 10.5]

--- a/src/hgraph/runtime/feedback_node.cpp
+++ b/src/hgraph/runtime/feedback_node.cpp
@@ -65,9 +65,13 @@ namespace hgraph
             // through the already-planned source state avoids constructing an
             // intermediate Value on every feedback tick. A sampled rebind can
             // expose the current-value schema instead of the delta schema, so
-            // retain capture_delta as the general fallback.
-            auto state = source_node.state().begin_mutation();
-            if (!state.try_copy_from(ts.delta_value()))
+            // retain capture_delta as the general fallback. That fallback may
+            // replace the planned state with immutable compact storage, in
+            // which case a later tick must capture again rather than request a
+            // mutation view.
+            const ValueView state = source_node.state();
+            if (!state.can_begin_mutation() ||
+                !state.begin_mutation().try_copy_from(ts.delta_value()))
             {
                 source_node.replace_state(capture_delta(ts));
             }

--- a/tests/cpp/test_std_operators.cpp
+++ b/tests/cpp/test_std_operators.cpp
@@ -559,6 +559,119 @@ namespace
         }
     };
 
+    using RebasedDict = TSD<Str, TS<Int>>;
+    using RebasedBundle =
+        TSB<"RebasedBundle",
+            Field<"unit_values", RebasedDict>,
+            Field<"target_units", RebasedDict>>;
+    using RebasedList = TSL<RebasedDict, std::size_t{2}>;
+
+    struct SelectRebasedPrice
+    {
+        static constexpr auto name = "select_rebased_price";
+
+        static Port<TS<Int>> compose(Wiring &, Port<TS<Int>>, Port<TS<Int>> price)
+        {
+            return price;
+        }
+    };
+
+    struct TsbNestedTsdProxyLagFeedbackGraph
+    {
+        static constexpr auto name = "tsb_nested_tsd_proxy_lag_feedback_graph";
+
+        static Port<TS<Int>> compose(Wiring &w, Port<RebasedDict> target,
+                                     Port<TS<Bool>> rebase, Port<RebasedDict> prices,
+                                     Port<TS<Int>> trigger)
+        {
+            auto state_feedback = stdlib::feedback<RebasedBundle>(w);
+            auto empty_values = wire<stdlib::const_, RebasedDict>(
+                w, stdlib::make_map<Str, Int>({}));
+            auto empty_targets = wire<stdlib::const_, RebasedDict>(
+                w, stdlib::make_map<Str, Int>({}));
+            auto initial_state =
+                stdlib::to_tsb<RebasedBundle>(w, empty_values, empty_targets);
+            auto state =
+                wire<stdlib::default_>(
+                    w,
+                    wire<stdlib::lag>(w, state_feedback(), Int{1}, trigger),
+                    initial_state)
+                    .as<RebasedBundle>();
+
+            auto prior_target =
+                wire<stdlib::getitem_>(w, state, Str{"target_units"})
+                    .as<RebasedDict>();
+            auto target_units =
+                wire<stdlib::if_then_else>(w, rebase, target, prior_target)
+                    .as<RebasedDict>();
+            auto unit_values =
+                wire<stdlib::map_>(w, fn<SelectRebasedPrice>(), target_units,
+                                   stdlib::no_key(prices))
+                    .as<RebasedDict>();
+            auto next_state =
+                stdlib::to_tsb<RebasedBundle>(w, unit_values, target_units);
+            state_feedback(next_state);
+
+            auto prior_values =
+                wire<stdlib::getitem_>(w, state, Str{"unit_values"})
+                    .as<RebasedDict>();
+            auto next =
+                wire<stdlib::getitem_>(w, prior_values, Str{"next"}).as<TS<Int>>();
+            auto missing = wire<stdlib::const_, TS<Int>>(w, Int{-1});
+            return wire<stdlib::sample>(
+                       w, trigger, wire<stdlib::default_>(w, next, missing))
+                .as<TS<Int>>();
+        }
+    };
+
+    struct TslNestedTsdProxyLagFeedbackGraph
+    {
+        static constexpr auto name = "tsl_nested_tsd_proxy_lag_feedback_graph";
+
+        static Port<TS<Int>> compose(Wiring &w, Port<RebasedDict> target,
+                                     Port<TS<Bool>> rebase, Port<RebasedDict> prices,
+                                     Port<TS<Int>> trigger)
+        {
+            auto state_feedback = stdlib::feedback<RebasedList>(w);
+            auto empty_values = wire<stdlib::const_, RebasedDict>(
+                w, stdlib::make_map<Str, Int>({}));
+            auto empty_targets = wire<stdlib::const_, RebasedDict>(
+                w, stdlib::make_map<Str, Int>({}));
+            auto initial_state =
+                stdlib::to_tsl<RebasedList>(w, empty_values, empty_targets);
+            auto state =
+                wire<stdlib::default_>(
+                    w,
+                    wire<stdlib::lag>(w, state_feedback(), Int{1}, trigger),
+                    initial_state)
+                    .as<RebasedList>();
+
+            auto target_index = wire<stdlib::const_, TS<Int>>(w, Int{1});
+            auto prior_target =
+                wire<stdlib::getitem_>(w, state, target_index).as<RebasedDict>();
+            auto target_units =
+                wire<stdlib::if_then_else>(w, rebase, target, prior_target)
+                    .as<RebasedDict>();
+            auto unit_values =
+                wire<stdlib::map_>(w, fn<SelectRebasedPrice>(), target_units,
+                                   stdlib::no_key(prices))
+                    .as<RebasedDict>();
+            auto next_state =
+                stdlib::to_tsl<RebasedList>(w, unit_values, target_units);
+            state_feedback(next_state);
+
+            auto values_index = wire<stdlib::const_, TS<Int>>(w, Int{0});
+            auto prior_values =
+                wire<stdlib::getitem_>(w, state, values_index).as<RebasedDict>();
+            auto next =
+                wire<stdlib::getitem_>(w, prior_values, Str{"next"}).as<TS<Int>>();
+            auto missing = wire<stdlib::const_, TS<Int>>(w, Int{-1});
+            return wire<stdlib::sample>(
+                       w, trigger, wire<stdlib::default_>(w, next, missing))
+                .as<TS<Int>>();
+        }
+    };
+
     struct NamedTsbDedupGraph
     {
         static constexpr auto name = "named_tsb_dedup_graph";
@@ -1969,6 +2082,30 @@ TEST_CASE("std operators: TSB proxy lag preserves sparse field deltas")
                  values<Value>(none, none, none,
                                bundle_delta(Int{2}, Float{2.0}),
                                bundle_delta(Int{3}, std::nullopt)));
+}
+
+TEST_CASE("std operators: structural proxy lag recursively preserves nested TSD keys")
+{
+    using namespace std::string_literals;
+
+    stdlib::register_standard_operators();
+
+    const auto target =
+        values<Value>(dict_delta<Str, TS<Int>>({{"next"s, Int{1}}}), none, none, none);
+    const auto rebase = values<Bool>(true, false, false, false);
+    const auto prices =
+        values<Value>(dict_delta<Str, TS<Int>>({{"next"s, Int{10}}}), none, none, none);
+    const auto trigger = values<Int>(0, 1, 2, 3);
+    const auto feedback_expected = values<Int>(-1, -1, 10, 10);
+
+    CHECK_OUTPUT(
+        eval_node<TsbNestedTsdProxyLagFeedbackGraph>(
+            target, rebase, prices, trigger),
+        feedback_expected);
+    CHECK_OUTPUT(
+        eval_node<TslNestedTsdProxyLagFeedbackGraph>(
+            target, rebase, prices, trigger),
+        feedback_expected);
 }
 
 TEST_CASE("std operators: schedule and resample are bounded by executor end time")


### PR DESCRIPTION
## Summary

- recursively dispatch proxy-based `lag` for TSB fields so nested TSD values retain their key-lifecycle semantics
- apply the same correction to fixed TSL elements, which had the analogous structural bypass
- keep feedback's captured-delta fallback safe when a subsequent update follows immutable compact state
- add matching public C++ and Python regressions for the `if_then_else`/`no_key(map_)` feedback sequence

## Root cause

The TSB proxy-lag composition wired every field directly to the leaf `lag_proxy_node`. A nested TSD therefore bypassed the TSD-specific lag composition that retains keyed children until delayed values have flushed. After the `if_then_else` reference rebind, the delayed state published a key removal at the fourth tick even though the mapped value remained valid. Fixed TSL expansion used the same direct leaf path.

The exact regression produced `[-1, -1, 10, -1]` before the fix and now produces `[-1, -1, 10, 10]` for both TSB and fixed-TSL state.

The public C++ reproduction also showed that feedback's general `capture_delta` fallback can replace planned writable state with immutable compact storage. A later feedback update now captures again instead of requesting an unsupported mutation view.

## Validation

- clean native C++ acceptance suite: 1,267 passed
- stable-ABI wheel built with Python 3.12
- complete non-WIP Python compatibility suite on Python 3.14: 1,614 passed, 10 skipped
- `git diff --check`

Fixes #40