### PR TITLE
Add differential hgraph parity harness

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -368,6 +368,51 @@ jobs:
         if: matrix.python-version == '3.12'
         run: uv run --no-sync python tests/python_extension_consumer/check.py
 
+  parity-smoke:
+    name: Differential parity smoke / Python 3.14
+    needs:
+      - reuse-build
+      - build-linux-wheel
+    if: needs.reuse-build.outputs.run-id == ''
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.14"
+      - name: Install parity controller
+        run: python -m pip install --upgrade uv hypothesis
+      - uses: actions/download-artifact@v7
+        with:
+          name: distribution-wheel-ubuntu-latest
+          path: dist
+      - name: Restore released-hgraph traces
+        uses: actions/cache@v5
+        with:
+          path: |
+            .parity/envs/reference-*
+            .parity/cache/reference-traces
+          key: parity-reference-${{ runner.os }}-py314-${{ hashFiles('tools/parity/**/*.py') }}
+          restore-keys: |
+            parity-reference-${{ runner.os }}-py314-
+      - name: Run fixed corpus and deterministic generated matrix
+        run: >-
+          python -m tools.parity campaign
+          --profile pr
+          --seed 20260726
+          --candidate-wheel dist/*.whl
+          --output-dir parity-results
+      - uses: actions/upload-artifact@v7
+        if: always()
+        with:
+          name: parity-smoke
+          path: parity-results
+          if-no-files-found: error
+
   native-cpp:
     name: Native C++ / ${{ matrix.os }}
     needs:

--- a/.github/workflows/parity-nightly.yml
+++ b/.github/workflows/parity-nightly.yml
@@ -1,0 +1,123 @@
+name: Nightly differential parity campaign
+
+on:
+  schedule:
+    - cron: "30 2 * * *"
+  workflow_dispatch:
+
+concurrency:
+  group: parity-nightly
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  build-candidate:
+    name: Build candidate wheel
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+      - name: Enable shared compiler cache
+        uses: mozilla-actions/sccache-action@v0.0.10
+        with:
+          version: v0.15.0
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+      - name: Install build tools
+        run: python -m pip install --upgrade uv
+      - name: Build the stable-ABI candidate wheel
+        env:
+          CMAKE_BUILD_PARALLEL_LEVEL: "2"
+        run: >-
+          uv build
+          --wheel
+          --python 3.12
+          --config-setting cmake.build-type=Release
+          --out-dir dist
+          --no-build-logs
+      - uses: actions/upload-artifact@v7
+        with:
+          name: parity-candidate-wheel
+          path: dist/*.whl
+          if-no-files-found: error
+
+  campaign:
+    name: Campaign shard ${{ matrix.shard }}
+    needs: build-candidate
+    runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [0, 1, 2, 3]
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.14"
+      - name: Install parity controller
+        run: python -m pip install --upgrade uv hypothesis
+      - uses: actions/download-artifact@v7
+        with:
+          name: parity-candidate-wheel
+          path: dist
+      - name: Restore released-hgraph traces
+        uses: actions/cache@v5
+        with:
+          path: |
+            .parity/envs/reference-*
+            .parity/cache/reference-traces
+          key: parity-reference-${{ runner.os }}-py314-${{ matrix.shard }}-${{ hashFiles('tools/parity/**/*.py') }}
+          restore-keys: |
+            parity-reference-${{ runner.os }}-py314-${{ matrix.shard }}-
+      - name: Run bounded nightly campaign
+        run: >-
+          python -m tools.parity campaign
+          --profile nightly
+          --seed ${{ github.run_number }}
+          --shard-index ${{ matrix.shard }}
+          --shard-count 4
+          --candidate-wheel dist/*.whl
+          --exit-zero
+          --output-dir parity-results
+      - uses: actions/upload-artifact@v7
+        if: always()
+        with:
+          name: parity-report-${{ matrix.shard }}
+          path: parity-results
+          if-no-files-found: error
+
+  publish:
+    name: Publish verified parity issues
+    needs: campaign
+    if: always() && needs.campaign.result != 'cancelled'
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.14"
+      - uses: actions/download-artifact@v7
+        with:
+          pattern: parity-report-*
+          path: parity-reports
+      - name: Create or update deduplicated issues
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: >-
+          python -m tools.parity publish-issues
+          parity-reports/*/report.json
+          --repo ${{ github.repository }}
+          --publish

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@
 benchmarks/.venv-upstream*/
 benchmarks/.venv-hg-cpp*/
 /reports/
+/.parity/
 
 python/_hgraph.abi3.so
 test_package/build/

--- a/benchmarks/orchestrate.py
+++ b/benchmarks/orchestrate.py
@@ -18,7 +18,6 @@ force a refresh). Results land in benchmarks/results/.
 """
 import argparse
 import datetime as dt
-import hashlib
 import json
 import os
 import platform
@@ -31,6 +30,10 @@ from pathlib import Path
 
 BENCH_DIR = Path(__file__).resolve().parent
 REPO_ROOT = BENCH_DIR.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+from tools.artifact_fingerprint import hg_cpp_source_fingerprint as _source_fingerprint
+
 ENVIRONMENT_KEY = (
     f"{sys.version_info.major}.{sys.version_info.minor}-"
     f"{sys.platform}-{platform.machine().lower()}"
@@ -54,30 +57,7 @@ def hg_cpp_python() -> Path:
 
 
 def hg_cpp_source_fingerprint() -> str:
-    digest = hashlib.sha256()
-    roots = (
-        REPO_ROOT / "CMakeLists.txt",
-        REPO_ROOT / "pyproject.toml",
-        REPO_ROOT / "include",
-        REPO_ROOT / "src",
-        REPO_ROOT / "python" / "CMakeLists.txt",
-        REPO_ROOT / "python" / "hgraph",
-    )
-    files = []
-    for root in roots:
-        if root.is_file():
-            files.append(root)
-        elif root.is_dir():
-            files.extend(path for path in root.rglob("*") if path.is_file() and "__pycache__" not in path.parts)
-    files.extend((REPO_ROOT / "python").glob("*.cpp"))
-    files.extend((REPO_ROOT / "python").glob("*.h"))
-    for path in sorted(files):
-        digest.update(path.relative_to(REPO_ROOT).as_posix().encode())
-        digest.update(b"\0")
-        digest.update(path.read_bytes())
-        digest.update(b"\0")
-    digest.update(f"python-{sys.version_info.major}.{sys.version_info.minor}".encode())
-    return digest.hexdigest()
+    return _source_fingerprint(REPO_ROOT)
 
 
 def _first_line(command: list[str]) -> str:

--- a/docs/source/developer_guide/index.rst
+++ b/docs/source/developer_guide/index.rst
@@ -24,6 +24,7 @@ The developer guide describes the internal design of the C++ implementation. The
    services
    operators
    parity_matrix
+   parity_testing
    record_replay_table
    python_integration
    python_bridge

--- a/docs/source/developer_guide/parity_testing.rst
+++ b/docs/source/developer_guide/parity_testing.rst
@@ -1,0 +1,165 @@
+Differential Parity Testing
+===========================
+
+The parity harness continuously compares the public Python authoring surface of
+the released Python hgraph runtime with the C++ runtime and compatibility bridge
+in this repository.  It complements the fixed compatibility suite: generated
+recipes explore multi-tick combinations which have not yet become ordinary
+regression tests.
+
+The released Python runtime is the behavioral oracle.  The harness resolves the
+latest hgraph release once at campaign setup, records its exact version and
+distribution environment, and uses it for the complete run.  ``hg_cpp`` is
+built and installed into a separate environment.  Every recipe then runs in a
+fresh isolated process, so imports, registry state, crashes, and timeouts cannot
+leak between implementations or stop the rest of a campaign.
+
+Quick Start
+-----------
+
+Install the optional controller dependency and validate the committed corpus:
+
+.. code-block:: bash
+
+   uv pip install --python .venv/bin/python "hypothesis>=6"
+   .venv/bin/python -m tools.parity validate
+
+Prepare the two isolated runtime environments:
+
+.. code-block:: bash
+
+   .venv/bin/python -m tools.parity setup
+
+Run the bounded pull-request profile:
+
+.. code-block:: bash
+
+   .venv/bin/python -m tools.parity campaign --profile pr
+
+Results are written below ``.parity/results``.  The reference environments,
+candidate wheels, and reference traces are content-addressed below
+``.parity``.  A change confined to recipes, tests, tooling, or documentation
+does not alter the candidate wheel fingerprint and therefore does not rebuild
+the native artifact.
+
+Useful focused commands are:
+
+.. code-block:: bash
+
+   python -m tools.parity replay tools/parity/corpus/issue-40-no-key-rebind.json
+   python -m tools.parity reduce path/to/failing-recipe.json
+   python -m tools.parity coverage --inventory
+   python -m tools.parity catalogue
+
+``--reference-python`` and ``--candidate-python`` select already-provisioned
+interpreters.  ``--candidate-wheel`` installs a pre-built stable-ABI wheel,
+which is how CI reuses the wheel already built by the distribution workflow.
+
+Recipe Contract
+---------------
+
+Recipes are versioned JSON data, not executable Python.  A recipe selects a
+checked-in graph template, supplies per-cycle inputs and bounded scalar
+parameters, and records semantic coverage tags:
+
+.. code-block:: json
+
+   {
+     "schema_version": 1,
+     "id": "feedback-accumulate-sparse",
+     "template": "feedback_accumulate",
+     "inputs": {"value": [1, 2, null, 3, -1, null, 5, 0]},
+     "parameters": {"initial": 7},
+     "features": [
+       "shape:TS",
+       "topology:feedback",
+       "lifecycle:multi-cycle"
+     ]
+   }
+
+``null`` means no tick.  Tagged objects represent identity-sensitive deltas,
+for example ``{"$remove": true}`` for a TSD removal and
+``{"$set_delta": {"added": [...], "removed": [...]}}`` for a TSS delta.
+Input names, tick counts, scalar types, expression operations, and template
+parameters are validated before either runtime imports hgraph.
+
+``tools/parity/catalog.py`` is the trusted language boundary.  Each template
+declares its inputs, feature tags, operator coverage, comparison tolerance, and
+public hgraph construction.  The same source executes in both environments.
+Do not add runtime semantics or compatibility shims to the harness.
+
+Generation and Coverage
+-----------------------
+
+Hypothesis recursively composes validated scalar expressions and produces
+stateful multi-cycle sequences for feedback, switching, and keyed TSD
+lifecycle.  Generated exploration uses 8--32 ticks by default; a reducer may
+shrink a failure below that range.
+
+Coverage is semantic rather than only line-based.  Reports count templates,
+time-series shapes, scalar types, operator families, topology, lifecycle
+events, tick lengths, and feature pairs.  They also compare the template
+catalogue with the runtime's public operator inventory, so unsupported
+generation surface remains visible.
+
+Add a template when a behavior cannot be represented by the existing bounded
+language:
+
+#. Implement the public graph construction in ``catalog.py`` without a module
+   level hgraph import.
+#. Declare its required inputs, operators, features, and any narrowly justified
+   floating-point tolerance.
+#. Add validation which rejects malformed or unbounded parameters.
+#. Add at least one multi-tick corpus recipe and controller tests.
+#. Confirm the recipe executes identically in the isolated reference and
+   candidate environments.
+
+Do not execute model-authored Python.  Model-assisted coverage work may propose
+recipe JSON or catalogue changes, but deterministic validation, replay, and
+review remain mandatory.
+
+Mismatch Lifecycle
+------------------
+
+A potential mismatch passes these gates:
+
+#. Replay both implementations three times in fresh processes.
+#. Quarantine a failed or nondeterministic reference; it is not evidence of an
+   ``hg_cpp`` defect.
+#. Use Hypothesis prefix shrinking followed by aligned tick removal, event
+   clearing, value simplification, and expression reduction.
+#. Replay the minimized case three more times.
+#. Compute a normalized fingerprint and suppress an already tracked
+   divergence.
+#. Publish one issue containing the minimized recipe, canonical traces,
+   versions, seed, reduction history, and acceptance criteria.
+
+Known differences live in ``tools/parity/known_divergences.json`` with their
+issue, rationale, and review date.  They remain in the corpus: once a fix lands,
+the same recipe changes from a known mismatch into a passing regression.
+
+A fix for Python-visible behavior must promote the minimized case to ordinary
+public Python wiring coverage and add equivalent native C++ ``eval_node``
+coverage.  The differential harness does not replace the C++-first testing
+contract.
+
+CI and Security
+---------------
+
+The normal distribution workflow runs the curated corpus and a deterministic
+generated matrix against its already-built Linux wheel under Python 3.14.
+This pull-request job has read-only permissions, makes no model calls, and
+never creates issues.
+
+The nightly workflow builds one candidate wheel, runs four bounded shards, and
+uploads complete reports.  Campaign jobs have read-only permissions.  A
+separate default-branch publisher receives only the validated report artifacts
+and has ``issues: write`` permission.  It creates or reopens deduplicated
+``bug``/``parity`` issues and then exits; individual crashes and mismatches do
+not stop later recipes.
+
+Model-assisted catalogue evolution is deliberately outside GitHub Actions.
+Invoke the ``hgraph-parity`` Codex skill during weekly maintenance.  It uses a
+cost-efficient model for constrained coverage proposals and reserves frontier
+analysis for a stable mismatch which deterministic reduction cannot simplify.
+No model credential is stored in this repository.

--- a/docs/source/developer_guide/testing.rst
+++ b/docs/source/developer_guide/testing.rst
@@ -183,7 +183,13 @@ never called when no inspector is registered.
 Python Compatibility Tests
 --------------------------
 
-Python tests live under ``tests/python`` and should be used where Python wiring or Python user nodes cross into the C++ runtime.
+Python tests live under ``python/tests`` and should be used where Python wiring
+or Python user nodes cross into the C++ runtime.
+
+The continuously evolving released-hgraph comparison is documented in
+:doc:`parity_testing`.  It generates bounded, multi-tick recipes and promotes a
+verified mismatch into the ordinary Python and native C++ regression layers;
+it does not replace either acceptance suite.
 
 Commands
 --------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,9 @@ test = [
     "tornado>=6.5",
     "trove-classifiers",
 ]
+parity = [
+    "hypothesis>=6",
+]
 web = [
     "tornado>=6.5",
 ]

--- a/python/tests/test_parity_harness.py
+++ b/python/tests/test_parity_harness.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
@@ -294,6 +295,55 @@ def test_issue_payload_is_deterministic_and_dry_run_has_no_github_write():
             "body": issue_body(failure),
         }
     ]
+
+
+def test_issue_publisher_does_not_deduplicate_distinct_same_template_failures(
+    monkeypatch,
+):
+    failure = {
+        "failure_fingerprint": "new-fingerprint",
+        "minimized_recipe": _scalar_recipe().to_dict(),
+        "difference": {
+            "classification": "value",
+            "path": "$.trace[1]",
+            "reference": 1,
+            "candidate": 2,
+        },
+        "reference": {"status": "ok", "trace": [1]},
+        "candidate": {"status": "ok", "trace": [2]},
+        "reduction": {"attempts": 0, "accepted": 0},
+    }
+    existing = {
+        "number": 44,
+        "state": "OPEN",
+        "title": "[parity] scalar_expression differs from released hgraph",
+        "body": "<!-- hgraph-parity:other-fingerprint -->",
+        "url": "https://github.com/hhenson/hg_cpp/issues/44",
+    }
+    calls = []
+
+    monkeypatch.setattr(
+        "tools.parity.issues._existing_issues", lambda _repo: [existing]
+    )
+
+    def fake_gh(arguments, *, repo, capture=False):
+        calls.append((arguments, repo, capture))
+        return SimpleNamespace(
+            stdout="https://github.com/hhenson/hg_cpp/issues/45\n"
+        )
+
+    monkeypatch.setattr("tools.parity.issues._gh", fake_gh)
+
+    assert publish_failures(
+        [failure], repo="hhenson/hg_cpp", publish=True
+    ) == [
+        {
+            "action": "created",
+            "url": "https://github.com/hhenson/hg_cpp/issues/45",
+            "fingerprint": "new-fingerprint",
+        }
+    ]
+    assert any(arguments[:2] == ["issue", "create"] for arguments, _, _ in calls)
 
 
 def test_coverage_reports_operator_frontier_and_semantic_pairs():

--- a/python/tests/test_parity_harness.py
+++ b/python/tests/test_parity_harness.py
@@ -1,0 +1,321 @@
+"""Tests for the model-free hgraph differential parity controller."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from tools.artifact_fingerprint import hg_cpp_source_fingerprint
+from tools.parity.campaign import run_campaign
+from tools.parity.canonical import canonicalize
+from tools.parity.catalog import validate_recipe
+from tools.parity.compare import compare_outcomes
+from tools.parity.coverage import coverage_report, recipe_features
+from tools.parity.environments import ParityEnvironments
+from tools.parity.issues import failure_fingerprint, issue_body, publish_failures
+from tools.parity.model import Recipe, RecipeError, load_corpus
+from tools.parity.reduce import reduce_recipe
+
+
+CORPUS = Path(__file__).parents[2] / "tools" / "parity" / "corpus"
+
+
+def _scalar_recipe(ticks=None):
+    ticks = ticks or [1, 2, 3, 4, 5, 6, 7, 8]
+    return Recipe.from_dict(
+        {
+            "schema_version": 1,
+            "id": "test-scalar-recipe",
+            "description": "test",
+            "template": "scalar_expression",
+            "inputs": {"value": ticks},
+            "parameters": {
+                "input_types": {"value": "int"},
+                "output_type": "int",
+                "expression": {"input": "value"},
+            },
+            "features": ["shape:TS"],
+        }
+    )
+
+
+def test_committed_parity_corpus_is_valid_and_unique():
+    recipes = load_corpus(CORPUS)
+    assert len(recipes) >= 7
+    for recipe in recipes:
+        validate_recipe(recipe)
+    assert len({recipe.fingerprint for recipe in recipes}) == len(recipes)
+
+
+def test_recipe_rejects_unbounded_or_unsafe_shapes():
+    raw = _scalar_recipe().to_dict()
+    raw["id"] = "../../escape"
+    with pytest.raises(RecipeError, match="id must"):
+        Recipe.from_dict(raw)
+
+    raw = _scalar_recipe().to_dict()
+    raw["inputs"]["value"] = [1] * 257
+    with pytest.raises(RecipeError, match="between 1 and 256"):
+        Recipe.from_dict(raw)
+
+    raw = _scalar_recipe().to_dict()
+    raw["parameters"]["expression"] = {
+        "op": "exec",
+        "args": [{"input": "value"}],
+    }
+    with pytest.raises(RecipeError, match="unsupported expression"):
+        validate_recipe(Recipe.from_dict(raw))
+
+
+def test_recipe_fingerprint_is_independent_of_json_key_order():
+    first = _scalar_recipe()
+    raw = first.to_dict()
+    raw["parameters"] = {
+        "expression": {"input": "value"},
+        "output_type": "int",
+        "input_types": {"value": "int"},
+    }
+    assert Recipe.from_dict(raw).fingerprint == first.fingerprint
+
+
+def test_canonicalization_preserves_tick_sensitive_value_semantics():
+    class Removed:
+        def __init__(self, item):
+            self.item = item
+
+        def __repr__(self):
+            return f"Removed({self.item!r})"
+
+    class FakeSetDelta:
+        @property
+        def added(self):
+            return {2, 1}
+
+        @property
+        def removed(self):
+            return {3}
+
+    value = {
+        "mapping": {"b": -0.0, "a": float("nan")},
+        "tuple": (1, 2),
+        "delta": FakeSetDelta(),
+        "removed": Removed("old"),
+    }
+    assert canonicalize(value) == {
+        "$map": [
+            ["delta", {"$set_delta": {"added": [1, 2], "removed": [3]}}],
+            [
+                "mapping",
+                {
+                    "$map": [
+                        ["a", {"$float": "nan"}],
+                        ["b", {"$float": "-0x0.0p+0"}],
+                    ]
+                },
+            ],
+            ["removed", {"$set_removed": "old"}],
+            ["tuple", {"$tuple": [1, 2]}],
+        ]
+    }
+
+
+def test_comparison_distinguishes_tick_values_and_supports_opt_in_float_tolerance():
+    reference = {
+        "status": "ok",
+        "trace": [None, {"$float": float(1.0).hex()}],
+    }
+    candidate = {
+        "status": "ok",
+        "trace": [None, {"$float": float(1.0001).hex()}],
+    }
+    assert compare_outcomes(reference, candidate) is not None
+    assert (
+        compare_outcomes(reference, candidate, float_abs_tolerance=0.001)
+        is None
+    )
+
+    candidate["status"] = "error"
+    candidate["phase"] = "runtime"
+    candidate["exception"] = {"category": "value"}
+    assert compare_outcomes(reference, candidate).classification == "status"
+
+
+def test_generated_recipes_are_deterministic_typed_and_multi_tick():
+    pytest.importorskip("hypothesis")
+    from tools.parity.generate import generate_recipes
+
+    first = generate_recipes(12, seed=17)
+    second = generate_recipes(12, seed=17)
+    assert [recipe.canonical_json() for recipe in first] == [
+        recipe.canonical_json() for recipe in second
+    ]
+    assert first
+    assert all(recipe.tick_count >= 8 for recipe in first)
+    for recipe in first:
+        validate_recipe(recipe)
+
+
+def test_reducer_shrinks_ticks_values_and_expression_while_preserving_failure():
+    recipe = _scalar_recipe([10, 20, 30, 99, 40, 50, 60, 70])
+    raw = recipe.to_dict()
+    raw["parameters"]["expression"] = {
+        "op": "add",
+        "args": [{"input": "value"}, {"const": 0}],
+    }
+    recipe = Recipe.from_dict(raw)
+
+    def failure(candidate):
+        values = candidate.inputs["value"]
+        return len(values) >= 2 and 99 in values
+
+    reduced = reduce_recipe(recipe, failure, time_budget_seconds=10)
+    assert failure(reduced.recipe)
+    assert reduced.recipe.tick_count == 2
+    assert reduced.accepted > 0
+    assert reduced.recipe.parameters["expression"] == {"input": "value"}
+
+
+def test_campaign_verifies_reduces_and_fingerprints_a_stable_mismatch(monkeypatch, tmp_path):
+    recipe = _scalar_recipe()
+    reference = {
+        "status": "ok",
+        "phase": "complete",
+        "trace": [1],
+        "implementation": {"distribution": "hgraph", "version": "1"},
+    }
+    candidate = {
+        "status": "ok",
+        "phase": "complete",
+        "trace": [2],
+        "implementation": {"distribution": "hg_cpp", "version": "1"},
+    }
+
+    class Cache:
+        def __init__(self, *_args, **_kwargs):
+            pass
+
+        def run(self, *_args, **_kwargs):
+            return reference, False
+
+    monkeypatch.setattr("tools.parity.campaign.ReferenceTraceCache", Cache)
+    monkeypatch.setattr(
+        "tools.parity.campaign.run_recipe",
+        lambda interpreter, *_args, **_kwargs: (
+            reference if str(interpreter) == "reference" else candidate
+        ),
+    )
+    environments = ParityEnvironments(
+        reference_python=Path("reference"),
+        candidate_python=Path("candidate"),
+        reference_identity=reference["implementation"],
+        candidate_identity=candidate["implementation"],
+        candidate_fingerprint="candidate-sha",
+    )
+    report = run_campaign(
+        [recipe],
+        environments,
+        verify_replays=3,
+        reduce_failures=False,
+        known_divergences_path=tmp_path / "missing.json",
+        cache_path=tmp_path / "cache",
+    )
+    assert report["summary"]["verified_failures"] == 1
+    assert report["summary"]["quarantined"] == 0
+    failure = report["verified_failures"][0]
+    assert failure["failure_fingerprint"] == failure_fingerprint(failure)
+
+
+def test_reference_failure_is_quarantined_not_promoted(monkeypatch, tmp_path):
+    recipe = _scalar_recipe()
+    reference = {
+        "status": "crash",
+        "phase": "process",
+        "process_returncode": -11,
+    }
+    candidate = {"status": "ok", "phase": "complete", "trace": [1]}
+
+    class Cache:
+        def __init__(self, *_args, **_kwargs):
+            pass
+
+        def run(self, *_args, **_kwargs):
+            return reference, False
+
+    monkeypatch.setattr("tools.parity.campaign.ReferenceTraceCache", Cache)
+    monkeypatch.setattr(
+        "tools.parity.campaign.run_recipe",
+        lambda interpreter, *_args, **_kwargs: (
+            reference if str(interpreter) == "reference" else candidate
+        ),
+    )
+    environments = ParityEnvironments(
+        reference_python=Path("reference"),
+        candidate_python=Path("candidate"),
+        reference_identity={"distribution": "hgraph"},
+        candidate_identity={"distribution": "hg_cpp"},
+        candidate_fingerprint="candidate-sha",
+    )
+    report = run_campaign(
+        [recipe],
+        environments,
+        reduce_failures=False,
+        known_divergences_path=tmp_path / "missing.json",
+        cache_path=tmp_path / "cache",
+    )
+    assert report["summary"]["verified_failures"] == 0
+    assert report["quarantined"][0]["classification"] == "reference-failure"
+
+
+def test_issue_payload_is_deterministic_and_dry_run_has_no_github_write():
+    failure = {
+        "minimized_recipe": _scalar_recipe().to_dict(),
+        "difference": {
+            "classification": "value",
+            "path": "$.trace[0]",
+            "reference": 1,
+            "candidate": 2,
+        },
+        "reference": {"status": "ok", "trace": [1]},
+        "candidate": {"status": "ok", "trace": [2]},
+        "reduction": {"attempts": 3, "accepted": 2},
+    }
+    fingerprint = failure_fingerprint(failure)
+    assert fingerprint in issue_body(failure)
+    actions = publish_failures(
+        [failure], repo="hhenson/hg_cpp", publish=False
+    )
+    assert actions == [
+        {
+            "action": "dry-run",
+            "title": "[parity] scalar_expression differs from released hgraph",
+            "fingerprint": fingerprint,
+            "body": issue_body(failure),
+        }
+    ]
+
+
+def test_coverage_reports_operator_frontier_and_semantic_pairs():
+    recipe = _scalar_recipe()
+    report = coverage_report(
+        [recipe], operator_inventory=("add_", "uncovered_operator")
+    )
+    assert "uncovered_operator" in report["missing_operators"]
+    assert "template:scalar_expression" in recipe_features(recipe)
+    assert report["pair_counts"]
+
+
+def test_wheel_fingerprint_excludes_parity_tooling(tmp_path):
+    (tmp_path / "python" / "hgraph").mkdir(parents=True)
+    (tmp_path / "src").mkdir()
+    (tmp_path / "tools" / "parity").mkdir(parents=True)
+    (tmp_path / "CMakeLists.txt").write_text("project(test)\n")
+    (tmp_path / "pyproject.toml").write_text("[project]\nname='test'\n")
+    (tmp_path / "src" / "runtime.cpp").write_text("int runtime;\n")
+    before = hg_cpp_source_fingerprint(tmp_path, python_version="3.12")
+    (tmp_path / "tools" / "parity" / "recipe.json").write_text(
+        json.dumps({"changed": True})
+    )
+    after = hg_cpp_source_fingerprint(tmp_path, python_version="3.12")
+    assert before == after

