### PR TITLE
Require exact scalar schemas for auto-const matching

### DIFF
--- a/docs/source/developer_guide/operators.rst
+++ b/docs/source/developer_guide/operators.rst
@@ -194,21 +194,21 @@ implementation's declared scalar type.
 
 When a candidate expects a time-series input and the call supplies a scalar value,
 the matcher tries the Python-style auto-const rule: the scalar value must match the
-candidate's current-value schema (with the same standard numeric coercions), and
+candidate's current-value schema, and
 the selected candidate wires an internal one-shot const source to supply that input.
 For example ``wire<add_>(w, price, Int{3})`` selects the same ``TS<Int>`` overload as
 ``wire<add_>(w, price, const_3)``.
 
-The auto-const coercion is **spelling, not conversion**: a scalar may widen into
-the candidate's current-value schema within the same numeric family (an ``int32``
-literal supplied for ``Int``, a ``float`` for ``Float`` — the C++ narrowing
-convenience), at one rank point. A **cross-family** value is **not a match** —
-an int supplied where a candidate wants ``TS<Float>`` rejects that candidate
-outright, exactly as upstream, which never matches an int into ``TS[float]``.
-``dedup(2)`` therefore selects the generic overload at ``TS[int]`` and can never
-reach the float-tolerance overload (issue #74). Bool is its own family and does
-not coerce. Scalar (configuration) parameters are unaffected: they keep the full
-standard numeric conversions of the ordinary ``wire<>`` scalar path.
+Atomic auto-const matches are exact: the scalar's interned schema must equal the
+candidate's current-value schema. Template matching performs no numeric widening
+or narrowing, so an ``int32`` does not match ``TS<Int>``, a ``Float`` does not
+match ``TS<float>``, and an int does not match ``TS<Float>``. This prevents a
+more-specific overload from changing the argument's type while it is being
+matched; for example ``dedup(2)`` selects the generic ``TS<Int>`` overload and
+cannot reach the float-tolerance overload. Existing structural current-value
+compatibility, including declared bundle inheritance, is preserved. Scalar
+(configuration) parameters are unaffected and keep the standard numeric
+conversions of the ordinary ``wire<>`` scalar path.
 
 
 ``OperatorImpl`` — a type-erased candidate

--- a/include/hgraph/types/operator_dispatch.h
+++ b/include/hgraph/types/operator_dispatch.h
@@ -813,29 +813,22 @@ namespace hgraph
             {
                 throw std::logic_error("operator auto-const target schema is not resolved");
             }
-            std::optional<Value> coerced;
-            if (const auto *source_schema = arg.scalar_value.schema();
-                source_schema != nullptr && current_value_schema_compatible(*target_schema, *source_schema))
+            const auto *source_schema = arg.scalar_value.schema();
+            if (source_schema == nullptr ||
+                !current_value_schema_compatible(*target_schema, *source_schema))
             {
-                coerced = arg.scalar_value;
-            }
-            else
-            {
-                coerced = coerce_scalar_value_to_meta(arg.scalar_value, target_schema->value_schema);
-            }
-            if (!coerced.has_value())
-            {
-                throw std::logic_error("operator scalar argument cannot be converted to the target time-series value");
+                throw std::logic_error(
+                    "operator scalar argument schema does not match the target time-series value");
             }
 
             ResolutionMap map;
-            map.bind_scalar("T", coerced->schema());
+            map.bind_scalar("T", source_schema);
             map.bind_ts("S", target_schema);
 
             const auto binding = value_type_for_wiring(
                 StaticNodeSignature<operator_auto_const>::scalar_schema(map));
             BundleBuilder bundle{binding};
-            bundle.set("value", std::move(*coerced));
+            bundle.set("value", arg.scalar_value.view());
 
             NodeBuilder builder;
             builder.implementation<operator_auto_const>(map);

--- a/src/hgraph/types/operator_dispatch.cpp
+++ b/src/hgraph/types/operator_dispatch.cpp
@@ -66,86 +66,34 @@ namespace hgraph
             return false;
         }
 
