### PR TITLE
Reject cross-family scalar auto-const coercion in overload matching

### DIFF
--- a/docs/source/developer_guide/operators.rst
+++ b/docs/source/developer_guide/operators.rst
@@ -199,6 +199,17 @@ the selected candidate wires an internal one-shot const source to supply that in
 For example ``wire<add_>(w, price, Int{3})`` selects the same ``TS<Int>`` overload as
 ``wire<add_>(w, price, const_3)``.
 
+The auto-const coercion is **spelling, not conversion**: a scalar may widen into
+the candidate's current-value schema within the same numeric family (an ``int32``
+literal supplied for ``Int``, a ``float`` for ``Float`` — the C++ narrowing
+convenience), at one rank point. A **cross-family** value is **not a match** —
+an int supplied where a candidate wants ``TS<Float>`` rejects that candidate
+outright, exactly as upstream, which never matches an int into ``TS[float]``.
+``dedup(2)`` therefore selects the generic overload at ``TS[int]`` and can never
+reach the float-tolerance overload (issue #74). Bool is its own family and does
+not coerce. Scalar (configuration) parameters are unaffected: they keep the full
+standard numeric conversions of the ordinary ``wire<>`` scalar path.
+
 
 ``OperatorImpl`` — a type-erased candidate
 ------------------------------------------

--- a/python/tests/test_parity_fixes.py
+++ b/python/tests/test_parity_fixes.py
@@ -1,4 +1,4 @@
-"""Public Python wiring regressions for fixed parity issues #69, #70, #72.
+"""Public Python wiring regressions for fixed parity issues #69, #70, #72, #74.
 
 Each test pins the released-hgraph trace the differential harness verified;
 the corpus retains the minimized recipes as passing regressions.
@@ -25,6 +25,19 @@ def test_float_dedup_applies_default_tolerance():
         return hg.dedup(v, 0.5)
 
     assert eval_node(dedup_tol, [1.0, 1.4, 2.0]) == [1.0, None, 2.0]
+
+
+def test_dedup_int_const_stays_int():
+    # Issue #74: an int scalar auto-const selects the generic dedup overload;
+    # it must not coerce into the float-tolerance overload (a regression from
+    # the #69 fix making that overload single-arg callable).
+    @graph
+    def dedup_const(lhs: TS[int], rhs: TS[int]) -> TS[int]:
+        return hg.dedup(2)
+
+    out = eval_node(dedup_const, [0], [None])
+    assert out == [2]
+    assert all(type(v) is int for v in out)
 
 
 def _selection(choose_minimum, lhs, rhs):

--- a/src/hgraph/types/operator_dispatch.cpp
+++ b/src/hgraph/types/operator_dispatch.cpp
@@ -66,6 +66,42 @@ namespace hgraph
             return false;
         }
 
+        enum class NumericFamily : std::uint8_t { integral, floating, other };
+
+        [[nodiscard]] NumericFamily numeric_family(const ValueTypeMetaData *schema)
+        {
+            if (schema == scalar_descriptor<std::int8_t>::value_meta() ||
+                schema == scalar_descriptor<std::int16_t>::value_meta() ||
+                schema == scalar_descriptor<std::int32_t>::value_meta() ||
+                schema == scalar_descriptor<Int>::value_meta() ||
+                schema == scalar_descriptor<std::uint8_t>::value_meta() ||
+                schema == scalar_descriptor<std::uint16_t>::value_meta() ||
+                schema == scalar_descriptor<std::uint32_t>::value_meta() ||
+                schema == scalar_descriptor<std::uint64_t>::value_meta())
+            {
+                return NumericFamily::integral;
+            }
+            if (schema == scalar_descriptor<float>::value_meta() || schema == scalar_descriptor<Float>::value_meta())
+            {
+                return NumericFamily::floating;
+            }
+            return NumericFamily::other;
+        }
+
+        /* Auto-const coercion is SPELLING, not conversion: a scalar may widen
+           into the candidate's current-value schema within the same numeric
+           family (an ``int32`` literal supplied for ``Int``, ``float`` for
+           ``Float``), but a CROSS-FAMILY value is NOT a match — upstream never
+           matches an int into ``TS[float]``, so ``dedup(2)`` selects the
+           generic overload, never the float-tolerance one (issue #74). Bool
+           is its own family and does not coerce. */
+        [[nodiscard]] bool scalar_coerces_to(const Value &value, const ValueTypeMetaData *target)
+        {
+            const NumericFamily family = numeric_family(value.schema());
+            if (family == NumericFamily::other || family != numeric_family(target)) { return false; }
+            return operator_dispatch_detail::coerce_scalar_value_to_meta(value, target).has_value();
+        }
+
         [[nodiscard]] bool scalar_value_matches_ts_pattern(const TypePattern &pattern,
                                                            const Value &value,
                                                            ResolutionMap &map,
@@ -86,8 +122,7 @@ namespace hgraph
                     {
                         return true;
                     }
-                    const bool coerced =
-                        operator_dispatch_detail::coerce_scalar_value_to_meta(value, bound->value_schema).has_value();
+                    const bool coerced = scalar_coerces_to(value, bound->value_schema);
                     if (coerced) { ++rank_adjustment; }
                     return coerced;
                 }
@@ -100,8 +135,7 @@ namespace hgraph
                 {
                     return true;
                 }
-                const bool coerced =
-                    operator_dispatch_detail::coerce_scalar_value_to_meta(value, pattern.meta->value_schema).has_value();
+                const bool coerced = scalar_coerces_to(value, pattern.meta->value_schema);
                 if (coerced) { ++rank_adjustment; }
                 return coerced;
             }