--- a/tools/artifact_fingerprint.py
+++ b/tools/artifact_fingerprint.py
@@ -1,0 +1,48 @@
+"""Content fingerprints shared by benchmarks and parity tooling."""
+
+from __future__ import annotations
+
+import hashlib
+import sys
+from pathlib import Path
+
+
+def hg_cpp_source_fingerprint(repo_root: Path, *, python_version: str | None = None) -> str:
+    """Hash inputs that can change the hg_cpp wheel.
+
+    Tooling, tests, documentation, and parity corpus files are deliberately
+    excluded. Changing those files must not force a native rebuild.
+    """
+
+    repo_root = repo_root.resolve()
+    digest = hashlib.sha256()
+    roots = (
+        repo_root / "CMakeLists.txt",
+        repo_root / "pyproject.toml",
+        repo_root / "cmake",
+        repo_root / "include",
+        repo_root / "src",
+        repo_root / "python" / "CMakeLists.txt",
+        repo_root / "python" / "hgraph",
+    )
+    files: list[Path] = []
+    for root in roots:
+        if root.is_file():
+            files.append(root)
+        elif root.is_dir():
+            files.extend(
+                path
+                for path in root.rglob("*")
+                if path.is_file() and "__pycache__" not in path.parts
+            )
+    files.extend((repo_root / "python").glob("*.cpp"))
+    files.extend((repo_root / "python").glob("*.h"))
+    for path in sorted(set(files)):
+        digest.update(path.relative_to(repo_root).as_posix().encode())
+        digest.update(b"\0")
+        digest.update(path.read_bytes())
+        digest.update(b"\0")
+    if python_version is None:
+        python_version = f"{sys.version_info.major}.{sys.version_info.minor}"
+    digest.update(f"python-{python_version}".encode())
+    return digest.hexdigest()

--- a/tools/parity/__init__.py
+++ b/tools/parity/__init__.py
@@ -1,0 +1,5 @@
+"""Differential correctness tooling for Python hgraph and hg_cpp."""
+
+from .model import Recipe, RecipeError
+
+__all__ = ["Recipe", "RecipeError"]

