### PR TITLE
Expand parity coverage; record ruled deviations and harden noise controls

### DIFF
--- a/docs/source/developer_guide/parity_testing.rst
+++ b/docs/source/developer_guide/parity_testing.rst
@@ -162,13 +162,18 @@ Two mechanisms keep an accepted deviation from re-filing as noise.  Exact
 suppress the deviation's whole parameter space — a template plus a
 ``parameters_not_equal`` map matching every recipe whose named parameters
 differ from the stated identity (an omitted parameter runs at the template
-default — the identity — and is outside the family).  Family suppression
+default — the identity — and is outside the family; an **empty** map matches
+every recipe of the template, used when a designed deviation shifts every
+trace, e.g. the ``service_adaptor`` transport cycle).  Family suppression
 covers only the deviation's own shape: both implementations completed and
 disagreed on a trace value.  A candidate crash or status difference inside
 the same parameter space still verifies and publishes normally.  A mismatch
 matching a family is classified as a known failure on first detection,
 before any verification replays or reduction budget is spent, because each
-new minimized variant would otherwise mint a fresh fingerprint.  For the same reason the generator does not explore
+new minimized variant would otherwise mint a fresh fingerprint.  The
+publisher re-checks the same records (``tools/parity/known.py``) before
+creating or reopening an issue, so a stale or concurrently produced report
+can never re-file a documented deviation.  For the same reason the generator does not explore
 documented-unspecified space at all (e.g. ``tsd_map_reduce`` recipes are
 generated with the identity zero only); the corpus keeps explicit deviation
 recipes as permanently known mismatches.  The publisher additionally files at

--- a/docs/source/developer_guide/parity_testing.rst
+++ b/docs/source/developer_guide/parity_testing.rst
@@ -111,9 +111,10 @@ independent baseline.
 The pull-request profile generates 48 cases of 8--32 ticks in addition to the
 curated corpus.  The nightly profile generates 5,000 cases of 8--64 ticks and
 may shrink a failure below that range.  Nightly-only parameter variants retain
-known high-value stress points, such as direct formatting of a selected REF,
-unchanged TSD key-set cardinality, and service-adaptor transport timing,
-without turning the merge smoke profile into a permanent failure.
+known high-value stress points, such as direct formatting of a selected REF
+and service-adaptor transport timing, without turning the merge smoke profile
+into a permanent failure.  Ruled parameter spaces which carry no differential
+signal, such as undeduplicated key-set cardinality, remain corpus-only.
 
 Coverage is semantic rather than only line-based.  Reports count templates,
 time-series shapes, scalar types, operator families, topology, lifecycle
@@ -163,23 +164,36 @@ suppress the deviation's whole parameter space — a template plus a
 ``parameters_not_equal`` map matching every recipe whose named parameters
 differ from the stated identity (an omitted parameter runs at the template
 default — the identity — and is outside the family; an **empty** map matches
-every recipe of the template, used when a designed deviation shifts every
-trace, e.g. the ``service_adaptor`` transport cycle).  Family suppression
-covers only the deviation's own shape: both implementations completed and
-disagreed on trace content — a differing value or a differing tick/field
-count, since ruled no-tick and timing deviations surface as missing ticks or
-missing map fields.  A candidate crash or status difference inside the same
-parameter space still verifies and publishes normally.  A mismatch
-matching a family is classified as a known failure on first detection,
-before any verification replays or reduction budget is spent, because each
-new minimized variant would otherwise mint a fresh fingerprint.  The
-publisher re-checks the same records (``tools/parity/known.py``) before
-creating or reopening an issue, so a stale or concurrently produced report
-can never re-file a documented deviation.  For the same reason the generator does not explore
-documented-unspecified space at all (e.g. ``tsd_map_reduce`` recipes are
-generated with the identity zero only); the corpus keeps explicit deviation
-recipes as permanently known mismatches.  The publisher additionally files at
-most one issue per fingerprint per run.
+every recipe of the template).  Parameter membership is necessary but not
+sufficient.  Each family also names a bounded ``relation`` which proves that
+the complete reference and candidate traces differ in exactly the documented
+way:
+
+* ``trace-value`` accepts only a trace value difference, used by the
+  non-identity reduce-zero deviation;
+* ``service-adaptor-one-cycle`` requires the candidate trace to equal one
+  leading no-tick cycle followed by the complete reference trace;
+* ``key-set-size-no-retick`` removes only ``size`` fields and then requires
+  every remaining field to compare within the template's float tolerance; and
+* ``subscription-resample-one-cycle`` requires repeated non-null subscription
+  keys and proves that inserting the reference's re-delivery cycles makes the
+  complete payload traces equal.
+
+An unknown relation, payload corruption, unrelated missing field, candidate
+crash, or status difference does not match and therefore continues through
+normal verification and publishing.  A mismatch satisfying both the parameter
+and trace relation is classified as a known failure on first detection, before
+any verification replays or reduction budget is spent, because each new
+minimized variant would otherwise mint a fresh fingerprint.  The publisher
+re-checks the same records (``tools/parity/known.py``) before creating or
+reopening an issue, so a stale or concurrently produced report cannot re-file
+a documented deviation.
+
+For the same reason the generator does not explore ruled parameter spaces which
+carry no independent signal (for example non-identity reduce zeros or
+undeduplicated key-set size); the corpus keeps explicit deviation recipes as
+permanently known mismatches.  The publisher additionally files at most one
+issue per fingerprint per run.
 
 A fix for Python-visible behavior must promote the minimized case to ordinary
 public Python wiring coverage and add equivalent native C++ ``eval_node``

--- a/docs/source/developer_guide/parity_testing.rst
+++ b/docs/source/developer_guide/parity_testing.rst
@@ -166,8 +166,10 @@ default — the identity — and is outside the family; an **empty** map matches
 every recipe of the template, used when a designed deviation shifts every
 trace, e.g. the ``service_adaptor`` transport cycle).  Family suppression
 covers only the deviation's own shape: both implementations completed and
-disagreed on a trace value.  A candidate crash or status difference inside
-the same parameter space still verifies and publishes normally.  A mismatch
+disagreed on trace content — a differing value or a differing tick/field
+count, since ruled no-tick and timing deviations surface as missing ticks or
+missing map fields.  A candidate crash or status difference inside the same
+parameter space still verifies and publishes normally.  A mismatch
 matching a family is classified as a known failure on first detection,
 before any verification replays or reduction budget is spent, because each
 new minimized variant would otherwise mint a fresh fingerprint.  The

--- a/docs/source/developer_guide/roadmap.rst
+++ b/docs/source/developer_guide/roadmap.rst
@@ -610,6 +610,15 @@ The following are intentional unless separately re-opened:
   TSS/TSD delta that nets to no change does not tick. Explicit writes are
   unaffected and match upstream exactly: a python node returning the same
   scalar each evaluation ticks each time, as do repeated TSD entry writes.
+- **Service-boundary timing** (design record: the scheduling matrix in
+  :doc:`services`): request stubs forward next cycle by design, so a
+  ``service_adaptor`` round trip observably lands one cycle after released
+  hgraph's same-cycle adaptor wiring; conversely a late or duplicate
+  subscription samples the existing shared output in the same cycle, one
+  cycle earlier than released hgraph's re-delivery. Both are pinned by
+  ``tests/cpp/test_service_wiring.cpp`` (the service-adaptor collection cases
+  and "late duplicate subscription samples the existing value"). First
+  subscriptions and request/reply match the Python timing model exactly.
 - Python ``REF`` is an opaque value and does not expose ``.output``.
 - ``None`` in CompoundScalar/Bundle construction means an unset field.
 - TSB deltas are canonically dense; sparse-bundle delta parity is not required.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,7 @@ test = [
     "connectorx>=0.4.5",
     "deltalake>=1.0",
     "duckdb>=1.4",
+    "hypothesis>=6",
     "pandas>=2.0",
     "packaging>=24",
     "polars[rtcompat]>=1.32",

--- a/python/tests/test_parity_harness.py
+++ b/python/tests/test_parity_harness.py
@@ -192,10 +192,12 @@ def test_generated_framework_recipes_prioritize_ref_and_non_peered_paths():
         and recipe.parameters["format_ref"]
         for recipe in recipes
     )
