### PR TITLE
len_ covers every sized type; eval_node resolves generic TSL sizes

### DIFF
--- a/docs/source/developer_guide/operators.rst
+++ b/docs/source/developer_guide/operators.rst
@@ -34,7 +34,9 @@ chosen implementation is baked into the graph.
    in ``include/hgraph/lib/std/std_operators.h`` — covering scalar arithmetic,
    comparison, logical / bitwise, string operators (``match_`` / ``replace`` /
    ``substr`` / ``split`` / ``join`` / ``format_``), ``str_``, const / zero,
-   collection container basics and TSS set algebra, stream basics
+   collection container basics and TSS set algebra (``len_`` covers every
+   sized shape — str / TSS / TSD / TSL of any element kind / TSB field count
+   / TSW buffer length / sized container scalars; issue #81), stream basics
    (``sample`` / ``filter_`` / ``take`` / ``drop`` / ``step`` / ``slice_`` /
    ``dedup`` / ``diff`` / ``count`` / ``clip`` / ``ewma``),
    flow-control basics (``merge`` / ``all_`` / ``any_`` / ``if_true`` /

--- a/docs/source/developer_guide/python_integration.rst
+++ b/docs/source/developer_guide/python_integration.rst
@@ -191,7 +191,11 @@ the ``_hgraph`` bridge module (built from ``python/module.cpp``):
   a TSS value/delta and rejects loudly, except the empty ``{}`` which is
   upstream's empty-set stand-in — TSD from ``{key: value}`` dicts with
   ``None`` = lenient removal, TSL from per-index lists) and friendly delta
-  read-back (``REMOVE`` sentinel). No implicit run bound is injected — a
+  read-back (``REMOVE`` sentinel). A generic ``TSL[..., SIZE]`` parameter
+  annotation resolves its size from the samples (int-keyed dict → max key
+  + 1; list → length) and wires the REAL dynamic list shape (issue #81);
+  only annotations the size binding cannot fully resolve fall back to
+  sample-scalar inference. No implicit run bound is injected — a
   test that cannot quiesce sets ``__end_time__`` explicitly and says why.
 - **Higher-order**: ``map_``/``reduce``/``switch_`` over **named operator
   callables** — the bridge pre-instantiates ``fn<X>()`` erasures for the

--- a/include/hgraph/lib/std/operators/impl/container_impl.h
+++ b/include/hgraph/lib/std/operators/impl/container_impl.h
@@ -270,10 +270,35 @@ struct contains_tsd_key {
 struct len_tsl {
   static constexpr bool schedule_on_start = true;
 
+  // Any element kind (upstream: TSL[TIME_SERIES_TYPE, SIZE]) — a TSL of
+  // bundles or nested lists has a size too (issue #81).
   static void eval(
-      In<"ts", TSL<TS<ScalarVar<"T">>, SIZE<"N">>, InputValidity::Unchecked> ts,
+      In<"ts", TSL<TsVar<"E">, SIZE<"N">>, InputValidity::Unchecked> ts,
       Out<TS<Int>> out) {
     container_impl_detail::set_if_changed(out, static_cast<Int>(ts.size()));
+  }
+};
+
+/** len_ over a TSW: the CURRENT buffer length (grows until the window
+    fills, then stays put — no-change means no tick). */
+struct len_tsw {
+  static constexpr auto name = "len_tsw";
+  static constexpr bool schedule_on_start = true;
+
+  static bool requires_(const ResolutionMap &, OperatorCallContext context) {
+    return context.args.size() == 1 &&
+           time_series_arg_matches<AnyTSW>(context, 0);
+  }
+
+  static void eval(In<"ts", TsVar<"S">, InputValidity::Unchecked> ts,
+                   Out<TS<Int>> out) {
+    if (!ts.valid()) {
+      container_impl_detail::set_if_changed(out, Int{0});
+      return;
+    }
+    const TSWInputView window_input{ts.base().borrowed_ref()};
+    container_impl_detail::set_if_changed(
+        out, static_cast<Int>(window_input.data_view().size()));
   }
 };
 

--- a/python/hgraph/_wiring/_runner.py
+++ b/python/hgraph/_wiring/_runner.py
@@ -277,6 +277,42 @@ def _evaluate_graph(graph_fn, config, args, kwargs):
     return _times_for_sparse(run.recorded("__run_graph__", sparse=True))
 
 
+def _resolve_generic_annotation(annotation, samples):
+    """Resolve a generic annotation whose only free variable is SIZE.
+
+    ``TSL[X, SIZE]`` (nested children included) becomes the concrete TSL by
+    inferring the outer size from the samples (int-keyed dict → max key + 1;
+    list/tuple → length). Any annotation the size binding cannot fully
+    resolve (free scalar/ts variables, SIGNAL, ...) returns None and the
+    caller falls back to sample-scalar inference."""
+    pattern = getattr(annotation, "pattern", None)
+    if pattern is None:
+        return None
+    size = 0
+    for sample in samples:
+        if sample is None:
+            continue
+        if isinstance(sample, dict):
+            keys = [k for k in sample
+                    if isinstance(k, int) and not isinstance(k, bool)]
+            if len(keys) != len(sample):
+                return None
+            if keys:
+                size = max(size, max(keys) + 1)
+        elif isinstance(sample, (list, tuple)):
+            size = max(size, len(sample))
+        else:
+            return None
+    if size == 0:
+        return None
+    scope = _hgraph.ResolutionScope()
+    scope.bind_size("SIZE", size)
+    resolved = scope.resolve_ts(pattern)
+    if resolved is None:
+        return None
+    return _TsExpr(resolved, f"resolved[{annotation!r}]")
+
+
 def _infer_ts_type(series):
     """The TS type for an eval_node input vector, from its first non-None
     sample (hgraph's operators are driven without annotations)."""
@@ -491,7 +527,12 @@ def eval_node(fn, *inputs, output_type=None, resolution_dict=None,
             from .._types import _GenericTsExpr
             if isinstance(annotation, _GenericTsExpr):
                 samples = series if isinstance(series, (list, tuple)) else [series]
-                annotation = _infer_ts_type(samples)
+                # A generic collection annotation (TSL[..., SIZE]) resolves
+                # against the samples first — binding the size yields the
+                # REAL dynamic time-series shape (issue #81); only a still-
+                # generic annotation falls back to sample-scalar inference.
+                annotation = (_resolve_generic_annotation(annotation, samples)
+                              or _infer_ts_type(samples))
             annotation = _producer_annotation(annotation)
             import types as _pytypes
             import typing as _typing

--- a/python/tests/test_len_sized_types.py
+++ b/python/tests/test_len_sized_types.py
@@ -1,0 +1,78 @@
+"""Pin issue #81: len_ works for every type that can produce a size.
+
+Covers the gaps found in triage: real TSW windows had no len_ overload,
+len_tsl only accepted scalar TS elements, and eval_node degraded generic
+``TSL[..., SIZE]`` annotations to dict scalars instead of resolving the size
+from the samples. ``len_(window(...))`` returning the WindowResult bundle's
+field count and ``len_(window(...).buffer)`` are pre-existing behaviour,
+pinned here so changes are deliberate.
+"""
+
+import pytest
+
+import hgraph as hg
+from hgraph import TS
+from hgraph.test import eval_node
+from hgraph._wiring._core import WiringError
+
+
+def test_len_over_tsw_window_buffer_growth():
+    # The current buffer length: grows until the window fills, then stays
+    # put (no-change means no tick, the 2026-07-17 ruling).
+    @hg.graph
+    def tsw_len(ts: TS[int]) -> TS[int]:
+        return hg.len_(hg.to_window(ts, 3))
+
+    assert eval_node(tsw_len, [1, 2, 3, 4, 5]) == [1, 2, 3, None, None]
+
+
+def test_len_over_nested_dynamic_tsl():
+    # The issue #81 repro: previously died with AttributeError inside
+    # eval_node; the generic SIZE now resolves from the sample.
+    @hg.graph
+    def nested(ts: hg.TSL[hg.TSL[TS[int], hg.Size[2]], hg.SIZE]) -> TS[int]:
+        return hg.len_(ts)
+
+    assert eval_node(nested, [{0: {0: 1, 1: 2}}]) == [1]
+
+
+def test_len_over_dynamic_tsl_is_a_real_tsl():
+    @hg.graph
+    def dyn(ts: hg.TSL[TS[int], hg.SIZE]) -> TS[int]:
+        return hg.len_(ts)
+
+    assert eval_node(dyn, [{0: 1, 1: 2, 2: 3}]) == [3]
+
+
+def test_len_over_fixed_tsl_of_composite_elements():
+    # len_tsl accepts any element kind (upstream TSL[TIME_SERIES_TYPE, SIZE]).
+    @hg.graph
+    def tsl_of_tss(a: hg.TSS[int], b: hg.TSS[int]) -> TS[int]:
+        return hg.len_(hg.TSL.from_ts(a, b))
+
+    assert eval_node(tsl_of_tss, [{1}], [{2}]) == [2]
+
+
+def test_len_over_window_result_bundle_and_buffer():
+    # hg.window returns the WindowResult TSB: len_ of the bundle is its
+    # field count (len_tsb), and len_ of .buffer is the tuple length.
+    @hg.graph
+    def bundle_len(ts: TS[int]) -> TS[int]:
+        return hg.len_(hg.window(ts, 3))
+
+    assert eval_node(bundle_len, [1, 2, 3, 4]) == [2, None, None, None]
+
+    @hg.graph
+    def buffer_len(ts: TS[int]) -> TS[int]:
+        return hg.len_(hg.window(ts, 3).buffer)
+
+    assert eval_node(buffer_len, [1, 2, 3, 4]) == [None, None, 3, 3]
+
+
+def test_len_over_unsized_type_raises_resolution_error():
+    with pytest.raises(WiringError, match="no matching overload"):
+        @hg.graph
+        def bad(ts: TS[int]) -> TS[int]:
+            return hg.len_(ts)
+
+        eval_node(bad, [1])

--- a/src/hgraph/lib/std/operators/container_impl.cpp
+++ b/src/hgraph/lib/std/operators/container_impl.cpp
@@ -12,6 +12,7 @@ namespace hgraph::stdlib
         register_overload<len_, len_tss>();
         register_overload<len_, len_tsd>();
         register_overload<len_, len_tsl>();
+        register_overload<len_, len_tsw>();
 
         register_overload<is_empty, is_empty_tss>();
         register_overload<is_empty, is_empty_tsd>();

--- a/tests/cpp/test_std_operators.cpp
+++ b/tests/cpp/test_std_operators.cpp
@@ -1180,6 +1180,45 @@ TEST_CASE("std operators: add_ supports datetime + timedelta -> datetime")
                  values<DateTime>(dt(1'500'000), dt(3'500'000)));
 }
 
+namespace
+{
+    struct LenOverWindowGraph
+    {
+        static constexpr auto name = "len_over_window_graph";
+        static Port<TS<Int>> compose(Wiring &w, Port<TS<Int>> ts)
+        {
+            auto window = wire<stdlib::to_window>(w, ts, Int{3});
+            return wire<stdlib::len_>(w, window).as<TS<Int>>();
+        }
+    };
+
+    struct LenOverTslOfTssGraph
+    {
+        static constexpr auto name = "len_over_tsl_of_tss_graph";
+        static Port<TS<Int>> compose(Wiring &w, Port<TSS<Int>> a, Port<TSS<Int>> b)
+        {
+            auto list = stdlib::to_tsl<TSL<TSS<Int>, 2>>(w, a, b);
+            return wire<stdlib::len_>(w, list).as<TS<Int>>();
+        }
+    };
+}  // namespace
+
+TEST_CASE("std operators: len_ covers windows and composite-element lists (issue #81)")
+{
+    stdlib::register_standard_operators();
+
+    // TSW: the current buffer length — grows until the window fills, then
+    // stays put (no-change means no tick).
+    CHECK_OUTPUT(eval_node<LenOverWindowGraph>(values<Int>(1, 2, 3, 4, 5)),
+                 values<Int>(1, 2, 3, none, none));
+
+    // A TSL whose element is composite (TSS children here) has a size too:
+    // len_tsl accepts any element kind.
+    CHECK_OUTPUT(eval_node<LenOverTslOfTssGraph>(values<Value>(set_delta<Int>({1}, {})),
+                                                 values<Value>(set_delta<Int>({2}, {}))),
+                 values<Int>(2));
+}
+
 TEST_CASE("std operators: date and timedelta arithmetic matches Python normalized days")
 {
     stdlib::register_standard_operators();


### PR DESCRIPTION
## Summary

Fixes issue #81. Triage separated the report into three real gaps:

1. **`len_` over a real TSW had no overload** (`hg.to_window(ts, 3)` → "no matching overload"). New `len_tsw` returns the current buffer length — `[1, 2, 3, None, None]` for a 3-window over five ticks (no-change-no-tick preserved). The reported `[2, None, ...]` for `hg.window(...)` turned out to be `len_tsb` correctly counting the **WindowResult bundle's** two fields (`hg.window` returns a TSB, upstream parity) — that and `len_(window(...).buffer)` are pinned as-is.
2. **`len_tsl` only accepted scalar `TS` elements.** It now accepts any element kind (upstream's `TSL[TIME_SERIES_TYPE, SIZE]`), so a TSL of TSS/TSB/nested-TSL children has a size.
3. **The eval_node harness never built real dynamic TSLs.** A generic `TSL[..., SIZE]` annotation was degraded to a dict-scalar `TS[dict[int,int]]` by sample inference (which is why single-level "worked"), and a nested generic died with `AttributeError: '_GenericTsExpr' object has no attribute 'handle'`. The harness now binds `SIZE` from the samples and resolves the annotation's type pattern to the real dynamic shape; unresolvable annotations keep the old fallback.

An unsized `len_` call still fails with the operator-resolution error listing candidates.

Docs: `operators.rst` status list; `python_integration.rst` eval_node bullet.

## Test plan

- [x] C++ suite — 1269 cases passed (new: TSW buffer-length growth, composite-element TSL via `to_tsl<TSL<TSS<Int>, 2>>`)
- [x] `test_len_sized_types.py` — 6 cases: TSW growth, nested dynamic TSL (the issue repro), dynamic TSL as a real TSL, composite-element fixed TSL, WindowResult bundle/buffer pins, unsized resolution error
- [x] Full Python tree excl. adaptors — 1552 passed, 10 skipped

Closes #81.

🤖 Generated with [Claude Code](https://claude.com/claude-code)