--- a/tools/parity/__main__.py
+++ b/tools/parity/__main__.py
@@ -1,0 +1,5 @@
+from .cli import main
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/parity/campaign.py
+++ b/tools/parity/campaign.py
@@ -1,0 +1,358 @@
+"""Differential campaign orchestration and failure promotion."""
+
+from __future__ import annotations
+
+import datetime as dt
+import json
+import time
+from pathlib import Path
+from typing import Any, Iterable
+
+from .catalog import CATALOG
+from .compare import compare_outcomes, semantic_signature
+from .coverage import coverage_report
+from .environments import PARITY_ROOT, ParityEnvironments
+from .issues import failure_fingerprint
+from .model import Recipe
+from .process import ReferenceTraceCache, run_recipe
+from .reduce import reduce_recipe
+
+
+def _load_known_fingerprints(path: Path) -> set[str]:
+    try:
+        raw = json.loads(path.read_text())
+    except (OSError, json.JSONDecodeError):
+        return set()
+    return {
+        item["fingerprint"]
+        for item in raw.get("divergences", ())
+        if isinstance(item, dict) and isinstance(item.get("fingerprint"), str)
+    }
+
+
+def _stable(results: list[dict[str, Any]]) -> bool:
+    return len({semantic_signature(result) for result in results}) == 1
+
+
+def _verify_pair(
+    environments: ParityEnvironments,
+    recipe: Recipe,
+    *,
+    timeout_seconds: float,
+    attempts: int,
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    reference = [
+        run_recipe(
+            environments.reference_python,
+            recipe,
+            timeout=timeout_seconds,
+        )
+        for _ in range(attempts)
+    ]
+    candidate = [
+        run_recipe(
+            environments.candidate_python,
+            recipe,
+            timeout=timeout_seconds,
+        )
+        for _ in range(attempts)
+    ]
+    return reference, candidate
+
+
+def run_campaign(
+    recipes: Iterable[Recipe],
+    environments: ParityEnvironments,
+    *,
+    operator_inventory: Iterable[str] = (),
+    timeout_seconds: float = 30.0,
+    time_budget_seconds: float = 600.0,
+    verify_replays: int = 3,
+    reduce_failures: bool = True,
+    reduction_budget_seconds: float = 120.0,
+    known_divergences_path: Path | None = None,
+    cache_path: Path | None = None,
+) -> dict[str, Any]:
+    recipes = list(recipes)
+    started = time.monotonic()
+    cache = ReferenceTraceCache(
+        cache_path or PARITY_ROOT / "cache" / "reference-traces",
+        environments.reference_identity,
+    )
+    known = _load_known_fingerprints(
+        known_divergences_path
+        or Path(__file__).with_name("known_divergences.json")
+    )
+    matches: list[dict[str, Any]] = []
+    failures: list[dict[str, Any]] = []
+    quarantined: list[dict[str, Any]] = []
+    known_failures: list[dict[str, Any]] = []
+    attempted: list[Recipe] = []
+    cache_hits = 0
+
+    for recipe in recipes:
+        if time.monotonic() - started >= time_budget_seconds:
+            break
+        attempted.append(recipe)
+        spec = CATALOG[recipe.template]
+        reference, cached = cache.run(
+            environments.reference_python,
+            recipe,
+            timeout=timeout_seconds,
+        )
+        cache_hits += int(cached)
+        candidate = run_recipe(
+            environments.candidate_python,
+            recipe,
+            timeout=timeout_seconds,
+        )
+
+        if reference.get("status") != "ok":
+            reference_replays, candidate_replays = _verify_pair(
+                environments,
+                recipe,
+                timeout_seconds=timeout_seconds,
+                attempts=verify_replays,
+            )
+            quarantined.append(
+                {
+                    "classification": "reference-failure",
+                    "recipe": recipe.to_dict(),
+                    "reference_stable": _stable(reference_replays),
+                    "reference_replays": reference_replays,
+                    "candidate_replays": candidate_replays,
+                }
+            )
+            continue
+
+        difference = compare_outcomes(
+            reference,
+            candidate,
+            float_abs_tolerance=spec.float_abs_tolerance,
+        )
+        if difference is None:
+            matches.append(
+                {
+                    "recipe_id": recipe.id,
+                    "recipe_fingerprint": recipe.fingerprint,
+                    "reference_cache_hit": cached,
+                }
+            )
+            continue
+
+        reference_replays, candidate_replays = _verify_pair(
+            environments,
+            recipe,
+            timeout_seconds=timeout_seconds,
+            attempts=verify_replays,
+        )
+        if (
+            not _stable(reference_replays)
+            or any(result.get("status") != "ok" for result in reference_replays)
+        ):
+            quarantined.append(
+                {
+                    "classification": "reference-unstable",
+                    "recipe": recipe.to_dict(),
+                    "reference_stable": _stable(reference_replays),
+                    "reference_replays": reference_replays,
+                    "candidate_replays": candidate_replays,
+                }
+            )
+            continue
+        if not _stable(candidate_replays):
+            quarantined.append(
+                {
+                    "classification": "candidate-unstable",
+                    "recipe": recipe.to_dict(),
+                    "reference_replays": reference_replays,
+                    "candidate_replays": candidate_replays,
+                }
+            )
+            continue
+        verified_difference = compare_outcomes(
+            reference_replays[0],
+            candidate_replays[0],
+            float_abs_tolerance=spec.float_abs_tolerance,
+        )
+        if verified_difference is None:
+            quarantined.append(
+                {
+                    "classification": "transient-mismatch",
+                    "recipe": recipe.to_dict(),
+                    "reference_replays": reference_replays,
+                    "candidate_replays": candidate_replays,
+                }
+            )
+            continue
+
+        minimized = recipe
+        reduction_payload = {
+            "attempts": 0,
+            "accepted": 0,
+            "timed_out": False,
+            "steps": [],
+        }
+        if reduce_failures:
+
+            def still_fails(candidate_recipe: Recipe) -> bool:
+                candidate_spec = CATALOG[candidate_recipe.template]
+                reference_result, _ = cache.run(
+                    environments.reference_python,
+                    candidate_recipe,
+                    timeout=timeout_seconds,
+                )
+                if reference_result.get("status") != "ok":
+                    return False
+                candidate_result = run_recipe(
+                    environments.candidate_python,
+                    candidate_recipe,
+                    timeout=timeout_seconds,
+                )
+                return (
+                    compare_outcomes(
+                        reference_result,
+                        candidate_result,
+                        float_abs_tolerance=candidate_spec.float_abs_tolerance,
+                    )
+                    is not None
+                )
+
+            reduction = reduce_recipe(
+                recipe,
+                still_fails,
+                time_budget_seconds=min(
+                    reduction_budget_seconds,
+                    max(
+                        1.0,
+                        time_budget_seconds - (time.monotonic() - started),
+                    ),
+                ),
+            )
+            minimized = reduction.recipe
+            reduction_payload = {
+                key: value
+                for key, value in reduction.to_dict().items()
+                if key != "recipe"
+            }
+
+        final_reference, final_candidate = _verify_pair(
+            environments,
+            minimized,
+            timeout_seconds=timeout_seconds,
+            attempts=verify_replays,
+        )
+        if (
+            not _stable(final_reference)
+            or not _stable(final_candidate)
+            or any(result.get("status") != "ok" for result in final_reference)
+        ):
+            quarantined.append(
+                {
+                    "classification": "reduced-case-unstable",
+                    "recipe": minimized.to_dict(),
+                    "reference_replays": final_reference,
+                    "candidate_replays": final_candidate,
+                    "reduction": reduction_payload,
+                }
+            )
+            continue
+        final_difference = compare_outcomes(
+            final_reference[0],
+            final_candidate[0],
+            float_abs_tolerance=CATALOG[
+                minimized.template
+            ].float_abs_tolerance,
+        )
+        if final_difference is None:
+            quarantined.append(
+                {
+                    "classification": "reduction-lost-mismatch",
+                    "recipe": minimized.to_dict(),
+                    "reduction": reduction_payload,
+                }
+            )
+            continue
+        failure = {
+            "original_recipe": recipe.to_dict(),
+            "minimized_recipe": minimized.to_dict(),
+            "difference": final_difference.to_dict(),
+            "reference": final_reference[0],
+            "candidate": final_candidate[0],
+            "reduction": reduction_payload,
+        }
+        failure["failure_fingerprint"] = failure_fingerprint(failure)
+        if failure["failure_fingerprint"] in known:
+            known_failures.append(failure)
+        else:
+            failures.append(failure)
+
+    elapsed = time.monotonic() - started
+    coverage = coverage_report(
+        attempted,
+        operator_inventory=operator_inventory,
+    )
+    return {
+        "schema_version": 1,
+        "created_at": dt.datetime.now(dt.timezone.utc).isoformat(
+            timespec="seconds"
+        ),
+        "reference_identity": environments.reference_identity,
+        "candidate_identity": environments.candidate_identity,
+        "candidate_fingerprint": environments.candidate_fingerprint,
+        "summary": {
+            "selected": len(recipes),
+            "attempted": len(attempted),
+            "matched": len(matches),
+            "verified_failures": len(failures),
+            "known_failures": len(known_failures),
+            "quarantined": len(quarantined),
+            "reference_cache_hits": cache_hits,
+            "elapsed_seconds": round(elapsed, 3),
+            "budget_exhausted": len(attempted) < len(recipes),
+        },
+        "matches": matches,
+        "verified_failures": failures,
+        "known_failures": known_failures,
+        "quarantined": quarantined,
+        "coverage": coverage,
+    }
+
+
+def render_campaign_markdown(report: dict[str, Any]) -> str:
+    summary = report["summary"]
+    lines = [
+        "# hgraph differential parity campaign",
+        "",
+        f"- reference: `{report['reference_identity']}`",
+        f"- candidate: `{report['candidate_identity']}`",
+        f"- selected/attempted: {summary['selected']}/{summary['attempted']}",
+        f"- matched: {summary['matched']}",
+        f"- verified mismatches: {summary['verified_failures']}",
+        f"- known mismatches: {summary['known_failures']}",
+        f"- quarantined: {summary['quarantined']}",
+        f"- reference cache hits: {summary['reference_cache_hits']}",
+        f"- elapsed: {summary['elapsed_seconds']}s",
+        "",
+    ]
+    if report["verified_failures"]:
+        lines.extend(["## Verified mismatches", ""])
+        for failure in report["verified_failures"]:
+            difference = failure["difference"]
+            lines.append(
+                f"- `{failure['minimized_recipe']['id']}`: "
+                f"{difference['classification']} at `{difference['path']}` "
+                f"(`{failure['failure_fingerprint']}`)"
+            )
+        lines.append("")
+    if report["quarantined"]:
+        lines.extend(["## Quarantine", ""])
+        for failure in report["quarantined"]:
+            lines.append(
+                f"- `{failure['recipe']['id']}`: {failure['classification']}"
+            )
+        lines.append("")
+    if not report["verified_failures"] and not report["quarantined"]:
+        lines.append("No new behavioral differences were found.")
+        lines.append("")
+    return "\n".join(lines)

--- a/tools/parity/canonical.py
+++ b/tools/parity/canonical.py
@@ -1,0 +1,113 @@
+"""Cross-runtime canonicalization without importing either hgraph package."""
+
+from __future__ import annotations
+
+import base64
+import dataclasses
+import datetime as dt
+import enum
+import json
+import math
+from collections.abc import Mapping
+from typing import Any
+
+
+CANONICAL_SCHEMA_VERSION = 1
+
+
+def _sort_key(value: Any) -> str:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+
+
+def _canonical_float(value: float) -> dict[str, str]:
+    if math.isnan(value):
+        encoded = "nan"
+    elif math.isinf(value):
+        encoded = "inf" if value > 0 else "-inf"
+    else:
+        encoded = value.hex()
+    return {"$float": encoded}
+
+
+def canonicalize(value: Any) -> Any:
+    """Convert a runtime value to a stable JSON-compatible representation."""
+
+    if value is None or isinstance(value, (bool, int, str)):
+        return value
+    if isinstance(value, float):
+        return _canonical_float(value)
+    if isinstance(value, bytes):
+        return {"$bytes": base64.b64encode(value).decode("ascii")}
+    if isinstance(value, enum.Enum):
+        return {
+            "$enum": {
+                "type": type(value).__qualname__,
+                "name": value.name,
+                "value": canonicalize(value.value),
+            }
+        }
+    if isinstance(value, dt.datetime):
+        return {"$datetime": value.isoformat()}
+    if isinstance(value, dt.date):
+        return {"$date": value.isoformat()}
+    if isinstance(value, dt.timedelta):
+        return {
+            "$timedelta": {
+                "days": value.days,
+                "seconds": value.seconds,
+                "microseconds": value.microseconds,
+            }
+        }
+
+    type_name = type(value).__name__
+    if type_name in {"_Removed", "Removed"} and repr(value) == "REMOVE":
+        return {"$remove": True}
+    if type_name in {"_RemovedIfExists", "RemovedIfExists"} and repr(value) == "REMOVE_IF_EXISTS":
+        return {"$remove_if_exists": True}
+    if type_name == "Removed" and hasattr(value, "item"):
+        return {"$set_removed": canonicalize(value.item)}
+    if hasattr(value, "added") and hasattr(value, "removed") and (
+        "SetDelta" in type_name or type_name == "_SetDelta"
+    ):
+        added = sorted((canonicalize(item) for item in value.added), key=_sort_key)
+        removed = sorted((canonicalize(item) for item in value.removed), key=_sort_key)
+        return {"$set_delta": {"added": added, "removed": removed}}
+
+    if dataclasses.is_dataclass(value) and not isinstance(value, type):
+        fields = [
+            [field.name, canonicalize(getattr(value, field.name))]
+            for field in dataclasses.fields(value)
+        ]
+        return {"$dataclass": {"type": type(value).__qualname__, "fields": fields}}
+    if isinstance(value, Mapping):
+        entries = [
+            [canonicalize(key), canonicalize(item)] for key, item in value.items()
+        ]
+        entries.sort(key=lambda pair: _sort_key(pair[0]))
+        return {"$map": entries}
+    if isinstance(value, tuple):
+        return {"$tuple": [canonicalize(item) for item in value]}
+    if isinstance(value, (set, frozenset)):
+        items = sorted((canonicalize(item) for item in value), key=_sort_key)
+        return {"$set": items}
+    if isinstance(value, list):
+        return [canonicalize(item) for item in value]
+
+    if hasattr(value, "__dict__"):
+        fields = [
+            [str(key), canonicalize(item)]
+            for key, item in sorted(vars(value).items(), key=lambda pair: str(pair[0]))
+            if not str(key).startswith("_")
+        ]
+        if fields:
+            return {"$object": {"type": type(value).__qualname__, "fields": fields}}
+    return {"$repr": {"type": type(value).__qualname__, "value": repr(value)}}
+
+
+def canonical_json(value: Any) -> str:
+    return json.dumps(
+        canonicalize(value),
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+    )

--- a/tools/parity/catalog.py
+++ b/tools/parity/catalog.py
@@ -1,0 +1,527 @@
+"""Bounded graph-template catalogue used by both runtime environments.
+
+This module intentionally does not import hgraph at module import time. The
+subprocess runner supplies whichever implementation is installed in its
+isolated environment.
+"""
+
+import json
+from dataclasses import dataclass
+
+from .model import Recipe, RecipeError
+
+
+_SCALAR_TYPES = {"bool": bool, "float": float, "int": int, "str": str}
+_NUMERIC_TYPES = {"float", "int"}
+_BINARY_OPS = {
+    "add": ("+", "same"),
+    "sub": ("-", "numeric"),
+    "mul": ("*", "numeric"),
+    "eq": ("==", "bool"),
+    "ne": ("!=", "bool"),
+    "lt": ("<", "bool"),
+    "le": ("<=", "bool"),
+    "gt": (">", "bool"),
+    "ge": (">=", "bool"),
+}
+_UNARY_OPS = {"neg", "pos", "abs", "dedup"}
+
+
+@dataclass(frozen=True)
+class TemplateSpec:
+    name: str
+    required_inputs: tuple[str, ...] | None
+    features: tuple[str, ...]
+    operators: tuple[str, ...]
+    execute: object
+    float_abs_tolerance: float = 0.0
+
+
+def _decode_value(hg, value):
+    if isinstance(value, list):
+        return [_decode_value(hg, item) for item in value]
+    if not isinstance(value, dict):
+        return value
+    if set(value) == {"$remove"} and value["$remove"] is True:
+        return hg.REMOVE
+    if set(value) == {"$remove_if_exists"} and value["$remove_if_exists"] is True:
+        return hg.REMOVE_IF_EXISTS
+    if set(value) == {"$set_delta"}:
+        delta = value["$set_delta"]
+        if not isinstance(delta, dict) or set(delta) != {"added", "removed"}:
+            raise RecipeError("$set_delta requires added and removed lists")
+        return hg.set_delta(
+            added=[_decode_value(hg, item) for item in delta["added"]],
+            removed=[_decode_value(hg, item) for item in delta["removed"]],
+        )
+    if set(value) == {"$frozendict"}:
+        from frozendict import frozendict
+
+        return frozendict(
+            {
+                key: _decode_value(hg, item)
+                for key, item in value["$frozendict"].items()
+            }
+        )
+    return {key: _decode_value(hg, item) for key, item in value.items()}
+
+
+def decoded_inputs(hg, recipe):
+    return {
+        name: [_decode_value(hg, value) for value in ticks]
+        for name, ticks in recipe.inputs.items()
+    }
+
+
+def _expression_type(expression, input_types):
+    if not isinstance(expression, dict):
+        raise RecipeError("expression must be an object")
+    if set(expression) == {"input"}:
+        name = expression["input"]
+        if name not in input_types:
+            raise RecipeError(f"expression references unknown input {name!r}")
+        return input_types[name]
+    if set(expression) == {"const"}:
+        value = expression["const"]
+        if isinstance(value, bool):
+            return "bool"
+        if isinstance(value, int):
+            return "int"
+        if isinstance(value, float):
+            return "float"
+        if isinstance(value, str):
+            return "str"
+        raise RecipeError("expression constants must be scalar JSON values")
+    operation = expression.get("op")
+    args = expression.get("args")
+    if operation in _BINARY_OPS:
+        if not isinstance(args, list) or len(args) != 2:
+            raise RecipeError(f"{operation} requires exactly two arguments")
+        lhs = _expression_type(args[0], input_types)
+        rhs = _expression_type(args[1], input_types)
+        if lhs != rhs:
+            raise RecipeError(f"{operation} arguments must have the same type")
+        rule = _BINARY_OPS[operation][1]
+        if rule == "numeric" and lhs not in _NUMERIC_TYPES:
+            raise RecipeError(f"{operation} requires numeric arguments")
+        if operation == "add" and lhs not in _NUMERIC_TYPES | {"str"}:
+            raise RecipeError("add requires numeric or string arguments")
+        return "bool" if rule == "bool" else lhs
+    if operation in _UNARY_OPS:
+        if not isinstance(args, list) or len(args) != 1:
+            raise RecipeError(f"{operation} requires exactly one argument")
+        item_type = _expression_type(args[0], input_types)
+        if operation in {"neg", "pos", "abs"} and item_type not in _NUMERIC_TYPES:
+            raise RecipeError(f"{operation} requires a numeric argument")
+        return item_type
+    raise RecipeError(f"unsupported expression operation {operation!r}")
+
+
+def _expression_source(expression):
+    if "input" in expression:
+        return expression["input"]
+    if "const" in expression:
+        return repr(expression["const"])
+    operation = expression["op"]
+    args = expression["args"]
+    if operation in _BINARY_OPS:
+        return (
+            f"({_expression_source(args[0])} "
+            f"{_BINARY_OPS[operation][0]} {_expression_source(args[1])})"
+        )
+    if operation == "neg":
+        return f"(-{_expression_source(args[0])})"
+    if operation == "pos":
+        return f"(+{_expression_source(args[0])})"
+    if operation == "abs":
+        return f"hg.abs_({_expression_source(args[0])})"
+    if operation == "dedup":
+        return f"hg.dedup({_expression_source(args[0])})"
+    raise AssertionError(operation)
+
+
+def _validate_scalar_expression(recipe):
+    input_types = recipe.parameters.get("input_types")
+    expression = recipe.parameters.get("expression")
+    if not isinstance(input_types, dict) or set(input_types) != set(recipe.inputs):
+        raise RecipeError(
+            "scalar_expression input_types must name every recipe input exactly once"
+        )
+    for name, type_name in input_types.items():
+        if type_name not in _SCALAR_TYPES:
+            raise RecipeError(f"unsupported scalar input type {type_name!r} for {name}")
+    output_type = _expression_type(expression, input_types)
+    declared_output = recipe.parameters.get("output_type", output_type)
+    if declared_output != output_type:
+        raise RecipeError(
+            f"declared output_type {declared_output!r} does not match {output_type!r}"
+        )
+
+
+def _scalar_expression(hg, recipe):
+    from hgraph.test import eval_node
+
+    input_types = recipe.parameters["input_types"]
+    output_type = _expression_type(recipe.parameters["expression"], input_types)
+    arguments = ", ".join(
+        f"{name}: hg.TS[{type_name}]" for name, type_name in input_types.items()
+    )
+    source = (
+        "@hg.graph\n"
+        f"def parity_graph({arguments}) -> hg.TS[{output_type}]:\n"
+        f"    return {_expression_source(recipe.parameters['expression'])}\n"
+    )
+    namespace = {"hg": hg}
+    exec(compile(source, f"<parity:{recipe.id}>", "exec"), namespace)
+    inputs = decoded_inputs(hg, recipe)
+    return eval_node(
+        namespace["parity_graph"],
+        *(inputs[name] for name in input_types),
+    )
+
+
+def _feedback_accumulate(hg, recipe):
+    from hgraph.test import eval_node
+
+    initial = recipe.parameters.get("initial", 0)
+
+    @hg.graph
+    def parity_graph(value: hg.TS[int]) -> hg.TS[int]:
+        state = hg.feedback(hg.TS[int], initial)
+        total = value + hg.passive(state())
+        state(total)
+        return total
+
+    inputs = decoded_inputs(hg, recipe)
+    return eval_node(parity_graph, inputs["value"])
+
+
+def _switch_arithmetic(hg, recipe):
+    from hgraph.test import eval_node
+
+    @hg.graph
+    def parity_graph(
+        selector: hg.TS[str], lhs: hg.TS[int], rhs: hg.TS[int]
+    ) -> hg.TS[int]:
+        return hg.switch_(
+            selector,
+            {
+                "plus": lambda lhs, rhs: lhs + rhs,
+                "minus": lambda lhs, rhs: lhs - rhs,
+            },
+            lhs,
+            rhs,
+        )
+
+    inputs = decoded_inputs(hg, recipe)
+    return eval_node(
+        parity_graph,
+        inputs["selector"],
+        inputs["lhs"],
+        inputs["rhs"],
+    )
+
+
+def _tsd_map_reduce(hg, recipe):
+    from hgraph.test import eval_node
+
+    increment = recipe.parameters.get("increment", 1)
+    zero = recipe.parameters.get("zero", 0)
+
+    @hg.graph
+    def parity_graph(values: hg.TSD[str, hg.TS[int]]) -> hg.TS[int]:
+        mapped = hg.map_(lambda value: value + increment, values)
+        return hg.reduce(lambda lhs, rhs: lhs + rhs, mapped, zero)
+
+    inputs = decoded_inputs(hg, recipe)
+    return eval_node(parity_graph, inputs["values"])
+
+
+def _issue_38_nested_tsd_feedback(hg, recipe):
+    from frozendict import frozendict
+    from hgraph.test import eval_node
+
+    class FeedbackPosition(hg.TimeSeriesSchema):
+        units: hg.TSD[str, hg.TS[float]]
+        unit_values: hg.TSD[str, hg.TS[float]]
+
+    @hg.graph
+    def update_position(
+        current: hg.TSB[FeedbackPosition],
+        prices: hg.TSD[str, hg.TS[float]],
+    ) -> hg.TSB[FeedbackPosition]:
+        units = hg.const(
+            frozendict({"next": 1.0}),
+            hg.TSD[str, hg.TS[float]],
+        )
+        return hg.combine[hg.TSB[FeedbackPosition]](
+            units=units,
+            unit_values=hg.map_(lambda unit, price: price, units, prices),
+        )
+
+    @hg.graph
+    def parity_graph(
+        roll: hg.TS[bool],
+        prices: hg.TSD[str, hg.TS[float]],
+        trigger: hg.TS[int],
+    ) -> hg.TS[float]:
+        position_feedback = hg.feedback(hg.TSB[FeedbackPosition])
+        initial_position = hg.combine[hg.TSB[FeedbackPosition]](
+            units=hg.const(
+                frozendict({"old": 0.5, "next": 0.5}),
+                hg.TSD[str, hg.TS[float]],
+            ),
+            unit_values=hg.const(
+                frozendict({"old": 10.0, "next": 10.0}),
+                hg.TSD[str, hg.TS[float]],
+            ),
+        )
+        position = hg.dedup(
+            hg.default(hg.lag(position_feedback(), 1, trigger), initial_position)
+        )
+        output = hg.switch_(
+            roll,
+            {
+                True: update_position,
+                False: lambda current, prices: hg.dedup(current),
+            },
+            position,
+            prices,
+        )
+        position_feedback(hg.dedup(output))
+        return hg.sample(trigger, position.unit_values["next"])
+
+    inputs = decoded_inputs(hg, recipe)
+    return eval_node(
+        parity_graph,
+        inputs["roll"],
+        inputs["prices"],
+        inputs["trigger"],
+    )
+
+
+def _issue_40_no_key_rebind(hg, recipe):
+    from frozendict import frozendict
+    from hgraph.test import eval_node
+
+    class RebasedFeedbackState(hg.TimeSeriesSchema):
+        unit_values: hg.TSD[str, hg.TS[float]]
+        target_units: hg.TSD[str, hg.TS[float]]
+
+    @hg.graph
+    def parity_graph(
+        target: hg.TSD[str, hg.TS[float]],
+        rebase: hg.TS[bool],
+        prices: hg.TSD[str, hg.TS[float]],
+        trigger: hg.TS[int],
+    ) -> hg.TS[float]:
+        state_feedback = hg.feedback(hg.TSB[RebasedFeedbackState])
+        initial_state = hg.combine[hg.TSB[RebasedFeedbackState]](
+            unit_values=hg.const(
+                frozendict(), hg.TSD[str, hg.TS[float]]
+            ),
+            target_units=hg.const(
+                frozendict(), hg.TSD[str, hg.TS[float]]
+            ),
+        )
+        state = hg.default(
+            hg.lag(state_feedback(), 1, trigger),
+            initial_state,
+        )
+        target_units = hg.if_then_else(
+            rebase,
+            target,
+            state.target_units,
+        )
+        unit_values = hg.map_(
+            lambda unit, price: price,
+            target_units,
+            hg.no_key(prices),
+        )
+        state_feedback(
+            hg.combine[hg.TSB[RebasedFeedbackState]](
+                unit_values=unit_values,
+                target_units=target_units,
+            )
+        )
+        return hg.sample(
+            trigger,
+            hg.default(state.unit_values["next"], -1.0),
+        )
+
+    inputs = decoded_inputs(hg, recipe)
+    return eval_node(
+        parity_graph,
+        inputs["target"],
+        inputs["rebase"],
+        inputs["prices"],
+        inputs["trigger"],
+    )
+
+
+def _stream_dataclass(hg, recipe):
+    from dataclasses import dataclass
+
+    from hgraph.reflection import fields, scalar_type
+    from hgraph.stream import Stream
+
+    @dataclass(frozen=True)
+    class Payload:
+        value: int
+
+    stream_fields = fields(hg.TSB[Stream[Payload]])
+    return {
+        name: (
+            scalar_type(field_type).__module__
+            + "."
+            + scalar_type(field_type).__qualname__
+        )
+        for name, field_type in sorted(stream_fields.items())
+    }
+
+
+CATALOG = {
+    "scalar_expression": TemplateSpec(
+        name="scalar_expression",
+        required_inputs=None,
+        features=("shape:TS", "topology:expression"),
+        operators=(
+            "abs_",
+            "add_",
+            "dedup",
+            "eq_",
+            "ge_",
+            "gt_",
+            "le_",
+            "lt_",
+            "mul_",
+            "ne_",
+            "neg_",
+            "pos_",
+            "sub_",
+        ),
+        execute=_scalar_expression,
+    ),
+    "feedback_accumulate": TemplateSpec(
+        name="feedback_accumulate",
+        required_inputs=("value",),
+        features=("shape:TS", "topology:feedback", "lifecycle:multi-cycle"),
+        operators=("add_", "feedback", "passive"),
+        execute=_feedback_accumulate,
+    ),
+    "switch_arithmetic": TemplateSpec(
+        name="switch_arithmetic",
+        required_inputs=("selector", "lhs", "rhs"),
+        features=("shape:TS", "topology:switch", "lifecycle:branch-rebind"),
+        operators=("add_", "sub_", "switch_"),
+        execute=_switch_arithmetic,
+    ),
+    "tsd_map_reduce": TemplateSpec(
+        name="tsd_map_reduce",
+        required_inputs=("values",),
+        features=("shape:TSD", "topology:map", "lifecycle:keyed"),
+        operators=("add_", "map_", "reduce"),
+        execute=_tsd_map_reduce,
+    ),
+    "issue_38_nested_tsd_feedback": TemplateSpec(
+        name="issue_38_nested_tsd_feedback",
+        required_inputs=("roll", "prices", "trigger"),
+        features=(
+            "shape:TSB",
+            "shape:TSD",
+            "topology:feedback",
+            "topology:map",
+            "topology:switch",
+            "lifecycle:key-removal",
+            "lifecycle:branch-rebind",
+        ),
+        operators=(
+            "combine",
+            "const",
+            "dedup",
+            "default",
+            "feedback",
+            "lag",
+            "map_",
+            "sample",
+            "switch_",
+        ),
+        execute=_issue_38_nested_tsd_feedback,
+    ),
+    "issue_40_no_key_rebind": TemplateSpec(
+        name="issue_40_no_key_rebind",
+        required_inputs=("target", "rebase", "prices", "trigger"),
+        features=(
+            "shape:TSB",
+            "shape:TSD",
+            "topology:feedback",
+            "topology:map",
+            "lifecycle:reference-rebind",
+            "lifecycle:keyed",
+        ),
+        operators=(
+            "combine",
+            "const",
+            "default",
+            "feedback",
+            "if_then_else",
+            "lag",
+            "map_",
+            "no_key",
+            "sample",
+        ),
+        execute=_issue_40_no_key_rebind,
+    ),
+    "stream_dataclass": TemplateSpec(
+        name="stream_dataclass",
+        required_inputs=("probe",),
+        features=("boundary:python-owned", "shape:TSB", "type:dataclass"),
+        operators=(),
+        execute=_stream_dataclass,
+    ),
+}
+
+
+def validate_recipe(recipe):
+    spec = CATALOG.get(recipe.template)
+    if spec is None:
+        raise RecipeError(f"unknown template {recipe.template!r}")
+    if spec.required_inputs is not None and set(recipe.inputs) != set(
+        spec.required_inputs
+    ):
+        raise RecipeError(
+            f"{recipe.template} requires inputs {spec.required_inputs}, "
+            f"got {tuple(recipe.inputs)}"
+        )
+    if recipe.template == "scalar_expression":
+        _validate_scalar_expression(recipe)
+    elif recipe.template == "feedback_accumulate":
+        initial = recipe.parameters.get("initial", 0)
+        if not isinstance(initial, int) or isinstance(initial, bool):
+            raise RecipeError("feedback_accumulate initial must be an integer")
+    elif recipe.template == "tsd_map_reduce":
+        for name, default in (("increment", 1), ("zero", 0)):
+            value = recipe.parameters.get(name, default)
+            if not isinstance(value, int) or isinstance(value, bool):
+                raise RecipeError(f"tsd_map_reduce {name} must be an integer")
+    return spec
+
+
+def execute_recipe(hg, recipe):
+    spec = validate_recipe(recipe)
+    return spec.execute(hg, recipe)
+
+
+def catalogue_manifest():
+    return {
+        name: {
+            "features": list(spec.features),
+            "operators": list(spec.operators),
+            "float_abs_tolerance": spec.float_abs_tolerance,
+        }
+        for name, spec in sorted(CATALOG.items())
+    }
+
+
+def catalogue_json():
+    return json.dumps(catalogue_manifest(), sort_keys=True, indent=2)

--- a/tools/parity/cli.py
+++ b/tools/parity/cli.py
@@ -1,0 +1,369 @@
+"""Command-line interface for hgraph differential parity testing."""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import sys
+from pathlib import Path
+
+from .campaign import render_campaign_markdown, run_campaign
+from .catalog import catalogue_json, validate_recipe
+from .compare import compare_outcomes
+from .coverage import coverage_json, render_coverage_markdown
+from .environments import PARITY_ROOT, prepare_environments
+from .generate import generate_recipes
+from .issues import publish_failures
+from .model import Recipe, RecipeError, load_corpus
+from .process import operator_inventory, run_recipe
+from .reduce import reduce_recipe
+
+
+CORPUS = Path(__file__).with_name("corpus")
+
+
+def _path(value: str | None) -> Path | None:
+    return Path(value).resolve() if value else None
+
+
+def _load_selected_recipes(paths: list[str] | None) -> list[Recipe]:
+    if not paths:
+        return load_corpus(CORPUS)
+    recipes: list[Recipe] = []
+    for raw_path in paths:
+        path = Path(raw_path)
+        if path.is_dir():
+            recipes.extend(load_corpus(path))
+        else:
+            recipes.append(Recipe.load(path))
+    return recipes
+
+
+def _prepare(args) -> object:
+    return prepare_environments(
+        reference_python=_path(getattr(args, "reference_python", None)),
+        candidate_python=_path(getattr(args, "candidate_python", None)),
+        candidate_wheel=_path(getattr(args, "candidate_wheel", None)),
+    )
+
+
+def command_validate(args) -> int:
+    recipes = _load_selected_recipes(args.paths)
+    for recipe in recipes:
+        validate_recipe(recipe)
+    print(f"validated {len(recipes)} parity recipe(s)")
+    return 0
+
+
+def command_catalogue(args) -> int:
+    print(catalogue_json())
+    return 0
+
+
+def command_setup(args) -> int:
+    environments = _prepare(args)
+    print(
+        json.dumps(
+            {
+                "reference_python": str(environments.reference_python),
+                "candidate_python": str(environments.candidate_python),
+                "reference_identity": environments.reference_identity,
+                "candidate_identity": environments.candidate_identity,
+                "candidate_fingerprint": environments.candidate_fingerprint,
+            },
+            indent=2,
+            sort_keys=True,
+        )
+    )
+    return 0
+
+
+def command_replay(args) -> int:
+    recipe = Recipe.load(args.recipe)
+    validate_recipe(recipe)
+    environments = _prepare(args)
+    reference = run_recipe(
+        environments.reference_python, recipe, timeout=args.timeout
+    )
+    candidate = run_recipe(
+        environments.candidate_python, recipe, timeout=args.timeout
+    )
+    difference = compare_outcomes(reference, candidate)
+    print(
+        json.dumps(
+            {
+                "recipe": recipe.to_dict(),
+                "reference": reference,
+                "candidate": candidate,
+                "difference": difference.to_dict() if difference else None,
+            },
+            indent=2,
+            sort_keys=True,
+        )
+    )
+    return 1 if difference else 0
+
+
+def command_reduce(args) -> int:
+    recipe = Recipe.load(args.recipe)
+    validate_recipe(recipe)
+    environments = _prepare(args)
+
+    def differs(candidate_recipe: Recipe) -> bool:
+        reference = run_recipe(
+            environments.reference_python,
+            candidate_recipe,
+            timeout=args.timeout,
+        )
+        candidate = run_recipe(
+            environments.candidate_python,
+            candidate_recipe,
+            timeout=args.timeout,
+        )
+        return (
+            reference.get("status") == "ok"
+            and compare_outcomes(reference, candidate) is not None
+        )
+
+    if not differs(recipe):
+        raise RecipeError("recipe does not currently reproduce a difference")
+    result = reduce_recipe(
+        recipe,
+        differs,
+        time_budget_seconds=args.time_budget,
+    )
+    output = json.dumps(result.to_dict(), indent=2, sort_keys=True) + "\n"
+    if args.output:
+        Path(args.output).write_text(output)
+        print(args.output)
+    else:
+        print(output, end="")
+    return 0
+
+
+def command_coverage(args) -> int:
+    recipes = _load_selected_recipes(args.paths)
+    if args.generated:
+        recipes.extend(
+            generate_recipes(args.generated, seed=args.seed)
+        )
+    environments = _prepare(args) if args.inventory else None
+    inventory = (
+        operator_inventory(environments.reference_python)["operators"]
+        if environments is not None
+        else ()
+    )
+    from .coverage import coverage_report
+
+    report = coverage_report(recipes, operator_inventory=inventory)
+    print(
+        render_coverage_markdown(report)
+        if args.format == "markdown"
+        else coverage_json(report),
+        end="",
+    )
+    return 0
+
+
+def command_campaign(args) -> int:
+    profile_defaults = {
+        "pr": {
+            "examples": 24,
+            "time_budget": 600.0,
+            "reduce": False,
+        },
+        "nightly": {
+            "examples": 100,
+            "time_budget": 2700.0,
+            "reduce": True,
+        },
+    }[args.profile]
+    examples = (
+        args.max_examples
+        if args.max_examples is not None
+        else profile_defaults["examples"]
+    )
+    time_budget = (
+        args.time_budget
+        if args.time_budget is not None
+        else profile_defaults["time_budget"]
+    )
+    reduce_failures = (
+        args.reduce
+        if args.reduce is not None
+        else profile_defaults["reduce"]
+    )
+    recipes = _load_selected_recipes(args.paths)
+    if examples:
+        recipes.extend(
+            generate_recipes(
+                examples,
+                seed=args.seed,
+                min_ticks=args.min_ticks,
+                max_ticks=args.max_ticks,
+                templates=(
+                    (
+                        "scalar_expression",
+                        "feedback_accumulate",
+                        "switch_arithmetic",
+                    )
+                    if args.profile == "pr"
+                    else None
+                ),
+            )
+        )
+    unique = {recipe.fingerprint: recipe for recipe in recipes}
+    recipes = list(unique.values())
+    recipes = [
+        recipe
+        for index, recipe in enumerate(recipes)
+        if index % args.shard_count == args.shard_index
+    ]
+    environments = _prepare(args)
+    inventory = operator_inventory(environments.reference_python)["operators"]
+    report = run_campaign(
+        recipes,
+        environments,
+        operator_inventory=inventory,
+        timeout_seconds=args.timeout,
+        time_budget_seconds=time_budget,
+        verify_replays=args.verify_replays,
+        reduce_failures=reduce_failures,
+        reduction_budget_seconds=args.reduction_budget,
+    )
+    stamp = dt.datetime.now(dt.timezone.utc).strftime("%Y%m%d-%H%M%S")
+    output_dir = (
+        Path(args.output_dir)
+        if args.output_dir
+        else PARITY_ROOT
+        / "results"
+        / f"{stamp}-{args.profile}-s{args.shard_index}"
+    )
+    output_dir.mkdir(parents=True, exist_ok=True)
+    (output_dir / "report.json").write_text(
+        json.dumps(report, indent=2, sort_keys=True) + "\n"
+    )
+    (output_dir / "report.md").write_text(render_campaign_markdown(report))
+    (output_dir / "coverage.json").write_text(
+        coverage_json(report["coverage"])
+    )
+    (output_dir / "coverage.md").write_text(
+        render_coverage_markdown(report["coverage"])
+    )
+    print(render_campaign_markdown(report))
+    print(f"report: {output_dir / 'report.json'}")
+    has_failure = bool(
+        report["verified_failures"] or report["quarantined"]
+    )
+    return 0 if args.exit_zero or not has_failure else 1
+
+
+def command_publish(args) -> int:
+    failures = []
+    for path in args.reports:
+        report = json.loads(Path(path).read_text())
+        failures.extend(report.get("verified_failures", ()))
+    actions = publish_failures(
+        failures,
+        repo=args.repo,
+        publish=args.publish,
+    )
+    print(json.dumps(actions, indent=2, sort_keys=True))
+    return 0
+
+
+def _environment_arguments(parser) -> None:
+    parser.add_argument("--reference-python")
+    parser.add_argument("--candidate-python")
+    parser.add_argument("--candidate-wheel")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="hgraph-parity")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    validate = subparsers.add_parser("validate")
+    validate.add_argument("paths", nargs="*")
+    validate.set_defaults(func=command_validate)
+
+    catalogue = subparsers.add_parser("catalogue")
+    catalogue.set_defaults(func=command_catalogue)
+
+    setup = subparsers.add_parser("setup")
+    _environment_arguments(setup)
+    setup.set_defaults(func=command_setup)
+
+    replay = subparsers.add_parser("replay")
+    replay.add_argument("recipe")
+    replay.add_argument("--timeout", type=float, default=30.0)
+    _environment_arguments(replay)
+    replay.set_defaults(func=command_replay)
+
+    reduce_parser = subparsers.add_parser("reduce")
+    reduce_parser.add_argument("recipe")
+    reduce_parser.add_argument("--timeout", type=float, default=30.0)
+    reduce_parser.add_argument("--time-budget", type=float, default=120.0)
+    reduce_parser.add_argument("--output")
+    _environment_arguments(reduce_parser)
+    reduce_parser.set_defaults(func=command_reduce)
+
+    coverage = subparsers.add_parser("coverage")
+    coverage.add_argument("paths", nargs="*")
+    coverage.add_argument("--generated", type=int, default=0)
+    coverage.add_argument("--seed", type=int, default=20260726)
+    coverage.add_argument("--inventory", action="store_true")
+    coverage.add_argument(
+        "--format", choices=("json", "markdown"), default="markdown"
+    )
+    _environment_arguments(coverage)
+    coverage.set_defaults(func=command_coverage)
+
+    campaign = subparsers.add_parser("campaign")
+    campaign.add_argument("paths", nargs="*")
+    campaign.add_argument("--profile", choices=("pr", "nightly"), default="pr")
+    campaign.add_argument("--seed", type=int, default=20260726)
+    campaign.add_argument("--max-examples", type=int)
+    campaign.add_argument("--min-ticks", type=int, default=8)
+    campaign.add_argument("--max-ticks", type=int, default=32)
+    campaign.add_argument("--timeout", type=float, default=30.0)
+    campaign.add_argument("--time-budget", type=float)
+    campaign.add_argument("--reduction-budget", type=float, default=120.0)
+    campaign.add_argument("--verify-replays", type=int, default=3)
+    campaign.add_argument(
+        "--reduce", action=argparse.BooleanOptionalAction, default=None
+    )
+    campaign.add_argument("--shard-index", type=int, default=0)
+    campaign.add_argument("--shard-count", type=int, default=1)
+    campaign.add_argument("--output-dir")
+    campaign.add_argument("--exit-zero", action="store_true")
+    _environment_arguments(campaign)
+    campaign.set_defaults(func=command_campaign)
+
+    publish = subparsers.add_parser("publish-issues")
+    publish.add_argument("reports", nargs="+")
+    publish.add_argument("--repo", default="hhenson/hg_cpp")
+    publish.add_argument("--publish", action="store_true")
+    publish.set_defaults(func=command_publish)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    if getattr(args, "shard_count", 1) < 1:
+        parser.error("--shard-count must be at least one")
+    if not 0 <= getattr(args, "shard_index", 0) < getattr(
+        args, "shard_count", 1
+    ):
+        parser.error("--shard-index must be in [0, shard-count)")
+    if getattr(args, "verify_replays", 2) < 2:
+        parser.error("--verify-replays must be at least two")
+    try:
+        return args.func(args)
+    except (RecipeError, RuntimeError, ValueError) as error:
+        parser.exit(2, f"error: {error}\n")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/parity/compare.py
+++ b/tools/parity/compare.py
@@ -1,0 +1,148 @@
+"""Semantic comparison of canonical fresh-process outcomes."""
+
+from __future__ import annotations
+
+import json
+import math
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(frozen=True)
+class Difference:
+    classification: str
+    path: str
+    reference: Any
+    candidate: Any
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "classification": self.classification,
+            "path": self.path,
+            "reference": self.reference,
+            "candidate": self.candidate,
+        }
+
+
+def _float_value(value: Any) -> float | None:
+    if not isinstance(value, dict) or set(value) != {"$float"}:
+        return None
+    encoded = value["$float"]
+    if encoded == "nan":
+        return math.nan
+    if encoded == "inf":
+        return math.inf
+    if encoded == "-inf":
+        return -math.inf
+    try:
+        return float.fromhex(encoded)
+    except (TypeError, ValueError):
+        return None
+
+
+def _first_difference(
+    reference: Any,
+    candidate: Any,
+    *,
+    path: str,
+    float_abs_tolerance: float,
+) -> Difference | None:
+    reference_float = _float_value(reference)
+    candidate_float = _float_value(candidate)
+    if reference_float is not None and candidate_float is not None:
+        equal = (
+            math.isnan(reference_float) and math.isnan(candidate_float)
+        ) or math.isclose(
+            reference_float,
+            candidate_float,
+            rel_tol=0.0,
+            abs_tol=float_abs_tolerance,
+        )
+        if equal:
+            return None
+    elif type(reference) is not type(candidate):
+        return Difference("value", path, reference, candidate)
+
+    if isinstance(reference, dict) and isinstance(candidate, dict):
+        if set(reference) != set(candidate):
+            return Difference(
+                "shape", path, sorted(reference), sorted(candidate)
+            )
+        for key in sorted(reference):
+            difference = _first_difference(
+                reference[key],
+                candidate[key],
+                path=f"{path}.{key}",
+                float_abs_tolerance=float_abs_tolerance,
+            )
+            if difference is not None:
+                return difference
+        return None
+    if isinstance(reference, list) and isinstance(candidate, list):
+        if len(reference) != len(candidate):
+            return Difference(
+                "length", path, len(reference), len(candidate)
+            )
+        for index, (reference_item, candidate_item) in enumerate(
+            zip(reference, candidate)
+        ):
+            difference = _first_difference(
+                reference_item,
+                candidate_item,
+                path=f"{path}[{index}]",
+                float_abs_tolerance=float_abs_tolerance,
+            )
+            if difference is not None:
+                return difference
+        return None
+    if reference != candidate:
+        return Difference("value", path, reference, candidate)
+    return None
+
+
+def compare_outcomes(
+    reference: dict[str, Any],
+    candidate: dict[str, Any],
+    *,
+    float_abs_tolerance: float = 0.0,
+) -> Difference | None:
+    reference_status = reference.get("status")
+    candidate_status = candidate.get("status")
+    if reference_status != candidate_status:
+        return Difference("status", "$.status", reference_status, candidate_status)
+    if reference_status != "ok":
+        reference_failure = (
+            reference.get("phase"),
+            reference.get("exception", {}).get("category"),
+        )
+        candidate_failure = (
+            candidate.get("phase"),
+            candidate.get("exception", {}).get("category"),
+        )
+        if reference_failure != candidate_failure:
+            return Difference(
+                "failure",
+                "$.exception",
+                reference_failure,
+                candidate_failure,
+            )
+        return None
+    return _first_difference(
+        reference.get("trace"),
+        candidate.get("trace"),
+        path="$.trace",
+        float_abs_tolerance=float_abs_tolerance,
+    )
+
+
+def semantic_signature(result: dict[str, Any]) -> str:
+    if result.get("status") == "ok":
+        value = {"status": "ok", "trace": result.get("trace")}
+    else:
+        value = {
+            "status": result.get("status"),
+            "phase": result.get("phase"),
+            "category": result.get("exception", {}).get("category"),
+            "returncode": result.get("process_returncode"),
+        }
+    return json.dumps(value, sort_keys=True, separators=(",", ":"))