-    assert any(
-        recipe.template == "tsd_key_set_pipeline"
-        and not recipe.parameters["dedup_size"]
+    # dedup_size=false is the ruled no-change space and is corpus-only now
+    # (PR #67 review); generated recipes always dedup.
+    assert all(
+        recipe.parameters["dedup_size"] is True
         for recipe in recipes
+        if recipe.template == "tsd_key_set_pipeline"
     )
 
 
@@ -730,6 +732,124 @@ def test_publisher_consults_known_divergences_and_never_reopens(
     assert dry == [
         {"action": "known-divergence", "fingerprint": "ruled-fingerprint"}
     ]
+
+
+def test_family_gate_covers_the_actual_ruled_length_outcomes():
+    # PR #67 review reproductions (base 0a6df5b7): the ruled deviations
+    # surface as LENGTH differences, not value differences — a shifted
+    # adaptor trace, a missing unchanged size field, and a missing
+    # empty-map tick. The family gate must classify these real comparator
+    # outcomes as known while still excluding crashes and status
+    # differences. Uses the committed known_divergences.json records.
+    from tools.parity.known import (
+        is_known_family_failure,
+        load_known_divergences,
+    )
+
+    _fingerprints, families = load_known_divergences()
+    ok = lambda trace: {"status": "ok", "trace": trace}
+
+    # 1. service_adaptor_roundtrip: ref [2] vs cand [None, 2].
+    adaptor_recipe = {
+        "template": "service_adaptor_roundtrip",
+        "inputs": {"value": [0]},
+        "parameters": {"increment": 2},
+    }
+    difference = compare_outcomes(ok([2]), ok([None, 2]))
+    assert difference.to_dict()["classification"] == "length"
+    assert is_known_family_failure(
+        adaptor_recipe, difference.to_dict(), ok([2]), ok([None, 2]), families
+    )
+
+    # 2. tsd_key_set_pipeline dedup_size=false: the unchanged size field is
+    # republished by the reference and omitted by the candidate.
+    pipeline_recipe = {
+        "template": "tsd_key_set_pipeline",
+        "inputs": {"values": [None]},
+        "parameters": {"dedup_size": False},
+    }
+    ref_tick = {"$map": [["size", 4], ["total", -1]]}
+    cand_tick = {"$map": [["total", -1]]}
+    difference = compare_outcomes(ok([ref_tick]), ok([cand_tick]))
+    assert difference.to_dict()["classification"] == "length"
+    assert difference.to_dict()["path"].startswith("$.trace")
+    assert is_known_family_failure(
+        pipeline_recipe,
+        difference.to_dict(),
+        ok([ref_tick]),
+        ok([cand_tick]),
+        families,
+    )
+
+    # A candidate crash in the same parameter space is NOT the deviation.
+    crash = {"status": "error", "phase": "runtime"}
+    difference = compare_outcomes(ok([2]), crash)
+    assert not is_known_family_failure(
+        adaptor_recipe, difference.to_dict(), ok([2]), crash, families
+    )
+
+
+def test_mesh_empty_initial_fingerprint_is_pinned_and_suppressed(monkeypatch):
+    # 3. mesh_key_set minimized to one initial empty map: released hgraph
+    # ticks an empty map, hg_cpp emits no tick (no-change ruling). The
+    # committed fingerprint must equal the one computed from the real
+    # comparator outcome so stale reports can never re-file it.
+    from tools.parity.known import load_known_divergences
+
+    fingerprints, _families = load_known_divergences()
+    recipe = Recipe.load(CORPUS / "mesh-empty-initial-no-tick.json")
+    reference = {"status": "ok", "trace": [{"$map": []}]}
+    candidate = {"status": "ok", "trace": []}
+    difference = compare_outcomes(reference, candidate)
+    failure = {
+        "minimized_recipe": recipe.to_dict(),
+        "difference": difference.to_dict(),
+        "reference": reference,
+        "candidate": candidate,
+        "reduction": {"attempts": 0, "accepted": 0},
+    }
+    fingerprint = failure_fingerprint(failure)
+    assert fingerprint in fingerprints
+
+    calls = []
+    monkeypatch.setattr(
+        "tools.parity.issues._existing_issues", lambda _repo: []
+    )
+
+    def fake_gh(arguments, *, repo, capture=False):
+        calls.append(arguments)
+        return SimpleNamespace(stdout="")
+
+    monkeypatch.setattr("tools.parity.issues._gh", fake_gh)
+    actions = publish_failures([failure], repo="hhenson/hg_cpp", publish=True)
+    assert actions == [
+        {"action": "known-divergence", "fingerprint": fingerprint}
+    ]
+    assert not any(arguments[:2] == ["issue", "create"] for arguments in calls)
+
+
+def test_generated_key_set_recipes_avoid_ruled_no_tick_space():
+    # The generator stays out of the ruled no-change space: dedup_size is
+    # always true, the initial map is never empty, and no delta nets to no
+    # entries (mesh_key_set inherits the same inputs).
+    pytest.importorskip("hypothesis")
+    from tools.parity.generate import generate_recipes
+
+    recipes = generate_recipes(320, seed=29)
+    keyed = [
+        r
+        for r in recipes
+        if r.template in ("tsd_key_set_pipeline", "mesh_key_set")
+    ]
+    assert keyed, "expected generated key-set recipes"
+    for recipe in keyed:
+        if recipe.template == "tsd_key_set_pipeline":
+            assert recipe.parameters["dedup_size"] is True
+        values = recipe.inputs["values"]
+        assert values[0]["$map"], "initial map must be non-empty"
+        for tick in values:
+            if tick is not None:
+                assert tick["$map"], "no delta may net to no entries"
 
 
 def test_empty_family_parameter_map_matches_the_whole_template():

--- a/python/tests/test_parity_harness.py
+++ b/python/tests/test_parity_harness.py
@@ -340,10 +340,11 @@ def test_campaign_classifies_known_family_without_verification(monkeypatch, tmp_
                 "divergences": [],
                 "families": [
                     {
-                        "family": "reduce-non-identity-zero",
-                        "template": "tsd_map_reduce",
-                        "parameters_not_equal": {"zero": 0},
-                    }
+                            "family": "reduce-non-identity-zero",
+                            "template": "tsd_map_reduce",
+                            "parameters_not_equal": {"zero": 0},
+                            "relation": "trace-value",
+                        }
                 ],
             }
         )
@@ -734,13 +735,10 @@ def test_publisher_consults_known_divergences_and_never_reopens(
     ]
 
 
-def test_family_gate_covers_the_actual_ruled_length_outcomes():
-    # PR #67 review reproductions (base 0a6df5b7): the ruled deviations
-    # surface as LENGTH differences, not value differences — a shifted
-    # adaptor trace, a missing unchanged size field, and a missing
-    # empty-map tick. The family gate must classify these real comparator
-    # outcomes as known while still excluding crashes and status
-    # differences. Uses the committed known_divergences.json records.
+def test_family_gate_requires_the_documented_trace_relation():
+    # PR #67 review reproductions (base 0a6df5b7). Parameter membership
+    # selects a possible deviation, but the complete traces must also satisfy
+    # that family's relation so payload regressions remain differential.
     from tools.parity.known import (
         is_known_family_failure,
         load_known_divergences,
@@ -760,16 +758,37 @@ def test_family_gate_covers_the_actual_ruled_length_outcomes():
     assert is_known_family_failure(
         adaptor_recipe, difference.to_dict(), ok([2]), ok([None, 2]), families
     )
+    corrupted = ok([None, 3])
+    difference = compare_outcomes(ok([2]), corrupted)
+    assert not is_known_family_failure(
+        adaptor_recipe,
+        difference.to_dict(),
+        ok([2]),
+        corrupted,
+        families,
+    )
 
     # 2. tsd_key_set_pipeline dedup_size=false: the unchanged size field is
-    # republished by the reference and omitted by the candidate.
+    # republished by the reference and omitted by the candidate. The float
+    # difference is inside the template tolerance and is not a second defect.
     pipeline_recipe = {
         "template": "tsd_key_set_pipeline",
         "inputs": {"values": [None]},
         "parameters": {"dedup_size": False},
     }
-    ref_tick = {"$map": [["size", 4], ["total", -1]]}
-    cand_tick = {"$map": [["total", -1]]}
+    ref_tick = {
+        "$map": [
+            ["size", 4],
+            ["total", -1],
+            ["variance", {"$float": "0x1.caaaaaaaaaaabp+3"}],
+        ]
+    }
+    cand_tick = {
+        "$map": [
+            ["total", -1],
+            ["variance", {"$float": "0x1.caaaaaaaaaaaap+3"}],
+        ]
+    }
     difference = compare_outcomes(ok([ref_tick]), ok([cand_tick]))
     assert difference.to_dict()["classification"] == "length"
     assert difference.to_dict()["path"].startswith("$.trace")
@@ -780,12 +799,134 @@ def test_family_gate_covers_the_actual_ruled_length_outcomes():
         ok([cand_tick]),
         families,
     )
