### PR TITLE
Reduce redundant CI rebuilds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,15 +3,22 @@ name: Build, test, and publish Python distributions
 on:
   push:
     branches:
-      - "**"
+      - main
     tags:
       - "v_*.*.*"
   pull_request:
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 permissions:
   actions: read
   contents: read
+
+env:
+  SCCACHE_GHA_ENABLED: "true"
 
 jobs:
   validate-release:
@@ -148,6 +155,10 @@ jobs:
       - uses: actions/checkout@v6
         with:
           persist-credentials: false
+      - name: Enable shared compiler cache
+        uses: mozilla-actions/sccache-action@v0.0.10
+        with:
+          version: v0.15.0
       - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
@@ -205,6 +216,10 @@ jobs:
       - uses: actions/checkout@v6
         with:
           persist-credentials: false
+      - name: Enable shared compiler cache
+        uses: mozilla-actions/sccache-action@v0.0.10
+        with:
+          version: v0.15.0
       - name: Verify official build toolchain
         shell: bash
         run: |
@@ -373,6 +388,10 @@ jobs:
       - uses: actions/checkout@v6
         with:
           persist-credentials: false
+      - name: Enable shared compiler cache
+        uses: mozilla-actions/sccache-action@v0.0.10
+        with:
+          version: v0.15.0
       - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
@@ -419,6 +438,10 @@ jobs:
       - uses: actions/checkout@v6
         with:
           persist-credentials: false
+      - name: Enable shared compiler cache
+        uses: mozilla-actions/sccache-action@v0.0.10
+        with:
+          version: v0.15.0
       - uses: mamba-org/setup-micromamba@v3
         with:
           environment-name: hgraph-native


### PR DESCRIPTION
## Summary

- run the full build workflow once for pull-request branches, while retaining push builds for `main` and release tags
- cancel superseded runs for the same workflow event and ref
- enable the GitHub Actions-backed `sccache` compiler cache in every C++ compilation job
- pin the cache action and `sccache` versions for reproducible CI behavior

## Why

Pull-request commits currently trigger both `push` and `pull_request` executions of the same build matrix. This doubles CI work. In addition, the repository already teaches CMake to use `sccache` or `ccache` when available, but CI installs neither, so small changes repeatedly compile unaffected translation units.

`sccache` hashes the compiler, arguments, source, and included inputs for individual compilations. It can therefore reuse unaffected object files while the workflow still rebuilds, audits, and tests the final distributions with their correct commit provenance.

## Validation

- `actionlint .github/workflows/build.yml`
- parsed `.github/workflows/build.yml` with Ruby/Psych
- downloaded the pinned `sccache 0.15.0` binary and ran `cmake --preset cpp --fresh`; CMake reported it as the compiler launcher
- `git diff --check`

The native and Python runtime suites were not rerun because this PR changes only GitHub Actions orchestration and does not change compiled sources or artifact contents.