--- a/tools/parity/corpus/feedback-accumulate-sparse.json
+++ b/tools/parity/corpus/feedback-accumulate-sparse.json
@@ -1,0 +1,33 @@
+{
+  "schema_version": 1,
+  "id": "feedback-accumulate-sparse",
+  "description": "Feedback state accumulates over twelve sparse input cycles.",
+  "template": "feedback_accumulate",
+  "inputs": {
+    "value": [
+      1,
+      2,
+      null,
+      3,
+      -1,
+      null,
+      5,
+      0,
+      null,
+      4,
+      -2,
+      1
+    ]
+  },
+  "parameters": {
+    "initial": 7
+  },
+  "features": [
+    "lifecycle:multi-cycle",
+    "operator:feedback",
+    "shape:TS",
+    "ticks:medium",
+    "topology:feedback",
+    "type:int"
+  ]
+}

--- a/tools/parity/corpus/issue-36-stream-dataclass.json
+++ b/tools/parity/corpus/issue-36-stream-dataclass.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": 1,
+  "id": "issue-36-stream-dataclass",
+  "description": "Frozen Python-owned dataclasses retain their public Stream bundle shape.",
+  "template": "stream_dataclass",
+  "inputs": {
+    "probe": [
+      true
+    ]
+  },
+  "parameters": {},
+  "features": [
+    "boundary:python-owned",
+    "shape:TSB",
+    "type:dataclass"
+  ],
+  "source_issue": "https://github.com/hhenson/hg_cpp/issues/36"
+}