+    missing_payload = ok([{"$map": [["size", 4]]}])
+    difference = compare_outcomes(ok([ref_tick]), missing_payload)
+    assert not is_known_family_failure(
+        pipeline_recipe,
+        difference.to_dict(),
+        ok([ref_tick]),
+        missing_payload,
+        families,
+    )
+
+    # 3. A different subscription key samples normally; a repeated key is
+    # same-cycle in hg_cpp and delayed one cycle in released hgraph. Payload
+    # values and every other tick must remain equal.
+    subscription_recipe = {
+        "template": "service_subscription",
+        "inputs": {"symbol": ["rates", None, "long_symbol", "rates"]},
+        "parameters": {"multiplier": 10, "path": "live"},
+    }
+    reference = ok([None, 50, None, None, 50])
+    candidate = ok([None, 50, None, 50])
+    difference = compare_outcomes(reference, candidate)
+    assert is_known_family_failure(
+        subscription_recipe,
+        difference.to_dict(),
+        reference,
+        candidate,
+        families,
+    )
+    corrupted = ok([None, 50, None, 51])
+    difference = compare_outcomes(reference, corrupted)
+    assert not is_known_family_failure(
+        subscription_recipe,
+        difference.to_dict(),
+        reference,
+        corrupted,
+        families,
+    )
+    first_subscriptions_only = {
+        **subscription_recipe,
+        "inputs": {"symbol": ["rates", None, "long_symbol"]},
+    }
+    assert not is_known_family_failure(
+        first_subscriptions_only,
+        difference.to_dict(),
+        reference,
+        corrupted,
+        families,
+    )
+
+    # 4. The non-identity reduce ruling covers a value difference only. A
+    # length difference in the same parameter space remains reportable.
+    reduce_recipe = {
+        "template": "tsd_map_reduce",
+        "inputs": {"values": [None]},
+        "parameters": {"zero": 2},
+    }
+    difference = compare_outcomes(ok([4]), ok([2]))
+    assert is_known_family_failure(
+        reduce_recipe,
+        difference.to_dict(),
+        ok([4]),
+        ok([2]),
+        families,
+    )
+    difference = compare_outcomes(ok([4]), ok([2, 2]))
+    assert not is_known_family_failure(
+        reduce_recipe,
+        difference.to_dict(),
+        ok([4]),
+        ok([2, 2]),
+        families,
+    )
 
     # A candidate crash in the same parameter space is NOT the deviation.
     crash = {"status": "error", "phase": "runtime"}
     difference = compare_outcomes(ok([2]), crash)
     assert not is_known_family_failure(
         adaptor_recipe, difference.to_dict(), ok([2]), crash, families
+    )
+
+
+def test_publisher_suppresses_stale_resubscription_variants(monkeypatch):
+    # Symbols and path deliberately differ from the exact issue-66 corpus
+    # fingerprint. The input-aware relation must still prevent a stale report
+    # from creating or reopening the documented deviation.
+    recipe = {
+        "schema_version": 1,
+        "id": "stale-resubscription-variant",
+        "description": "Stale report with a different repeated symbol.",
+        "template": "service_subscription",
+        "inputs": {"symbol": ["fx", None, "long_symbol", "fx"]},
+        "parameters": {"multiplier": 0, "path": "quotes"},
+        "features": [],
+    }
+    reference = {"status": "ok", "trace": [None, 0, None, None, 0]}
+    candidate = {"status": "ok", "trace": [None, 0, None, 0]}
+    failure = {
+        "minimized_recipe": recipe,
+        "difference": compare_outcomes(reference, candidate).to_dict(),
+        "reference": reference,
+        "candidate": candidate,
+        "reduction": {"attempts": 0, "accepted": 0},
+    }
+    failure["failure_fingerprint"] = failure_fingerprint(failure)
+    assert failure["failure_fingerprint"] != (
+        "6d05f5590cc2ff1d6ff45fa63f5189771924d30b9df7d754569979a3d2718b0b"
+    )
+
+    calls = []
+    monkeypatch.setattr(
+        "tools.parity.issues._existing_issues", lambda _repo: []
+    )
+
+    def fake_gh(arguments, *, repo, capture=False):
+        calls.append(arguments)
+        return SimpleNamespace(stdout="")
+
+    monkeypatch.setattr("tools.parity.issues._gh", fake_gh)
+    actions = publish_failures([failure], repo="hhenson/hg_cpp", publish=True)
+    assert actions == [
+        {
+            "action": "known-divergence",
+            "fingerprint": failure["failure_fingerprint"],
+        }
+    ]
+    assert not any(
+        arguments[:2] in (["issue", "create"], ["issue", "reopen"])
+        for arguments in calls
     )
 
 
@@ -799,7 +940,7 @@ def test_mesh_empty_initial_fingerprint_is_pinned_and_suppressed(monkeypatch):
     fingerprints, _families = load_known_divergences()
     recipe = Recipe.load(CORPUS / "mesh-empty-initial-no-tick.json")
     reference = {"status": "ok", "trace": [{"$map": []}]}
-    candidate = {"status": "ok", "trace": []}
+    candidate = {"status": "ok", "trace": None}
     difference = compare_outcomes(reference, candidate)
     failure = {
         "minimized_recipe": recipe.to_dict(),
@@ -809,6 +950,9 @@ def test_mesh_empty_initial_fingerprint_is_pinned_and_suppressed(monkeypatch):
         "reduction": {"attempts": 0, "accepted": 0},
     }
     fingerprint = failure_fingerprint(failure)
+    assert fingerprint == (
+        "7834fe8ecb1c87ca79cd6ef4229a20376622857e8b1b7b56b6a76d02e4613182"
+    )
     assert fingerprint in fingerprints
 
     calls = []
@@ -853,7 +997,10 @@ def test_generated_key_set_recipes_avoid_ruled_no_tick_space():
 
 
 def test_empty_family_parameter_map_matches_the_whole_template():
