### PR TITLE
Expand differential parity coverage across framework surfaces

### DIFF
--- a/.github/workflows/parity-nightly.yml
+++ b/.github/workflows/parity-nightly.yml
@@ -49,10 +49,12 @@ jobs:
     name: Campaign shard ${{ matrix.shard }}
     needs: build-candidate
     runs-on: ubuntu-24.04
+    timeout-minutes: 90
     strategy:
       fail-fast: false
+      max-parallel: 8
       matrix:
-        shard: [0, 1, 2, 3]
+        shard: [0, 1, 2, 3, 4, 5, 6, 7]
     permissions:
       contents: read
     steps:
@@ -83,7 +85,7 @@ jobs:
           --profile nightly
           --seed ${{ github.run_number }}
           --shard-index ${{ matrix.shard }}
-          --shard-count 4
+          --shard-count 8
           --candidate-wheel dist/*.whl
           --exit-zero
           --output-dir parity-results

--- a/docs/source/developer_guide/parity_testing.rst
+++ b/docs/source/developer_guide/parity_testing.rst
@@ -80,6 +80,8 @@ parameters, and records semantic coverage tags:
 ``null`` means no tick.  Tagged objects represent identity-sensitive deltas,
 for example ``{"$remove": true}`` for a TSD removal and
 ``{"$set_delta": {"added": [...], "removed": [...]}}`` for a TSS delta.
+``{"$map": [[key, value], ...]}`` represents a mapping whose keys cannot be
+expressed as JSON object strings, including integer-keyed TSD input.
 Input names, tick counts, scalar types, expression operations, and template
 parameters are validated before either runtime imports hgraph.
 
@@ -92,9 +94,26 @@ Generation and Coverage
 -----------------------
 
 Hypothesis recursively composes validated scalar expressions and produces
-stateful multi-cycle sequences for feedback, switching, and keyed TSD
-lifecycle.  Generated exploration uses 8--32 ticks by default; a reducer may
-shrink a failure below that range.
+stateful multi-cycle sequences for feedback, switching, keyed TSD lifecycle,
+reference, subscription, and request/reply services, automatic and
+multi-client adaptors, context capture across switching branches, grouped
+operator pipelines, and mesh lifecycle driven by a TSD key set.  TSD key-set
+recipes include value-only updates,
+same-cycle replacement, removal, repopulation, and empty transitions.
+
+Twelve of the thirteen generated families pass their inputs through a fixed
+structural ``TSL`` projection before use.  This intentionally combines a
+non-peered container with a ``REF``-producing child projection, so ordinary
+operators and framework boundaries must consume REF-transparent sources.
+The remaining scalar-expression family retains direct inputs to preserve an
+independent baseline.
+
+The pull-request profile generates 48 cases of 8--32 ticks in addition to the
+curated corpus.  The nightly profile generates 5,000 cases of 8--64 ticks and
+may shrink a failure below that range.  Nightly-only parameter variants retain
+known high-value stress points, such as direct formatting of a selected REF,
+unchanged TSD key-set cardinality, and service-adaptor transport timing,
+without turning the merge smoke profile into a permanent failure.
 
 Coverage is semantic rather than only line-based.  Reports count templates,
 time-series shapes, scalar types, operator families, topology, lifecycle
@@ -178,8 +197,12 @@ generated matrix against its already-built Linux wheel under Python 3.14.
 This pull-request job has read-only permissions, makes no model calls, and
 never creates issues.
 
-The nightly workflow builds one candidate wheel, runs four bounded shards, and
-uploads complete reports.  Campaign jobs have read-only permissions.  A
+The nightly workflow builds one candidate wheel, runs eight bounded shards
+over a deterministic 5,000-example matrix, and uploads complete reports.  Each
+shard has a one-hour campaign budget and a 90-minute job ceiling; the example
+limit remains the normal stopping condition, while the time budget prevents a
+slow or pathological family from monopolizing a runner.  Campaign jobs have
+read-only permissions.  A
 separate default-branch publisher receives only the validated report artifacts
 and has ``issues: write`` permission.  It creates or reopens deduplicated
 ``bug``/``parity`` issues and then exits; individual crashes and mismatches do

--- a/python/tests/test_parity_harness.py
+++ b/python/tests/test_parity_harness.py
@@ -12,12 +12,14 @@ from tools.artifact_fingerprint import hg_cpp_source_fingerprint
 from tools.parity.campaign import run_campaign
 from tools.parity.canonical import canonicalize
 from tools.parity.catalog import validate_recipe
+from tools.parity.cli import CAMPAIGN_PROFILES
 from tools.parity.compare import compare_outcomes
 from tools.parity.coverage import coverage_report, recipe_features
 from tools.parity.environments import ParityEnvironments
 from tools.parity.issues import failure_fingerprint, issue_body, publish_failures
 from tools.parity.model import Recipe, RecipeError, load_corpus
 from tools.parity.reduce import reduce_recipe
+from tools.parity.runner import _fallback_operator_names
 
 
 CORPUS = Path(__file__).parents[2] / "tools" / "parity" / "corpus"
@@ -44,7 +46,7 @@ def _scalar_recipe(ticks=None):
 
 def test_committed_parity_corpus_is_valid_and_unique():
     recipes = load_corpus(CORPUS)
-    assert len(recipes) >= 7
+    assert len(recipes) >= 19
     for recipe in recipes:
         validate_recipe(recipe)
     assert len({recipe.fingerprint for recipe in recipes}) == len(recipes)
@@ -98,11 +100,15 @@ def test_canonicalization_preserves_tick_sensitive_value_semantics():
         def removed(self):
             return {3}
 
+    Sentinel = type("Sentinel", (), {})
+    remove = Sentinel()
+    remove.name = "REMOVE"
     value = {
         "mapping": {"b": -0.0, "a": float("nan")},
         "tuple": (1, 2),
         "delta": FakeSetDelta(),
         "removed": Removed("old"),
+        "remove": remove,
     }
     assert canonicalize(value) == {
         "$map": [
@@ -116,6 +122,7 @@ def test_canonicalization_preserves_tick_sensitive_value_semantics():
                     ]
                 },
             ],
+            ["remove", {"$remove": True}],
             ["removed", {"$set_removed": "old"}],
             ["tuple", {"$tuple": [1, 2]}],
         ]
@@ -156,6 +163,57 @@ def test_generated_recipes_are_deterministic_typed_and_multi_tick():
     assert all(recipe.tick_count >= 8 for recipe in first)
     for recipe in first:
         validate_recipe(recipe)
+
+
+def test_generated_framework_recipes_prioritize_ref_and_non_peered_paths():
+    pytest.importorskip("hypothesis")
+    from tools.parity.generate import generate_recipes
+
+    recipes = generate_recipes(240, seed=29)
+    templates = {recipe.template for recipe in recipes}
+    assert {
+        "service_reference",
+        "service_request_reply",
+        "service_subscription",
+        "adaptor_loopback",
+        "service_adaptor_roundtrip",
+        "context_switch",
+        "operator_pipeline",
+        "tsd_key_set_pipeline",
+        "mesh_key_set",
+    } <= templates
+    assert sum(
+        "reference:REF" in recipe.features
+        and "binding:non-peered" in recipe.features
+        for recipe in recipes
+    ) >= len(recipes) * 0.8
+    assert any(
+        recipe.template == "operator_pipeline"
+        and recipe.parameters["format_ref"]
+        for recipe in recipes
+    )
+    assert any(
+        recipe.template == "tsd_key_set_pipeline"
+        and not recipe.parameters["dedup_size"]
+        for recipe in recipes
+    )
+
+
+def test_campaign_profiles_scale_nightly_breadth_and_tick_depth():
+    assert CAMPAIGN_PROFILES["pr"]["examples"] == 48
+    assert CAMPAIGN_PROFILES["nightly"]["examples"] == 5000
+    assert CAMPAIGN_PROFILES["nightly"]["max_ticks"] == 64
+    assert CAMPAIGN_PROFILES["nightly"]["time_budget"] == 3600.0
+
+
+def test_operator_inventory_fallback_excludes_callable_types_and_helpers():
+    operator_type = type("OperatorWiringNodeClass", (), {})
+    namespace = SimpleNamespace(
+        add_=operator_type(),
+        TS=type("TS", (), {}),
+        helper=lambda: None,
+    )
+    assert _fallback_operator_names(namespace) == {"add_"}
 
 
 def test_reducer_shrinks_ticks_values_and_expression_while_preserving_failure():

--- a/tools/parity/canonical.py
+++ b/tools/parity/canonical.py
@@ -60,6 +60,13 @@ def canonicalize(value: Any) -> Any:
         }
 
     type_name = type(value).__name__
+    if type_name == "Sentinel" and getattr(value, "name", None) == "REMOVE":
+        return {"$remove": True}
+    if (
+        type_name == "Sentinel"
+        and getattr(value, "name", None) == "REMOVE_IF_EXISTS"
+    ):
+        return {"$remove_if_exists": True}
     if type_name in {"_Removed", "Removed"} and repr(value) == "REMOVE":
         return {"$remove": True}
     if type_name in {"_RemovedIfExists", "RemovedIfExists"} and repr(value) == "REMOVE_IF_EXISTS":

--- a/tools/parity/catalog.py
+++ b/tools/parity/catalog.py
@@ -63,6 +63,26 @@ def _decode_value(hg, value):
                 for key, item in value["$frozendict"].items()
             }
         )
+    if set(value) == {"$map"}:
+        entries = value["$map"]
+        if (
+            not isinstance(entries, list)
+            or not all(
+                isinstance(entry, list) and len(entry) == 2
+                for entry in entries
+            )
+        ):
+            raise RecipeError("$map requires a list of [key, value] pairs")
+        result = {}
+        for key, item in entries:
+            decoded_key = _decode_value(hg, key)
+            try:
+                if decoded_key in result:
+                    raise RecipeError("$map keys must be unique")
+                result[decoded_key] = _decode_value(hg, item)
+            except TypeError as error:
+                raise RecipeError("$map keys must be hashable") from error
+        return result
     return {key: _decode_value(hg, item) for key, item in value.items()}
 
 
@@ -71,6 +91,11 @@ def decoded_inputs(hg, recipe):
         name: [_decode_value(hg, value) for value in ticks]
         for name, ticks in recipe.inputs.items()
     }
+
+
+def _via_non_peered_ref(hg, value):
+    """Project a structural TSL child, producing a REF-transparent source."""
+    return hg.getitem_(hg.TSL.from_ts(value, value), 0)
 
 
 def _expression_type(expression, input_types):
@@ -187,6 +212,7 @@ def _feedback_accumulate(hg, recipe):
 
     @hg.graph
     def parity_graph(value: hg.TS[int]) -> hg.TS[int]:
+        value = _via_non_peered_ref(hg, value)
         state = hg.feedback(hg.TS[int], initial)
         total = value + hg.passive(state())
         state(total)
@@ -203,6 +229,9 @@ def _switch_arithmetic(hg, recipe):
     def parity_graph(
         selector: hg.TS[str], lhs: hg.TS[int], rhs: hg.TS[int]
     ) -> hg.TS[int]:
+        selector = _via_non_peered_ref(hg, selector)
+        lhs = _via_non_peered_ref(hg, lhs)
+        rhs = _via_non_peered_ref(hg, rhs)
         return hg.switch_(
             selector,
             {
@@ -230,8 +259,311 @@ def _tsd_map_reduce(hg, recipe):
 
     @hg.graph
     def parity_graph(values: hg.TSD[str, hg.TS[int]]) -> hg.TS[int]:
+        values = _via_non_peered_ref(hg, values)
         mapped = hg.map_(lambda value: value + increment, values)
         return hg.reduce(lambda lhs, rhs: lhs + rhs, mapped, zero)
+
+    inputs = decoded_inputs(hg, recipe)
+    return eval_node(parity_graph, inputs["values"])
+
+
+def _service_reference(hg, recipe):
+    from hgraph.test import eval_node
+
+    base = recipe.parameters.get("base", 40)
+    path = recipe.parameters.get("path", "desk")
+
+    @hg.reference_service
+    def configured_value(path: str) -> hg.TS[int]: ...
+
+    @hg.service_impl(interfaces=configured_value)
+    def configured_value_impl(path: str) -> hg.TS[int]:
+        return hg.const(base + len(path), tp=hg.TS[int])
+
+    @hg.graph
+    def parity_graph(value: hg.TS[int]) -> hg.TS[int]:
+        hg.register_service(path, configured_value_impl)
+        value = _via_non_peered_ref(hg, value)
+        return value + hg.passive(configured_value(path=path))
+
+    inputs = decoded_inputs(hg, recipe)
+    return eval_node(parity_graph, inputs["value"])
+
+
+def _service_request_reply(hg, recipe):
+    from hgraph.test import eval_node
+
+    increment = recipe.parameters.get("increment", 3)
+    path = recipe.parameters.get("path", "requests")
+
+    @hg.request_reply_service
+    def adjust(path: str, request: hg.TS[int]) -> hg.TS[int]: ...
+
+    @hg.service_impl(interfaces=adjust)
+    def adjust_impl(
+        request: hg.TSD[int, hg.TS[int]]
+    ) -> hg.TSD[int, hg.TS[int]]:
+        return hg.map_(lambda value: value + increment, request)
+
+    @hg.graph
+    def parity_graph(value: hg.TS[int]) -> hg.TS[int]:
+        hg.register_service(path, adjust_impl)
+        value = _via_non_peered_ref(hg, value)
+        return adjust(path, value)
+
+    inputs = decoded_inputs(hg, recipe)
+    return eval_node(
+        parity_graph,
+        inputs["value"],
+        __end_time__=hg.MIN_ST + (recipe.tick_count + 4) * hg.MIN_TD,
+    )
+
+
+def _service_subscription(hg, recipe):
+    from hgraph.test import eval_node
+
+    multiplier = recipe.parameters.get("multiplier", 10)
+    path = recipe.parameters.get("path", "quotes")
+
+    @hg.subscription_service
+    def quote(path: str, symbol: hg.TS[str]) -> hg.TS[int]: ...
+
+    @hg.graph
+    def quote_value(symbol: hg.TS[str]) -> hg.TS[int]:
+        return hg.len_(symbol) * multiplier
+
+    @hg.service_impl(interfaces=quote)
+    def quote_values(
+        symbol: hg.TSS[str],
+    ) -> hg.TSD[str, hg.TS[int]]:
+        return hg.map_(
+            quote_value,
+            __keys__=symbol,
+            __key_arg__="symbol",
+        )
+
+    @hg.graph
+    def parity_graph(symbol: hg.TS[str]) -> hg.TS[int]:
+        hg.register_service(path, quote_values)
+        symbol = _via_non_peered_ref(hg, symbol)
+        return quote(path, symbol)
+
+    inputs = decoded_inputs(hg, recipe)
+    return eval_node(
+        parity_graph,
+        inputs["symbol"],
+        __end_time__=hg.MIN_ST + (recipe.tick_count + 3) * hg.MIN_TD,
+    )
+
+
+def _adaptor_loopback(hg, recipe):
+    from hgraph.test import eval_node
+
+    factor = recipe.parameters.get("factor", 2)
+    path = recipe.parameters.get("path", "loopback")
+
+    @hg.adaptor
+    def loopback(path: str, value: hg.TS[int]) -> hg.TS[int]: ...
+
+    @hg.adaptor_impl(interfaces=loopback)
+    def loopback_impl(path: str, value: hg.TS[int]) -> hg.TS[int]:
+        return value * factor
+
+    @hg.graph
+    def parity_graph(value: hg.TS[int]) -> hg.TS[int]:
+        hg.register_adaptor(path, loopback_impl)
+        value = _via_non_peered_ref(hg, value)
+        return loopback(path, value)
+
+    inputs = decoded_inputs(hg, recipe)
+    return eval_node(parity_graph, inputs["value"])
+
+
+def _service_adaptor_roundtrip(hg, recipe):
+    from hgraph.test import eval_node
+
+    increment = recipe.parameters.get("increment", 1)
+
+    @hg.service_adaptor
+    def echo(request: hg.TS[int]) -> hg.TS[int]: ...
+
+    @hg.service_adaptor_impl(interfaces=echo)
+    def echo_impl(
+        path: str, request: hg.TSD[int, hg.TS[int]]
+    ) -> hg.TSD[int, hg.TS[int]]:
+        return hg.map_(lambda value: value + increment, request)
+
+    @hg.graph
+    def parity_graph(value: hg.TS[int]) -> hg.TS[int]:
+        hg.register_adaptor(None, echo_impl)
+        value = _via_non_peered_ref(hg, value)
+        return echo(value)
+
+    inputs = decoded_inputs(hg, recipe)
+    return eval_node(
+        parity_graph,
+        inputs["value"],
+        __end_time__=hg.MIN_ST + (recipe.tick_count + 2) * hg.MIN_TD,
+    )
+
+
+def _context_switch(hg, recipe):
+    from hgraph.test import eval_node
+
+    @hg.graph
+    def add_offset(value: hg.TS[int]) -> hg.TS[int]:
+        return value + hg.get_context("offset", hg.TS[int])
+
+    @hg.graph
+    def subtract_offset(value: hg.TS[int]) -> hg.TS[int]:
+        return value - hg.get_context("offset", hg.TS[int])
+
+    @hg.graph
+    def parity_graph(
+        selector: hg.TS[str],
+        value: hg.TS[int],
+        offset: hg.TS[int],
+    ) -> hg.TS[int]:
+        selector = _via_non_peered_ref(hg, selector)
+        value = _via_non_peered_ref(hg, value)
+        offset = _via_non_peered_ref(hg, offset)
+        with offset:
+            return hg.switch_(
+                selector,
+                {"add": add_offset, "subtract": subtract_offset},
+                value,
+            )
+
+    inputs = decoded_inputs(hg, recipe)
+    return eval_node(
+        parity_graph,
+        inputs["selector"],
+        inputs["value"],
+        inputs["offset"],
+    )
+
+
+def _operator_pipeline(hg, recipe):
+    from hgraph.test import eval_node
+
+    format_ref = recipe.parameters.get("format_ref", False)
+
+    class OperatorResult(hg.TimeSeriesSchema):
+        quotient: hg.TS[int]
+        remainder: hg.TS[int]
+        minimum: hg.TS[int]
+        maximum: hg.TS[int]
+        selected: hg.TS[int]
+        formatted: hg.TS[str]
+        length: hg.TS[int]
+        both: hg.TS[bool]
+        either: hg.TS[bool]
+        inverse: hg.TS[bool]
+        valid: hg.TS[bool]
+        modified: hg.TS[bool]
+
+    @hg.graph
+    def parity_graph(
+        lhs: hg.TS[int],
+        rhs: hg.TS[int],
+        choose_minimum: hg.TS[bool],
+    ) -> hg.TSB[OperatorResult]:
+        lhs = _via_non_peered_ref(hg, lhs)
+        rhs = _via_non_peered_ref(hg, rhs)
+        choose_minimum = _via_non_peered_ref(hg, choose_minimum)
+        quotient = lhs // rhs
+        remainder = lhs % rhs
+        minimum = hg.min_(lhs, rhs)
+        maximum = hg.max_(lhs, rhs)
+        selected = hg.if_then_else(choose_minimum, minimum, maximum)
+        formatted_value = selected if format_ref else selected + 0
+        formatted = hg.format_("{}:{}", formatted_value, remainder)
+        comparison = lhs > rhs
+        return hg.combine[hg.TSB[OperatorResult]](
+            quotient=quotient,
+            remainder=remainder,
+            minimum=minimum,
+            maximum=maximum,
+            selected=selected,
+            formatted=formatted,
+            length=hg.len_(formatted),
+            both=hg.and_(choose_minimum, comparison),
+            either=hg.or_(choose_minimum, comparison),
+            inverse=hg.not_(choose_minimum),
+            valid=hg.valid(selected),
+            modified=hg.modified(selected),
+        )
+
+    inputs = decoded_inputs(hg, recipe)
+    return eval_node(
+        parity_graph,
+        inputs["lhs"],
+        inputs["rhs"],
+        inputs["choose_minimum"],
+    )
+
+
+def _tsd_key_set_pipeline(hg, recipe):
+    from hgraph.test import eval_node
+
+    dedup_size = recipe.parameters.get("dedup_size", True)
+
+    class SetOperatorResult(hg.TimeSeriesSchema):
+        size: hg.TS[int]
+        empty: hg.TS[bool]
+        contains: hg.TS[bool]
+        minimum: hg.TS[int]
+        maximum: hg.TS[int]
+        total: hg.TS[int]
+        average: hg.TS[float]
+        deviation: hg.TS[float]
+        variance: hg.TS[float]
+
+    @hg.graph
+    def parity_graph(
+        values: hg.TSD[int, hg.TS[int]], probe: hg.TS[int]
+    ) -> hg.TSB[SetOperatorResult]:
+        values = _via_non_peered_ref(hg, values)
+        probe = _via_non_peered_ref(hg, probe)
+        keys = hg.keys_(values)
+        size = hg.len_(keys)
+        if dedup_size:
+            size = hg.dedup(size)
+        return hg.combine[hg.TSB[SetOperatorResult]](
+            size=size,
+            empty=hg.is_empty(keys),
+            contains=hg.contains_(keys, probe),
+            minimum=hg.min_(keys, default_value=0),
+            maximum=hg.max_(keys, default_value=0),
+            total=hg.sum_(keys),
+            average=hg.mean(keys),
+            deviation=hg.std(keys),
+            variance=hg.var(keys),
+        )
+
+    inputs = decoded_inputs(hg, recipe)
+    return eval_node(parity_graph, inputs["values"], inputs["probe"])
+
+
+def _mesh_key_set(hg, recipe):
+    from hgraph.test import eval_node
+
+    factor = recipe.parameters.get("factor", 2)
+
+    @hg.graph
+    def keyed_value(key: hg.TS[int]) -> hg.TS[int]:
+        return key * factor
+
+    @hg.graph
+    def parity_graph(
+        values: hg.TSD[int, hg.TS[int]],
+    ) -> hg.TSD[int, hg.TS[int]]:
+        values = _via_non_peered_ref(hg, values)
+        return hg.mesh_(
+            keyed_value,
+            __keys__=hg.keys_(values),
+            __key_arg__="key",
+        )
 
     inputs = decoded_inputs(hg, recipe)
     return eval_node(parity_graph, inputs["values"])
@@ -405,23 +737,230 @@ CATALOG = {
     "feedback_accumulate": TemplateSpec(
         name="feedback_accumulate",
         required_inputs=("value",),
-        features=("shape:TS", "topology:feedback", "lifecycle:multi-cycle"),
-        operators=("add_", "feedback", "passive"),
+        features=(
+            "shape:TS",
+            "shape:TSL",
+            "topology:feedback",
+            "lifecycle:multi-cycle",
+            "reference:REF",
+            "binding:non-peered",
+        ),
+        operators=("add_", "feedback", "getitem_", "passive"),
         execute=_feedback_accumulate,
     ),
     "switch_arithmetic": TemplateSpec(
         name="switch_arithmetic",
         required_inputs=("selector", "lhs", "rhs"),
-        features=("shape:TS", "topology:switch", "lifecycle:branch-rebind"),
-        operators=("add_", "sub_", "switch_"),
+        features=(
+            "shape:TS",
+            "shape:TSL",
+            "topology:switch",
+            "lifecycle:branch-rebind",
+            "reference:REF",
+            "binding:non-peered",
+        ),
+        operators=("add_", "getitem_", "sub_", "switch_"),
         execute=_switch_arithmetic,
     ),
     "tsd_map_reduce": TemplateSpec(
         name="tsd_map_reduce",
         required_inputs=("values",),
-        features=("shape:TSD", "topology:map", "lifecycle:keyed"),
-        operators=("add_", "map_", "reduce"),
+        features=(
+            "shape:TSD",
+            "shape:TSL",
+            "topology:map",
+            "lifecycle:keyed",
+            "reference:REF",
+            "binding:non-peered",
+        ),
+        operators=("add_", "getitem_", "map_", "reduce"),
         execute=_tsd_map_reduce,
+    ),
+    "service_reference": TemplateSpec(
+        name="service_reference",
+        required_inputs=("value",),
+        features=(
+            "shape:TS",
+            "framework:service",
+            "service:reference",
+            "configuration:path",
+            "shape:TSL",
+            "reference:REF",
+            "binding:non-peered",
+        ),
+        operators=("add_", "const", "getitem_", "passive"),
+        execute=_service_reference,
+    ),
+    "service_request_reply": TemplateSpec(
+        name="service_request_reply",
+        required_inputs=("value",),
+        features=(
+            "shape:TS",
+            "shape:TSD",
+            "framework:service",
+            "service:request-reply",
+            "lifecycle:transport-delay",
+            "configuration:path",
+            "shape:TSL",
+            "reference:REF",
+            "binding:non-peered",
+        ),
+        operators=("add_", "getitem_", "map_"),
+        execute=_service_request_reply,
+    ),
+    "service_subscription": TemplateSpec(
+        name="service_subscription",
+        required_inputs=("symbol",),
+        features=(
+            "shape:TS",
+            "shape:TSS",
+            "shape:TSD",
+            "framework:service",
+            "service:subscription",
+            "lifecycle:keyed",
+            "lifecycle:transport-delay",
+            "shape:TSL",
+            "reference:REF",
+            "binding:non-peered",
+        ),
+        operators=("getitem_", "len_", "map_", "mul_"),
+        execute=_service_subscription,
+    ),
+    "adaptor_loopback": TemplateSpec(
+        name="adaptor_loopback",
+        required_inputs=("value",),
+        features=(
+            "shape:TS",
+            "framework:adaptor",
+            "adaptor:automatic",
+            "adaptor:explicit-path",
+            "configuration:path",
+            "shape:TSL",
+            "reference:REF",
+            "binding:non-peered",
+        ),
+        operators=("getitem_", "mul_"),
+        execute=_adaptor_loopback,
+    ),
+    "service_adaptor_roundtrip": TemplateSpec(
+        name="service_adaptor_roundtrip",
+        required_inputs=("value",),
+        features=(
+            "shape:TS",
+            "shape:TSD",
+            "framework:adaptor",
+            "adaptor:service",
+            "adaptor:multi-client",
+            "implementation:path-injection",
+            "lifecycle:transport-delay",
+            "shape:TSL",
+            "reference:REF",
+            "binding:non-peered",
+        ),
+        operators=("add_", "getitem_", "map_"),
+        execute=_service_adaptor_roundtrip,
+    ),
+    "context_switch": TemplateSpec(
+        name="context_switch",
+        required_inputs=("selector", "value", "offset"),
+        features=(
+            "shape:TS",
+            "framework:context",
+            "topology:context",
+            "topology:switch",
+            "lifecycle:branch-rebind",
+            "shape:TSL",
+            "reference:REF",
+            "binding:non-peered",
+        ),
+        operators=("add_", "getitem_", "sub_", "switch_"),
+        execute=_context_switch,
+    ),
+    "operator_pipeline": TemplateSpec(
+        name="operator_pipeline",
+        required_inputs=("lhs", "rhs", "choose_minimum"),
+        features=(
+            "shape:TS",
+            "shape:TSB",
+            "topology:operator-composition",
+            "type:int",
+            "type:bool",
+            "type:str",
+            "shape:TSL",
+            "reference:REF",
+            "binding:non-peered",
+        ),
+        operators=(
+            "add_",
+            "and_",
+            "combine",
+            "floordiv_",
+            "format_",
+            "getitem_",
+            "gt_",
+            "if_then_else",
+            "len_",
+            "max_",
+            "min_",
+            "mod_",
+            "modified",
+            "not_",
+            "or_",
+            "valid",
+        ),
+        execute=_operator_pipeline,
+    ),
+    "tsd_key_set_pipeline": TemplateSpec(
+        name="tsd_key_set_pipeline",
+        required_inputs=("values", "probe"),
+        features=(
+            "shape:TSS",
+            "shape:TSD",
+            "shape:TSB",
+            "shape:TSL",
+            "topology:operator-composition",
+            "topology:key-set-projection",
+            "lifecycle:keyed",
+            "type:int",
+            "type:bool",
+            "type:float",
+            "reference:REF",
+            "binding:non-peered",
+        ),
+        operators=(
+            "combine",
+            "contains_",
+            "dedup",
+            "getitem_",
+            "is_empty",
+            "keys_",
+            "len_",
+            "max_",
+            "mean",
+            "min_",
+            "std",
+            "sum_",
+            "var",
+        ),
+        execute=_tsd_key_set_pipeline,
+        float_abs_tolerance=1e-12,
+    ),
+    "mesh_key_set": TemplateSpec(
+        name="mesh_key_set",
+        required_inputs=("values",),
+        features=(
+            "shape:TSD",
+            "shape:TSS",
+            "shape:TSL",
+            "topology:mesh",
+            "topology:key-set-projection",
+            "lifecycle:keyed",
+            "lifecycle:nested-graph",
+            "reference:REF",
+            "binding:non-peered",
+        ),
+        operators=("getitem_", "keys_", "mesh_", "mul_"),
+        execute=_mesh_key_set,
     ),
     "issue_38_nested_tsd_feedback": TemplateSpec(
         name="issue_38_nested_tsd_feedback",
@@ -434,6 +973,8 @@ CATALOG = {
             "topology:switch",
             "lifecycle:key-removal",
             "lifecycle:branch-rebind",
+            "reference:REF",
+            "binding:non-peered",
         ),
         operators=(
             "combine",
@@ -458,6 +999,8 @@ CATALOG = {
             "topology:map",
             "lifecycle:reference-rebind",
             "lifecycle:keyed",
+            "reference:REF",
+            "binding:non-peered",
         ),
         operators=(
             "combine",
@@ -482,6 +1025,32 @@ CATALOG = {
 }
 
 
+def _validate_bounded_int_parameter(recipe, name, default, *, minimum, maximum):
+    value = recipe.parameters.get(name, default)
+    if (
+        not isinstance(value, int)
+        or isinstance(value, bool)
+        or not minimum <= value <= maximum
+    ):
+        raise RecipeError(
+            f"{recipe.template} {name} must be an integer in "
+            f"[{minimum}, {maximum}]"
+        )
+
+
+def _validate_path_parameter(recipe, default):
+    path = recipe.parameters.get("path", default)
+    if (
+        not isinstance(path, str)
+        or not 1 <= len(path) <= 32
+        or any(character not in "abcdefghijklmnopqrstuvwxyz0123456789-_" for character in path)
+    ):
+        raise RecipeError(
+            f"{recipe.template} path must be 1-32 lowercase letters, "
+            "digits, hyphens, or underscores"
+        )
+
+
 def validate_recipe(recipe):
     spec = CATALOG.get(recipe.template)
     if spec is None:
@@ -504,6 +1073,46 @@ def validate_recipe(recipe):
             value = recipe.parameters.get(name, default)
             if not isinstance(value, int) or isinstance(value, bool):
                 raise RecipeError(f"tsd_map_reduce {name} must be an integer")
+    elif recipe.template == "service_reference":
+        _validate_bounded_int_parameter(
+            recipe, "base", 40, minimum=-100, maximum=100
+        )
+        _validate_path_parameter(recipe, "desk")
+    elif recipe.template == "service_request_reply":
+        _validate_bounded_int_parameter(
+            recipe, "increment", 3, minimum=-20, maximum=20
+        )
+        _validate_path_parameter(recipe, "requests")
+    elif recipe.template == "service_subscription":
+        _validate_bounded_int_parameter(
+            recipe, "multiplier", 10, minimum=-20, maximum=20
+        )
+        _validate_path_parameter(recipe, "quotes")
+    elif recipe.template == "adaptor_loopback":
+        _validate_bounded_int_parameter(
+            recipe, "factor", 2, minimum=-20, maximum=20
+        )
+        _validate_path_parameter(recipe, "loopback")
+    elif recipe.template == "service_adaptor_roundtrip":
+        _validate_bounded_int_parameter(
+            recipe, "increment", 1, minimum=-20, maximum=20
+        )
+    elif recipe.template == "operator_pipeline":
+        if not isinstance(
+            recipe.parameters.get("format_ref", False), bool
+        ):
+            raise RecipeError("operator_pipeline format_ref must be a boolean")
+    elif recipe.template == "tsd_key_set_pipeline":
+        if not isinstance(
+            recipe.parameters.get("dedup_size", True), bool
+        ):
+            raise RecipeError(
+                "tsd_key_set_pipeline dedup_size must be a boolean"
+            )
+    elif recipe.template == "mesh_key_set":
+        _validate_bounded_int_parameter(
+            recipe, "factor", 2, minimum=-20, maximum=20
+        )
     return spec
 
 

--- a/tools/parity/cli.py
+++ b/tools/parity/cli.py
@@ -22,6 +22,29 @@ from .reduce import reduce_recipe
 
 CORPUS = Path(__file__).with_name("corpus")
 
+CAMPAIGN_PROFILES = {
+    "pr": {
+        "examples": 48,
+        "time_budget": 900.0,
+        "reduce": False,
+        "min_ticks": 8,
+        "max_ticks": 32,
+        "templates": (
+            "scalar_expression",
+            "feedback_accumulate",
+            "switch_arithmetic",
+        ),
+    },
+    "nightly": {
+        "examples": 5000,
+        "time_budget": 3600.0,
+        "reduce": True,
+        "min_ticks": 8,
+        "max_ticks": 64,
+        "templates": None,
+    },
+}
+
 
 def _path(value: str | None) -> Path | None:
     return Path(value).resolve() if value else None
@@ -167,18 +190,7 @@ def command_coverage(args) -> int:
 
 
 def command_campaign(args) -> int:
-    profile_defaults = {
-        "pr": {
-            "examples": 24,
-            "time_budget": 600.0,
-            "reduce": False,
-        },
-        "nightly": {
-            "examples": 100,
-            "time_budget": 2700.0,
-            "reduce": True,
-        },
-    }[args.profile]
+    profile_defaults = CAMPAIGN_PROFILES[args.profile]
     examples = (
         args.max_examples
         if args.max_examples is not None
@@ -194,23 +206,25 @@ def command_campaign(args) -> int:
         if args.reduce is not None
         else profile_defaults["reduce"]
     )
+    min_ticks = (
+        args.min_ticks
+        if args.min_ticks is not None
+        else profile_defaults["min_ticks"]
+    )
+    max_ticks = (
+        args.max_ticks
+        if args.max_ticks is not None
+        else profile_defaults["max_ticks"]
+    )
     recipes = _load_selected_recipes(args.paths)
     if examples:
         recipes.extend(
             generate_recipes(
                 examples,
                 seed=args.seed,
-                min_ticks=args.min_ticks,
-                max_ticks=args.max_ticks,
-                templates=(
-                    (
-                        "scalar_expression",
-                        "feedback_accumulate",
-                        "switch_arithmetic",
-                    )
-                    if args.profile == "pr"
-                    else None
-                ),
+                min_ticks=min_ticks,
+                max_ticks=max_ticks,
+                templates=profile_defaults["templates"],
             )
         )
     unique = {recipe.fingerprint: recipe for recipe in recipes}
@@ -324,8 +338,8 @@ def build_parser() -> argparse.ArgumentParser:
     campaign.add_argument("--profile", choices=("pr", "nightly"), default="pr")
     campaign.add_argument("--seed", type=int, default=20260726)
     campaign.add_argument("--max-examples", type=int)
-    campaign.add_argument("--min-ticks", type=int, default=8)
-    campaign.add_argument("--max-ticks", type=int, default=32)
+    campaign.add_argument("--min-ticks", type=int)
+    campaign.add_argument("--max-ticks", type=int)
     campaign.add_argument("--timeout", type=float, default=30.0)
     campaign.add_argument("--time-budget", type=float)
     campaign.add_argument("--reduction-budget", type=float, default=120.0)

--- a/tools/parity/corpus/adaptor-loopback-multi-tick.json
+++ b/tools/parity/corpus/adaptor-loopback-multi-tick.json
@@ -1,0 +1,22 @@
+{
+  "schema_version": 1,
+  "id": "adaptor-loopback-multi-tick",
+  "description": "A configured automatic adaptor transfers sparse REF-transparent input through a registered path.",
+  "template": "adaptor_loopback",
+  "inputs": {
+    "value": [2, 4, null, -3, 0, null, 7, 1, -5, null]
+  },
+  "parameters": {
+    "factor": 3,
+    "path": "loopback"
+  },
+  "features": [
+    "framework:adaptor",
+    "adaptor:automatic",
+    "adaptor:explicit-path",
+    "configuration:path",
+    "reference:REF",
+    "binding:non-peered",
+    "lifecycle:multi-cycle"
+  ]
+}

--- a/tools/parity/corpus/context-switch-rebinding.json
+++ b/tools/parity/corpus/context-switch-rebinding.json
@@ -1,0 +1,21 @@
+{
+  "schema_version": 1,
+  "id": "context-switch-rebinding",
+  "description": "A context-bound time series is imported into switching branches while inputs update independently.",
+  "template": "context_switch",
+  "inputs": {
+    "selector": ["add", null, null, "subtract", null, "add", null, "subtract", null, "add"],
+    "value": [1, 2, null, null, 3, null, -1, 7, null, 4],
+    "offset": [10, null, 20, null, null, -5, null, 2, 4, null]
+  },
+  "parameters": {},
+  "features": [
+    "framework:context",
+    "topology:context",
+    "topology:switch",
+    "lifecycle:branch-rebind",
+    "reference:REF",
+    "binding:non-peered",
+    "lifecycle:multi-cycle"
+  ]
+}

--- a/tools/parity/corpus/mesh-key-set-lifecycle.json
+++ b/tools/parity/corpus/mesh-key-set-lifecycle.json
@@ -1,0 +1,34 @@
+{
+  "schema_version": 1,
+  "id": "mesh-key-set-lifecycle",
+  "description": "A REF-transparent TSD key-set projection creates and removes keyed mesh graphs across value-only and membership updates.",
+  "template": "mesh_key_set",
+  "inputs": {
+    "values": [
+      {"$map": [[1, 10], [2, 20]]},
+      null,
+      {"$map": [[1, 11]]},
+      {"$map": [[3, 30], [1, {"$remove": true}]]},
+      null,
+      {"$map": [[2, {"$remove": true}]]},
+      {"$map": [[-1, -10], [4, 40]]},
+      {"$map": [[3, 33]]},
+      {"$map": [[3, {"$remove": true}], [-1, {"$remove": true}]]},
+      {"$map": [[4, {"$remove": true}]]}
+    ]
+  },
+  "parameters": {
+    "factor": 3
+  },
+  "features": [
+    "shape:TSD",
+    "shape:TSS",
+    "topology:mesh",
+    "topology:key-set-projection",
+    "lifecycle:key-removal",
+    "lifecycle:value-only-update",
+    "lifecycle:nested-graph",
+    "reference:REF",
+    "binding:non-peered"
+  ]
+}

--- a/tools/parity/corpus/operator-pipeline-multi-tick.json
+++ b/tools/parity/corpus/operator-pipeline-multi-tick.json
@@ -1,0 +1,24 @@
+{
+  "schema_version": 1,
+  "id": "operator-pipeline-multi-tick",
+  "description": "Composes integer, comparison, conditional, logical, string, validity, and modification operators.",
+  "template": "operator_pipeline",
+  "inputs": {
+    "lhs": [17, -8, null, 0, 25, null, -31, 9, null, 4, -2, 13],
+    "rhs": [5, null, -3, 2, null, 7, -4, null, 3, -2, null, 6],
+    "choose_minimum": [true, null, false, null, true, false, null, true, false, null, true, false]
+  },
+  "parameters": {
+    "format_ref": false
+  },
+  "features": [
+    "topology:operator-composition",
+    "operator:arithmetic",
+    "operator:conditional",
+    "operator:logical",
+    "operator:string",
+    "reference:REF",
+    "binding:non-peered",
+    "lifecycle:multi-cycle"
+  ]
+}

--- a/tools/parity/corpus/service-reference-multi-tick.json
+++ b/tools/parity/corpus/service-reference-multi-tick.json
@@ -1,0 +1,21 @@
+{
+  "schema_version": 1,
+  "id": "service-reference-multi-tick",
+  "description": "Reference-service registration, path configuration, passive consumption, and sparse multi-tick input.",
+  "template": "service_reference",
+  "inputs": {
+    "value": [1, 2, null, -3, 0, null, 5, 8, null, 1]
+  },
+  "parameters": {
+    "base": 7,
+    "path": "desk"
+  },
+  "features": [
+    "framework:service",
+    "service:reference",
+    "configuration:path",
+    "reference:REF",
+    "binding:non-peered",
+    "lifecycle:multi-cycle"
+  ]
+}

--- a/tools/parity/corpus/service-request-reply-multi-tick.json
+++ b/tools/parity/corpus/service-request-reply-multi-tick.json
@@ -1,0 +1,21 @@
+{
+  "schema_version": 1,
+  "id": "service-request-reply-multi-tick",
+  "description": "Request/reply service transport across delayed request and response boundaries.",
+  "template": "service_request_reply",
+  "inputs": {
+    "value": [5, 7, null, -2, 0, null, 11, 3, null, 4]
+  },
+  "parameters": {
+    "increment": 3,
+    "path": "requests"
+  },
+  "features": [
+    "framework:service",
+    "service:request-reply",
+    "lifecycle:transport-delay",
+    "reference:REF",
+    "binding:non-peered",
+    "lifecycle:multi-cycle"
+  ]
+}

--- a/tools/parity/corpus/service-subscription-rebinding.json
+++ b/tools/parity/corpus/service-subscription-rebinding.json
@@ -1,0 +1,21 @@
+{
+  "schema_version": 1,
+  "id": "service-subscription-rebinding",
+  "description": "Subscription keys rebind across sparse ticks while a compute-node implementation supplies keyed responses.",
+  "template": "service_subscription",
+  "inputs": {
+    "symbol": ["fx", null, "rates", "a", null, "EURUSD", null, "fx", "long_symbol", null, "a", "rates"]
+  },
+  "parameters": {
+    "multiplier": 4,
+    "path": "quotes"
+  },
+  "features": [
+    "framework:service",
+    "service:subscription",
+    "lifecycle:keyed",
+    "lifecycle:reference-rebind",
+    "reference:REF",
+    "binding:non-peered"
+  ]
+}

--- a/tools/parity/corpus/tsd-key-set-pipeline.json
+++ b/tools/parity/corpus/tsd-key-set-pipeline.json
@@ -1,0 +1,36 @@
+{
+  "schema_version": 1,
+  "id": "tsd-key-set-pipeline",
+  "description": "A REF-transparent TSD key-set projection drives membership, extrema, and aggregate operators across keyed lifecycle events.",
+  "template": "tsd_key_set_pipeline",
+  "inputs": {
+    "values": [
+      {"$map": []},
+      {"$map": [[1, 10], [3, 30]]},
+      null,
+      {"$map": [[1, 11]]},
+      {"$map": [[-2, -20], [1, {"$remove": true}]]},
+      {"$map": [[4, 40]]},
+      null,
+      {"$map": [[3, {"$remove": true}], [-2, {"$remove": true}]]},
+      {"$map": [[0, 0], [2, 20], [4, {"$remove": true}]]},
+      null,
+      {"$map": [[0, {"$remove": true}], [2, {"$remove": true}]]}
+    ],
+    "probe": [1, null, 3, null, -2, 4, 0, null, 2, -1, 0]
+  },
+  "parameters": {
+    "dedup_size": true
+  },
+  "features": [
+    "shape:TSD",
+    "shape:TSS",
+    "topology:operator-composition",
+    "topology:key-set-projection",
+    "lifecycle:key-removal",
+    "lifecycle:value-only-update",
+    "reference:REF",
+    "binding:non-peered",
+    "lifecycle:multi-cycle"
+  ]
+}

--- a/tools/parity/generate.py
+++ b/tools/parity/generate.py
@@ -194,11 +194,212 @@ def recipe_payload_strategy(*, min_ticks: int = 8, max_ticks: int = 32):
             ],
         }
 
+    def sparse_ticks(draw, count, values):
+        return [draw(values)] + [
+            draw(st.one_of(st.none(), values)) for _ in range(count - 1)
+        ]
+
+    @st.composite
+    def service_reference(draw):
+        count = draw(st.integers(min_value=min_ticks, max_value=max_ticks))
+        return {
+            "template": "service_reference",
+            "inputs": {
+                "value": sparse_ticks(
+                    draw, count, st.integers(min_value=-20, max_value=20)
+                )
+            },
+            "parameters": {
+                "base": draw(st.integers(min_value=-20, max_value=20)),
+                "path": draw(st.sampled_from(("desk", "rates", "reference"))),
+            },
+            "features": [*CATALOG["service_reference"].features],
+        }
+
+    @st.composite
+    def service_request_reply(draw):
+        count = draw(st.integers(min_value=min_ticks, max_value=max_ticks))
+        return {
+            "template": "service_request_reply",
+            "inputs": {
+                "value": sparse_ticks(
+                    draw, count, st.integers(min_value=-20, max_value=20)
+                )
+            },
+            "parameters": {
+                "increment": draw(st.integers(min_value=-5, max_value=5)),
+                "path": draw(st.sampled_from(("requests", "adjust", "reply"))),
+            },
+            "features": [*CATALOG["service_request_reply"].features],
+        }
+
+    @st.composite
+    def service_subscription(draw):
+        count = draw(st.integers(min_value=min_ticks, max_value=max_ticks))
+        symbols = st.sampled_from(("a", "fx", "rates", "EURUSD", "long_symbol"))
+        return {
+            "template": "service_subscription",
+            "inputs": {"symbol": sparse_ticks(draw, count, symbols)},
+            "parameters": {
+                "multiplier": draw(st.integers(min_value=-3, max_value=10)),
+                "path": draw(st.sampled_from(("quotes", "prices", "live"))),
+            },
+            "features": [*CATALOG["service_subscription"].features],
+        }
+
+    @st.composite
+    def adaptor_loopback(draw):
+        count = draw(st.integers(min_value=min_ticks, max_value=max_ticks))
+        return {
+            "template": "adaptor_loopback",
+            "inputs": {
+                "value": sparse_ticks(
+                    draw, count, st.integers(min_value=-20, max_value=20)
+                )
+            },
+            "parameters": {
+                "factor": draw(st.integers(min_value=-5, max_value=5)),
+                "path": draw(st.sampled_from(("loopback", "io", "duplex"))),
+            },
+            "features": [*CATALOG["adaptor_loopback"].features],
+        }
+
+    @st.composite
+    def service_adaptor_roundtrip(draw):
+        count = draw(st.integers(min_value=min_ticks, max_value=max_ticks))
+        return {
+            "template": "service_adaptor_roundtrip",
+            "inputs": {
+                "value": sparse_ticks(
+                    draw, count, st.integers(min_value=-20, max_value=20)
+                )
+            },
+            "parameters": {
+                "increment": draw(st.integers(min_value=-5, max_value=5)),
+            },
+            "features": [*CATALOG["service_adaptor_roundtrip"].features],
+        }
+
+    @st.composite
+    def context_switch(draw):
+        count = draw(st.integers(min_value=min_ticks, max_value=max_ticks))
+        selector = sparse_ticks(
+            draw, count, st.sampled_from(("add", "subtract"))
+        )
+        value = sparse_ticks(
+            draw, count, st.integers(min_value=-20, max_value=20)
+        )
+        offset = sparse_ticks(
+            draw, count, st.integers(min_value=-20, max_value=20)
+        )
+        return {
+            "template": "context_switch",
+            "inputs": {
+                "selector": selector,
+                "value": value,
+                "offset": offset,
+            },
+            "features": [*CATALOG["context_switch"].features],
+        }
+
+    @st.composite
+    def operator_pipeline(draw):
+        count = draw(st.integers(min_value=min_ticks, max_value=max_ticks))
+        nonzero = st.one_of(
+            st.integers(min_value=-9, max_value=-1),
+            st.integers(min_value=1, max_value=9),
+        )
+        return {
+            "template": "operator_pipeline",
+            "inputs": {
+                "lhs": sparse_ticks(
+                    draw, count, st.integers(min_value=-50, max_value=50)
+                ),
+                "rhs": sparse_ticks(draw, count, nonzero),
+                "choose_minimum": sparse_ticks(draw, count, st.booleans()),
+            },
+            "parameters": {"format_ref": draw(st.booleans())},
+            "features": [*CATALOG["operator_pipeline"].features],
+        }
+
+    @st.composite
+    def tsd_key_set_pipeline(draw):
+        count = draw(st.integers(min_value=min_ticks, max_value=max_ticks))
+        universe = tuple(range(-4, 5))
+        initial = set(draw(st.sets(st.sampled_from(universe), max_size=4)))
+        active = set(initial)
+        ticks: list[Any] = [
+            {
+                "$map": [
+                    [key, draw(st.integers(min_value=-20, max_value=20))]
+                    for key in sorted(initial)
+                ]
+            }
+        ]
+        for _ in range(count - 1):
+            action = draw(
+                st.sampled_from(("none", "update", "add", "remove", "replace"))
+            )
+            if action == "none":
+                ticks.append(None)
+                continue
+            available = [item for item in universe if item not in active]
+            removable = sorted(active)
+            entries: list[list[Any]] = []
+            if action == "update" and removable:
+                key = draw(st.sampled_from(removable))
+                entries.append(
+                    [key, draw(st.integers(min_value=-20, max_value=20))]
+                )
+            if action in {"add", "replace"} and available:
+                key = draw(st.sampled_from(available))
+                active.add(key)
+                entries.append(
+                    [key, draw(st.integers(min_value=-20, max_value=20))]
+                )
+            if action in {"remove", "replace"} and removable:
+                key = draw(st.sampled_from(removable))
+                active.remove(key)
+                entries.append([key, {"$remove": True}])
+            ticks.append({"$map": entries})
+        return {
+            "template": "tsd_key_set_pipeline",
+            "inputs": {
+                "values": ticks,
+                "probe": sparse_ticks(
+                    draw, count, st.integers(min_value=-4, max_value=4)
+                ),
+            },
+            "parameters": {"dedup_size": draw(st.booleans())},
+            "features": [*CATALOG["tsd_key_set_pipeline"].features],
+        }
+
+    @st.composite
+    def mesh_key_set(draw):
+        source = draw(tsd_key_set_pipeline())
+        return {
+            "template": "mesh_key_set",
+            "inputs": {"values": source["inputs"]["values"]},
+            "parameters": {
+                "factor": draw(st.integers(min_value=-5, max_value=5))
+            },
+            "features": [*CATALOG["mesh_key_set"].features],
+        }
+
     return st.one_of(
         scalar_expression(),
         feedback_accumulate(),
         switch_arithmetic(),
         tsd_map_reduce(),
+        service_reference(),
+        service_request_reply(),
+        service_subscription(),
+        adaptor_loopback(),
+        service_adaptor_roundtrip(),
+        context_switch(),
+        operator_pipeline(),
+        tsd_key_set_pipeline(),
+        mesh_key_set(),
     )
 
 

--- a/tools/parity/runner.py
+++ b/tools/parity/runner.py
@@ -64,6 +64,22 @@ def _exception_category(error: BaseException) -> str:
     return "runtime"
 
 
+def _is_public_operator(value) -> bool:
+    return any(
+        cls.__name__ == "OperatorWiringNodeClass"
+        for cls in type(value).__mro__
+    )
+
+
+def _fallback_operator_names(hg) -> set[str]:
+    return {
+        name
+        for name in dir(hg)
+        if not name.startswith("_")
+        and _is_public_operator(getattr(hg, name, None))
+    }
+
+
 def _operator_inventory(hg) -> list[str]:
     names: set[str] = set()
     try:
@@ -79,11 +95,7 @@ def _operator_inventory(hg) -> list[str]:
     except ImportError:
         pass
     if not names:
-        names.update(
-            name
-            for name in dir(hg)
-            if not name.startswith("_") and callable(getattr(hg, name, None))
-        )
+        names.update(_fallback_operator_names(hg))
     return sorted(names)
 
 


### PR DESCRIPTION
## What changed

- add bounded multi-tick parity templates and corpus cases for reference, request/reply, and subscription services; automatic adaptors; context rebinding; operator pipelines; TSD-derived key sets; and mesh lifecycle
- route 12 of 13 generated families through a non-peered structural TSL projection that yields REF-transparent child inputs
- cover TSD value updates, same-cycle replacement, removals, empty/repopulate transitions, and non-string keys
- expand the PR campaign to 48 generated cases over 8–32 ticks and the nightly campaign to 5,000 cases over 8–64 ticks across eight shards
- correct public operator inventory discovery and normalize released-hgraph REMOVE sentinels

## Why

The existing campaign was no longer finding new behavior because it concentrated on scalar and basic keyed graphs. Framework boundaries, REF/non-peered values, and TSD-derived key sets have historically exposed more subtle lifecycle and notification differences.

## Impact

The curated PR profile remains a bounded merge smoke test. The larger nightly profile explores the new high-risk surfaces and continues after mismatches so verified cases can be reduced, deduplicated, and published as parity issues.

A local discovery sample found 17 stable mismatches. Deterministic reduction completed without timeouts or quarantines and collapsed them to three unique published issues:

- #64 — service-adaptor transport timing
- #65 — TSD-derived key-set notification shape
- #66 — subscription lifecycle timing

## Validation

- `cmake --preset cpp --fresh`
- `cmake --build --preset cpp --target clean`
- `cmake --build --preset cpp --parallel`
- `ctest --preset cpp --parallel 2` — 1,268 passed
- stable-ABI Python 3.12 wheel installed into a fresh Python 3.14 environment
- `python -m pytest python/tests -q -m "not wip"` — 1,646 passed, 10 skipped
- focused parity controller suite — 20 passed
- PR differential campaign — 67 attempted, 65 matched, 2 known mismatches, 0 new mismatches, 0 quarantined
- reduction campaign — 17/17 verified, 0 quarantined, 3 unique minimized fingerprints