--- a/tools/parity/corpus/issue-38-nested-tsd-feedback.json
+++ b/tools/parity/corpus/issue-38-nested-tsd-feedback.json
@@ -1,0 +1,42 @@
+{
+  "schema_version": 1,
+  "id": "issue-38-nested-tsd-feedback",
+  "description": "A mapped nested TSD update survives switch, dedup, feedback, lag, and sibling-key removal.",
+  "template": "issue_38_nested_tsd_feedback",
+  "inputs": {
+    "roll": [
+      false,
+      true,
+      false,
+      false
+    ],
+    "prices": [
+      {
+        "next": 10.0,
+        "old": 10.0
+      },
+      {
+        "next": 20.0
+      },
+      null,
+      null
+    ],
+    "trigger": [
+      0,
+      1,
+      2,
+      3
+    ]
+  },
+  "parameters": {},
+  "features": [
+    "lifecycle:branch-rebind",
+    "lifecycle:key-removal",
+    "shape:TSB",
+    "shape:TSD",
+    "topology:feedback",
+    "topology:map",
+    "topology:switch"
+  ],
+  "source_issue": "https://github.com/hhenson/hg_cpp/issues/38"
+}

--- a/tools/parity/corpus/issue-40-no-key-rebind.json
+++ b/tools/parity/corpus/issue-40-no-key-rebind.json
@@ -1,0 +1,46 @@
+{
+  "schema_version": 1,
+  "id": "issue-40-no-key-rebind",
+  "description": "A no_key map retains validity after if_then_else feedback rebinding.",
+  "template": "issue_40_no_key_rebind",
+  "inputs": {
+    "target": [
+      {
+        "next": 1.0
+      },
+      null,
+      null,
+      null
+    ],
+    "rebase": [
+      true,
+      false,
+      false,
+      false
+    ],
+    "prices": [
+      {
+        "next": 10.5
+      },
+      null,
+      null,
+      null
+    ],
+    "trigger": [
+      0,
+      1,
+      2,
+      3
+    ]
+  },
+  "parameters": {},
+  "features": [
+    "lifecycle:keyed",
+    "lifecycle:reference-rebind",
+    "shape:TSB",
+    "shape:TSD",
+    "topology:feedback",
+    "topology:map"
+  ],
+  "source_issue": "https://github.com/hhenson/hg_cpp/issues/40"
+}

--- a/tools/parity/corpus/issue-44-tsd-reduce-empty.json
+++ b/tools/parity/corpus/issue-44-tsd-reduce-empty.json
@@ -1,0 +1,33 @@
+{
+  "schema_version": 1,
+  "id": "issue-44-tsd-reduce-empty",
+  "description": "Track released-hgraph parity for a non-zero TSD reduction seed when the mapped dictionary becomes empty.",
+  "template": "tsd_map_reduce",
+  "inputs": {
+    "values": [
+      {
+        "a": -2
+      },
+      {
+        "a": {
+          "$remove": true
+        }
+      }
+    ]
+  },
+  "parameters": {
+    "increment": -3,
+    "zero": -3
+  },
+  "features": [
+    "lifecycle:key-removal",
+    "lifecycle:keyed",
+    "operator:map_",
+    "operator:reduce",
+    "shape:TSD",
+    "ticks:short",
+    "topology:map",
+    "type:int"
+  ],
+  "source_issue": "https://github.com/hhenson/hg_cpp/issues/44"
+}

--- a/tools/parity/corpus/scalar-expression-multi-tick.json
+++ b/tools/parity/corpus/scalar-expression-multi-tick.json
@@ -1,0 +1,76 @@
+{
+  "schema_version": 1,
+  "id": "scalar-expression-multi-tick",
+  "description": "A nested arithmetic and dedup composition over twelve sparse ticks.",
+  "template": "scalar_expression",
+  "inputs": {
+    "lhs": [
+      1,
+      2,
+      null,
+      4,
+      4,
+      -3,
+      null,
+      8,
+      0,
+      5,
+      null,
+      13
+    ],
+    "rhs": [
+      3,
+      null,
+      5,
+      6,
+      6,
+      2,
+      1,
+      null,
+      9,
+      -5,
+      4,
+      1
+    ]
+  },
+  "parameters": {
+    "input_types": {
+      "lhs": "int",
+      "rhs": "int"
+    },
+    "output_type": "int",
+    "expression": {
+      "op": "dedup",
+      "args": [
+        {
+          "op": "sub",
+          "args": [
+            {
+              "op": "mul",
+              "args": [
+                {
+                  "input": "lhs"
+                },
+                {
+                  "const": 2
+                }
+              ]
+            },
+            {
+              "input": "rhs"
+            }
+          ]
+        }
+      ]
+    }
+  },
+  "features": [
+    "operator:dedup",
+    "operator:mul",
+    "operator:sub",
+    "shape:TS",
+    "ticks:medium",
+    "topology:expression",
+    "type:int"
+  ]
+}

--- a/tools/parity/corpus/switch-arithmetic-rebinding.json
+++ b/tools/parity/corpus/switch-arithmetic-rebinding.json
@@ -1,0 +1,53 @@
+{
+  "schema_version": 1,
+  "id": "switch-arithmetic-rebinding",
+  "description": "Named switch branches repeatedly rebind while inputs tick independently.",
+  "template": "switch_arithmetic",
+  "inputs": {
+    "selector": [
+      "plus",
+      null,
+      "minus",
+      null,
+      "plus",
+      "minus",
+      null,
+      "plus",
+      "minus",
+      "plus"
+    ],
+    "lhs": [
+      10,
+      20,
+      30,
+      null,
+      50,
+      60,
+      70,
+      null,
+      90,
+      100
+    ],
+    "rhs": [
+      1,
+      2,
+      3,
+      4,
+      null,
+      6,
+      7,
+      8,
+      null,
+      10
+    ]
+  },
+  "parameters": {},
+  "features": [
+    "lifecycle:branch-rebind",
+    "operator:switch_",
+    "shape:TS",
+    "ticks:medium",
+    "topology:switch",
+    "type:int"
+  ]
+}

--- a/tools/parity/corpus/tsd-map-reduce-lifecycle.json
+++ b/tools/parity/corpus/tsd-map-reduce-lifecycle.json
@@ -1,0 +1,64 @@
+{
+  "schema_version": 1,
+  "id": "tsd-map-reduce-lifecycle",
+  "description": "A keyed map and reduction spans additions, updates, removals, idle cycles, clear, and repopulation.",
+  "template": "tsd_map_reduce",
+  "inputs": {
+    "values": [
+      {
+        "a": 1,
+        "b": 2
+      },
+      {
+        "a": 3
+      },
+      {
+        "c": 4
+      },
+      null,
+      {
+        "b": {
+          "$remove": true
+        }
+      },
+      {
+        "a": -1,
+        "c": 5
+      },
+      {
+        "a": {
+          "$remove": true
+        }
+      },
+      null,
+      {
+        "c": {
+          "$remove": true
+        }
+      },
+      {
+        "b": 8
+      },
+      {
+        "a": 2
+      },
+      {
+        "b": 9
+      }
+    ]
+  },
+  "parameters": {
+    "increment": 1,
+    "zero": 0
+  },
+  "features": [
+    "lifecycle:key-removal",
+    "lifecycle:keyed",
+    "operator:map_",
+    "operator:reduce",
+    "shape:TSD",
+    "ticks:medium",
+    "topology:map",
+    "type:int"
+  ]
+}

--- a/tools/parity/coverage.py
+++ b/tools/parity/coverage.py
@@ -1,0 +1,100 @@
+"""Semantic coverage accounting for recipes and the operator catalogue."""
+
+from __future__ import annotations
+
+import itertools
+import json
+from collections import Counter
+from typing import Any, Iterable
+
+from .catalog import CATALOG
+from .model import Recipe
+
+
+def recipe_features(recipe: Recipe) -> tuple[str, ...]:
+    spec = CATALOG[recipe.template]
+    values = set(recipe.features) | set(spec.features)
+    values.update(f"operator:{name}" for name in spec.operators)
+    values.add(f"template:{recipe.template}")
+    values.add(
+        "ticks:short"
+        if recipe.tick_count < 8
+        else "ticks:medium"
+        if recipe.tick_count <= 32
+        else "ticks:long"
+    )
+    return tuple(sorted(values))
+
+
+def coverage_report(
+    recipes: Iterable[Recipe],
+    *,
+    operator_inventory: Iterable[str] = (),
+) -> dict[str, Any]:
+    recipes = list(recipes)
+    feature_counts: Counter[str] = Counter()
+    pair_counts: Counter[tuple[str, str]] = Counter()
+    for recipe in recipes:
+        features = recipe_features(recipe)
+        feature_counts.update(features)
+        pair_counts.update(itertools.combinations(features, 2))
+
+    catalogued_operators = sorted(
+        {
+            operator
+            for spec in CATALOG.values()
+            for operator in spec.operators
+        }
+    )
+    inventory = sorted(set(operator_inventory))
+    return {
+        "schema_version": 1,
+        "recipe_count": len(recipes),
+        "template_counts": dict(
+            sorted(Counter(recipe.template for recipe in recipes).items())
+        ),
+        "feature_counts": dict(sorted(feature_counts.items())),
+        "pair_counts": {
+            " | ".join(pair): count
+            for pair, count in sorted(pair_counts.items())
+        },
+        "catalogued_operators": catalogued_operators,
+        "operator_inventory": inventory,
+        "missing_operators": sorted(set(inventory) - set(catalogued_operators)),
+    }
+
+
+def render_coverage_markdown(report: dict[str, Any]) -> str:
+    lines = [
+        "# hgraph parity coverage",
+        "",
+        f"- recipes: {report['recipe_count']}",
+        f"- templates: {len(report['template_counts'])}",
+        f"- semantic features: {len(report['feature_counts'])}",
+        f"- observed feature pairs: {len(report['pair_counts'])}",
+        f"- catalogued operators: {len(report['catalogued_operators'])}",
+        f"- inventory operators not catalogued: {len(report['missing_operators'])}",
+        "",
+        "## Template counts",
+        "",
+    ]
+    lines.extend(
+        f"- `{name}`: {count}"
+        for name, count in report["template_counts"].items()
+    )
+    lines.extend(["", "## Coverage frontier", ""])
+    if report["missing_operators"]:
+        lines.extend(
+            f"- `{name}`" for name in report["missing_operators"][:100]
+        )
+        if len(report["missing_operators"]) > 100:
+            lines.append(
+                f"- … {len(report['missing_operators']) - 100} more"
+            )
+    else:
+        lines.append("- Every inventoried operator is represented in the catalogue.")
+    return "\n".join(lines) + "\n"
+
+
+def coverage_json(report: dict[str, Any]) -> str:
+    return json.dumps(report, indent=2, sort_keys=True) + "\n"