-    from tools.parity.known import matches_known_family
+    from tools.parity.known import (
+        is_known_family_failure,
+        matches_known_family,
+    )
 
     families = [
         {
@@ -868,6 +1015,19 @@ def test_empty_family_parameter_map_matches_the_whole_template():
     )
     assert not matches_known_family(
         {"template": "service_subscription", "parameters": {}}, families
+    )
+    difference = {
+        "classification": "value",
+        "path": "$.trace[0]",
+        "reference": 1,
+        "candidate": 2,
+    }
+    assert not is_known_family_failure(
+        {"template": "service_adaptor_roundtrip", "parameters": {}},
+        difference,
+        {"status": "ok", "trace": [1]},
+        {"status": "ok", "trace": [2]},
+        [{**families[0], "relation": "not-a-supported-relation"}],
     )
 
 

--- a/python/tests/test_parity_harness.py
+++ b/python/tests/test_parity_harness.py
@@ -169,7 +169,7 @@ def test_generated_framework_recipes_prioritize_ref_and_non_peered_paths():
     pytest.importorskip("hypothesis")
     from tools.parity.generate import generate_recipes
 
-    recipes = generate_recipes(240, seed=29)
+    recipes = generate_recipes(320, seed=29)
     templates = {recipe.template for recipe in recipes}
     assert {
         "service_reference",
@@ -655,6 +655,114 @@ def test_issue_publisher_deduplicates_same_fingerprint_within_one_run(
         sum(1 for arguments, _, _ in calls if arguments[:2] == ["issue", "create"])
         == 1
     )
+
+
+def test_publisher_consults_known_divergences_and_never_reopens(
+    monkeypatch, tmp_path
+):
+    # The consolidation step takes the known-divergence records into account:
+    # a failure whose fingerprint (or family) is known is reported as
+    # "known-divergence" — it is neither created nor REOPENED, even when a
+    # closed issue with the matching marker exists.
+    failure = {
+        "failure_fingerprint": "ruled-fingerprint",
+        "minimized_recipe": _scalar_recipe().to_dict(),
+        "difference": {
+            "classification": "value",
+            "path": "$.trace[0]",
+            "reference": 1,
+            "candidate": 2,
+        },
+        "reference": {"status": "ok", "trace": [1]},
+        "candidate": {"status": "ok", "trace": [2]},
+        "reduction": {"attempts": 0, "accepted": 0},
+    }
+    known_path = tmp_path / "known_divergences.json"
+    known_path.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "divergences": [{"fingerprint": "ruled-fingerprint"}],
+                "families": [],
+            }
+        )
+    )
+    closed = {
+        "number": 99,
+        "state": "CLOSED",
+        "title": "[parity] scalar_expression differs from released hgraph",
+        "body": "<!-- hgraph-parity:ruled-fingerprint -->",
+        "url": "https://github.com/hhenson/hg_cpp/issues/99",
+    }
+    calls = []
+
+    monkeypatch.setattr(
+        "tools.parity.issues._existing_issues", lambda _repo: [closed]
+    )
+
+    def fake_gh(arguments, *, repo, capture=False):
+        calls.append((arguments, repo, capture))
+        return SimpleNamespace(stdout="")
+
+    monkeypatch.setattr("tools.parity.issues._gh", fake_gh)
+
+    actions = publish_failures(
+        [failure],
+        repo="hhenson/hg_cpp",
+        publish=True,
+        known_divergences_path=known_path,
+    )
+    assert actions == [
+        {"action": "known-divergence", "fingerprint": "ruled-fingerprint"}
+    ]
+    assert not any(
+        arguments[:2] in (["issue", "create"], ["issue", "reopen"])
+        for arguments, _, _ in calls
+    )
+
+    # Dry-run reports the same classification.
+    dry = publish_failures(
+        [failure],
+        repo="hhenson/hg_cpp",
+        publish=False,
+        known_divergences_path=known_path,
+    )
+    assert dry == [
+        {"action": "known-divergence", "fingerprint": "ruled-fingerprint"}
+    ]
+
+
+def test_empty_family_parameter_map_matches_the_whole_template():
+    from tools.parity.known import matches_known_family
+
+    families = [
+        {
+            "family": "whole-template",
+            "template": "service_adaptor_roundtrip",
+            "parameters_not_equal": {},
+        }
+    ]
+    assert matches_known_family(
+        {"template": "service_adaptor_roundtrip", "parameters": {"increment": 3}},
+        families,
+    )
+    assert not matches_known_family(
+        {"template": "service_subscription", "parameters": {}}, families
+    )
+
+
+def test_generated_subscription_recipes_never_resubscribe():
+    # Re-subscribing a previously computed symbol is the designed same-cycle
+    # sampling deviation (issue #66): the generator must not explore it.
+    pytest.importorskip("hypothesis")
+    from tools.parity.generate import generate_recipes
+
+    recipes = generate_recipes(240, seed=29)
+    subs = [r for r in recipes if r.template == "service_subscription"]
+    assert subs, "expected generated service_subscription recipes"
+    for recipe in subs:
+        symbols = [s for s in recipe.inputs["symbol"] if s is not None]
+        assert len(symbols) == len(set(symbols))
 
 
 def test_coverage_reports_operator_frontier_and_semantic_pairs():

--- a/python/tests/test_service_timing_semantics.py
+++ b/python/tests/test_service_timing_semantics.py
@@ -1,0 +1,62 @@
+"""Service-boundary timing semantics (documented upstream deviations).
+
+The scheduling matrix in ``docs/source/developer_guide/services.rst`` is the
+design record: request stubs forward next cycle by design, and a late or
+duplicate subscription samples the existing shared output in the same cycle.
+Released hgraph observably differs on both edges (same-cycle adaptor round
+trips; one-cycle re-subscription re-delivery). See the Accepted Deviations
+list in ``roadmap.rst`` and parity issues #64 / #66.
+"""
+
+import hgraph as hg
+from hgraph import TS, TSD, TSS, graph
+from hgraph.test import eval_node
+
+
+def test_service_adaptor_roundtrip_takes_one_transport_cycle():
+    # Issue #64: released hgraph completes the adaptor round trip in the
+    # same engine cycle ([1]); hg_cpp's request stub forwards next cycle by
+    # design, so the reply lands one cycle later.
+    @hg.service_adaptor
+    def echo(request: TS[int]) -> TS[int]: ...
+
+    @hg.service_adaptor_impl(interfaces=echo)
+    def echo_impl(path: str, request: TSD[int, TS[int]]) -> TSD[int, TS[int]]:
+        return hg.map_(lambda value: value + 0, request)
+
+    @graph
+    def roundtrip(value: TS[int]) -> TS[int]:
+        hg.register_adaptor(None, echo_impl)
+        return echo(value)
+
+    out = eval_node(roundtrip, [1], __end_time__=hg.MIN_ST + 3 * hg.MIN_TD)
+    assert out == [None, 1]
+
+
+def test_resubscription_samples_existing_value_in_the_same_cycle():
+    # Issue #66: re-subscribing a previously computed symbol samples the
+    # existing shared-output entry in the same cycle; released hgraph takes
+    # the usual one-cycle transport hop again. First subscriptions match
+    # upstream exactly (value one cycle after subscribe).
+    @hg.subscription_service
+    def quote(path: str, symbol: TS[str]) -> TS[int]: ...
+
+    @graph
+    def quote_value(symbol: TS[str]) -> TS[int]:
+        return hg.len_(symbol) * 7
+
+    @hg.service_impl(interfaces=quote)
+    def quote_values(symbol: TSS[str]) -> TSD[str, TS[int]]:
+        return hg.map_(quote_value, __keys__=symbol, __key_arg__="symbol")
+
+    @graph
+    def subscribe(symbol: TS[str]) -> TS[int]:
+        hg.register_service("live", quote_values)
+        return quote("live", symbol)
+
+    out = eval_node(
+        subscribe,
+        ["rates", None, "fx", "rates"],
+        __end_time__=hg.MIN_ST + 7 * hg.MIN_TD,
+    )
+    assert out == [None, 35, None, 35]

--- a/tools/parity/campaign.py
+++ b/tools/parity/campaign.py
@@ -18,74 +18,10 @@ from .process import ReferenceTraceCache, run_recipe
 from .reduce import reduce_recipe
 
 
-def _load_known_divergences(path: Path) -> tuple[set[str], list[dict[str, Any]]]:
-    """Exact fingerprints plus family rules from known_divergences.json.
-
-    A family rule classifies every failure inside a documented deviation's
-    parameter space as known, so new minimized variants (which mint new
-    fingerprints) do not publish as issues: ``{"template": ...,
-    "parameters_not_equal": {name: identity, ...}}`` matches a recipe of that
-    template whose named parameters all differ from the stated identity.
-    """
-    try:
-        raw = json.loads(path.read_text())
-    except (OSError, json.JSONDecodeError):
-        return set(), []
-    fingerprints = {
-        item["fingerprint"]
-        for item in raw.get("divergences", ())
-        if isinstance(item, dict) and isinstance(item.get("fingerprint"), str)
-    }
-    families = [
-        item
-        for item in raw.get("families", ())
-        if isinstance(item, dict)
-        and isinstance(item.get("template"), str)
-        and isinstance(item.get("parameters_not_equal"), dict)
-    ]
-    return fingerprints, families
-
-
-def _matches_known_family(
-    recipe: dict[str, Any], families: list[dict[str, Any]]
-) -> bool:
-    parameters = recipe.get("parameters") or {}
-    # A missing parameter resolves to the template default, which is the
-    # stated identity (e.g. tsd_map_reduce defaults zero to 0), so an omitted
-    # parameter never places a recipe inside a deviation family.
-    return any(
-        recipe.get("template") == family["template"]
-        and all(
-            parameters.get(name, identity) != identity
-            for name, identity in family["parameters_not_equal"].items()
-        )
-        for family in families
-    )
-
-
-def _is_known_family_failure(
-    recipe: dict[str, Any],
-    difference: dict[str, Any],
-    reference: dict[str, Any],
-    candidate: dict[str, Any],
-    families: list[dict[str, Any]],
-) -> bool:
-    """True when a mismatch is the documented deviation itself.
-
-    Family suppression covers only the deviation's shape: both
-    implementations completed and disagreed on a trace value (for the reduce
-    family, the capacity-history-dependent application of a non-identity
-    zero). Anything else inside the parameter space — a candidate crash, a
-    status or shape difference — is not the documented deviation and must
-    continue through the normal verification and publishing pipeline.
-    """
-    return (
-        reference.get("status") == "ok"
-        and candidate.get("status") == "ok"
-        and difference.get("classification") == "value"
-        and str(difference.get("path", "")).startswith("$.trace")
-        and _matches_known_family(recipe, families)
-    )
+from .known import (
+    is_known_family_failure as _is_known_family_failure,
+    load_known_divergences as _load_known_divergences,
+)
 
 
 def _stable(results: list[dict[str, Any]]) -> bool:

--- a/tools/parity/campaign.py
+++ b/tools/parity/campaign.py
@@ -141,10 +141,9 @@ def run_campaign(
             candidate,
             known_families,
         ):
-            # First-pass sanity check: a completed-run trace-value mismatch
-            # inside a documented deviation's parameter space is a known
-            # failure; do not spend verification replays or reduction budget
-            # minting a new fingerprint for it.
+            # The shared matcher proved both parameter membership and the
+            # family's documented trace relation. Do not spend verification
+            # replays or reduction budget minting another fingerprint for it.
             failure = {
                 "original_recipe": recipe.to_dict(),
                 "minimized_recipe": recipe.to_dict(),

--- a/tools/parity/corpus/issue-64-service-adaptor-cycle.json
+++ b/tools/parity/corpus/issue-64-service-adaptor-cycle.json
@@ -1,0 +1,27 @@
+{
+  "schema_version": 1,
+  "id": "issue-64-service-adaptor-cycle",
+  "description": "Track the designed service_adaptor transport timing: the round trip lands one cycle after released hgraph's same-cycle adaptor wiring (known deviation, services.rst scheduling matrix).",
+  "template": "service_adaptor_roundtrip",
+  "inputs": {
+    "value": [
+      1
+    ]
+  },
+  "parameters": {
+    "increment": 0
+  },
+  "features": [
+    "adaptor:multi-client",
+    "adaptor:service",
+    "binding:non-peered",
+    "framework:adaptor",
+    "implementation:path-injection",
+    "lifecycle:transport-delay",
+    "reference:REF",
+    "shape:TS",
+    "shape:TSD",
+    "shape:TSL"
+  ],
+  "source_issue": "https://github.com/hhenson/hg_cpp/issues/64"
+}

--- a/tools/parity/corpus/issue-65-key-set-size-no-retick.json
+++ b/tools/parity/corpus/issue-65-key-set-size-no-retick.json
@@ -1,0 +1,46 @@
+{
+  "schema_version": 1,
+  "id": "issue-65-key-set-size-no-retick",
+  "description": "Track the no-change-means-no-tick ruling for an undeduped key-set size: a delta netting to an unchanged length re-ticks in released hgraph and does not tick in hg_cpp (known deviation, ruling 2026-07-17).",
+  "template": "tsd_key_set_pipeline",
+  "inputs": {
+    "probe": [
+      null,
+      null
+    ],
+    "values": [
+      {
+        "$map": [
+          [-2, -13],
+          [-1, -7],
+          [0, 20],
+          [2, 11]
+        ]
+      },
+      {
+        "$map": [
+          [-3, -16],
+          [-1, {"$remove": true}]
+        ]
+      }
+    ]
+  },
+  "parameters": {
+    "dedup_size": false
+  },
+  "features": [
+    "binding:non-peered",
+    "lifecycle:keyed",
+    "reference:REF",
+    "shape:TSB",
+    "shape:TSD",
+    "shape:TSL",
+    "shape:TSS",
+    "topology:key-set-projection",
+    "topology:operator-composition",
+    "type:bool",
+    "type:float",
+    "type:int"
+  ],
+  "source_issue": "https://github.com/hhenson/hg_cpp/issues/65"
+}

--- a/tools/parity/corpus/issue-66-resubscribe-sampling.json
+++ b/tools/parity/corpus/issue-66-resubscribe-sampling.json
@@ -1,0 +1,31 @@
+{
+  "schema_version": 1,
+  "id": "issue-66-resubscribe-sampling",
+  "description": "Track the designed late-subscription sampling timing: re-subscribing a previously computed symbol delivers the existing value in the same cycle, one cycle earlier than released hgraph (known deviation, services.rst scheduling matrix).",
+  "template": "service_subscription",
+  "inputs": {
+    "symbol": [
+      "rates",
+      null,
+      "fx",
+      "rates"
+    ]
+  },
+  "parameters": {
+    "multiplier": 7,
+    "path": "live"
+  },
+  "features": [
+    "binding:non-peered",
+    "framework:service",
+    "lifecycle:keyed",
+    "lifecycle:transport-delay",
+    "reference:REF",
+    "service:subscription",
+    "shape:TS",
+    "shape:TSD",
+    "shape:TSL",
+    "shape:TSS"
+  ],
+  "source_issue": "https://github.com/hhenson/hg_cpp/issues/66"
+}

--- a/tools/parity/corpus/mesh-empty-initial-no-tick.json
+++ b/tools/parity/corpus/mesh-empty-initial-no-tick.json
@@ -1,0 +1,25 @@
+{
+  "schema_version": 1,
+  "id": "mesh-empty-initial-no-tick",
+  "description": "Track the no-change-means-no-tick ruling for a mesh over an initially empty key set: released hgraph ticks an empty map, hg_cpp emits no tick (known deviation, ruling 2026-07-17).",
+  "template": "mesh_key_set",
+  "inputs": {
+    "values": [
+      {
+        "$map": []
+      }
+    ]
+  },
+  "parameters": {
+    "factor": 2
+  },
+  "features": [
+    "binding:non-peered",
+    "lifecycle:keyed",
+    "reference:REF",
+    "shape:TSD",
+    "shape:TSS",
+    "topology:mesh"
+  ],
+  "source_review": "https://github.com/hhenson/hg_cpp/pull/67 (review, base 0a6df5b7)"
+}

--- a/tools/parity/generate.py
+++ b/tools/parity/generate.py
@@ -341,7 +341,13 @@ def recipe_payload_strategy(*, min_ticks: int = 8, max_ticks: int = 32):
     def tsd_key_set_pipeline(draw):
         count = draw(st.integers(min_value=min_ticks, max_value=max_ticks))
         universe = tuple(range(-4, 5))
-        initial = set(draw(st.sets(st.sampled_from(universe), max_size=4)))
+        # A non-empty initial map: an empty first delta is the ruled
+        # no-change-means-no-tick space (released hgraph ticks an empty map,
+        # hg_cpp emits no tick — mesh_key_set inherits these inputs). The
+        # corpus tracks the empty-initial case explicitly.
+        initial = set(
+            draw(st.sets(st.sampled_from(universe), min_size=1, max_size=4))
+        )
         active = set(initial)
         ticks: list[Any] = [
             {
@@ -376,7 +382,9 @@ def recipe_payload_strategy(*, min_ticks: int = 8, max_ticks: int = 32):
                 key = draw(st.sampled_from(removable))
                 active.remove(key)
                 entries.append([key, {"$remove": True}])
-            ticks.append({"$map": entries})
+            # An action that nets to no entries is the ruled empty-delta
+            # no-tick space; emit a quiet tick instead.
+            ticks.append({"$map": entries} if entries else None)
         return {
             "template": "tsd_key_set_pipeline",
             "inputs": {
@@ -385,7 +393,11 @@ def recipe_payload_strategy(*, min_ticks: int = 8, max_ticks: int = 32):
                     draw, count, st.integers(min_value=-4, max_value=4)
                 ),
             },
-            "parameters": {"dedup_size": draw(st.booleans())},
+            # dedup_size stays true: the undeduped size re-tick is the ruled
+            # no-change-means-no-tick deviation (issue #65); differential
+            # exploration there measures the deviation, not candidate
+            # defects. The corpus tracks the dedup_size=false case.
+            "parameters": {"dedup_size": True},
             "features": [*CATALOG["tsd_key_set_pipeline"].features],
         }
 

--- a/tools/parity/generate.py
+++ b/tools/parity/generate.py
@@ -236,10 +236,25 @@ def recipe_payload_strategy(*, min_ticks: int = 8, max_ticks: int = 32):
     @st.composite
     def service_subscription(draw):
         count = draw(st.integers(min_value=min_ticks, max_value=max_ticks))
-        symbols = st.sampled_from(("a", "fx", "rates", "EURUSD", "long_symbol"))
+        # Each symbol subscribes at most once: re-subscribing a previously
+        # computed symbol is the designed same-cycle sampling deviation
+        # (services.rst scheduling matrix; issue #66), so differential
+        # exploration there measures the deviation, not candidate defects.
+        # The corpus tracks the re-subscription case explicitly.
+        pool = list(
+            draw(
+                st.permutations(("a", "fx", "rates", "EURUSD", "long_symbol"))
+            )
+        )
+        ticks = [pool.pop(0)]
+        for _ in range(count - 1):
+            if pool and draw(st.booleans()):
+                ticks.append(pool.pop(0))
+            else:
+                ticks.append(None)
         return {
             "template": "service_subscription",
-            "inputs": {"symbol": sparse_ticks(draw, count, symbols)},
+            "inputs": {"symbol": ticks},
             "parameters": {
                 "multiplier": draw(st.integers(min_value=-3, max_value=10)),
                 "path": draw(st.sampled_from(("quotes", "prices", "live"))),

--- a/tools/parity/issues.py
+++ b/tools/parity/issues.py
@@ -162,11 +162,35 @@ def publish_failures(
     *,
     repo: str,
     publish: bool,
+    known_divergences_path: Path | None = None,
 ) -> list[dict[str, Any]]:
+    from .known import is_known_family_failure, load_known_divergences
+
     failures = list(failures)
+    known_fingerprints, known_families = load_known_divergences(
+        known_divergences_path
+    )
+
+    def known_action(failure: dict[str, Any]) -> dict[str, Any] | None:
+        # The publisher re-checks the known-divergence records so a stale or
+        # concurrently produced report can never file — or reopen — an issue
+        # for a documented deviation.
+        fingerprint = failure.get("failure_fingerprint") or failure_fingerprint(
+            failure
+        )
+        if fingerprint not in known_fingerprints and not is_known_family_failure(
+            failure.get("minimized_recipe") or {},
+            failure.get("difference") or {},
+            failure.get("reference") or {},
+            failure.get("candidate") or {},
+            known_families,
+        ):
+            return None
+        return {"action": "known-divergence", "fingerprint": fingerprint}
     if not publish:
         return [
-            {
+            known_action(failure)
+            or {
                 "action": "dry-run",
                 "title": issue_title(failure),
                 "fingerprint": failure.get("failure_fingerprint")
@@ -198,6 +222,10 @@ def publish_failures(
         )
         marker = f"<!-- {FINGERPRINT_PREFIX}{fingerprint} -->"
         title = issue_title(failure)
+        known = known_action(failure)
+        if known is not None:
+            actions.append(known)
+            continue
         if fingerprint in handled_this_run:
             # One issue per fingerprint per publish: later failures in the
             # same run (e.g. from other shards) fold into the first.

--- a/tools/parity/known.py
+++ b/tools/parity/known.py
@@ -10,9 +10,11 @@
   transport-timing difference).
 
 Family suppression covers only the documented deviation's shape: both
-implementations completed and disagreed on a trace value. Anything else — a
-candidate crash, a status or shape difference — is not the documented
-deviation and must continue through the normal pipeline.
+implementations completed and disagreed on trace content — a differing value
+or a differing tick/field count (``value`` or ``length``), since ruled
+no-tick/timing deviations surface as missing ticks or missing map fields.
+Anything else — a candidate crash or a status difference — is not the
+documented deviation and must continue through the normal pipeline.
 """
 
 from __future__ import annotations
@@ -76,7 +78,7 @@ def is_known_family_failure(
     return (
         reference.get("status") == "ok"
         and candidate.get("status") == "ok"
-        and difference.get("classification") == "value"
+        and difference.get("classification") in ("value", "length")
         and str(difference.get("path", "")).startswith("$.trace")
         and matches_known_family(recipe, families)
     )

--- a/tools/parity/known.py
+++ b/tools/parity/known.py
@@ -6,15 +6,12 @@
 - ``families``: a template plus a ``parameters_not_equal`` map matching every
   recipe of that template whose named parameters all differ from the stated
   identity. An empty map matches every recipe of the template (used when a
-  documented deviation shifts every trace of a template, e.g. a designed
-  transport-timing difference).
+  documented deviation applies to every recipe of a template).
 
-Family suppression covers only the documented deviation's shape: both
-implementations completed and disagreed on trace content — a differing value
-or a differing tick/field count (``value`` or ``length``), since ruled
-no-tick/timing deviations surface as missing ticks or missing map fields.
-Anything else — a candidate crash or a status difference — is not the
-documented deviation and must continue through the normal pipeline.
+Each family names a bounded ``relation`` which proves the observed traces are
+the documented deviation.  Parameter membership alone is insufficient: a
+payload regression inside an affected template must continue through the
+normal verification and publishing pipeline.
 """
 
 from __future__ import annotations
@@ -23,8 +20,14 @@ import json
 from pathlib import Path
 from typing import Any
 
+from .compare import compare_outcomes
+
 
 DEFAULT_PATH = Path(__file__).with_name("known_divergences.json")
+TRACE_VALUE = "trace-value"
+SERVICE_ADAPTOR_ONE_CYCLE = "service-adaptor-one-cycle"
+KEY_SET_SIZE_NO_RETICK = "key-set-size-no-retick"
+SUBSCRIPTION_RESAMPLE_ONE_CYCLE = "subscription-resample-one-cycle"
 
 
 def load_known_divergences(
@@ -49,22 +52,163 @@ def load_known_divergences(
     return fingerprints, families
 
 
-def matches_known_family(
-    recipe: dict[str, Any], families: list[dict[str, Any]]
+def _matches_family_parameters(
+    recipe: dict[str, Any], family: dict[str, Any]
 ) -> bool:
     parameters = recipe.get("parameters") or {}
     # A missing parameter resolves to the template default, which is the
     # stated identity, so an omitted parameter never places a recipe inside a
     # deviation family. An empty parameters_not_equal map matches the whole
     # template.
+    return recipe.get("template") == family["template"] and all(
+        parameters.get(name, identity) != identity
+        for name, identity in family["parameters_not_equal"].items()
+    )
+
+
+def matches_known_family(
+    recipe: dict[str, Any], families: list[dict[str, Any]]
+) -> bool:
     return any(
-        recipe.get("template") == family["template"]
-        and all(
-            parameters.get(name, identity) != identity
-            for name, identity in family["parameters_not_equal"].items()
-        )
+        _matches_family_parameters(recipe, family)
         for family in families
     )
+
+
+def _trace_value_relation(
+    _recipe: dict[str, Any],
+    difference: dict[str, Any],
+    _reference: dict[str, Any],
+    _candidate: dict[str, Any],
+    _family: dict[str, Any],
+) -> bool:
+    return difference.get("classification") == "value"
+
+
+def _service_adaptor_one_cycle_relation(
+    _recipe: dict[str, Any],
+    _difference: dict[str, Any],
+    reference: dict[str, Any],
+    candidate: dict[str, Any],
+    _family: dict[str, Any],
+) -> bool:
+    reference_trace = reference.get("trace")
+    candidate_trace = candidate.get("trace")
+    return (
+        isinstance(reference_trace, list)
+        and isinstance(candidate_trace, list)
+        and candidate_trace == [None, *reference_trace]
+    )
+
+
+def _without_map_field(trace: Any, field: str) -> Any:
+    if not isinstance(trace, list):
+        return trace
+
+    normalized = []
+    for tick in trace:
+        if not (
+            isinstance(tick, dict)
+            and set(tick) == {"$map"}
+            and isinstance(tick["$map"], list)
+        ):
+            normalized.append(tick)
+            continue
+        entries = [
+            entry
+            for entry in tick["$map"]
+            if not (
+                isinstance(entry, list)
+                and len(entry) == 2
+                and entry[0] == field
+            )
+        ]
+        normalized.append({"$map": entries} if entries else None)
+    return normalized
+
+
+def _key_set_size_no_retick_relation(
+    _recipe: dict[str, Any],
+    difference: dict[str, Any],
+    reference: dict[str, Any],
+    candidate: dict[str, Any],
+    family: dict[str, Any],
+) -> bool:
+    if difference.get("classification") not in ("value", "length"):
+        return False
+    reference_trace = reference.get("trace")
+    candidate_trace = candidate.get("trace")
+    if reference_trace == candidate_trace:
+        return False
+    normalized_reference = {
+        "status": "ok",
+        "trace": _without_map_field(reference_trace, "size"),
+    }
+    normalized_candidate = {
+        "status": "ok",
+        "trace": _without_map_field(candidate_trace, "size"),
+    }
+    return (
+        compare_outcomes(
+            normalized_reference,
+            normalized_candidate,
+            float_abs_tolerance=family.get("float_abs_tolerance", 0.0),
+        )
+        is None
+    )
+
+
+def _repeated_non_null_positions(values: Any) -> list[int]:
+    if not isinstance(values, list):
+        return []
+    seen = set()
+    repeated = []
+    for index, value in enumerate(values):
+        if value is None:
+            continue
+        if value in seen:
+            repeated.append(index)
+        else:
+            seen.add(value)
+    return repeated
+
+
+def _subscription_resample_one_cycle_relation(
+    recipe: dict[str, Any],
+    _difference: dict[str, Any],
+    reference: dict[str, Any],
+    candidate: dict[str, Any],
+    _family: dict[str, Any],
+) -> bool:
+    repeated = _repeated_non_null_positions(
+        (recipe.get("inputs") or {}).get("symbol")
+    )
+    reference_trace = reference.get("trace")
+    candidate_trace = candidate.get("trace")
+    if (
+        not repeated
+        or not isinstance(reference_trace, list)
+        or not isinstance(candidate_trace, list)
+    ):
+        return False
+
+    expected_reference = list(candidate_trace)
+    for inserted, position in enumerate(repeated):
+        index = position + inserted
+        if index >= len(expected_reference) or expected_reference[index] is None:
+            return False
+        expected_reference.insert(index, None)
+    return expected_reference == reference_trace
+
+
+RELATIONS = {
+    TRACE_VALUE: _trace_value_relation,
+    SERVICE_ADAPTOR_ONE_CYCLE: _service_adaptor_one_cycle_relation,
+    KEY_SET_SIZE_NO_RETICK: _key_set_size_no_retick_relation,
+    SUBSCRIPTION_RESAMPLE_ONE_CYCLE: (
+        _subscription_resample_one_cycle_relation
+    ),
+}
 
 
 def is_known_family_failure(
@@ -75,12 +219,23 @@ def is_known_family_failure(
     families: list[dict[str, Any]],
 ) -> bool:
     """True when a mismatch is a documented deviation itself."""
-    return (
-        reference.get("status") == "ok"
-        and candidate.get("status") == "ok"
-        and difference.get("classification") in ("value", "length")
-        and str(difference.get("path", "")).startswith("$.trace")
-        and matches_known_family(recipe, families)
-    )
+    if (
+        reference.get("status") != "ok"
+        or candidate.get("status") != "ok"
+        or not str(difference.get("path", "")).startswith("$.trace")
+    ):
+        return False
 
-
+    for family in families:
+        if not _matches_family_parameters(recipe, family):
+            continue
+        relation = RELATIONS.get(family.get("relation"))
+        if relation is not None and relation(
+            recipe,
+            difference,
+            reference,
+            candidate,
+            family,
+        ):
+            return True
+    return False

--- a/tools/parity/known.py
+++ b/tools/parity/known.py
@@ -1,0 +1,84 @@
+"""Known-divergence records shared by the campaign classifier and publisher.
+
+``known_divergences.json`` carries two suppression shapes:
+
+- ``divergences``: exact failure fingerprints.
+- ``families``: a template plus a ``parameters_not_equal`` map matching every
+  recipe of that template whose named parameters all differ from the stated
+  identity. An empty map matches every recipe of the template (used when a
+  documented deviation shifts every trace of a template, e.g. a designed
+  transport-timing difference).
+
+Family suppression covers only the documented deviation's shape: both
+implementations completed and disagreed on a trace value. Anything else — a
+candidate crash, a status or shape difference — is not the documented
+deviation and must continue through the normal pipeline.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+
+DEFAULT_PATH = Path(__file__).with_name("known_divergences.json")
+
+
+def load_known_divergences(
+    path: Path | None = None,
+) -> tuple[set[str], list[dict[str, Any]]]:
+    try:
+        raw = json.loads((path or DEFAULT_PATH).read_text())
+    except (OSError, json.JSONDecodeError):
+        return set(), []
+    fingerprints = {
+        item["fingerprint"]
+        for item in raw.get("divergences", ())
+        if isinstance(item, dict) and isinstance(item.get("fingerprint"), str)
+    }
+    families = [
+        item
+        for item in raw.get("families", ())
+        if isinstance(item, dict)
+        and isinstance(item.get("template"), str)
+        and isinstance(item.get("parameters_not_equal"), dict)
+    ]
+    return fingerprints, families
+
+
+def matches_known_family(
+    recipe: dict[str, Any], families: list[dict[str, Any]]
+) -> bool:
+    parameters = recipe.get("parameters") or {}
+    # A missing parameter resolves to the template default, which is the
+    # stated identity, so an omitted parameter never places a recipe inside a
+    # deviation family. An empty parameters_not_equal map matches the whole
+    # template.
+    return any(
+        recipe.get("template") == family["template"]
+        and all(
+            parameters.get(name, identity) != identity
+            for name, identity in family["parameters_not_equal"].items()
+        )
+        for family in families
+    )
+
+
+def is_known_family_failure(
+    recipe: dict[str, Any],
+    difference: dict[str, Any],
+    reference: dict[str, Any],
+    candidate: dict[str, Any],
+    families: list[dict[str, Any]],
+) -> bool:
+    """True when a mismatch is a documented deviation itself."""
+    return (
+        reference.get("status") == "ok"
+        and candidate.get("status") == "ok"
+        and difference.get("classification") == "value"
+        and str(difference.get("path", "")).startswith("$.trace")
+        and matches_known_family(recipe, families)
+    )
+
+

--- a/tools/parity/known_divergences.json
+++ b/tools/parity/known_divergences.json
@@ -16,6 +16,16 @@
   ],
   "families": [
     {
+      "family": "key-set-size-no-retick",
+      "template": "tsd_key_set_pipeline",
+      "parameters_not_equal": {
+        "dedup_size": true
+      },
+      "issue": "https://github.com/hhenson/hg_cpp/issues/65",
+      "reason": "No-change-means-no-tick ruling (2026-07-17, roadmap.rst): an undeduped len_ over the key set does not re-tick an unchanged length in hg_cpp, while released hgraph re-ticks the equal value. Value mismatches for dedup_size=false recipes are the ruled deviation, not candidate defects.",
+      "review_after": "2027-07-26"
+    },
+    {
       "family": "reduce-non-identity-zero",
       "template": "tsd_map_reduce",
       "parameters_not_equal": {

--- a/tools/parity/known_divergences.json
+++ b/tools/parity/known_divergences.json
@@ -24,6 +24,12 @@
       "issue": "https://github.com/hhenson/hg_cpp/issues/66",
       "reason": "Designed service-boundary timing (services.rst scheduling matrix): a late/duplicate subscription samples the existing shared output in the same cycle, one cycle earlier than released hgraph's re-delivery. Pinned by test_service_wiring.cpp 'late duplicate subscription samples the existing value'.",
       "review_after": "2027-07-26"
+    },
+    {
+      "fingerprint": "4f76383d8d5b01e2f31d2005cbf44bd67ebd89912f887b909c834fc73314699f",
+      "issue": "https://github.com/hhenson/hg_cpp/pull/67",
+      "reason": "No-change-means-no-tick ruling (2026-07-17, roadmap.rst): a mesh over an initially empty key set emits no tick in hg_cpp where released hgraph ticks an empty map. Fingerprint pinned by test_parity_harness.py against the corpus recipe mesh-empty-initial-no-tick.",
+      "review_after": "2027-07-26"
     }
   ],
   "families": [

--- a/tools/parity/known_divergences.json
+++ b/tools/parity/known_divergences.json
@@ -12,9 +12,29 @@
       "issue": "https://github.com/hhenson/hg_cpp/issues/46",
       "reason": "Accepted deviation (same family as issue #44): a never-ticking TSD reduce with a non-identity zero publishes 2*zero in released hgraph (empty node tree, both leaves bound to zero) and exactly zero in hg_cpp. See the documented reduce deviation in docs/source/developer_guide/parity_matrix.rst.",
       "review_after": "2027-07-26"
+    },
+    {
+      "fingerprint": "e64b8a5662c389c92396ef0805a60bb97e109ee943222ed1e22fadbae88eb28e",
+      "issue": "https://github.com/hhenson/hg_cpp/issues/64",
+      "reason": "Designed service-boundary timing (services.rst scheduling matrix): a service_adaptor request forwards next cycle by design, so the round trip lands one cycle after released hgraph's same-cycle adaptor wiring. Pinned by test_service_wiring.cpp service-adaptor cases.",
+      "review_after": "2027-07-26"
+    },
+    {
+      "fingerprint": "6d05f5590cc2ff1d6ff45fa63f5189771924d30b9df7d754569979a3d2718b0b",
+      "issue": "https://github.com/hhenson/hg_cpp/issues/66",
+      "reason": "Designed service-boundary timing (services.rst scheduling matrix): a late/duplicate subscription samples the existing shared output in the same cycle, one cycle earlier than released hgraph's re-delivery. Pinned by test_service_wiring.cpp 'late duplicate subscription samples the existing value'.",
+      "review_after": "2027-07-26"
     }
   ],
   "families": [
+    {
+      "family": "service-adaptor-transport-cycle",
+      "template": "service_adaptor_roundtrip",
+      "parameters_not_equal": {},
+      "issue": "https://github.com/hhenson/hg_cpp/issues/64",
+      "reason": "The designed one-cycle service_adaptor request hop shifts every trace of this template relative to released hgraph, so every completed-run value mismatch here is the documented timing deviation. The empty parameters map matches the whole template.",
+      "review_after": "2027-07-26"
+    },
     {
       "family": "key-set-size-no-retick",
       "template": "tsd_key_set_pipeline",

--- a/tools/parity/known_divergences.json
+++ b/tools/parity/known_divergences.json
@@ -26,7 +26,7 @@
       "review_after": "2027-07-26"
     },
     {
-      "fingerprint": "4f76383d8d5b01e2f31d2005cbf44bd67ebd89912f887b909c834fc73314699f",
+      "fingerprint": "7834fe8ecb1c87ca79cd6ef4229a20376622857e8b1b7b56b6a76d02e4613182",
       "issue": "https://github.com/hhenson/hg_cpp/pull/67",
       "reason": "No-change-means-no-tick ruling (2026-07-17, roadmap.rst): a mesh over an initially empty key set emits no tick in hg_cpp where released hgraph ticks an empty map. Fingerprint pinned by test_parity_harness.py against the corpus recipe mesh-empty-initial-no-tick.",
       "review_after": "2027-07-26"
@@ -37,8 +37,9 @@
       "family": "service-adaptor-transport-cycle",
       "template": "service_adaptor_roundtrip",
       "parameters_not_equal": {},
+      "relation": "service-adaptor-one-cycle",
       "issue": "https://github.com/hhenson/hg_cpp/issues/64",
-      "reason": "The designed one-cycle service_adaptor request hop shifts every trace of this template relative to released hgraph, so every completed-run value mismatch here is the documented timing deviation. The empty parameters map matches the whole template.",
+      "reason": "The designed service_adaptor request hop adds exactly one leading no-tick cycle to the hg_cpp trace. Suppress only when removing that cycle makes the complete payload trace equal to released hgraph.",
       "review_after": "2027-07-26"
     },
     {
@@ -47,8 +48,19 @@
       "parameters_not_equal": {
         "dedup_size": true
       },
+      "relation": "key-set-size-no-retick",
+      "float_abs_tolerance": 1e-12,
       "issue": "https://github.com/hhenson/hg_cpp/issues/65",
-      "reason": "No-change-means-no-tick ruling (2026-07-17, roadmap.rst): an undeduped len_ over the key set does not re-tick an unchanged length in hg_cpp, while released hgraph re-ticks the equal value. Value mismatches for dedup_size=false recipes are the ruled deviation, not candidate defects.",
+      "reason": "No-change-means-no-tick ruling (2026-07-17, roadmap.rst): suppress only when removing size fields from both dedup_size=false traces makes every other field equal within the template tolerance.",
+      "review_after": "2027-07-26"
+    },
+    {
+      "family": "service-resubscription-sampling",
+      "template": "service_subscription",
+      "parameters_not_equal": {},
+      "relation": "subscription-resample-one-cycle",
+      "issue": "https://github.com/hhenson/hg_cpp/issues/66",
+      "reason": "Designed service-boundary timing: for a repeated non-null subscription key, hg_cpp samples the existing value in the repeat cycle while released hgraph re-delivers it one cycle later. Suppress only when inserting those delay cycles makes the payload traces equal.",
       "review_after": "2027-07-26"
     },
     {
@@ -57,6 +69,7 @@
       "parameters_not_equal": {
         "zero": 0
       },
+      "relation": "trace-value",
       "issue": "https://github.com/hhenson/hg_cpp/issues/44",
       "reason": "Released hgraph applies a non-identity reduce zero a capacity-history-dependent number of times; any mismatch with zero != 0 is the documented reduce deviation, not a candidate defect.",
       "review_after": "2027-07-26"


### PR DESCRIPTION
## Summary

- **Expanded differential parity coverage** (base commit): new harness templates — service_reference, service_request_reply, service_subscription, adaptor_loopback, service_adaptor_roundtrip, context_switch, operator_pipeline, tsd_key_set_pipeline, mesh_key_set — prioritizing REF/non-peered paths, plus nightly profile scale-up (5000 examples, 64 ticks).
- **Triage of the three issues the expanded coverage surfaced** (all ruled deviations, none runtime defects):
  - #65 (`tsd_key_set_pipeline`): the no-change-means-no-tick ruling (2026-07-17) — undeduped `len_` doesn't re-tick an unchanged key-set length. Family rule on `dedup_size` + corpus recipe.
  - #64 (`service_adaptor_roundtrip`): request stubs forward next cycle by design (`services.rst` scheduling matrix) — one cycle later than upstream's same-cycle adaptor wiring. Whole-template family rule + corpus recipe.
  - #66 (`service_subscription`): late/duplicate subscriptions sample the existing shared output same-cycle — one cycle earlier than upstream's re-delivery. Fingerprint + corpus recipe; the generator now subscribes each symbol at most once so first-subscription delivery stays fully differential.
- **Docs**: service-boundary timing added to the roadmap **Accepted Deviations** list; `parity_testing.rst` documents empty-map (whole-template) families and the publisher-side known-check.
- **Consolidation hardening** (per review feedback): known-divergence records move to shared `tools/parity/known.py`; `publish_failures` now consults them directly and will never create **or reopen** an issue for a ruled deviation, so stale shard reports can't re-file.
- **Python-tier pins**: `test_service_timing_semantics.py` pins both timing traces; the `len_` ruling was already pinned by `test_no_change_means_no_tick`.

## Test plan

- [x] `python/tests/test_parity_harness.py` — 23 passed (new: publisher known-divergence skip/no-reopen, empty-map family, unique-symbol generation)
- [x] `python/tests/test_service_timing_semantics.py` — 2 passed
- [x] Full Python tree (excl. adaptors/benchmarks) — 1508 passed, 10 skipped
- [x] `python -m tools.parity validate tools/parity/corpus` — 22 recipes valid
- [x] C++ suite — 1264 cases passed (no runtime changes on this branch)

Closes the triage trail for #64, #65, #66 (already closed with analysis).

🤖 Generated with [Claude Code](https://claude.com/claude-code)