### PR TITLE
Add timedelta/datetime/time attribute operators

### DIFF
--- a/docs/source/developer_guide/operators.rst
+++ b/docs/source/developer_guide/operators.rst
@@ -38,7 +38,13 @@ chosen implementation is baked into the graph.
    (``sample`` / ``filter_`` / ``take`` / ``drop`` / ``step`` / ``slice_`` /
    ``dedup`` / ``diff`` / ``count`` / ``clip`` / ``ewma``),
    flow-control basics (``merge`` / ``all_`` / ``any_`` / ``if_true`` /
-   ``if_then_else`` / ``if_cmp``), date / time-series-property operators, and
+   ``if_then_else`` / ``if_cmp``), date / datetime / time / timedelta
+   attribute operators (the upstream ``getattr_`` tables — ``year`` /
+   ``month`` / ``day`` / ``hour`` / ``minute`` / ``second`` /
+   ``microsecond`` / ``weekday`` / ``isoweekday`` / ``timestamp`` over
+   ``TS<Date>`` / ``TS<DateTime>`` / ``TS<Time>``, ``days`` / ``seconds`` /
+   ``microseconds`` / ``total_seconds`` over ``TS<TimeDelta>``; issue #82),
+   time-series-property operators, and
    simple IO sink overloads, including
    homogeneous, mixed, heterogeneous-temporal, result-differs and optional-scalar
    (``DivideByZero`` policy) overloads — proven by

--- a/docs/source/developer_guide/roadmap.rst
+++ b/docs/source/developer_guide/roadmap.rst
@@ -638,12 +638,14 @@ The following are intentional unless separately re-opened:
   (``hgraph.adaptors.data_frame._to_frame_converters`` /
   ``_data_frame_record_replay``).
 - ``datetime.timestamp()`` (the ``timestamp`` attribute operator, issue #82)
-  is the **UTC** epoch second count: hgraph datetimes are UTC by convention,
-  where upstream's naive ``datetime.timestamp()`` is local-timezone
-  dependent.  The two agree whenever the process timezone is UTC (CI); a
-  local-tz-dependent result is not a compatibility target.  Upstream's
-  deprecated ``datepart`` custom accessor and the ``date``/``time``
-  conversion methods stay on ``convert[...]``.
+  is the **UTC** fractional epoch second count (``TS[float]``, preserving
+  microseconds — Python's own return type): hgraph datetimes are UTC by
+  convention, where upstream's naive ``datetime.timestamp()`` is
+  local-timezone dependent (and upstream's accessor table declares ``int``,
+  which loses the fraction — neither is a compatibility target).  The values
+  agree whenever the process timezone is UTC (CI).  Upstream's deprecated
+  ``datepart`` custom accessor and the ``date``/``time`` conversion methods
+  stay on ``convert[...]``.
 - C++ contexts are name-based.  The Python bridge preserves the compatible
   type/name authoring syntax by lowering it onto that model.
 - Arbitrary Python object-class dispatch is a bridge adaptation; native

--- a/docs/source/developer_guide/roadmap.rst
+++ b/docs/source/developer_guide/roadmap.rst
@@ -637,6 +637,13 @@ The following are intentional unless separately re-opened:
   record/replay model are Arrow-native
   (``hgraph.adaptors.data_frame._to_frame_converters`` /
   ``_data_frame_record_replay``).
+- ``datetime.timestamp()`` (the ``timestamp`` attribute operator, issue #82)
+  is the **UTC** epoch second count: hgraph datetimes are UTC by convention,
+  where upstream's naive ``datetime.timestamp()`` is local-timezone
+  dependent.  The two agree whenever the process timezone is UTC (CI); a
+  local-tz-dependent result is not a compatibility target.  Upstream's
+  deprecated ``datepart`` custom accessor and the ``date``/``time``
+  conversion methods stay on ``convert[...]``.
 - C++ contexts are name-based.  The Python bridge preserves the compatible
   type/name authoring syntax by lowering it onto that model.
 - Arbitrary Python object-class dispatch is a bridge adaptation; native

--- a/include/hgraph/lib/std/operators/impl/temporal_impl.h
+++ b/include/hgraph/lib/std/operators/impl/temporal_impl.h
@@ -608,10 +608,10 @@ namespace hgraph::stdlib
 
     struct timestamp_datetime_impl
     {
-        static void eval(In<"ts", TS<DateTime>> ts, Out<TS<Int>> out)
+        static void eval(In<"ts", TS<DateTime>> ts, Out<TS<Float>> out)
         {
-            out.set(static_cast<Int>(
-                std::chrono::floor<std::chrono::seconds>(ts.value().time_since_epoch()).count()));
+            // Python's datetime.timestamp(): fractional epoch seconds.
+            out.set(std::chrono::duration<Float>(ts.value().time_since_epoch()).count());
         }
     };
 

--- a/include/hgraph/lib/std/operators/impl/temporal_impl.h
+++ b/include/hgraph/lib/std/operators/impl/temporal_impl.h
@@ -478,6 +478,177 @@ namespace hgraph::stdlib
         }
     };
 
+    // ---- timedelta attributes (python's normalized (days, seconds,
+    //      microseconds) decomposition: days floors toward -inf, the
+    //      remainders are non-negative) ----
+
+    struct days_timedelta_impl
+    {
+        static void eval(In<"ts", TS<TimeDelta>> ts, Out<TS<Int>> out)
+        {
+            out.set(static_cast<Int>(std::chrono::floor<std::chrono::days>(ts.value()).count()));
+        }
+    };
+
+    struct seconds_timedelta_impl
+    {
+        static void eval(In<"ts", TS<TimeDelta>> ts, Out<TS<Int>> out)
+        {
+            const TimeDelta remainder = ts.value() - std::chrono::floor<std::chrono::days>(ts.value());
+            out.set(static_cast<Int>(std::chrono::floor<std::chrono::seconds>(remainder).count()));
+        }
+    };
+
+    struct microseconds_timedelta_impl
+    {
+        static void eval(In<"ts", TS<TimeDelta>> ts, Out<TS<Int>> out)
+        {
+            const TimeDelta remainder = ts.value() - std::chrono::floor<std::chrono::seconds>(ts.value());
+            out.set(static_cast<Int>(remainder.count()));
+        }
+    };
+
+    struct total_seconds_timedelta_impl
+    {
+        static void eval(In<"ts", TS<TimeDelta>> ts, Out<TS<Float>> out)
+        {
+            out.set(std::chrono::duration<Float>(ts.value()).count());
+        }
+    };
+
+    // ---- datetime component extraction (the datetime overloads of the
+    //      date attribute operators plus the time-of-day attributes) ----
+
+    namespace datetime_parts_detail
+    {
+        [[nodiscard]] inline Date civil_date(DateTime when)
+        {
+            return Date{std::chrono::floor<std::chrono::days>(when)};
+        }
+
+        [[nodiscard]] inline std::int64_t microseconds_of_day(DateTime when)
+        {
+            return time_of_day(when).microseconds;
+        }
+    }  // namespace datetime_parts_detail
+
+    struct year_datetime_impl
+    {
+        static void eval(In<"ts", TS<DateTime>> ts, Out<TS<Int>> out)
+        {
+            out.set(static_cast<Int>(static_cast<int>(datetime_parts_detail::civil_date(ts.value()).year())));
+        }
+    };
+
+    struct month_datetime_impl
+    {
+        static void eval(In<"ts", TS<DateTime>> ts, Out<TS<Int>> out)
+        {
+            out.set(static_cast<Int>(static_cast<unsigned>(datetime_parts_detail::civil_date(ts.value()).month())));
+        }
+    };
+
+    struct day_datetime_impl
+    {
+        static void eval(In<"ts", TS<DateTime>> ts, Out<TS<Int>> out)
+        {
+            out.set(static_cast<Int>(static_cast<unsigned>(datetime_parts_detail::civil_date(ts.value()).day())));
+        }
+    };
+
+    struct weekday_datetime_impl
+    {
+        static void eval(In<"ts", TS<DateTime>> ts, Out<TS<Int>> out)
+        {
+            const std::chrono::weekday wd{std::chrono::floor<std::chrono::days>(ts.value())};
+            out.set(static_cast<Int>(wd.iso_encoding() - 1));
+        }
+    };
+
+    struct isoweekday_datetime_impl
+    {
+        static void eval(In<"ts", TS<DateTime>> ts, Out<TS<Int>> out)
+        {
+            const std::chrono::weekday wd{std::chrono::floor<std::chrono::days>(ts.value())};
+            out.set(static_cast<Int>(wd.iso_encoding()));
+        }
+    };
+
+    struct hour_datetime_impl
+    {
+        static void eval(In<"ts", TS<DateTime>> ts, Out<TS<Int>> out)
+        {
+            out.set(static_cast<Int>(datetime_parts_detail::microseconds_of_day(ts.value()) / 3'600'000'000));
+        }
+    };
+
+    struct minute_datetime_impl
+    {
+        static void eval(In<"ts", TS<DateTime>> ts, Out<TS<Int>> out)
+        {
+            out.set(static_cast<Int>(datetime_parts_detail::microseconds_of_day(ts.value()) / 60'000'000 % 60));
+        }
+    };
+
+    struct second_datetime_impl
+    {
+        static void eval(In<"ts", TS<DateTime>> ts, Out<TS<Int>> out)
+        {
+            out.set(static_cast<Int>(datetime_parts_detail::microseconds_of_day(ts.value()) / 1'000'000 % 60));
+        }
+    };
+
+    struct microsecond_datetime_impl
+    {
+        static void eval(In<"ts", TS<DateTime>> ts, Out<TS<Int>> out)
+        {
+            out.set(static_cast<Int>(datetime_parts_detail::microseconds_of_day(ts.value()) % 1'000'000));
+        }
+    };
+
+    struct timestamp_datetime_impl
+    {
+        static void eval(In<"ts", TS<DateTime>> ts, Out<TS<Int>> out)
+        {
+            out.set(static_cast<Int>(
+                std::chrono::floor<std::chrono::seconds>(ts.value().time_since_epoch()).count()));
+        }
+    };
+
+    // ---- time-of-day attributes over TS<Time> (upstream's time table) ----
+
+    struct hour_time_impl
+    {
+        static void eval(In<"ts", TS<Time>> ts, Out<TS<Int>> out)
+        {
+            out.set(static_cast<Int>(ts.value().microseconds / 3'600'000'000));
+        }
+    };
+
+    struct minute_time_impl
+    {
+        static void eval(In<"ts", TS<Time>> ts, Out<TS<Int>> out)
+        {
+            out.set(static_cast<Int>(ts.value().microseconds / 60'000'000 % 60));
+        }
+    };
+
+    struct second_time_impl
+    {
+        static void eval(In<"ts", TS<Time>> ts, Out<TS<Int>> out)
+        {
+            out.set(static_cast<Int>(ts.value().microseconds / 1'000'000 % 60));
+        }
+    };
+
+    struct microsecond_time_impl
+    {
+        static void eval(In<"ts", TS<Time>> ts, Out<TS<Int>> out)
+        {
+            out.set(static_cast<Int>(ts.value().microseconds % 1'000'000));
+        }
+    };
+
     struct month_of_year_impl
     {
         static void eval(In<"ts", TS<Date>> ts, Out<TS<Int>> out)

--- a/include/hgraph/lib/std/operators/temporal.h
+++ b/include/hgraph/lib/std/operators/temporal.h
@@ -51,6 +51,54 @@ namespace hgraph::stdlib
     {
     };
 
+    /** hgraph's timedelta ATTRIBUTES (port.days / .seconds / .microseconds)
+        and ``total_seconds()`` — issue #82. Python's normalization: ``days``
+        floors toward -inf; ``seconds`` / ``microseconds`` are the
+        non-negative remainders. */
+    struct days : Operator<"days", In<"ts", TS<TimeDelta>>, Out<TS<Int>>>
+    {
+    };
+
+    struct seconds : Operator<"seconds", In<"ts", TS<TimeDelta>>, Out<TS<Int>>>
+    {
+    };
+
+    struct microseconds : Operator<"microseconds", In<"ts", TS<TimeDelta>>, Out<TS<Int>>>
+    {
+    };
+
+    struct total_seconds : Operator<"total_seconds", In<"ts", TS<TimeDelta>>, Out<TS<Float>>>
+    {
+    };
+
+    /** hgraph's datetime / time ATTRIBUTES (port.hour / .minute / .second /
+        .microsecond) plus the datetime methods (``weekday()`` /
+        ``isoweekday()`` / ``timestamp()``) — issue #82. The datetime
+        overloads register under the existing ``year`` / ``month`` / ``day``
+        / ``weekday`` / ``isoweekday`` markers. */
+    struct hour : Operator<"hour", In<"ts", TS<DateTime>>, Out<TS<Int>>>
+    {
+    };
+
+    struct minute : Operator<"minute", In<"ts", TS<DateTime>>, Out<TS<Int>>>
+    {
+    };
+
+    struct second : Operator<"second", In<"ts", TS<DateTime>>, Out<TS<Int>>>
+    {
+    };
+
+    struct microsecond : Operator<"microsecond", In<"ts", TS<DateTime>>, Out<TS<Int>>>
+    {
+    };
+
+    /** ``timestamp`` — seconds since the Unix epoch. hgraph datetimes are
+        UTC by convention, so this is the UTC epoch count (upstream's naive
+        ``datetime.timestamp()`` is local-tz dependent; recorded deviation). */
+    struct timestamp : Operator<"timestamp", In<"ts", TS<DateTime>>, Out<TS<Int>>>
+    {
+    };
+
     /** ``evaluation_time_in_range`` — where the evaluation time sits
         relative to [start, end]: LT / EQ / GT, self-scheduling at the
         boundaries (datetime / date / daily-recurring time overloads). */

--- a/include/hgraph/lib/std/operators/temporal.h
+++ b/include/hgraph/lib/std/operators/temporal.h
@@ -92,10 +92,11 @@ namespace hgraph::stdlib
     {
     };
 
-    /** ``timestamp`` — seconds since the Unix epoch. hgraph datetimes are
-        UTC by convention, so this is the UTC epoch count (upstream's naive
+    /** ``timestamp`` — FRACTIONAL seconds since the Unix epoch (Python's
+        ``datetime.timestamp()`` returns a float). hgraph datetimes are UTC
+        by convention, so this is the UTC epoch count (upstream's naive
         ``datetime.timestamp()`` is local-tz dependent; recorded deviation). */
-    struct timestamp : Operator<"timestamp", In<"ts", TS<DateTime>>, Out<TS<Int>>>
+    struct timestamp : Operator<"timestamp", In<"ts", TS<DateTime>>, Out<TS<Float>>>
     {
     };
 

--- a/python/hgraph/_wiring/_core.py
+++ b/python/hgraph/_wiring/_core.py
@@ -340,6 +340,25 @@ WiringPort.as_dict = _port_as_dict
 WiringPort.as_scalar_ts = _port_as_scalar_ts
 
 
+class _CallableWiringPort(WiringPort):
+    """A wiring port that tolerates a no-arg call: upstream's method-style
+    accessors (``td.total_seconds()``, ``dt.weekday()``) spell an attribute
+    THEN a call, while hgraph attribute sugar also allows the bare form —
+    this port serves both (issue #82)."""
+
+    __slots__ = ()
+
+    def __call__(self):
+        return self
+
+
+# Upstream getattr_ *method* tables (date/datetime/time/timedelta): names the
+# DSL may spell with trailing parentheses.
+_METHOD_STYLE_ACCESSORS = frozenset({
+    "weekday", "isoweekday", "isoformat", "total_seconds", "timestamp",
+})
+
+
 def _port_getattr(self, name):
     if name.startswith("_"):
         raise AttributeError(name)
@@ -356,7 +375,16 @@ def _port_getattr(self, name):
         # hgraph attribute sugar: port.year / .month / .weekday ... resolve
         # as unary operators when no bundle field matches.
         if name in _hgraph.operator_names():
-            return wire(name, self)
+            try:
+                port = wire(name, self)
+            except WiringError as error:
+                # No overload for this port's type either: surface the
+                # Python attribute protocol (upstream raises AttributeError).
+                raise AttributeError(
+                    f"{_unwrap(self).ts_type} has no attribute '{name}'") from error
+            if name in _METHOD_STYLE_ACCESSORS:
+                return _CallableWiringPort(_unwrap(port))
+            return port
         raise
 
 

--- a/python/tests/test_parity_fixes.py
+++ b/python/tests/test_parity_fixes.py
@@ -1,4 +1,4 @@
-"""Public Python wiring regressions for fixed parity issues #69, #70, #72, #74.
+"""Public Python wiring regressions for fixed parity issues #69, #70, #72, #74, #82.
 
 Each test pins the released-hgraph trace the differential harness verified;
 the corpus retains the minimized recipes as passing regressions.
@@ -38,6 +38,52 @@ def test_dedup_int_const_stays_int():
     out = eval_node(dedup_const, [0], [None])
     assert out == [2]
     assert all(type(v) is int for v in out)
+
+
+def test_timedelta_and_datetime_accessors():
+    # Issue #82: the upstream getattr_ tables for timedelta/datetime/time.
+    from datetime import date, datetime, time, timedelta
+
+    @graph
+    def day_count(a: TS[date], b: TS[date]) -> TS[int]:
+        return (a - b).days
+
+    assert eval_node(day_count, [date(2026, 7, 27)], [date(2026, 7, 20)]) == [7]
+
+    @graph
+    def td_parts(td: TS[timedelta]) -> TS[int]:
+        return td.days * 1_000_000_000_000 + td.seconds * 1_000_000 + td.microseconds
+
+    # Python normalization: -1 day + 1s + 5us → days=-1, seconds=1, microseconds=5.
+    negative = timedelta(days=-1, seconds=1, microseconds=5)
+    assert eval_node(td_parts, [negative]) == [-1 * 1_000_000_000_000 + 1 * 1_000_000 + 5]
+
+    @graph
+    def td_total(td: TS[timedelta]) -> TS[float]:
+        return td.total_seconds()
+
+    assert eval_node(td_total, [timedelta(days=1, seconds=30)]) == [86430.0]
+
+    @graph
+    def dt_parts(dt: TS[datetime]) -> TS[int]:
+        return (dt.year * 10_000 + dt.month * 100 + dt.day) * 1_000_000 + (
+            dt.hour * 10_000 + dt.minute * 100 + dt.second)
+
+    stamp = datetime(2026, 7, 27, 13, 5, 9, 123456)
+    assert eval_node(dt_parts, [stamp]) == [20260727_130509]
+
+    @graph
+    def dt_micro_weekday(dt: TS[datetime]) -> TS[int]:
+        return dt.microsecond + dt.weekday() * 10_000_000 + dt.isoweekday() * 100_000_000
+
+    # 2026-07-27 is a Monday: weekday()=0, isoweekday()=1.
+    assert eval_node(dt_micro_weekday, [stamp]) == [123456 + 0 + 100_000_000]
+
+    @graph
+    def time_parts(t: TS[time]) -> TS[int]:
+        return t.hour * 10_000 + t.minute * 100 + t.second
+
+    assert eval_node(time_parts, [time(13, 5, 9)]) == [130509]
 
 
 def _selection(choose_minimum, lhs, rhs):

--- a/python/tests/test_parity_fixes.py
+++ b/python/tests/test_parity_fixes.py
@@ -85,6 +85,19 @@ def test_timedelta_and_datetime_accessors():
 
     assert eval_node(time_parts, [time(13, 5, 9)]) == [130509]
 
+    # timestamp(): fractional UTC epoch seconds (TS[float]) — the recorded
+    # deviation from upstream's local-tz-dependent naive timestamp.
+    from datetime import timezone
+
+    @graph
+    def dt_timestamp(dt: TS[datetime]) -> TS[float]:
+        return dt.timestamp()
+
+    half_second = datetime(1970, 1, 1, 0, 0, 0, 500000)
+    assert eval_node(dt_timestamp, [half_second]) == [0.5]
+    assert eval_node(dt_timestamp, [stamp]) == [
+        stamp.replace(tzinfo=timezone.utc).timestamp()]
+
 
 def _selection(choose_minimum, lhs, rhs):
     return hg.if_then_else(choose_minimum, hg.min_(lhs, rhs), hg.max_(lhs, rhs))

--- a/src/hgraph/lib/std/operators/temporal_impl.cpp
+++ b/src/hgraph/lib/std/operators/temporal_impl.cpp
@@ -18,6 +18,28 @@ namespace hgraph::stdlib
         register_overload<isoweekday, isoweekday_impl>();
         register_overload<month_of_year, month_of_year_impl>();
         register_overload<year, year_impl>();
+        // Issue #82: timedelta attributes and the datetime/time overloads of
+        // the attribute operators (upstream's getattr_ tables).
+        register_overload<days, days_timedelta_impl>();
+        register_overload<seconds, seconds_timedelta_impl>();
+        register_overload<microseconds, microseconds_timedelta_impl>();
+        register_overload<total_seconds, total_seconds_timedelta_impl>();
+        register_overload<year, year_datetime_impl>();
+        register_overload<month, month_datetime_impl>();
+        register_overload<month_of_year, month_datetime_impl>();
+        register_overload<day, day_datetime_impl>();
+        register_overload<day_of_month, day_datetime_impl>();
+        register_overload<weekday, weekday_datetime_impl>();
+        register_overload<isoweekday, isoweekday_datetime_impl>();
+        register_overload<hour, hour_datetime_impl>();
+        register_overload<minute, minute_datetime_impl>();
+        register_overload<second, second_datetime_impl>();
+        register_overload<microsecond, microsecond_datetime_impl>();
+        register_overload<timestamp, timestamp_datetime_impl>();
+        register_overload<hour, hour_time_impl>();
+        register_overload<minute, minute_time_impl>();
+        register_overload<second, second_time_impl>();
+        register_overload<microsecond, microsecond_time_impl>();
         register_overload<explode, explode_date_impl>();
         register_overload<valid, valid_impl>();
         register_graph_overload<valid, valid_ref_graph_impl>();

--- a/tests/cpp/test_std_operators.cpp
+++ b/tests/cpp/test_std_operators.cpp
@@ -1180,6 +1180,40 @@ TEST_CASE("std operators: add_ supports datetime + timedelta -> datetime")
                  values<DateTime>(dt(1'500'000), dt(3'500'000)));
 }
 
+TEST_CASE("std operators: timedelta and datetime attribute operators (issue #82)")
+{
+    stdlib::register_standard_operators();
+
+    // Python's normalized decomposition: -1 day + 1s + 5us has days=-1,
+    // seconds=1, microseconds=5; total_seconds is the exact float.
+    const TimeDelta negative = duration_cast<TimeDelta>(days{-1}) + seconds{1} + microseconds{5};
+    CHECK_OUTPUT(eval_node<stdlib::days>(values<TimeDelta>(negative)), values<Int>(-1));
+    CHECK_OUTPUT(eval_node<stdlib::seconds>(values<TimeDelta>(negative)), values<Int>(1));
+    CHECK_OUTPUT(eval_node<stdlib::microseconds>(values<TimeDelta>(negative)), values<Int>(5));
+    CHECK_OUTPUT(eval_node<stdlib::total_seconds>(
+                     values<TimeDelta>(duration_cast<TimeDelta>(days{1}) + seconds{30})),
+                 values<Float>(86430.0));
+
+    // 2026-07-27T13:05:09.123456 is a Monday.
+    const DateTime stamp = DateTime{sys_days{ymd(2026, 7, 27)}} + hours{13} + minutes{5} +
+                           seconds{9} + microseconds{123'456};
+    CHECK_OUTPUT(eval_node<stdlib::year>(values<DateTime>(stamp)), values<Int>(2026));
+    CHECK_OUTPUT(eval_node<stdlib::month>(values<DateTime>(stamp)), values<Int>(7));
+    CHECK_OUTPUT(eval_node<stdlib::day>(values<DateTime>(stamp)), values<Int>(27));
+    CHECK_OUTPUT(eval_node<stdlib::hour>(values<DateTime>(stamp)), values<Int>(13));
+    CHECK_OUTPUT(eval_node<stdlib::minute>(values<DateTime>(stamp)), values<Int>(5));
+    CHECK_OUTPUT(eval_node<stdlib::second>(values<DateTime>(stamp)), values<Int>(9));
+    CHECK_OUTPUT(eval_node<stdlib::microsecond>(values<DateTime>(stamp)), values<Int>(123'456));
+    CHECK_OUTPUT(eval_node<stdlib::weekday>(values<DateTime>(stamp)), values<Int>(0));
+    CHECK_OUTPUT(eval_node<stdlib::isoweekday>(values<DateTime>(stamp)), values<Int>(1));
+    CHECK_OUTPUT(eval_node<stdlib::timestamp>(values<DateTime>(stamp)),
+                 values<Int>(duration_cast<seconds>(stamp.time_since_epoch()).count()));
+
+    CHECK_OUTPUT(eval_node<stdlib::hour>(values<Time>(time_of_day(13, 5, 9))), values<Int>(13));
+    CHECK_OUTPUT(eval_node<stdlib::minute>(values<Time>(time_of_day(13, 5, 9))), values<Int>(5));
+    CHECK_OUTPUT(eval_node<stdlib::second>(values<Time>(time_of_day(13, 5, 9))), values<Int>(9));
+}
+
 TEST_CASE("std operators: date and timedelta arithmetic matches Python normalized days")
 {
     stdlib::register_standard_operators();

--- a/tests/cpp/test_std_operators.cpp
+++ b/tests/cpp/test_std_operators.cpp
@@ -1206,8 +1206,14 @@ TEST_CASE("std operators: timedelta and datetime attribute operators (issue #82)
     CHECK_OUTPUT(eval_node<stdlib::microsecond>(values<DateTime>(stamp)), values<Int>(123'456));
     CHECK_OUTPUT(eval_node<stdlib::weekday>(values<DateTime>(stamp)), values<Int>(0));
     CHECK_OUTPUT(eval_node<stdlib::isoweekday>(values<DateTime>(stamp)), values<Int>(1));
+    // timestamp(): FRACTIONAL epoch seconds (python parity) — the half
+    // second survives, before and after the epoch.
+    CHECK_OUTPUT(eval_node<stdlib::timestamp>(values<DateTime>(DateTime{microseconds{500'000}})),
+                 values<Float>(0.5));
+    CHECK_OUTPUT(eval_node<stdlib::timestamp>(values<DateTime>(DateTime{microseconds{-500'000}})),
+                 values<Float>(-0.5));
     CHECK_OUTPUT(eval_node<stdlib::timestamp>(values<DateTime>(stamp)),
-                 values<Int>(duration_cast<seconds>(stamp.time_since_epoch()).count()));
+                 values<Float>(std::chrono::duration<Float>(stamp.time_since_epoch()).count()));
 
     CHECK_OUTPUT(eval_node<stdlib::hour>(values<Time>(time_of_day(13, 5, 9))), values<Int>(13));
     CHECK_OUTPUT(eval_node<stdlib::minute>(values<Time>(time_of_day(13, 5, 9))), values<Int>(5));


### PR DESCRIPTION
## Summary

Fixes issue #82: `(date_a - date_b).days` failed at graph level because `getattr_` only had TSB overloads and no temporal attribute operators existed beyond the date table. This ports the upstream `getattr_` tables as native unary operators reached through the existing attribute sugar:

- **`TS<TimeDelta>`** — `days` / `seconds` / `microseconds` with Python's normalized decomposition (days floors toward −inf; remainders non-negative, pinned with `timedelta(days=-1, seconds=1, microseconds=5)`), plus `total_seconds()` → `TS<Float>`.
- **`TS<DateTime>`** — `year`/`month`/`day` (registered under the existing date markers plus `day_of_month`/`month_of_year`), `hour`/`minute`/`second`/`microsecond`, `weekday()`/`isoweekday()`, `timestamp()`.
- **`TS<Time>`** — `hour`/`minute`/`second`/`microsecond`.

DSL ergonomics: method-style accessor names return a `_CallableWiringPort`, so the upstream call spelling (`td.total_seconds()`, `dt.weekday()`) and the bare attribute form both wire. An attribute resolving to neither a bundle field nor an operator overload for the port's type now raises `AttributeError` (Python attribute protocol, upstream parity) instead of a bare `WiringError`.

Recorded deviation (roadmap.rst): `timestamp()` is the **UTC** epoch count — hgraph datetimes are UTC by convention, upstream's naive `datetime.timestamp()` is local-tz dependent (identical under CI's UTC). Upstream's deprecated `datepart` and the `date`/`time` conversion methods stay on `convert[...]`.

## Test plan

- [x] C++ suite — 1269 cases passed (new: full accessor matrix over TimeDelta/DateTime/Time)
- [x] `test_parity_fixes.py::test_timedelta_and_datetime_accessors` — the issue repro (`(a-b).days == [7]`), negative-timedelta normalization, datetime/time components, weekday/isoweekday call forms
- [x] Full Python tree excl. adaptors — 1547 passed, 10 skipped

Closes #82.

🤖 Generated with [Claude Code](https://claude.com/claude-code)