### PR TITLE
Restore lazy optional adaptor imports

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -85,9 +85,8 @@ wheel_dir="$(mktemp -d)"
 test_env="$(mktemp -d)"
 uv build --wheel --python 3.12 --out-dir "$wheel_dir"
 uv venv --python 3.14 "$test_env"
-uv pip install --python "$test_env/bin/python" \
-  "$wheel_dir"/*.whl "pytest>=8" "frozendict>=2.4" "tornado>=6.5" \
-  "polars[rtcompat]>=1.32" trove-classifiers
+wheel_path="$(find "$wheel_dir" -maxdepth 1 -name '*.whl' -print -quit)"
+uv pip install --python "$test_env/bin/python" "${wheel_path}[test]"
 "$test_env/bin/python" -m pytest python/tests -q -m "not wip"
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,9 +45,15 @@ python = [
     "nanobind==2.13.0",
 ]
 test = [
+    "boto3>=1.34",
+    "connectorx>=0.4.5",
+    "deltalake>=1.0",
+    "duckdb>=1.4",
+    "pandas>=2.0",
     "packaging>=24",
     "polars[rtcompat]>=1.32",
     "pytest>=8",
+    "sqlalchemy>=2.0",
     "tornado>=6.5",
     "trove-classifiers",
 ]
@@ -58,6 +64,7 @@ sql = [
     "connectorx>=0.4.5",
     "duckdb>=1.4",
     "pandas>=2.0",
+    "polars>=1.32",
     "sqlalchemy>=2.0",
 ]
 snowflake = [
@@ -69,6 +76,7 @@ kafka = [
 delta = [
     "boto3>=1.34",
     "deltalake>=1.0",
+    "polars>=1.32",
 ]
 perspective = [
     "perspective-python>=3.8",

--- a/python/hgraph/adaptors/delta/delta_adaptor_raw.py
+++ b/python/hgraph/adaptors/delta/delta_adaptor_raw.py
@@ -3,10 +3,7 @@ from concurrent.futures import Executor
 from datetime import datetime, timedelta
 from enum import Enum
 
-import boto3
-import polars as pl
 import pyarrow as pa
-from deltalake import DeltaTable, QueryBuilder, write_deltalake
 
 from hgraph import (
     AUTO_RESOLVE, MIN_DT, SCHEMA, STATE, Frame, TS, TSB, TSD,
@@ -28,6 +25,32 @@ __all__ = (
 
 _RAW_FRAME_STREAM = TSB[Stream[Data[Frame]]]
 _TIME_STREAM = TSB[Stream[Data[datetime]]]
+
+
+def _require_delta_lake():
+    try:
+        from deltalake import DeltaTable, QueryBuilder, write_deltalake
+    except ModuleNotFoundError as error:
+        raise RuntimeError("Delta adaptors require the 'delta' extra") from error
+    return DeltaTable, QueryBuilder, write_deltalake
+
+
+def _require_polars():
+    try:
+        import polars
+    except ModuleNotFoundError as error:
+        raise RuntimeError("Delta adaptors require the 'delta' extra") from error
+    return polars
+
+
+def _require_boto3():
+    try:
+        import boto3
+    except ModuleNotFoundError as error:
+        raise RuntimeError(
+            "Delta S3 storage requires the 'delta' extra"
+        ) from error
+    return boto3
 
 
 class DeltaWriteMode(Enum):
@@ -86,6 +109,7 @@ def delta_read_adaptor_raw_impl(
         if previous is not None:
             previous.result()
         try:
+            DeltaTable, _, _ = _require_delta_lake()
             logger.info("Will read delta table %s with filters %s", table_path, filters)
             delta_table = DeltaTable(table_path, storage_options=credentials or None)
             result = delta_table.to_pyarrow_table(
@@ -154,6 +178,7 @@ def delta_query_adaptor_raw_impl(
         if previous is not None:
             previous.result()
         try:
+            DeltaTable, QueryBuilder, _ = _require_delta_lake()
             builder = QueryBuilder()
             for table in tables:
                 builder.register(
@@ -225,6 +250,8 @@ def delta_write_adaptor_raw_impl(
         if previous is not None:
             previous.result()
         try:
+            pl = _require_polars()
+            _, _, write_deltalake = _require_delta_lake()
             frame = pl.from_arrow(data)
             predicate = None
             if keys:
@@ -296,6 +323,7 @@ def delta_table_maintenance(
         def run():
             table_path = base + table
             try:
+                DeltaTable, _, _ = _require_delta_lake()
                 delta_table = DeltaTable(
                     table_path, storage_options=options or None)
                 logger.info("Compaction for %s: %s", table_path,
@@ -315,6 +343,7 @@ def delta_table_maintenance(
 @generator
 def delta_storage_options(path: str, _state: STATE = None) -> TS[object]:
     if path.startswith("s3://"):
+        boto3 = _require_boto3()
         credentials = boto3.Session().get_credentials()
         _state.storage_options = {
             "aws_access_key_id": credentials.access_key,

--- a/python/hgraph/adaptors/sql/sql_adaptor_raw.py
+++ b/python/hgraph/adaptors/sql/sql_adaptor_raw.py
@@ -4,7 +4,6 @@ from concurrent.futures import Executor
 from datetime import datetime, timezone
 from enum import Enum
 
-import polars as pl
 import pyarrow as pa
 import pyarrow.compute as pc
 
@@ -25,7 +24,11 @@ from hgraph import (
 from hgraph.adaptors.executor import adaptor_executor
 from hgraph.stream import Data, Stream, StreamStatus
 
-from .sql_connection import SqlAdaptorConnection, start_sql_adaptor
+from .sql_connection import (
+    SqlAdaptorConnection,
+    _require_polars,
+    start_sql_adaptor,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -164,6 +167,7 @@ def sql_write_adaptor_raw_impl(
             previous.result()
         start = time.perf_counter_ns()
         try:
+            pl = _require_polars()
             with connection.connection.connect() as query_connection:
                 autocommit = query_connection.execution_options(autocommit=True)
                 data_frame = pl.from_arrow(frame)

--- a/python/hgraph/adaptors/sql/sql_connection.py
+++ b/python/hgraph/adaptors/sql/sql_connection.py
@@ -3,10 +3,7 @@ import re
 from datetime import timedelta
 from urllib.parse import quote
 
-import adbc_driver_snowflake.dbapi
-import polars as pl
 import pyarrow as pa
-from sqlalchemy import QueuePool, create_engine, event
 
 from hgraph import STATE, TS, generator
 
@@ -23,8 +20,35 @@ class SqlAdaptorConnection:
     ...
 
 
+def _require_polars():
+    try:
+        import polars
+    except ModuleNotFoundError as error:
+        raise RuntimeError("SQL adaptors require the 'sql' extra") from error
+    return polars
+
+
+def _require_sqlalchemy():
+    try:
+        from sqlalchemy import QueuePool, create_engine, event
+    except ModuleNotFoundError as error:
+        raise RuntimeError("SQL connections require the 'sql' extra") from error
+    return QueuePool, create_engine, event
+
+
+def _require_snowflake():
+    try:
+        import adbc_driver_snowflake.dbapi
+    except ModuleNotFoundError as error:
+        raise RuntimeError(
+            "Snowflake connections require the 'snowflake' extra"
+        ) from error
+    return adbc_driver_snowflake.dbapi
+
+
 class SqlAdaptorConnectionSQLServer(SqlAdaptorConnection):
     def __init__(self, path, connection_params: dict[str, object]):
+        _, create_engine, event = _require_sqlalchemy()
         self.path = path
         self.connection = create_engine(path, **connection_params)
 
@@ -36,20 +60,22 @@ class SqlAdaptorConnectionSQLServer(SqlAdaptorConnection):
                 connection.rollback()
 
     def read_database(self, query: str) -> pa.Table:
+        pl = _require_polars()
         return pl.read_database_uri(query=query, uri=self.path).to_arrow()
 
 
 class SqlAdaptorConnectionSnowflake(SqlAdaptorConnection):
     def __init__(self, connection_params: dict[str, object]):
+        snowflake = _require_snowflake()
         self.lowercase_columns = (
             connection_params.pop(
                 "hgraph.sql_adaptor.lowercase_columns", "false"
             ).lower() == "true"
         )
-        self.connection = adbc_driver_snowflake.dbapi.connect(
-            db_kwargs=connection_params)
+        self.connection = snowflake.connect(db_kwargs=connection_params)
 
     def read_database(self, query: str) -> pa.Table:
+        pl = _require_polars()
         frame = pl.read_database(connection=self.connection, query=query)
         if self.lowercase_columns:
             frame = frame.rename({column: column.lower() for column in frame.columns})
@@ -124,6 +150,7 @@ def stop_sql_server_adaptor(_state: STATE = None):
 def create_sql_db_connection(
     path: str, connection_params: dict[str, object], _state: STATE,
 ) -> SqlAdaptorConnection:
+    QueuePool, _, _ = _require_sqlalchemy()
     default_params = {
         "poolclass": QueuePool,
         "pool_size": 5,

--- a/python/tests/adaptors/delta/test_delta_adaptor.py
+++ b/python/tests/adaptors/delta/test_delta_adaptor.py
@@ -161,7 +161,9 @@ def test_delta_table_maintenance_compacts_and_vacuums(monkeypatch):
             calls.append(("vacuum", kwargs))
 
     monkeypatch.setattr(
-        "hgraph.adaptors.delta.delta_adaptor_raw.DeltaTable", _DeltaTable)
+        "hgraph.adaptors.delta.delta_adaptor_raw._require_delta_lake",
+        lambda: (_DeltaTable, None, None),
+    )
 
     @hg.graph
     def app() -> hg.TS[bool]:

--- a/python/tests/test_optional_adaptor_imports.py
+++ b/python/tests/test_optional_adaptor_imports.py
@@ -1,0 +1,76 @@
+"""Runtime checks for optional adaptor dependency boundaries."""
+
+import os
+from pathlib import Path
+import subprocess
+import sys
+import textwrap
+
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_optional_adaptor_namespaces_import_without_client_dependencies():
+    script = textwrap.dedent(
+        """
+        import sys
+
+        blocked = {
+            "adbc_driver_snowflake", "boto3", "connectorx", "deltalake",
+            "duckdb", "pandas", "polars", "sqlalchemy",
+        }
+
+        class BlockOptionalImports:
+            def find_spec(self, fullname, path=None, target=None):
+                if fullname.partition(".")[0] in blocked:
+                    raise ModuleNotFoundError(
+                        f"blocked optional dependency: {fullname}",
+                        name=fullname,
+                    )
+                return None
+
+        sys.meta_path.insert(0, BlockOptionalImports())
+
+        import hgraph.adaptors.delta
+        import hgraph.adaptors.sql
+
+        from hgraph.adaptors.delta.delta_adaptor_raw import (
+            _require_boto3,
+            _require_delta_lake,
+            _require_polars as require_delta_polars,
+        )
+        from hgraph.adaptors.sql.sql_connection import (
+            _require_polars as require_sql_polars,
+            _require_snowflake,
+            _require_sqlalchemy,
+        )
+
+        helpers = (
+            (_require_boto3, "delta"),
+            (_require_delta_lake, "delta"),
+            (require_delta_polars, "delta"),
+            (require_sql_polars, "sql"),
+            (_require_sqlalchemy, "sql"),
+            (_require_snowflake, "snowflake"),
+        )
+        for helper, extra in helpers:
+            try:
+                helper()
+            except RuntimeError as error:
+                assert f"'{extra}' extra" in str(error), str(error)
+            else:
+                raise AssertionError(f"{helper.__name__} imported a blocked client")
+        """
+    )
+    python_path = os.pathsep.join(
+        filter(None, (str(ROOT / "python"), os.environ.get("PYTHONPATH")))
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        cwd=ROOT,
+        env={**os.environ, "PYTHONPATH": python_path},
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr

--- a/python/tests/test_packaging.py
+++ b/python/tests/test_packaging.py
@@ -1,9 +1,15 @@
 """Packaging contract checks for the optional Python bridge."""
 
+import os
 from pathlib import Path
 import re
+import subprocess
+import sys
+import textwrap
 import tomllib
 
+from packaging.requirements import Requirement
+from packaging.utils import canonicalize_name
 from packaging.version import Version
 from trove_classifiers import classifiers as valid_classifiers
 
@@ -113,6 +119,99 @@ def test_full_suite_dependencies_include_the_dataframe_runtime():
     assert "polars[rtcompat]>=1.32" in test_dependencies
 
 
+def _dependency_names(requirements):
+    return {
+        canonicalize_name(Requirement(requirement).name)
+        for requirement in requirements
+    }
+
+
+def test_adaptor_extras_include_their_runtime_dependencies():
+    extras = load_project()["project"]["optional-dependencies"]
+
+    assert "polars>=1.32" in extras["sql"]
+    assert "polars>=1.32" in extras["delta"]
+    assert (
+        _dependency_names(extras["sql"]) | _dependency_names(extras["delta"])
+    ) <= _dependency_names(extras["test"])
+
+
+def test_full_suite_gate_installs_the_wheel_test_extra():
+    instructions = (ROOT / "AGENTS.md").read_text()
+
+    assert 'wheel_path="$(find "$wheel_dir"' in instructions
+    assert (
+        'uv pip install --python "$test_env/bin/python" '
+        '"${wheel_path}[test]"'
+    ) in instructions
+
+
+def test_optional_adaptor_namespaces_import_without_client_dependencies():
+    script = textwrap.dedent(
+        """
+        import sys
+
+        blocked = {
+            "adbc_driver_snowflake", "boto3", "connectorx", "deltalake",
+            "duckdb", "pandas", "polars", "sqlalchemy",
+        }
+
+        class BlockOptionalImports:
+            def find_spec(self, fullname, path=None, target=None):
+                if fullname.partition(".")[0] in blocked:
+                    raise ModuleNotFoundError(
+                        f"blocked optional dependency: {fullname}",
+                        name=fullname,
+                    )
+                return None
+
+        sys.meta_path.insert(0, BlockOptionalImports())
+
+        import hgraph.adaptors.delta
+        import hgraph.adaptors.sql
+
+        from hgraph.adaptors.delta.delta_adaptor_raw import (
+            _require_boto3,
+            _require_delta_lake,
+            _require_polars as require_delta_polars,
+        )
+        from hgraph.adaptors.sql.sql_connection import (
+            _require_polars as require_sql_polars,
+            _require_snowflake,
+            _require_sqlalchemy,
+        )
+
+        helpers = (
+            (_require_boto3, "delta"),
+            (_require_delta_lake, "delta"),
+            (require_delta_polars, "delta"),
+            (require_sql_polars, "sql"),
+            (_require_sqlalchemy, "sql"),
+            (_require_snowflake, "snowflake"),
+        )
+        for helper, extra in helpers:
+            try:
+                helper()
+            except RuntimeError as error:
+                assert f"'{extra}' extra" in str(error), str(error)
+            else:
+                raise AssertionError(f"{helper.__name__} imported a blocked client")
+        """
+    )
+    python_path = os.pathsep.join(
+        filter(None, (str(ROOT / "python"), os.environ.get("PYTHONPATH")))
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        cwd=ROOT,
+        env={**os.environ, "PYTHONPATH": python_path},
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+
+
 def test_release_workflow_targets_supported_platforms():
     workflow = (ROOT / ".github/workflows/build.yml").read_text()
 
@@ -169,6 +268,9 @@ def main():
     test_wheel_uses_shared_runtime_for_downstream_native_extensions()
     test_source_distribution_excludes_private_release_evidence()
     test_full_suite_dependencies_include_the_dataframe_runtime()
+    test_adaptor_extras_include_their_runtime_dependencies()
+    test_full_suite_gate_installs_the_wheel_test_extra()
+    test_optional_adaptor_namespaces_import_without_client_dependencies()
     test_release_workflow_targets_supported_platforms()
     test_release_workflow_reuses_tested_commit_artifacts()
     test_release_workflow_audits_distribution_contents()
@@ -181,6 +283,9 @@ def main():
     print("PASS test_wheel_uses_shared_runtime_for_downstream_native_extensions")
     print("PASS test_source_distribution_excludes_private_release_evidence")
     print("PASS test_full_suite_dependencies_include_the_dataframe_runtime")
+    print("PASS test_adaptor_extras_include_their_runtime_dependencies")
+    print("PASS test_full_suite_gate_installs_the_wheel_test_extra")
+    print("PASS test_optional_adaptor_namespaces_import_without_client_dependencies")
     print("PASS test_release_workflow_targets_supported_platforms")
     print("PASS test_release_workflow_reuses_tested_commit_artifacts")
     print("PASS test_release_workflow_audits_distribution_contents")

--- a/python/tests/test_packaging.py
+++ b/python/tests/test_packaging.py
@@ -1,11 +1,7 @@
 """Packaging contract checks for the optional Python bridge."""
 
-import os
 from pathlib import Path
 import re
-import subprocess
-import sys
-import textwrap
 import tomllib
 
 from packaging.requirements import Requirement
@@ -146,72 +142,6 @@ def test_full_suite_gate_installs_the_wheel_test_extra():
     ) in instructions
 
 
-def test_optional_adaptor_namespaces_import_without_client_dependencies():
-    script = textwrap.dedent(
-        """
-        import sys
-
-        blocked = {
-            "adbc_driver_snowflake", "boto3", "connectorx", "deltalake",
-            "duckdb", "pandas", "polars", "sqlalchemy",
-        }
-
-        class BlockOptionalImports:
-            def find_spec(self, fullname, path=None, target=None):
-                if fullname.partition(".")[0] in blocked:
-                    raise ModuleNotFoundError(
-                        f"blocked optional dependency: {fullname}",
-                        name=fullname,
-                    )
-                return None
-
-        sys.meta_path.insert(0, BlockOptionalImports())
-
-        import hgraph.adaptors.delta
-        import hgraph.adaptors.sql
-
-        from hgraph.adaptors.delta.delta_adaptor_raw import (
-            _require_boto3,
-            _require_delta_lake,
-            _require_polars as require_delta_polars,
-        )
-        from hgraph.adaptors.sql.sql_connection import (
-            _require_polars as require_sql_polars,
-            _require_snowflake,
-            _require_sqlalchemy,
-        )
-
-        helpers = (
-            (_require_boto3, "delta"),
-            (_require_delta_lake, "delta"),
-            (require_delta_polars, "delta"),
-            (require_sql_polars, "sql"),
-            (_require_sqlalchemy, "sql"),
-            (_require_snowflake, "snowflake"),
-        )
-        for helper, extra in helpers:
-            try:
-                helper()
-            except RuntimeError as error:
-                assert f"'{extra}' extra" in str(error), str(error)
-            else:
-                raise AssertionError(f"{helper.__name__} imported a blocked client")
-        """
-    )
-    python_path = os.pathsep.join(
-        filter(None, (str(ROOT / "python"), os.environ.get("PYTHONPATH")))
-    )
-    result = subprocess.run(
-        [sys.executable, "-c", script],
-        cwd=ROOT,
-        env={**os.environ, "PYTHONPATH": python_path},
-        capture_output=True,
-        text=True,
-    )
-
-    assert result.returncode == 0, result.stderr
-
-
 def test_release_workflow_targets_supported_platforms():
     workflow = (ROOT / ".github/workflows/build.yml").read_text()
 
@@ -270,7 +200,6 @@ def main():
     test_full_suite_dependencies_include_the_dataframe_runtime()
     test_adaptor_extras_include_their_runtime_dependencies()
     test_full_suite_gate_installs_the_wheel_test_extra()
-    test_optional_adaptor_namespaces_import_without_client_dependencies()
     test_release_workflow_targets_supported_platforms()
     test_release_workflow_reuses_tested_commit_artifacts()
     test_release_workflow_audits_distribution_contents()
@@ -285,7 +214,6 @@ def main():
     print("PASS test_full_suite_dependencies_include_the_dataframe_runtime")
     print("PASS test_adaptor_extras_include_their_runtime_dependencies")
     print("PASS test_full_suite_gate_installs_the_wheel_test_extra")
-    print("PASS test_optional_adaptor_namespaces_import_without_client_dependencies")
     print("PASS test_release_workflow_targets_supported_platforms")
     print("PASS test_release_workflow_reuses_tested_commit_artifacts")
     print("PASS test_release_workflow_audits_distribution_contents")

--- a/uv.lock
+++ b/uv.lock
@@ -445,6 +445,7 @@ dataframe = [
 delta = [
     { name = "boto3" },
     { name = "deltalake" },
+    { name = "polars" },
 ]
 dev = [
     { name = "cmake" },
@@ -482,12 +483,19 @@ sql = [
     { name = "connectorx" },
     { name = "duckdb" },
     { name = "pandas" },
+    { name = "polars" },
     { name = "sqlalchemy" },
 ]
 test = [
+    { name = "boto3" },
+    { name = "connectorx" },
+    { name = "deltalake" },
+    { name = "duckdb" },
     { name = "packaging" },
+    { name = "pandas" },
     { name = "polars", extra = ["rtcompat"] },
     { name = "pytest" },
+    { name = "sqlalchemy" },
     { name = "tornado" },
     { name = "trove-classifiers" },
 ]
@@ -499,10 +507,14 @@ web = [
 requires-dist = [
     { name = "adbc-driver-snowflake", marker = "extra == 'snowflake'", specifier = ">=1.8" },
     { name = "boto3", marker = "extra == 'delta'", specifier = ">=1.34" },
+    { name = "boto3", marker = "extra == 'test'", specifier = ">=1.34" },
     { name = "cmake", marker = "extra == 'dev'", specifier = ">=3.26" },
     { name = "connectorx", marker = "extra == 'sql'", specifier = ">=0.4.5" },
+    { name = "connectorx", marker = "extra == 'test'", specifier = ">=0.4.5" },
     { name = "deltalake", marker = "extra == 'delta'", specifier = ">=1.0" },
+    { name = "deltalake", marker = "extra == 'test'", specifier = ">=1.0" },
     { name = "duckdb", marker = "extra == 'sql'", specifier = ">=1.4" },
+    { name = "duckdb", marker = "extra == 'test'", specifier = ">=1.4" },
     { name = "frozendict", specifier = ">=2.4" },
     { name = "kafka-python", marker = "extra == 'kafka'", specifier = ">=2.2" },
     { name = "myst-parser", marker = "extra == 'dev'", specifier = ">=2.0" },
@@ -514,8 +526,11 @@ requires-dist = [
     { name = "packaging", marker = "extra == 'dev'", specifier = ">=24" },
     { name = "packaging", marker = "extra == 'test'", specifier = ">=24" },
     { name = "pandas", marker = "extra == 'sql'", specifier = ">=2.0" },
+    { name = "pandas", marker = "extra == 'test'", specifier = ">=2.0" },
     { name = "perspective-python", marker = "extra == 'perspective'", specifier = ">=3.8" },
     { name = "polars", marker = "extra == 'dataframe'", specifier = ">=1.32" },
+    { name = "polars", marker = "extra == 'delta'", specifier = ">=1.32" },
+    { name = "polars", marker = "extra == 'sql'", specifier = ">=1.32" },
     { name = "polars", extras = ["rtcompat"], marker = "extra == 'test'", specifier = ">=1.32" },
     { name = "pyarrow", specifier = ">=24,<25" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8" },
@@ -528,6 +543,7 @@ requires-dist = [
     { name = "sphinxcontrib-mermaid", marker = "extra == 'dev'", specifier = ">=1.0" },
     { name = "sphinxcontrib-mermaid", marker = "extra == 'docs'", specifier = ">=1.0" },
     { name = "sqlalchemy", marker = "extra == 'sql'", specifier = ">=2.0" },
+    { name = "sqlalchemy", marker = "extra == 'test'", specifier = ">=2.0" },
     { name = "tornado", marker = "extra == 'perspective'", specifier = ">=6.5" },
     { name = "tornado", marker = "extra == 'test'", specifier = ">=6.5" },
     { name = "tornado", marker = "extra == 'web'", specifier = ">=6.5" },


### PR DESCRIPTION
## Summary

- defer SQL, Snowflake, Delta Lake, boto3, and Polars imports until the corresponding adaptor operation is used
- raise targeted errors naming the required optional extra when a client dependency is unavailable
- declare Polars in the SQL and Delta extras and make the wheel's `test` extra cover the SQL/Delta dependencies exercised by the complete suite
- update the local completion gate to install `${wheel_path}[test]` instead of maintaining a separate package list
- add regression coverage that blocks every optional SQL/Delta client while importing both adaptor namespaces

## Root cause

The native adaptor migration moved optional SQL and Delta clients to module-level imports. At the same time, the local Python acceptance command used a manually maintained dependency list while CI installed every extra. That combination made optional namespaces require unrelated clients during test collection and let the local gate drift from wheel metadata.

## Impact

Applications can import SQL and Delta adaptor APIs without paying for unused client dependencies. Actual adaptor use reports which extra is required. A fresh wheel's `test` extra is now sufficient to run the complete compatibility suite, while Snowflake remains absent unless explicitly requested.

## Validation

- focused packaging, SQL, Delta, and subscriber tests: 36 passed
- clean native C++ suite: 1267/1267 passed
- Python 3.14 non-WIP suite from a Python 3.12 stable-ABI wheel installed into a fresh environment via `[test]`: 1617 passed, 10 skipped

The first complete Python run encountered one transient real-time JSON catalogue timing failure; that test passed immediately in isolation and the complete rerun passed.