--- a/tools/parity/environments.py
+++ b/tools/parity/environments.py
@@ -1,0 +1,198 @@
+"""Content-addressed isolated environments for differential execution."""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import platform
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+from tools.artifact_fingerprint import hg_cpp_source_fingerprint
+
+from .process import environment_identity
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PARITY_ROOT = REPO_ROOT / ".parity"
+
+
+def _python_in(venv: Path) -> Path:
+    return venv / ("Scripts/python.exe" if os.name == "nt" else "bin/python")
+
+
+def _run(command: list[str], *, cwd: Path = REPO_ROOT) -> None:
+    completed = subprocess.run(command, cwd=cwd)
+    if completed.returncode:
+        raise RuntimeError(
+            f"parity environment command failed ({completed.returncode}): "
+            f"{' '.join(command)}"
+        )
+
+
+def _environment_key(interpreter: Path | str) -> str:
+    completed = subprocess.run(
+        [
+            str(interpreter),
+            "-c",
+            "import platform,sys;"
+            "print(f'{sys.version_info.major}.{sys.version_info.minor}-"
+            "{sys.platform}-{platform.machine().lower()}')",
+        ],
+        capture_output=True,
+        check=True,
+        text=True,
+    )
+    return completed.stdout.strip()
+
+
+def _ensure_venv(path: Path, interpreter: Path | str) -> Path:
+    python = _python_in(path)
+    if not python.exists():
+        path.parent.mkdir(parents=True, exist_ok=True)
+        _run(["uv", "venv", "--python", str(interpreter), str(path)])
+    return python
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as source:
+        for chunk in iter(lambda: source.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+@dataclass(frozen=True)
+class ParityEnvironments:
+    reference_python: Path
+    candidate_python: Path
+    reference_identity: dict
+    candidate_identity: dict
+    candidate_fingerprint: str
+
+
+def ensure_reference_environment(
+    *,
+    interpreter: Path | str = sys.executable,
+) -> tuple[Path, dict]:
+    key = _environment_key(interpreter)
+    venv = PARITY_ROOT / "envs" / f"reference-{key}"
+    python = _ensure_venv(venv, interpreter)
+    # Resolve the latest release at campaign setup, then use this exact
+    # environment for every shard and record its installed version.
+    _run(
+        [
+            "uv",
+            "pip",
+            "install",
+            "--python",
+            str(python),
+            "--upgrade",
+            "hgraph",
+        ]
+    )
+    return python, environment_identity(python)
+
+
+def _built_candidate_wheel(source_fingerprint: str) -> Path:
+    wheel_dir = PARITY_ROOT / "wheels" / source_fingerprint
+    wheels = sorted(wheel_dir.glob("*.whl"))
+    if len(wheels) == 1:
+        return wheels[0]
+    wheel_dir.mkdir(parents=True, exist_ok=True)
+    _run(
+        [
+            "uv",
+            "build",
+            "--wheel",
+            "--python",
+            "3.12",
+            "--config-setting",
+            "cmake.build-type=Release",
+            "--out-dir",
+            str(wheel_dir),
+            "--no-build-logs",
+        ]
+    )
+    wheels = sorted(wheel_dir.glob("*.whl"))
+    if len(wheels) != 1:
+        raise RuntimeError(
+            f"expected one candidate wheel in {wheel_dir}, found {len(wheels)}"
+        )
+    return wheels[0]
+
+
+def ensure_candidate_environment(
+    *,
+    interpreter: Path | str = sys.executable,
+    candidate_wheel: Path | None = None,
+) -> tuple[Path, dict, str]:
+    key = _environment_key(interpreter)
+    venv = PARITY_ROOT / "envs" / f"candidate-{key}"
+    python = _ensure_venv(venv, interpreter)
+    if candidate_wheel is None:
+        fingerprint = hg_cpp_source_fingerprint(
+            REPO_ROOT, python_version="3.12"
+        )
+        candidate_wheel = _built_candidate_wheel(fingerprint)
+    else:
+        candidate_wheel = candidate_wheel.resolve()
+        fingerprint = _sha256(candidate_wheel)
+    marker = venv / ".wheel-fingerprint"
+    installed = marker.read_text().strip() if marker.exists() else ""
+    if installed != fingerprint:
+        _run(
+            [
+                "uv",
+                "pip",
+                "install",
+                "--python",
+                str(python),
+                "--reinstall",
+                str(candidate_wheel),
+            ]
+        )
+        marker.write_text(fingerprint + "\n")
+    return python, environment_identity(python), fingerprint
+
+
+def prepare_environments(
+    *,
+    interpreter: Path | str = sys.executable,
+    reference_python: Path | None = None,
+    candidate_python: Path | None = None,
+    candidate_wheel: Path | None = None,
+) -> ParityEnvironments:
+    if reference_python is None:
+        reference_python, reference_identity = ensure_reference_environment(
+            interpreter=interpreter
+        )
+    else:
+        reference_python = reference_python.resolve()
+        reference_identity = environment_identity(reference_python)
+    if candidate_python is None:
+        candidate_python, candidate_identity, fingerprint = (
+            ensure_candidate_environment(
+                interpreter=interpreter,
+                candidate_wheel=candidate_wheel,
+            )
+        )
+    else:
+        if candidate_wheel is not None:
+            raise ValueError(
+                "candidate_wheel cannot be combined with candidate_python"
+            )
+        candidate_python = candidate_python.resolve()
+        candidate_identity = environment_identity(candidate_python)
+        fingerprint = "external-" + hashlib.sha256(
+            str(candidate_python).encode()
+        ).hexdigest()
+    return ParityEnvironments(
+        reference_python=reference_python,
+        candidate_python=candidate_python,
+        reference_identity=reference_identity,
+        candidate_identity=candidate_identity,
+        candidate_fingerprint=fingerprint,
+    )

--- a/tools/parity/generate.py
+++ b/tools/parity/generate.py
@@ -1,0 +1,247 @@
+"""Typed property-based recipe generation.
+
+Hypothesis is an optional controller dependency and is imported lazily so the
+installed hg_cpp runtime and its compatibility suite do not depend on it.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from typing import Any
+
+from .catalog import CATALOG, validate_recipe
+from .model import Recipe, SCHEMA_VERSION
+
+
+def _recipe_from_payload(payload: dict[str, Any], seed: int) -> Recipe:
+    encoded = json.dumps(payload, sort_keys=True, separators=(",", ":"))
+    suffix = hashlib.sha256(encoded.encode()).hexdigest()[:12]
+    raw = {
+        "schema_version": SCHEMA_VERSION,
+        "id": f"generated-{payload['template'].replace('_', '-')}-{suffix}",
+        "description": "Deterministically generated parity exploration case.",
+        "template": payload["template"],
+        "inputs": payload["inputs"],
+        "parameters": payload.get("parameters", {}),
+        "features": sorted(set(payload.get("features", ()))),
+        "seed": seed,
+    }
+    recipe = Recipe.from_dict(raw)
+    validate_recipe(recipe)
+    return recipe
+
+
+def recipe_payload_strategy(*, min_ticks: int = 8, max_ticks: int = 32):
+    from hypothesis import strategies as st
+
+    if not 1 <= min_ticks <= max_ticks <= 256:
+        raise ValueError("tick bounds must satisfy 1 <= min <= max <= 256")
+
+    @st.composite
+    def scalar_expression(draw):
+        type_name = draw(st.sampled_from(("int", "float")))
+        count = draw(st.integers(min_value=min_ticks, max_value=max_ticks))
+        if type_name == "int":
+            scalar = st.integers(min_value=-20, max_value=20)
+        else:
+            scalar = st.floats(
+                min_value=-20,
+                max_value=20,
+                allow_nan=False,
+                allow_infinity=False,
+                width=32,
+            )
+        lhs = [draw(scalar)] + [
+            draw(st.one_of(st.none(), scalar)) for _ in range(count - 1)
+        ]
+        rhs = [draw(scalar)] + [
+            draw(st.one_of(st.none(), scalar)) for _ in range(count - 1)
+        ]
+        leaves = st.one_of(
+            st.just({"input": "lhs"}),
+            st.just({"input": "rhs"}),
+            scalar.map(lambda value: {"const": value}),
+        )
+
+        def extend(children):
+            binary = st.builds(
+                lambda operation, args: {
+                    "op": operation,
+                    "args": list(args),
+                },
+                st.sampled_from(("add", "sub", "mul")),
+                st.tuples(children, children),
+            )
+            unary = st.builds(
+                lambda operation, item: {"op": operation, "args": [item]},
+                st.sampled_from(("neg", "pos", "abs", "dedup")),
+                children,
+            )
+            return st.one_of(binary, unary)
+
+        expression = draw(st.recursive(leaves, extend, max_leaves=8))
+        operations: set[str] = set()
+
+        def visit(item):
+            if "op" in item:
+                operations.add(item["op"])
+                for argument in item["args"]:
+                    visit(argument)
+
+        visit(expression)
+        return {
+            "template": "scalar_expression",
+            "inputs": {"lhs": lhs, "rhs": rhs},
+            "parameters": {
+                "input_types": {"lhs": type_name, "rhs": type_name},
+                "output_type": type_name,
+                "expression": expression,
+            },
+            "features": [
+                *CATALOG["scalar_expression"].features,
+                f"type:{type_name}",
+                f"ticks:{'long' if count > 16 else 'medium'}",
+                *(f"operator:{operation}" for operation in sorted(operations)),
+            ],
+        }
+
+    @st.composite
+    def feedback_accumulate(draw):
+        count = draw(st.integers(min_value=min_ticks, max_value=max_ticks))
+        scalar = st.integers(min_value=-20, max_value=20)
+        values = [draw(scalar)] + [
+            draw(st.one_of(st.none(), scalar)) for _ in range(count - 1)
+        ]
+        return {
+            "template": "feedback_accumulate",
+            "inputs": {"value": values},
+            "parameters": {"initial": draw(st.integers(-5, 5))},
+            "features": [
+                *CATALOG["feedback_accumulate"].features,
+                "type:int",
+                "operator:feedback",
+            ],
+        }
+
+    @st.composite
+    def switch_arithmetic(draw):
+        count = draw(st.integers(min_value=min_ticks, max_value=max_ticks))
+        scalar = st.integers(min_value=-20, max_value=20)
+        selector = [draw(st.sampled_from(("plus", "minus")))] + [
+            draw(st.one_of(st.none(), st.sampled_from(("plus", "minus"))))
+            for _ in range(count - 1)
+        ]
+        lhs = [draw(scalar)] + [
+            draw(st.one_of(st.none(), scalar)) for _ in range(count - 1)
+        ]
+        rhs = [draw(scalar)] + [
+            draw(st.one_of(st.none(), scalar)) for _ in range(count - 1)
+        ]
+        return {
+            "template": "switch_arithmetic",
+            "inputs": {"selector": selector, "lhs": lhs, "rhs": rhs},
+            "features": [
+                *CATALOG["switch_arithmetic"].features,
+                "type:int",
+                "operator:switch_",
+            ],
+        }
+
+    @st.composite
+    def tsd_map_reduce(draw):
+        count = draw(st.integers(min_value=min_ticks, max_value=max_ticks))
+        active = {"a"}
+        ticks: list[Any] = [{"a": draw(st.integers(-10, 10))}]
+        keys = ("a", "b", "c")
+        for _ in range(count - 1):
+            action = draw(st.sampled_from(("none", "update", "add", "remove")))
+            if action == "none":
+                ticks.append(None)
+                continue
+            if action == "remove" and active:
+                key = draw(st.sampled_from(sorted(active)))
+                ticks.append({key: {"$remove": True}})
+                active.remove(key)
+                continue
+            available = [key for key in keys if key not in active]
+            if action == "add" and available:
+                key = draw(st.sampled_from(available))
+                active.add(key)
+            elif active:
+                key = draw(st.sampled_from(sorted(active)))
+            else:
+                key = draw(st.sampled_from(keys))
+                active.add(key)
+            ticks.append({key: draw(st.integers(-10, 10))})
+        return {
+            "template": "tsd_map_reduce",
+            "inputs": {"values": ticks},
+            "parameters": {
+                "increment": draw(st.integers(-3, 3)),
+                "zero": draw(st.integers(-3, 3)),
+            },
+            "features": [
+                *CATALOG["tsd_map_reduce"].features,
+                "type:int",
+                "operator:map_",
+                "operator:reduce",
+            ],
+        }
+
+    return st.one_of(
+        scalar_expression(),
+        feedback_accumulate(),
+        switch_arithmetic(),
+        tsd_map_reduce(),
+    )
+
+
+def generate_recipes(
+    count: int,
+    *,
+    seed: int,
+    min_ticks: int = 8,
+    max_ticks: int = 32,
+    templates: tuple[str, ...] | None = None,
+) -> list[Recipe]:
+    from hypothesis import HealthCheck, Phase, given, seed as hypothesis_seed, settings
+
+    if count < 1:
+        return []
+    payloads: list[dict[str, Any]] = []
+
+    def collect(payload):
+        payloads.append(payload)
+
+    strategy = recipe_payload_strategy(
+        min_ticks=min_ticks, max_ticks=max_ticks
+    )
+    if templates is not None:
+        allowed = frozenset(templates)
+        unknown = allowed - frozenset(CATALOG)
+        if unknown:
+            raise ValueError(
+                f"unknown generated template(s): {', '.join(sorted(unknown))}"
+            )
+        strategy = strategy.filter(
+            lambda payload: payload["template"] in allowed
+        )
+    generated = given(strategy)(collect)
+    generated = settings(
+        max_examples=count,
+        database=None,
+        deadline=None,
+        phases=(Phase.generate,),
+        suppress_health_check=(HealthCheck.too_slow,),
+    )(generated)
+    hypothesis_seed(seed)(generated)()
+
+    recipes: list[Recipe] = []
+    seen: set[str] = set()
+    for payload in payloads:
+        recipe = _recipe_from_payload(payload, seed)
+        if recipe.fingerprint not in seen:
+            seen.add(recipe.fingerprint)
+            recipes.append(recipe)
+    return recipes

--- a/tools/parity/issues.py
+++ b/tools/parity/issues.py
@@ -1,0 +1,262 @@
+"""Deterministic issue payloads and trusted GitHub publishing."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+import subprocess
+import tempfile
+from pathlib import Path
+from typing import Any, Iterable
+
+
+FINGERPRINT_PREFIX = "hgraph-parity:"
+
+
+def _value_shape(value: Any, *, data_mapping: bool = False) -> Any:
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, int):
+        return "<int>"
+    if isinstance(value, float):
+        return "<float>"
+    if isinstance(value, str):
+        return value
+    if isinstance(value, list):
+        return [
+            _value_shape(item, data_mapping=data_mapping) for item in value
+        ]
+    if isinstance(value, dict):
+        if data_mapping and not any(str(key).startswith("$") for key in value):
+            return {
+                "$data-map": sorted(
+                    (
+                        _value_shape(item, data_mapping=True)
+                        for item in value.values()
+                    ),
+                    key=lambda item: json.dumps(item, sort_keys=True),
+                )
+            }
+        return {
+            key: _value_shape(item, data_mapping=data_mapping)
+            for key, item in sorted(value.items())
+        }
+    return f"<{type(value).__name__}>"
+
+
+def failure_fingerprint(failure: dict[str, Any]) -> str:
+    recipe = failure["minimized_recipe"]
+    difference = failure["difference"]
+    payload = {
+        "template": recipe["template"],
+        "inputs": {
+            name: _value_shape(ticks, data_mapping=True)
+            for name, ticks in sorted(recipe["inputs"].items())
+        },
+        "parameters": _value_shape(recipe.get("parameters", {})),
+        "difference": {
+            "classification": difference["classification"],
+            "path": re.sub(r"\[\d+\]", "[]", difference["path"]),
+            "reference_shape": _value_shape(difference.get("reference")),
+            "candidate_shape": _value_shape(difference.get("candidate")),
+        },
+        "reference_status": failure.get("reference", {}).get("status"),
+        "candidate_status": failure.get("candidate", {}).get("status"),
+    }
+    encoded = json.dumps(payload, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(encoded.encode()).hexdigest()
+
+
+def issue_title(failure: dict[str, Any]) -> str:
+    recipe = failure["minimized_recipe"]
+    return f"[parity] {recipe['template']} differs from released hgraph"
+
+
+def issue_body(failure: dict[str, Any]) -> str:
+    fingerprint = failure.get("failure_fingerprint") or failure_fingerprint(failure)
+    recipe = failure["minimized_recipe"]
+    reference = failure["reference"]
+    candidate = failure["candidate"]
+    reduction = failure.get("reduction", {})
+    source_issue = recipe.get("source_issue")
+    provenance = (
+        f"\nRelated seed: {source_issue}\n" if source_issue else ""
+    )
+    return f"""<!-- {FINGERPRINT_PREFIX}{fingerprint} -->
+## Differential result
+
+A deterministic graph recipe passes with the released Python hgraph reference
+and differs under hg_cpp. The case reproduced three times in fresh processes
+and was reduced before this issue was created.
+{provenance}
+- Difference: `{failure['difference']['classification']}` at `{failure['difference']['path']}`
+- Reference: `{reference.get('implementation', {})}`
+- Candidate: `{candidate.get('implementation', {})}`
+- Original seed: `{recipe.get('seed')}`
+- Reduction: {reduction.get('accepted', 0)} accepted changes from {reduction.get('attempts', 0)} attempts
+- Failure fingerprint: `{fingerprint}`
+
+## Minimized recipe
+
+```json
+{json.dumps(recipe, indent=2, sort_keys=True)}
+```
+
+## Expected reference trace
+
+```json
+{json.dumps(reference, indent=2, sort_keys=True)}
+```
+
+## Actual hg_cpp trace
+
+```json
+{json.dumps(candidate, indent=2, sort_keys=True)}
+```
+
+## Acceptance criteria
+
+- The minimized recipe produces the released hgraph trace.
+- The fix adds public Python wiring regression coverage.
+- The same behavior receives equivalent native C++ `eval_node` coverage.
+"""
+
+
+def _gh(
+    arguments: list[str],
+    *,
+    repo: str,
+    capture: bool = False,
+) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["gh", *arguments, "--repo", repo],
+        check=True,
+        capture_output=capture,
+        text=True,
+    )
+
+
+def _existing_issues(repo: str) -> list[dict[str, Any]]:
+    completed = _gh(
+        [
+            "issue",
+            "list",
+            "--state",
+            "all",
+            "--limit",
+            "1000",
+            "--json",
+            "number,state,title,body,url",
+        ],
+        repo=repo,
+        capture=True,
+    )
+    return json.loads(completed.stdout)
+
+
+def publish_failures(
+    failures: Iterable[dict[str, Any]],
+    *,
+    repo: str,
+    publish: bool,
+) -> list[dict[str, Any]]:
+    failures = list(failures)
+    if not publish:
+        return [
+            {
+                "action": "dry-run",
+                "title": issue_title(failure),
+                "fingerprint": failure.get("failure_fingerprint")
+                or failure_fingerprint(failure),
+                "body": issue_body(failure),
+            }
+            for failure in failures
+        ]
+
+    _gh(
+        [
+            "label",
+            "create",
+            "parity",
+            "--color",
+            "5319E7",
+            "--description",
+            "Verified behavioral difference from released hgraph",
+            "--force",
+        ],
+        repo=repo,
+    )
+    existing = _existing_issues(repo)
+    actions: list[dict[str, Any]] = []
+    for failure in failures:
+        fingerprint = failure.get("failure_fingerprint") or failure_fingerprint(
+            failure
+        )
+        marker = f"<!-- {FINGERPRINT_PREFIX}{fingerprint} -->"
+        title = issue_title(failure)
+        match = next(
+            (
+                issue
+                for issue in existing
+                if marker in (issue.get("body") or "")
+                or (
+                    issue.get("state", "").upper() == "OPEN"
+                    and issue.get("title") == title
+                )
+            ),
+            None,
+        )
+        if match is not None:
+            if match["state"].upper() == "CLOSED":
+                _gh(
+                    ["issue", "reopen", str(match["number"])],
+                    repo=repo,
+                )
+                action = "reopened"
+            else:
+                action = "deduplicated"
+            actions.append(
+                {
+                    "action": action,
+                    "number": match["number"],
+                    "url": match["url"],
+                    "fingerprint": fingerprint,
+                }
+            )
+            continue
+
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".md", encoding="utf-8", delete=False
+        ) as body_file:
+            body_file.write(issue_body(failure))
+            body_path = Path(body_file.name)
+        try:
+            completed = _gh(
+                [
+                    "issue",
+                    "create",
+                    "--title",
+                    title,
+                    "--body-file",
+                    str(body_path),
+                    "--label",
+                    "bug",
+                    "--label",
+                    "parity",
+                ],
+                repo=repo,
+                capture=True,
+            )
+        finally:
+            body_path.unlink(missing_ok=True)
+        actions.append(
+            {
+                "action": "created",
+                "url": completed.stdout.strip(),
+                "fingerprint": fingerprint,
+            }
+        )
+    return actions

--- a/tools/parity/issues.py
+++ b/tools/parity/issues.py
@@ -202,10 +202,6 @@ def publish_failures(
                 issue
                 for issue in existing
                 if marker in (issue.get("body") or "")
-                or (
-                    issue.get("state", "").upper() == "OPEN"
-                    and issue.get("title") == title
-                )
             ),
             None,
         )

--- a/tools/parity/known_divergences.json
+++ b/tools/parity/known_divergences.json
@@ -1,0 +1,11 @@
+{
+  "schema_version": 1,
+  "divergences": [
+    {
+      "fingerprint": "81c998bdb8bbd40abf634dc8285a79830b5996564c52996222c2443110a35d89",
+      "issue": "https://github.com/hhenson/hg_cpp/issues/44",
+      "reason": "TSD map/reduce empty transition applies a non-zero seed differently.",
+      "review_after": "2026-08-26"
+    }
+  ]
+}