-        enum class NumericFamily : std::uint8_t { integral, floating, other };
-
-        [[nodiscard]] NumericFamily numeric_family(const ValueTypeMetaData *schema)
-        {
-            if (schema == scalar_descriptor<std::int8_t>::value_meta() ||
-                schema == scalar_descriptor<std::int16_t>::value_meta() ||
-                schema == scalar_descriptor<std::int32_t>::value_meta() ||
-                schema == scalar_descriptor<Int>::value_meta() ||
-                schema == scalar_descriptor<std::uint8_t>::value_meta() ||
-                schema == scalar_descriptor<std::uint16_t>::value_meta() ||
-                schema == scalar_descriptor<std::uint32_t>::value_meta() ||
-                schema == scalar_descriptor<std::uint64_t>::value_meta())
-            {
-                return NumericFamily::integral;
-            }
-            if (schema == scalar_descriptor<float>::value_meta() || schema == scalar_descriptor<Float>::value_meta())
-            {
-                return NumericFamily::floating;
-            }
-            return NumericFamily::other;
-        }
-
-        /* Auto-const coercion is SPELLING, not conversion: a scalar may widen
-           into the candidate's current-value schema within the same numeric
-           family (an ``int32`` literal supplied for ``Int``, ``float`` for
-           ``Float``), but a CROSS-FAMILY value is NOT a match — upstream never
-           matches an int into ``TS[float]``, so ``dedup(2)`` selects the
-           generic overload, never the float-tolerance one (issue #74). Bool
-           is its own family and does not coerce. */
-        [[nodiscard]] bool scalar_coerces_to(const Value &value, const ValueTypeMetaData *target)
-        {
-            const NumericFamily family = numeric_family(value.schema());
-            if (family == NumericFamily::other || family != numeric_family(target)) { return false; }
-            return operator_dispatch_detail::coerce_scalar_value_to_meta(value, target).has_value();
-        }
-
         [[nodiscard]] bool scalar_value_matches_ts_pattern(const TypePattern &pattern,
                                                            const Value &value,
-                                                           ResolutionMap &map,
-                                                           int &rank_adjustment)
+                                                           ResolutionMap &map)
         {
             if (pattern.kind == TypePattern::Kind::REF && !pattern.children.empty())
             {
                 // A scalar promoting into a REF input: the const it lifts to
                 // adapts through the to-REF binding, so match the TARGET.
-                return scalar_value_matches_ts_pattern(pattern.children[0], value, map, rank_adjustment);
+                return scalar_value_matches_ts_pattern(pattern.children[0], value, map);
             }
             if (pattern.kind == TypePattern::Kind::Var)
             {
                 if (const TSValueTypeMetaData *bound = map.find_ts(pattern.name))
                 {
-                    if (const auto *schema = value.schema();
-                        schema != nullptr && current_value_schema_compatible(*bound, *schema))
-                    {
-                        return true;
-                    }
-                    const bool coerced = scalar_coerces_to(value, bound->value_schema);
-                    if (coerced) { ++rank_adjustment; }
-                    return coerced;
+                    const auto *schema = value.schema();
+                    return schema != nullptr && current_value_schema_compatible(*bound, *schema);
                 }
             }
             if (pattern.kind == TypePattern::Kind::Concrete)
             {
                 if (pattern.meta == nullptr) { return false; }
-                if (const auto *schema = value.schema();
-                    schema != nullptr && current_value_schema_compatible(*pattern.meta, *schema))
-                {
-                    return true;
-                }
-                const bool coerced = scalar_coerces_to(value, pattern.meta->value_schema);
-                if (coerced) { ++rank_adjustment; }
-                return coerced;
+                const auto *schema = value.schema();
+                return schema != nullptr && current_value_schema_compatible(*pattern.meta, *schema);
             }
             if (pattern.kind == TypePattern::Kind::TS &&
                 pattern.scalar.kind == ScalarPattern::Kind::Concrete)
             {
-                if (value.schema() == pattern.scalar.meta) { return true; }
-                const bool coerced = scalar_coerces_to(value, pattern.scalar.meta);
-                if (coerced) { ++rank_adjustment; }
-                return coerced;
+                return value.schema() == pattern.scalar.meta;
             }
             return value_schema_matches_ts_pattern(pattern, value.schema(), map);
         }