@@ -109,8 +143,7 @@ namespace hgraph
                 pattern.scalar.kind == ScalarPattern::Kind::Concrete)
             {
                 if (value.schema() == pattern.scalar.meta) { return true; }
-                const bool coerced =
-                    operator_dispatch_detail::coerce_scalar_value_to_meta(value, pattern.scalar.meta).has_value();
+                const bool coerced = scalar_coerces_to(value, pattern.scalar.meta);
                 if (coerced) { ++rank_adjustment; }
                 return coerced;
             }

--- a/tests/cpp/test_std_operators.cpp
+++ b/tests/cpp/test_std_operators.cpp
@@ -335,6 +335,25 @@ namespace
         }
     };
 
+    struct DedupIntConstGraph
+    {
+        static constexpr auto name = "dedup_int_const_graph";
+        static Port<TS<Int>> compose(Wiring &w, Port<TS<Int>> driver)
+        {
+            (void)driver;
+            return wire<stdlib::dedup>(w, Int{2}).as<TS<Int>>();
+        }
+    };
+
+    struct DedupIntToleranceGraph
+    {
+        static constexpr auto name = "dedup_int_tolerance_graph";
+        static Port<TS<Float>> compose(Wiring &w, Port<TS<Float>> ts)
+        {
+            return wire<stdlib::dedup>(w, ts, Int{1}).as<TS<Float>>();
+        }
+    };
+
     struct FormatKwargsGraph
     {
         static constexpr auto name = "format_kwargs_graph";
@@ -2381,6 +2400,21 @@ TEST_CASE("std operators: valid over a REF source stays silent until the referen
                  values<Bool>(none));
     CHECK_OUTPUT(eval_node<ValidOverRefSelectionGraph>(values<Bool>(true), values<Int>(8), values<Int>(-6)),
                  values<Bool>(true));
+}
+
+TEST_CASE("std operators: an int const dedup stays int")
+{
+    stdlib::register_standard_operators();
+
+    // parity issue #74: an int scalar auto-const is NOT a match for a
+    // ``TS<Float>`` input (cross-family coercion), so the generic dedup
+    // overload wins; the float-tolerance overload (single-arg callable since
+    // the #69 fix) can never capture it.
+    CHECK_OUTPUT(eval_node<DedupIntConstGraph>(values<Int>(none)), values<Int>(2));
+
+    // The same rule as a hard reject: an int tolerance for the float
+    // overload's ``TS<Float>`` abs_tol leaves no matching candidate.
+    REQUIRE_THROWS_AS(eval_node<DedupIntToleranceGraph>(values<Float>(1.0)), OperatorResolutionError);
 }
 
 TEST_CASE("std operators: an operand combination with no registered implementation raises")

--- a/tools/parity/corpus/issue-74-dedup-int-const.json
+++ b/tools/parity/corpus/issue-74-dedup-int-const.json
@@ -1,0 +1,36 @@
+{
+  "schema_version": 1,
+  "id": "issue-74-dedup-int-const",
+  "description": "dedup of an int const stays int: the scalar auto-const selects the generic overload rather than coercing into the float-tolerance overload.",
+  "template": "scalar_expression",
+  "inputs": {
+    "lhs": [
+      0
+    ],
+    "rhs": [
+      null
+    ]
+  },
+  "parameters": {
+    "expression": {
+      "args": [
+        {
+          "const": 2
+        }
+      ],
+      "op": "dedup"
+    },
+    "input_types": {
+      "lhs": "int",
+      "rhs": "int"
+    },
+    "output_type": "int"
+  },
+  "features": [
+    "operator:dedup",
+    "shape:TS",
+    "topology:expression",
+    "type:int"
+  ],
+  "source_issue": "https://github.com/hhenson/hg_cpp/issues/74"
+}


### PR DESCRIPTION
## Summary

Fixes parity issue #74 — a regression from PR #73's #69 fix. Making the float-tolerance `dedup` overload single-arg callable exposed a dispatch flaw: a scalar auto-const reaching a concrete `TS<Float>` input via int→float coercion cost only +1 rank, while the generic `TS<ScalarVar<T>>` candidate carries ~100 — so `dedup(2)` in an int graph resolved to the float overload and emitted `2.0` where released hgraph emits `2`.

**The rule (ruling 2026-07-27): int→float is not a match.** Auto-const coercion is spelling, not conversion:

- **Same numeric family** widening (`int32` literal → `Int`, `float` → `Float` — the C++ narrowing convenience) still matches, at one rank point.
- **Cross-family** values (int↔float, bool→anything) now reject the candidate outright — exactly as upstream, whose `TS[float]` inputs never accept an int. `numeric_family`/`scalar_coerces_to` gate all three coercion sites in `scalar_value_matches_ts_pattern`.
- Scalar **configuration** parameters are unaffected and keep the full standard numeric conversions of the ordinary `wire<>` scalar path.

Doc record: the auto-const paragraph in `developer_guide/operators.rst`.

## Test plan

- [x] C++ suite — 1268 cases passed (new: int-const dedup stays int; an int `abs_tol` for the float overload's `TS<Float>` input raises `OperatorResolutionError`)
- [x] Full Python tree excl. adaptors (incl. ported gate + parity harness tests) — 1546 passed, 10 skipped
- [x] Minimized issue-74 recipe reproduces the released-hgraph trace (`[2]`, int)
- [x] `python -m tools.parity validate tools/parity/corpus` — 27 recipes valid

Closes #74.

🤖 Generated with [Claude Code](https://claude.com/claude-code)