--- a/tools/parity/model.py
+++ b/tools/parity/model.py
@@ -1,0 +1,178 @@
+"""Versioned, data-only parity recipe model."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Mapping
+
+
+SCHEMA_VERSION = 1
+_IDENTIFIER = re.compile(r"^[a-z][a-z0-9_-]{2,79}$")
+_INPUT_NAME = re.compile(r"^[a-z_][a-z0-9_]{0,63}$")
+_MAX_TICKS = 256
+
+
+class RecipeError(ValueError):
+    """A recipe is malformed or outside the bounded parity language."""
+
+
+@dataclass(frozen=True)
+class Recipe:
+    schema_version: int
+    id: str
+    template: str
+    inputs: Mapping[str, tuple[Any, ...]]
+    parameters: Mapping[str, Any]
+    features: tuple[str, ...]
+    description: str = ""
+    source_issue: str | None = None
+    seed: int | None = None
+
+    @classmethod
+    def from_dict(cls, raw: Mapping[str, Any]) -> "Recipe":
+        if not isinstance(raw, Mapping):
+            raise RecipeError("recipe must be a JSON object")
+        version = raw.get("schema_version")
+        if version != SCHEMA_VERSION:
+            raise RecipeError(
+                f"unsupported schema_version {version!r}; expected {SCHEMA_VERSION}"
+            )
+        recipe_id = raw.get("id")
+        if not isinstance(recipe_id, str) or not _IDENTIFIER.fullmatch(recipe_id):
+            raise RecipeError(
+                "id must be 3-80 lowercase letters, digits, hyphens, or underscores"
+            )
+        template = raw.get("template")
+        if not isinstance(template, str) or not _IDENTIFIER.fullmatch(template):
+            raise RecipeError("template must be a bounded-language identifier")
+
+        raw_inputs = raw.get("inputs")
+        if not isinstance(raw_inputs, Mapping) or not raw_inputs:
+            raise RecipeError("inputs must be a non-empty object")
+        inputs: dict[str, tuple[Any, ...]] = {}
+        for name, ticks in raw_inputs.items():
+            if not isinstance(name, str) or not _INPUT_NAME.fullmatch(name):
+                raise RecipeError(f"invalid input name {name!r}")
+            if not isinstance(ticks, list):
+                raise RecipeError(f"input {name!r} must contain a JSON tick list")
+            if not 1 <= len(ticks) <= _MAX_TICKS:
+                raise RecipeError(
+                    f"input {name!r} must have between 1 and {_MAX_TICKS} ticks"
+                )
+            inputs[name] = tuple(ticks)
+
+        parameters = raw.get("parameters", {})
+        if not isinstance(parameters, Mapping):
+            raise RecipeError("parameters must be an object")
+        features = raw.get("features", [])
+        if (
+            not isinstance(features, list)
+            or not all(isinstance(value, str) and value for value in features)
+        ):
+            raise RecipeError("features must be a list of non-empty strings")
+        if len(set(features)) != len(features):
+            raise RecipeError("features must not contain duplicates")
+        description = raw.get("description", "")
+        if not isinstance(description, str):
+            raise RecipeError("description must be a string")
+        source_issue = raw.get("source_issue")
+        if source_issue is not None and not isinstance(source_issue, str):
+            raise RecipeError("source_issue must be a string or null")
+        seed = raw.get("seed")
+        if seed is not None and (not isinstance(seed, int) or isinstance(seed, bool)):
+            raise RecipeError("seed must be an integer or null")
+
+        recipe = cls(
+            schema_version=version,
+            id=recipe_id,
+            template=template,
+            inputs=inputs,
+            parameters=dict(parameters),
+            features=tuple(features),
+            description=description,
+            source_issue=source_issue,
+            seed=seed,
+        )
+        recipe._validate_json_values()
+        return recipe
+
+    @classmethod
+    def load(cls, path: Path | str) -> "Recipe":
+        path = Path(path)
+        try:
+            raw = json.loads(path.read_text())
+        except (OSError, json.JSONDecodeError) as error:
+            raise RecipeError(f"cannot load recipe {path}: {error}") from error
+        return cls.from_dict(raw)
+
+    def to_dict(self) -> dict[str, Any]:
+        result: dict[str, Any] = {
+            "schema_version": self.schema_version,
+            "id": self.id,
+            "description": self.description,
+            "template": self.template,
+            "inputs": {name: list(ticks) for name, ticks in self.inputs.items()},
+            "parameters": dict(self.parameters),
+            "features": list(self.features),
+        }
+        if self.source_issue is not None:
+            result["source_issue"] = self.source_issue
+        if self.seed is not None:
+            result["seed"] = self.seed
+        return result
+
+    def canonical_json(self) -> str:
+        return json.dumps(
+            self.to_dict(),
+            sort_keys=True,
+            separators=(",", ":"),
+            ensure_ascii=False,
+            allow_nan=False,
+        )
+
+    @property
+    def fingerprint(self) -> str:
+        return hashlib.sha256(self.canonical_json().encode()).hexdigest()
+
+    @property
+    def tick_count(self) -> int:
+        return max(len(ticks) for ticks in self.inputs.values())
+
+    def replace(
+        self,
+        *,
+        inputs: Mapping[str, tuple[Any, ...]] | None = None,
+        parameters: Mapping[str, Any] | None = None,
+        recipe_id: str | None = None,
+    ) -> "Recipe":
+        raw = self.to_dict()
+        if inputs is not None:
+            raw["inputs"] = {name: list(ticks) for name, ticks in inputs.items()}
+        if parameters is not None:
+            raw["parameters"] = dict(parameters)
+        if recipe_id is not None:
+            raw["id"] = recipe_id
+        return Recipe.from_dict(raw)
+
+    def _validate_json_values(self) -> None:
+        try:
+            json.dumps(
+                {"inputs": self.inputs, "parameters": self.parameters},
+                allow_nan=False,
+            )
+        except (TypeError, ValueError) as error:
+            raise RecipeError(
+                "inputs and parameters must use finite, JSON-serializable values"
+            ) from error
+
+
+def load_corpus(path: Path) -> list[Recipe]:
+    recipes = [Recipe.load(recipe_path) for recipe_path in sorted(path.glob("*.json"))]
+    ids = [recipe.id for recipe in recipes]
+    if len(ids) != len(set(ids)):
+        raise RecipeError(f"duplicate recipe id in {path}")
+    return recipes

--- a/tools/parity/process.py
+++ b/tools/parity/process.py
@@ -1,0 +1,185 @@
+"""Subprocess isolation, result parsing, and reference trace caching."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import subprocess
+from pathlib import Path
+from typing import Any
+
+from .model import Recipe
+from .runner import RESULT_MARKER
+
+
+RUNNER = Path(__file__).with_name("runner.py")
+
+
+def _harness_fingerprint() -> str:
+    digest = hashlib.sha256()
+    for name in ("canonical.py", "catalog.py", "model.py", "runner.py"):
+        path = RUNNER.with_name(name)
+        digest.update(name.encode())
+        digest.update(b"\0")
+        digest.update(path.read_bytes())
+        digest.update(b"\0")
+    return digest.hexdigest()
+
+
+HARNESS_FINGERPRINT = _harness_fingerprint()
+
+
+def _sanitized_environment() -> dict[str, str]:
+    environment = os.environ.copy()
+    for name in (
+        "HGRAPH_USE_CPP",
+        "PYTHONPATH",
+        "PYTHONHOME",
+        "VIRTUAL_ENV",
+    ):
+        environment.pop(name, None)
+    environment.update(PYTHONHASHSEED="0", TZ="UTC")
+    return environment
+
+
+def _parse_result(stdout: str) -> dict[str, Any] | None:
+    for line in reversed(stdout.splitlines()):
+        if line.startswith(RESULT_MARKER):
+            try:
+                value = json.loads(line[len(RESULT_MARKER) :])
+            except json.JSONDecodeError:
+                return None
+            return value if isinstance(value, dict) else None
+    return None
+
+
+def _invoke(
+    interpreter: Path | str,
+    arguments: list[str],
+    *,
+    input_text: str | None = None,
+    timeout: float = 30.0,
+) -> dict[str, Any]:
+    command = [str(interpreter), "-I", str(RUNNER), *arguments]
+    try:
+        completed = subprocess.run(
+            command,
+            input=input_text,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            cwd=RUNNER.parents[2],
+            env=_sanitized_environment(),
+        )
+    except subprocess.TimeoutExpired as error:
+        return {
+            "status": "timeout",
+            "phase": "process",
+            "timeout_seconds": timeout,
+            "diagnostic": (error.stderr or "")[-4000:],
+        }
+    except OSError as error:
+        return {
+            "status": "infrastructure-error",
+            "phase": "process",
+            "diagnostic": str(error),
+        }
+
+    parsed = _parse_result(completed.stdout)
+    if parsed is not None:
+        parsed.setdefault("process_returncode", completed.returncode)
+        if completed.stderr:
+            parsed.setdefault("process_stderr", completed.stderr[-4000:])
+        return parsed
+    return {
+        "status": "crash" if completed.returncode else "harness-error",
+        "phase": "process",
+        "process_returncode": completed.returncode,
+        "diagnostic": (
+            f"stdout:\n{completed.stdout[-4000:]}\n"
+            f"stderr:\n{completed.stderr[-4000:]}"
+        ),
+    }
+
+
+def environment_identity(
+    interpreter: Path | str, *, timeout: float = 30.0
+) -> dict[str, Any]:
+    result = _invoke(interpreter, ["--identity"], timeout=timeout)
+    if result.get("status") != "ok":
+        raise RuntimeError(f"cannot inspect parity environment: {result}")
+    return result["identity"]
+
+
+def operator_inventory(
+    interpreter: Path | str, *, timeout: float = 30.0
+) -> dict[str, Any]:
+    result = _invoke(interpreter, ["--inventory"], timeout=timeout)
+    if result.get("status") != "ok":
+        raise RuntimeError(f"cannot inspect operator inventory: {result}")
+    return result
+
+
+def run_recipe(
+    interpreter: Path | str,
+    recipe: Recipe,
+    *,
+    timeout: float = 30.0,
+) -> dict[str, Any]:
+    return _invoke(
+        interpreter,
+        [],
+        input_text=recipe.canonical_json(),
+        timeout=timeout,
+    )
+
+
+class ReferenceTraceCache:
+    def __init__(self, path: Path, identity: dict[str, Any]):
+        self.path = path
+        self.identity = identity
+
+    def _key(self, recipe: Recipe) -> str:
+        payload = json.dumps(
+            {
+                "recipe": recipe.fingerprint,
+                "identity": self.identity,
+                "runner_schema": 1,
+                "harness": HARNESS_FINGERPRINT,
+            },
+            sort_keys=True,
+            separators=(",", ":"),
+        )
+        return hashlib.sha256(payload.encode()).hexdigest()
+
+    def get(self, recipe: Recipe) -> dict[str, Any] | None:
+        path = self.path / f"{self._key(recipe)}.json"
+        try:
+            value = json.loads(path.read_text())
+        except (OSError, json.JSONDecodeError):
+            return None
+        return value if isinstance(value, dict) else None
+
+    def put(self, recipe: Recipe, result: dict[str, Any]) -> None:
+        if result.get("status") != "ok":
+            return
+        self.path.mkdir(parents=True, exist_ok=True)
+        path = self.path / f"{self._key(recipe)}.json"
+        temporary = path.with_suffix(".tmp")
+        temporary.write_text(json.dumps(result, sort_keys=True))
+        temporary.replace(path)
+
+    def run(
+        self,
+        interpreter: Path | str,
+        recipe: Recipe,
+        *,
+        timeout: float = 30.0,
+        bypass: bool = False,
+    ) -> tuple[dict[str, Any], bool]:
+        if not bypass and (cached := self.get(recipe)) is not None:
+            return cached, True
+        result = run_recipe(interpreter, recipe, timeout=timeout)
+        self.put(recipe, result)
+        return result, False