@@ -419,8 +367,7 @@ namespace hgraph
                     else
                     {
                         ++rank_adjustment;
-                        matched = scalar_value_matches_ts_pattern(
-                            param.ts, arg.scalar_value, tail_scope, rank_adjustment);
+                        matched = scalar_value_matches_ts_pattern(param.ts, arg.scalar_value, tail_scope);
                     }
                     if (!matched)
                     {
@@ -461,7 +408,7 @@ namespace hgraph
                         // specific than a candidate taking it as a true
                         // scalar parameter (python's overload rule).
                         ++rank_adjustment;
-                        if (!scalar_value_matches_ts_pattern(param.ts, arg.scalar_value, map, rank_adjustment))
+                        if (!scalar_value_matches_ts_pattern(param.ts, arg.scalar_value, map))
                         {
                             why = fmt::format("scalar argument {} cannot be promoted to {}", i,
                                               ts_pattern_to_string(param.ts));

--- a/tests/cpp/test_operators.cpp
+++ b/tests/cpp/test_operators.cpp
@@ -77,6 +77,22 @@ namespace
         }
     };
 
+    template <fixed_string Name, typename T>
+    struct exact_auto_const_ : Operator<Name, In<"ts", TS<T>>, Out<TS<T>>>
+    {
+    };
+
+    template <typename T>
+    struct exact_auto_const_impl
+    {
+        static void eval(In<"ts", TS<T>> ts, Out<TS<T>> out) { out.set(ts.value()); }
+    };
+
+    using exact_int_auto_const_ = exact_auto_const_<"exact_int_auto_const", Int>;
+    using exact_int8_auto_const_ = exact_auto_const_<"exact_int8_auto_const", std::int8_t>;
+    using exact_float_auto_const_ = exact_auto_const_<"exact_float_auto_const", Float>;
+    using exact_float32_auto_const_ = exact_auto_const_<"exact_float32_auto_const", float>;
+
     // --- a scalar-argument operator: in * factor (exercises scalar matching + bundle) ---
     struct scale_ : Operator<"scale", In<"in", TsVar<"S">>, Scalar<"factor", ScalarVar<"T">>, Out<TsVar<"S">>>
     {
@@ -782,6 +798,65 @@ TEST_CASE("operators: scalar values auto-wire as const inputs for TS parameters"
     // The Int{3} second argument is a scalar where add_ expects a TS input; it auto-wires as
     // a const TS<Int> and is added per cycle.
     CHECK_OUTPUT(eval_node<add_>(values<Int>(1, 2, 3), Int{3}), values<Int>(4, 5, 6));
+}
+
+TEST_CASE("operators: scalar auto-const inputs require exact atomic schemas")
+{
+    register_overload<exact_int_auto_const_, exact_auto_const_impl<Int>>();
+    register_overload<exact_int8_auto_const_, exact_auto_const_impl<std::int8_t>>();
+    register_overload<exact_float_auto_const_, exact_auto_const_impl<Float>>();
+    register_overload<exact_float32_auto_const_, exact_auto_const_impl<float>>();
+
+    CHECK_OUTPUT(eval_node<exact_int_auto_const_>(Int{7}), values<Int>(7));
+    CHECK_OUTPUT(eval_node<exact_float32_auto_const_>(float{1.25F}), values<float>(1.25F));
+
+    // Numeric family membership is irrelevant to template matching: neither
+    // widening nor narrowing may change the scalar's atomic schema.
+    REQUIRE_THROWS_AS(eval_node<exact_int_auto_const_>(std::int32_t{7}), OperatorResolutionError);
+    REQUIRE_THROWS_AS(eval_node<exact_int8_auto_const_>(Int{7}), OperatorResolutionError);
+    REQUIRE_THROWS_AS(eval_node<exact_float_auto_const_>(float{1.25F}), OperatorResolutionError);
+    REQUIRE_THROWS_AS(eval_node<exact_float32_auto_const_>(Float{1.25}), OperatorResolutionError);
+}
+
+TEST_CASE("operators: a scalar must exactly match an already-bound time-series variable")
+{
+    register_overload<add_, add_generic>();
+
+    CHECK_OUTPUT(eval_node<add_>(values<Int>(1), Int{2}), values<Int>(1));
+    REQUIRE_THROWS_AS(eval_node<add_>(values<Int>(1), std::int32_t{2}), OperatorResolutionError);
+}
+
+TEST_CASE("operators: runtime concrete patterns require exact scalar auto-const schemas")
+{
+    OperatorImpl impl;
+    impl.name = "runtime_concrete_auto_const";
+    impl.label = "runtime_concrete_auto_const";
+    impl.params.push_back(ParamPattern{
+        .kind = ParamPattern::Kind::Input,
+        .name = "ts",
+        .ts = TypePattern::concrete(ts_type<TS<Int>>()),
+    });
+    impl.rank = operator_dispatch_detail::operator_rank(impl.params);
+    OperatorRegistry::instance().register_overload(std::move(impl));
+
+    WiringArg exact;
+    exact.kind = WiringArg::Kind::Scalar;
+    exact.scalar_value = Value{Int{7}};
+    exact.scalar_meta = exact.scalar_value.schema();
+    std::array<WiringArg, 1> exact_args{std::move(exact)};
+    CHECK(OperatorRegistry::instance()
+              .resolve("runtime_concrete_auto_const", std::span<const WiringArg>{exact_args})
+              .impl != nullptr);
+
+    WiringArg widened;
+    widened.kind = WiringArg::Kind::Scalar;
+    widened.scalar_value = Value{std::int32_t{7}};
+    widened.scalar_meta = widened.scalar_value.schema();
+    std::array<WiringArg, 1> widened_args{std::move(widened)};
+    REQUIRE_THROWS_AS(
+        OperatorRegistry::instance().resolve(
+            "runtime_concrete_auto_const", std::span<const WiringArg>{widened_args}),
+        OperatorResolutionError);
 }
 
 TEST_CASE("operators: sink operators return void and do not expose a null output port")


### PR DESCRIPTION
## Summary

Implements the issue #78 ruling, completing the #74/#77 sequence: **template matching must not change the type of the value being matched**. A plain scalar promoted to an auto-const source now matches a time-series input only when its atomic schema equals the candidate's current-value schema exactly — no numeric upcasting or downcasting of any kind (PR #77 had left same-family widening/narrowing such as `int32 → TS<Int>` or `Float → TS<float>` in place).

- `scalar_value_matches_ts_pattern` drops the coercion paths entirely (concrete `TS<T>` patterns, already-bound time-series variables, concrete time-series patterns, and the variadic tail all share it); the `NumericFamily` gate from #77 is removed as dead.
- Wire-time auto-const materialization no longer converts: a non-matching schema is a logic error instead of a silent conversion, and the const source is built at the scalar's own schema.
- Ordinary scalar **configuration** parameters keep their existing standard numeric conversions — the exact rule covers time-series inputs only.
- `developer_guide/operators.rst` updated: exact auto-const matching distinguished from scalar-configuration conversion.

## Test plan

- [x] C++ suite — 1271 cases passed (new: exact/widening/narrowing accept-reject matrix across `Int`/`int8`/`Float`/`float`, bound-variable mismatch rejection, runtime concrete-pattern rejection — all through public wiring APIs with `eval_node`)
- [x] Full Python tree excl. adaptors — 1546 passed, 10 skipped (python-visible dedup regressions from #74 unchanged)
- [x] `python -m tools.parity validate tools/parity/corpus` — 27 recipes valid

Closes #78.

🤖 Generated with [Claude Code](https://claude.com/claude-code)