--- a/tools/parity/reduce.py
+++ b/tools/parity/reduce.py
@@ -1,0 +1,225 @@
+"""Failure-preserving reduction for recipe ticks, values, and expressions."""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass
+from typing import Callable, Iterable
+
+from .catalog import validate_recipe
+from .model import Recipe, RecipeError
+
+
+@dataclass(frozen=True)
+class ReductionResult:
+    recipe: Recipe
+    attempts: int
+    accepted: int
+    timed_out: bool
+    steps: tuple[str, ...]
+
+    def to_dict(self) -> dict:
+        return {
+            "attempts": self.attempts,
+            "accepted": self.accepted,
+            "timed_out": self.timed_out,
+            "steps": list(self.steps),
+            "recipe": self.recipe.to_dict(),
+        }
+
+
+def _valid_candidate(recipe: Recipe) -> bool:
+    try:
+        validate_recipe(recipe)
+    except RecipeError:
+        return False
+    return True
+
+
+def _expression_candidates(expression) -> Iterable[dict]:
+    if not isinstance(expression, dict) or "op" not in expression:
+        return
+    args = expression.get("args", ())
+    for argument in args:
+        if isinstance(argument, dict):
+            yield argument
+    for index, argument in enumerate(args):
+        for replacement in _expression_candidates(argument):
+            new_args = list(args)
+            new_args[index] = replacement
+            yield {"op": expression["op"], "args": new_args}
+
+
+def reduce_recipe(
+    recipe: Recipe,
+    predicate: Callable[[Recipe], bool],
+    *,
+    time_budget_seconds: float = 120.0,
+    hypothesis_examples: int = 80,
+) -> ReductionResult:
+    """Minimize ``recipe`` while ``predicate(candidate)`` remains true."""
+
+    started = time.monotonic()
+    current = recipe
+    attempts = 0
+    accepted = 0
+    steps: list[str] = []
+
+    def expired() -> bool:
+        return time.monotonic() - started >= time_budget_seconds
+
+    def try_candidate(candidate: Recipe, step: str) -> bool:
+        nonlocal current, attempts, accepted
+        if expired() or not _valid_candidate(candidate):
+            return False
+        attempts += 1
+        if predicate(candidate):
+            current = candidate
+            accepted += 1
+            steps.append(step)
+            return True
+        return False
+
+    # Let Hypothesis shrink the cycle prefix before the structural delta pass.
+    if current.tick_count > 1 and not expired():
+        try:
+            from hypothesis import Phase, find, settings
+            from hypothesis.errors import NoSuchExample
+            from hypothesis import strategies as st
+
+            base = current
+
+            def prefix_fails(count: int) -> bool:
+                candidate = base.replace(
+                    inputs={
+                        name: ticks[:count] for name, ticks in base.inputs.items()
+                    }
+                )
+                return _valid_candidate(candidate) and predicate(candidate)
+
+            attempts += 1
+            try:
+                count = find(
+                    st.integers(min_value=1, max_value=current.tick_count),
+                    prefix_fails,
+                    settings=settings(
+                        max_examples=hypothesis_examples,
+                        database=None,
+                        deadline=None,
+                        phases=(Phase.generate, Phase.shrink),
+                    ),
+                )
+            except NoSuchExample:
+                count = current.tick_count
+            if count < current.tick_count:
+                current = current.replace(
+                    inputs={
+                        name: ticks[:count]
+                        for name, ticks in current.inputs.items()
+                    }
+                )
+                accepted += 1
+                steps.append(f"hypothesis-prefix:{count}")
+        except ImportError:
+            pass
+
+    # Delta-debug aligned ranges of ticks.
+    granularity = 2
+    while current.tick_count > 1 and not expired():
+        tick_count = current.tick_count
+        chunk_size = max(1, tick_count // granularity)
+        changed = False
+        for start in range(0, tick_count, chunk_size):
+            stop = min(tick_count, start + chunk_size)
+            if stop - start >= tick_count:
+                continue
+            candidate = current.replace(
+                inputs={
+                    name: ticks[:start] + ticks[stop:]
+                    for name, ticks in current.inputs.items()
+                }
+            )
+            if try_candidate(candidate, f"remove-ticks:{start}:{stop}"):
+                changed = True
+                granularity = 2
+                break
+        if not changed:
+            if chunk_size == 1:
+                break
+            granularity = min(tick_count, granularity * 2)
+
+    # Remove individual input events while retaining the cycle.
+    changed = True
+    while changed and not expired():
+        changed = False
+        for name, ticks in current.inputs.items():
+            for index, value in enumerate(ticks):
+                if value is None:
+                    continue
+                replacement = list(ticks)
+                replacement[index] = None
+                candidate_inputs = dict(current.inputs)
+                candidate_inputs[name] = tuple(replacement)
+                if try_candidate(
+                    current.replace(inputs=candidate_inputs),
+                    f"clear-event:{name}:{index}",
+                ):
+                    changed = True
+                    break
+            if changed:
+                break
+
+    # Simplify scalar magnitudes and mapping widths.
+    for name in tuple(current.inputs):
+        index = 0
+        while index < len(current.inputs[name]) and not expired():
+            value = current.inputs[name][index]
+            candidates: list[object] = []
+            if isinstance(value, bool):
+                candidates = [False]
+            elif isinstance(value, int):
+                candidates = [0, 1, -1]
+            elif isinstance(value, float):
+                candidates = [0.0, 1.0, -1.0]
+            elif isinstance(value, dict) and not any(
+                str(key).startswith("$") for key in value
+            ):
+                candidates = [
+                    {key: item}
+                    for key, item in sorted(value.items())
+                    if len(value) > 1
+                ]
+            for simpler in candidates:
+                if simpler == value:
+                    continue
+                replacement = list(current.inputs[name])
+                replacement[index] = simpler
+                candidate_inputs = dict(current.inputs)
+                candidate_inputs[name] = tuple(replacement)
+                if try_candidate(
+                    current.replace(inputs=candidate_inputs),
+                    f"simplify-value:{name}:{index}",
+                ):
+                    break
+            index += 1
+
+    if current.template == "scalar_expression" and not expired():
+        changed = True
+        while changed:
+            changed = False
+            expression = current.parameters["expression"]
+            for candidate_expression in _expression_candidates(expression):
+                parameters = dict(current.parameters)
+                parameters["expression"] = candidate_expression
+                candidate = current.replace(parameters=parameters)
+                if try_candidate(candidate, "simplify-expression"):
+                    changed = True
+                    break
+
+    return ReductionResult(
+        recipe=current,
+        attempts=attempts,
+        accepted=accepted,
+        timed_out=expired(),
+        steps=tuple(steps),
+    )

--- a/tools/parity/runner.py
+++ b/tools/parity/runner.py
@@ -1,0 +1,170 @@
+"""Fresh-process executor for one parity recipe.
+
+Invoke this file with ``python -I`` so the selected environment supplies the
+only importable hgraph package.
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.metadata
+import json
+import platform
+import sys
+import traceback
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT))
+
+from tools.parity.canonical import CANONICAL_SCHEMA_VERSION, canonicalize
+from tools.parity.catalog import execute_recipe
+from tools.parity.model import Recipe
+
+
+RESULT_MARKER = "@@PARITY_RESULT@@"
+
+
+def _distribution_identity() -> dict[str, str]:
+    for distribution in ("hg_cpp", "hgraph"):
+        try:
+            version = importlib.metadata.version(distribution)
+        except importlib.metadata.PackageNotFoundError:
+            continue
+        return {"distribution": distribution, "version": version}
+    return {"distribution": "unknown", "version": "unknown"}
+
+
+def identity() -> dict:
+    result = _distribution_identity()
+    result.update(
+        python=platform.python_version(),
+        python_implementation=platform.python_implementation(),
+        platform=platform.platform(),
+        machine=platform.machine().lower(),
+    )
+    return result
+
+
+def _exception_category(error: BaseException) -> str:
+    name = type(error).__name__
+    if "Wiring" in name or "Resolution" in name:
+        return "wiring"
+    if isinstance(error, TypeError):
+        return "type"
+    if isinstance(error, ValueError):
+        return "value"
+    if isinstance(error, KeyError):
+        return "key"
+    if isinstance(error, ZeroDivisionError):
+        return "division-by-zero"
+    if isinstance(error, AssertionError):
+        return "assertion"
+    return "runtime"
+
+
+def _operator_inventory(hg) -> list[str]:
+    names: set[str] = set()
+    try:
+        import _hgraph
+
+        names.update(str(name) for name in _hgraph.operator_names())
+    except (ImportError, AttributeError):
+        pass
+    try:
+        import hgraph._operators as operators
+
+        names.update(str(name) for name in getattr(operators, "__all__", ()))
+    except ImportError:
+        pass
+    if not names:
+        names.update(
+            name
+            for name in dir(hg)
+            if not name.startswith("_") and callable(getattr(hg, name, None))
+        )
+    return sorted(names)
+
+
+def run_recipe(raw: dict) -> dict:
+    recipe = Recipe.from_dict(raw)
+    result = {
+        "schema_version": 1,
+        "canonical_schema_version": CANONICAL_SCHEMA_VERSION,
+        "recipe_id": recipe.id,
+        "recipe_fingerprint": recipe.fingerprint,
+        "implementation": identity(),
+    }
+    try:
+        import hgraph as hg
+    except BaseException as error:
+        result.update(
+            status="error",
+            phase="import",
+            exception={
+                "category": _exception_category(error),
+                "type": type(error).__name__,
+            },
+            diagnostic=traceback.format_exc(limit=20),
+        )
+        return result
+
+    try:
+        value = execute_recipe(hg, recipe)
+    except BaseException as error:
+        category = _exception_category(error)
+        result.update(
+            status="error",
+            phase="wiring" if category == "wiring" else "runtime",
+            exception={"category": category, "type": type(error).__name__},
+            diagnostic=traceback.format_exc(limit=30),
+        )
+        return result
+    result.update(status="ok", phase="complete", trace=canonicalize(value))
+    return result
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--identity", action="store_true")
+    parser.add_argument("--inventory", action="store_true")
+    args = parser.parse_args()
+    if args.identity:
+        print(RESULT_MARKER + json.dumps({"status": "ok", "identity": identity()}))
+        return 0
+    if args.inventory:
+        import hgraph as hg
+
+        print(
+            RESULT_MARKER
+            + json.dumps(
+                {
+                    "status": "ok",
+                    "identity": identity(),
+                    "operators": _operator_inventory(hg),
+                }
+            )
+        )
+        return 0
+
+    try:
+        raw = json.loads(sys.stdin.read())
+        result = run_recipe(raw)
+    except BaseException as error:
+        result = {
+            "schema_version": 1,
+            "status": "error",
+            "phase": "harness",
+            "exception": {
+                "category": _exception_category(error),
+                "type": type(error).__name__,
+            },
+            "diagnostic": traceback.format_exc(limit=30),
+        }
+    print(RESULT_MARKER + json.dumps(result, sort_keys=True, ensure_ascii=False))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/uv.lock
+++ b/uv.lock
@@ -469,6 +469,9 @@ docs = [
 kafka = [
     { name = "kafka-python" },
 ]
+parity = [
+    { name = "hypothesis" },
+]
 perspective = [
     { name = "perspective-python" },
     { name = "tornado" },
@@ -516,6 +519,7 @@ requires-dist = [
     { name = "duckdb", marker = "extra == 'sql'", specifier = ">=1.4" },
     { name = "duckdb", marker = "extra == 'test'", specifier = ">=1.4" },
     { name = "frozendict", specifier = ">=2.4" },
+    { name = "hypothesis", marker = "extra == 'parity'", specifier = ">=6" },
     { name = "kafka-python", marker = "extra == 'kafka'", specifier = ">=2.2" },
     { name = "myst-parser", marker = "extra == 'dev'", specifier = ">=2.0" },
     { name = "myst-parser", marker = "extra == 'docs'", specifier = ">=2.0" },
@@ -550,7 +554,60 @@ requires-dist = [
     { name = "trove-classifiers", marker = "extra == 'dev'" },
     { name = "trove-classifiers", marker = "extra == 'test'" },
 ]
-provides-extras = ["python", "test", "web", "sql", "snowflake", "kafka", "delta", "perspective", "dataframe", "docs", "dev"]
+provides-extras = ["python", "test", "parity", "web", "sql", "snowflake", "kafka", "delta", "perspective", "dataframe", "docs", "dev"]
+
+[[package]]
+name = "hypothesis"
+version = "6.161.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "sortedcontainers" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/17/94/d208ced653376e7e0a2f0429ee5be864dd0b59393b98a8b41a35ceb4d035/hypothesis-6.161.5.tar.gz", hash = "sha256:ba73a3c3b68e63a0bee5ea1a8a13efce60bcc7ee5fc7e71df2954db39c225b95", size = 486653, upload-time = "2026-07-25T14:39:34.866Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/34/58/e48aa878d119474631fc097d511b5e70807dfe56be4b244cce0275f1805e/hypothesis-6.161.5-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:4c89e0c35d7cd70af2a0a5f0b5ad69d1898c369adf15115c6d4271d47bf1b280", size = 766970, upload-time = "2026-07-25T14:38:42.613Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/ff/c83c1a4d5d3c4b6a4dc1fcb5069245171b7a30ad5dd31f44282e8881e089/hypothesis-6.161.5-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:1bb987e519a6d00675bab124c925000637e2e59384196b0ded5d108dc1851449", size = 762574, upload-time = "2026-07-25T14:38:15.427Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/04/7a5ba16cd14340009d1d8aa46083bf3a3a55c5b0d1ccf553e6f6748ee0e8/hypothesis-6.161.5-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5990e9e2e145ff5369c95ad684bd6eee7ebd2d4de37d37eea4c6ca5e339e2a52", size = 1091754, upload-time = "2026-07-25T14:38:38.562Z" },
+    { url = "https://files.pythonhosted.org/packages/70/69/031913f7408ebb41e31a9b20e5bca75c5a64ab151d57ca75e944a09ba6e0/hypothesis-6.161.5-cp310-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:2a5c6400c58c9c3d616ad7177ada12ae577e5103b3b0df6e79920729250bf100", size = 1120372, upload-time = "2026-07-25T14:38:18.962Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/95/360884e86ab99099340fca781531286c26d40ce32c853097e76537cc0726/hypothesis-6.161.5-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:71aa718e08bdfbacd1a5d8f86ffd55f1d86e64a57cec6a107144d883b522823e", size = 1141230, upload-time = "2026-07-25T14:39:03.757Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/5b/6f3c9fbe9191432f33c9aaf951cf5a5416533848999f2e2c6a20ec00098b/hypothesis-6.161.5-cp310-abi3-manylinux_2_31_riscv64.whl", hash = "sha256:66912038467e1af791f76336bc079d669f7c8bbf7aeb85bdd52e83259d885122", size = 1096611, upload-time = "2026-07-25T14:38:34.688Z" },
+    { url = "https://files.pythonhosted.org/packages/32/c7/d126b9f66295fed5d5745f98ad92f485c98dee303dd67ea7a53fe4a903aa/hypothesis-6.161.5-cp310-abi3-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:99d8b2380d0bba602df963d6e42d56bb50cf1734376c1b9b14dcab3cec21814e", size = 1133382, upload-time = "2026-07-25T14:38:20.27Z" },
+    { url = "https://files.pythonhosted.org/packages/56/de/277a17091687f298079c197cadd806d64908c5a08c9c91bb27b834192503/hypothesis-6.161.5-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:19e57e621c6abd98123a91bd4b022bde7760ba709f1ca121f822d9aa291bd001", size = 1265592, upload-time = "2026-07-25T14:38:11.734Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/e5/3f15b1a43cb70b223427ce3a9a6afbe430bf1754b3346ac546a3df38b96b/hypothesis-6.161.5-cp310-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:3b74cced62995ed2e0096fa63d0b7babd1fa08ce1944cff41134275516848708", size = 1393424, upload-time = "2026-07-25T14:38:46.738Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/1d/a3cf1441550dbf5a362dcfa19c831721f3bb6a749eb53ecbdfc983959027/hypothesis-6.161.5-cp310-abi3-musllinux_1_2_riscv64.whl", hash = "sha256:fd37a0257647288be8c27d56a78a31da2b65e3b6254511f03164f5e1c786187a", size = 1266197, upload-time = "2026-07-25T14:39:33.052Z" },
+    { url = "https://files.pythonhosted.org/packages/57/e5/2616432d6144057b6c8f4409c95d95610bdbdf07fecb6618e98761861c24/hypothesis-6.161.5-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:cf9dfba054164e481f05774c70b65ea88ba735b986cdc44f5210ef40871a32e9", size = 1308330, upload-time = "2026-07-25T14:39:27.86Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/cd/9e9c7a88858f84447e44e45c8b9fd1058120b4d5fa9bab9c3ceb9b9cf96b/hypothesis-6.161.5-cp310-abi3-win32.whl", hash = "sha256:8763938787e6c98e461f8c11139981597d083e6915a9956db1c26cc609bc7b19", size = 652819, upload-time = "2026-07-25T14:38:35.915Z" },
+    { url = "https://files.pythonhosted.org/packages/03/23/aae37b5bb2014e0e01e372498f7f5977b9fd61a0179143854b7fb0538b1c/hypothesis-6.161.5-cp310-abi3-win_amd64.whl", hash = "sha256:79b5d069095a726dca5b6b7e4c5d268acc809a6595c46d7eee860708f960cb8f", size = 658970, upload-time = "2026-07-25T14:39:05.239Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/37/71a53545f2732574bdd7a45a6e073043bce3447fec4aa722211ebf742f2e/hypothesis-6.161.5-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:37016b6b4842993b06ee453dda4dedac5ef328cefa6daa36372d261abf12db43", size = 768565, upload-time = "2026-07-25T14:38:14.362Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/56/7f32ba1443d5819b324444e7d5ebcf207ba4a0f9219a1693a7994293fd3f/hypothesis-6.161.5-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:d60a204b86936b29d8914f93a99c59a2ecd4e311be793bf32a3f94774d41e016", size = 760188, upload-time = "2026-07-25T14:38:07.894Z" },
+    { url = "https://files.pythonhosted.org/packages/07/0d/699436929d2980103c9ddba153872ebed55cfcc13f0f78c1741ac6128205/hypothesis-6.161.5-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cee9f1a563830a9137b9d1505c9c4fac760bc43dfbfa5873bebefe36c8dca4ec", size = 1090570, upload-time = "2026-07-25T14:39:00.492Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/a5/2c28b58d16443fd8ad63e4f287440291a42135073748e5e511084f32a6f3/hypothesis-6.161.5-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d7fcf44f9876b7b4fdc40b607342219c634cf6a1acc708dc0ff88e8e48ae8ea2", size = 1140601, upload-time = "2026-07-25T14:39:21.403Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/fe/f0f87c38dc741687bace80553478f8c9796ba5b6e68793a80990d79ec5ac/hypothesis-6.161.5-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:59088f6458d2a6ef04724a2a639418c97dd8b8c280bfd222fcc5566854560caf", size = 1263341, upload-time = "2026-07-25T14:38:41.257Z" },
+    { url = "https://files.pythonhosted.org/packages/44/db/02e30bcdb3434f4eee8fdbebf5cf151fecd37d2a76f2fc19f2745c93ca38/hypothesis-6.161.5-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:ea8e7e6bed5407ab902026d8cac74d10cac894a496d82e261a0beaca499114dc", size = 1307604, upload-time = "2026-07-25T14:39:19.867Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/70/1f6349a244f13c5a383a62ca674d3175018c7fc30fbaad10faa859d5c2cf/hypothesis-6.161.5-cp312-cp312-win_amd64.whl", hash = "sha256:a4ad11f4eafd561a672cb9fa977d0f58ab4ae9cf4b160dd3c12c351089f3e2be", size = 656103, upload-time = "2026-07-25T14:38:57.639Z" },
+    { url = "https://files.pythonhosted.org/packages/52/07/86f98ebd945f3f8a821c1e7bf9b530902675145d93ed44fa56a309cc24fd/hypothesis-6.161.5-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:3b4c308ff19741ab9f795cac61cce61227f55a1b9767ad525a34de8b01391d1d", size = 768455, upload-time = "2026-07-25T14:38:27.821Z" },
+    { url = "https://files.pythonhosted.org/packages/70/11/93c00ba5c77b886017ea8eaa42de8ca937e319032c4251b0540fc1838ae1/hypothesis-6.161.5-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:ef16fac46cd5675504a4d3824f443f6842b80fae8b6d15ecffa9c90e0fcf4522", size = 760099, upload-time = "2026-07-25T14:38:04.918Z" },
+    { url = "https://files.pythonhosted.org/packages/86/13/c8787cfae81c816976c1b3aaa43294c3abd6fd055a0147122edd7357a349/hypothesis-6.161.5-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:dc4c6aab8dbabb98b9c5ca8da8fa9294d2e5173432a12abcb447e83e666fa430", size = 1090486, upload-time = "2026-07-25T14:39:26.243Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/be/48f4f56bfb24787aa27e5ae851d1aee5214ab6e95311cf8c88a56707941f/hypothesis-6.161.5-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6f485e3c7ead1f76a8c060b16c6b50e5615264819e95b794c6fc6882a9cbfdc4", size = 1140433, upload-time = "2026-07-25T14:38:59.043Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/50/c119bfec24d267e4af5bdefda8fd490f7b3a7ee36a52d5ac0b88e07c10b3/hypothesis-6.161.5-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:75bb899b2db5c45dbfa6ef704c26259bfd27fb3418179c3bd5788b7f2ecce72d", size = 1263296, upload-time = "2026-07-25T14:38:06.719Z" },
+    { url = "https://files.pythonhosted.org/packages/81/89/eeb97a9684e3eaae801dd538058202b0b65c2aaecea0211e17d79f731170/hypothesis-6.161.5-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:894e5d9e2cd97798c3dc2731699098c7f800a7905572db1677e0d27d3b41f541", size = 1307324, upload-time = "2026-07-25T14:38:24.881Z" },
+    { url = "https://files.pythonhosted.org/packages/15/9d/e0c64a64721ba169dff5a6f12236d5102f8c76f661598d7837591ec7b375/hypothesis-6.161.5-cp313-cp313-win_amd64.whl", hash = "sha256:62452bb19d73496a74919d82afc6306bf9bd42b8cf1dfce21da3802c596a59b1", size = 656067, upload-time = "2026-07-25T14:38:37.157Z" },
+    { url = "https://files.pythonhosted.org/packages/31/27/0c6884785ab6afb41305296b2a5fac2c5d1d26dba40e85c70909b8692fce/hypothesis-6.161.5-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:35b41648b547a233dd89bed37a3ce8c8298a454fd7133b27b0a37ced135eddfe", size = 768668, upload-time = "2026-07-25T14:39:15.033Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/12/17c63bba85201d5fa9db89841e8548c4fa6b240b2437c80d606a65889eb6/hypothesis-6.161.5-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:429d2179b01787a54f8ccd150c02077a6feb973f14ef31664227148c6a1fadff", size = 760240, upload-time = "2026-07-25T14:38:43.93Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/df/1084fd695a1516120a5ea26c026d9f0a071fdf9efcba774c94c09332b372/hypothesis-6.161.5-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b23fc5441ef297d56797dd372889dec38ddf3662468772b347db2fd8fd43eced", size = 1090987, upload-time = "2026-07-25T14:39:06.646Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/a3/bef99daeaf6d1d2db09790cd4ec9ce0cdcac52faaf1fd80b4eaba5d5ea5e/hypothesis-6.161.5-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5f42dcc7fee0d4d56d011218b8c4d5afa6cdee5dbc690652d2a1a598d21969a3", size = 1140613, upload-time = "2026-07-25T14:38:26.284Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/09/ce1f6e29d897c7dcb7de1665a9e30d1e00500933caec697a4338db9e7bd0/hypothesis-6.161.5-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:2825fac0d0428cb5e7826347aa4e60106d28f32948cd58c837097f3bd96dbf6c", size = 1263802, upload-time = "2026-07-25T14:38:33.277Z" },
+    { url = "https://files.pythonhosted.org/packages/81/e5/7b33aae590bc457fffba70c4f19cc150e3ca356f8e15322f9224c5372a64/hypothesis-6.161.5-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:e9f859ecfd3e00ebb8a36fbb36a8951513fd8e09103a56c645b102e0a51dd1bc", size = 1307642, upload-time = "2026-07-25T14:39:29.729Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/8b/4156a9e70bf8c69f54954539ca805e7311048516b665c5f87bee2c1955b7/hypothesis-6.161.5-cp314-cp314-pyemscripten_2026_0_wasm32.whl", hash = "sha256:b2647c2d5da341467c1ffaad0dd86d8612e27da2419e76b3b6ee79a33bba7d86", size = 600146, upload-time = "2026-07-25T14:38:17.815Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/db/48a518f3f2facd7b280592f81dbb0ba09109656be4ad3dbf0d95a02b4c02/hypothesis-6.161.5-cp314-cp314-win_amd64.whl", hash = "sha256:7c40dd1a3e99497d48a3cfd4c5d71bdb0cd70402a9e09eceb160f045edc92b3a", size = 655981, upload-time = "2026-07-25T14:39:16.52Z" },
+    { url = "https://files.pythonhosted.org/packages/25/92/1e9f9f44ef75fc052cc0e3700cfc7d52fd4af1ed9e8b2945d19956bb83cb/hypothesis-6.161.5-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:6c1b7e1d508a3cc5c10ea7a7a4a7d3b0b56fe6291e8936bb9d052af530380b15", size = 767251, upload-time = "2026-07-25T14:38:52.608Z" },
+    { url = "https://files.pythonhosted.org/packages/48/31/0c3f824bbb1fccc0338930c8ef855880065d9d58dddf9547a1b9ae4e664d/hypothesis-6.161.5-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:b0926ba51452c24b92fbcbb30d28cc43fd6cd9e636ea2134fbc1cc2c9da109de", size = 758710, upload-time = "2026-07-25T14:38:09.156Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/6b/5811dbb4c1dc0a772519fb9af9c4089128bceeb5deb4c36a887e1e731920/hypothesis-6.161.5-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ba8d0346308b558bfbb49f965ed1d9d5bb65758f4530cb30ce1f9bd911a130b4", size = 1089583, upload-time = "2026-07-25T14:38:49.83Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/29/f9cbfd9d0aaea5370a7ceb966f6c8d47e9101ee9a6623606e9f564a59c6e/hypothesis-6.161.5-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2c64079ef4633ab7b540f532107188d75999ee5b342116636312e09ada15783e", size = 1139525, upload-time = "2026-07-25T14:38:29.262Z" },
+    { url = "https://files.pythonhosted.org/packages/99/27/f56a03be4ee21f25828e8fba8a502d6840826aea4ff784ff54cbd1f51175/hypothesis-6.161.5-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:ed3eede1c23689edb4773b4c2303ee91518e82056a0a4893fc8415b18e5c3e8b", size = 1261963, upload-time = "2026-07-25T14:38:31.931Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/ea/72e11fe6832a68674271655be5cb6f035502dd328ea629b3ee510fb130a5/hypothesis-6.161.5-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:82b1088ebcad5ab6d146caf9a1552019472a8a9302727f1be5939e30460a101b", size = 1306382, upload-time = "2026-07-25T14:38:13.011Z" },
+    { url = "https://files.pythonhosted.org/packages/df/8b/bb039d11a805db0977904c245fa3dcf6d266808482d9dfc6dad3e5f1b256/hypothesis-6.161.5-cp314-cp314t-win_amd64.whl", hash = "sha256:bbe8705ff394a573624cd53f2192dad6255c86346704adf9873cb3acb9b940e5", size = 656131, upload-time = "2026-07-25T14:38:16.712Z" },
+]
 
 [[package]]
 name = "idna"
@@ -1159,6 +1216,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/75/a7/9810d872919697c9d01295633f5d574fb416d47e535f258272ca1f01f447/snowballstemmer-3.0.1.tar.gz", hash = "sha256:6d5eeeec8e9f84d4d56b847692bacf79bc2c8e90c7f80ca4444ff8b6f2e52895", size = 105575, upload-time = "2025-05-09T16:34:51.843Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c8/78/3565d011c61f5a43488987ee32b6f3f656e7f107ac2782dd57bdd7d91d9a/snowballstemmer-3.0.1-py3-none-any.whl", hash = "sha256:6cd7b3897da8d6c9ffb968a6781fa6532dce9c3618a4b127d920dab764a19064", size = 103274, upload-time = "2025-05-09T16:34:50.371Z" },
+]
+
+[[package]]
+name = "sortedcontainers"
+version = "2.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e8/c4/ba2f8066cceb6f23394729afe52f3bf7adec04bf9ed2c820b39e19299111/sortedcontainers-2.4.0.tar.gz", hash = "sha256:25caa5a06cc30b6b83d11423433f65d1f9d76c4c6a0c90e3379eaa43b9bfdb88", size = 30594, upload-time = "2021-05-16T22:03:42.897Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/32/46/9cb0e58b2deb7f82b84065f37f3bffeb12413f947f9388e4cac22c4621ce/sortedcontainers-2.4.0-py2.py3-none-any.whl", hash = "sha256:a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0", size = 29575, upload-time = "2021-05-16T22:03:41.177Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- add a deterministic differential-testing harness that runs versioned, multi-tick recipes against released Python `hgraph` and the current `hg_cpp` wheel in isolated processes
- canonicalize and compare semantic traces, replay candidate/reference failures, shrink reproducible mismatches, quarantine unstable cases, and produce coverage/frontier reports
- seed an eight-case regression corpus covering scalar expressions, feedback, switch rebinding, TSD lifecycle behavior, stream dataclasses, and recent issues
- add a read-only PR smoke campaign plus a sharded nightly campaign with a separate, least-privilege issue publisher
- cache reference traces and candidate wheels using content fingerprints, while sharing the artifact fingerprint implementation with benchmark orchestration
- document local/CI workflows and add the optional Hypothesis-based `parity` dependency

## Why

Project-level downstream tests exercise only a small part of hgraph's API surface and tend to expose mismatches late. This provides a continuously evolving, reproducible compatibility campaign that can explore longer tick sequences and composed operators, then turn failures into compact actionable cases.

The first generated campaign found and reduced a genuine TSD map/reduce mismatch. It is tracked in #44 and retained in the corpus as a known divergence so subsequent campaigns continue without filing duplicates.

## Impact

PR checks run a bounded, deterministic and read-only parity sample. Nightly runs build the candidate once, shard the campaign, retain reports as artifacts, and grant issue-write permission only to the final publishing job. Generated build and trace artifacts remain ignored locally.

## Validation

- native C++ suite: 1,267/1,267 passed
- fresh stable-ABI wheel on Python 3.14: 1,628 passed, 11 skipped
- focused parity and benchmark tests: 41 passed
- final local parity campaign: 32 selected, 31 matched, 1 known divergence, 0 new verified failures, 0 quarantined
- 8 corpus recipes validated
- Sphinx documentation build with warnings as errors passed
- workflow YAML parsing, skill validation, `uv lock --check`, and `git diff --check` passed