### PR TITLE
Add native dataclass bundle schema lifting

### DIFF
--- a/docs/source/user_guide/python_compatibility.rst
+++ b/docs/source/user_guide/python_compatibility.rst
@@ -163,11 +163,22 @@ projection is lazy: assigning the whole object does not recursively validate
 its fields, while reading a declared field converts that attribute to the
 declared output type and reports an error if it is incompatible.
 
-``TSB[Quote]`` is the field-expanded time-series form. ``as_scalar_ts()``
-constructs ``Quote`` using keyword arguments and honours dataclass defaults,
-default factories, keyword-only fields, ``init=False``, and ``__post_init__``.
+``TSB[Quote]`` is the canonical field-expanded time-series form; callers do
+not need to publish a peer ``TimeSeriesSchema`` created with
+``TimeSeriesSchema.from_scalar_schema``. ``as_scalar_ts()`` constructs
+``Quote`` using keyword arguments and honours dataclass defaults, default
+factories, keyword-only fields, ``init=False``, and ``__post_init__``.
 Generic dataclasses such as ``Box[int]`` retain their concrete specialisation
 through storage, Bundle conversion, and runtime dispatch.
+
+The lift is deliberately conservative. Every stored dataclass field ``field:
+T`` becomes ``field: TS[T]``. Scalar collections remain scalar values, and a
+nested dataclass remains ``TS[Nested]`` rather than becoming a nested ``TSB``;
+the runtime does not infer ``TSL``, ``TSD``, ``TSS``, or another time-series
+topology from a scalar annotation. ``ClassVar``, ``InitVar``, and computed
+properties are not stored fields. Unresolved annotations and time-series
+annotations inside a scalar dataclass are rejected while constructing the
+schema.
 
 An annotated non-dataclass class must opt in:
 

--- a/include/hgraph/types/metadata/type_registry.h
+++ b/include/hgraph/types/metadata/type_registry.h
@@ -333,6 +333,12 @@ namespace hgraph
         const TSValueTypeMetaData *tsb(std::string_view name,
                                        const std::vector<std::pair<std::string, const TSValueTypeMetaData *>> &fields);
         /**
+         * Lift a value-layer Bundle to its canonical TSB by wrapping each
+         * field schema in ``TS``. Named identity is preserved; structural
+         * Bundles produce structural TSBs.
+         */
+        const TSValueTypeMetaData *tsb(const ValueTypeMetaData *bundle_value);
+        /**
          * Look up a previously-registered *named* ``TSB`` by name. Returns
          * the canonical named-TSB metadata, or ``nullptr`` if no TS schema
          * is registered under ``name``, or if the schema registered under

--- a/include/hgraph/types/static_schema.h
+++ b/include/hgraph/types/static_schema.h
@@ -208,6 +208,30 @@ namespace hgraph
         static constexpr auto name_sv = Name;
     };
 
+    /** Derive a TSB schema from a value-layer Bundle by lifting each field to ``TS<Field>``. */
+    template <typename TValueBundle>
+    struct TimeSeriesBundleFromScalar
+    {
+        static_assert(!std::is_same_v<TValueBundle, TValueBundle>,
+                      "TimeSeriesBundleFromScalar requires Bundle or UnNamedBundle");
+    };
+
+    template <typename... TFields>
+    struct TimeSeriesBundleFromScalar<UnNamedBundle<TFields...>>
+    {
+        using type = UnNamedTSB<Field<TFields::name_sv, TS<typename TFields::schema>>...>;
+    };
+
+    template <fixed_string Name, typename... TFields>
+    struct TimeSeriesBundleFromScalar<Bundle<Name, TFields...>>
+    {
+        using type = TSB<Name, Field<TFields::name_sv, TS<typename TFields::schema>>...>;
+    };
+
+    /** Public shorthand for the canonical field-expanded form of a scalar Bundle. */
+    template <typename TValueBundle>
+    using TSBFromScalar = typename TimeSeriesBundleFromScalar<TValueBundle>::type;
+
     template <fixed_string Name, typename... TConstraints>
     struct TsVar
     {

--- a/python/hgraph/_types.py
+++ b/python/hgraph/_types.py
@@ -1008,11 +1008,15 @@ def _python_object_value_type(scalar, type_args=()):
             fields.append((field_name, None))
             has_self_recursion = True
         else:
-            fields.append((
-                field_name,
-                _python_object_field_value_type(
-                    field_type, scalar, substitutions),
-            ))
+            try:
+                value_type = _python_object_field_value_type(
+                    field_type, scalar, substitutions)
+            except (NameError, TypeError, ValueError) as error:
+                raise TypeError(
+                    f"Python structured scalar {scalar.__qualname__} field "
+                    f"{field_name!r} must resolve to a supported scalar type"
+                ) from error
+            fields.append((field_name, value_type))
 
     local_name = scalar.__name__
     if type_args:
@@ -2195,24 +2199,35 @@ class _TSBMeta(type):
             if isinstance(ts_argument, _TsExpr):
                 ts_replacements[_type_var_name(parameter)] = ts_argument.handle
 
-        # hgraph parity: schema INHERITANCE - base-class fields first (MRO
-        # reversed), subclass fields after; later duplicates override.
-        annotations = {}
-        for klass in reversed(origin.__mro__):
-            annotations.update(_evaluated_annotations(klass))
         is_cs = issubclass(origin, _CS)
         is_python_object = _is_python_object_class(origin)
         compound_meta = None
-        if is_cs or is_python_object:
+        scalar_schema = (
+            schema
+            if is_cs or is_python_object
+            else origin.scalar_type()
+            if issubclass(origin, TimeSeriesSchema)
+            else None
+        )
+        if scalar_schema is not None:
             # TSB[structured scalar]: scalar annotations LIFT to TS fields;
             # the bundle keeps the scalar Bundle name so conversion uses the
             # registered native or Python-owned construction policy.
             try:
-                compound_meta = _value_type(schema)
+                compound_meta = _value_type(scalar_schema)
             except _GenericType:
                 # Keep an unspecialized structured scalar as a C++ type
                 # pattern; its nominal Bundle is created after resolution.
                 compound_meta = None
+            if compound_meta is not None:
+                expression = _TsExpr(
+                    _hgraph.tsb(compound_meta), f"TSB[{origin.__name__}]")
+                _TSB_SCHEMA_CLASSES[expression.handle] = origin
+                _hgraph.register_tsb_compound_class(
+                    expression.handle, compound_meta)
+                return expression
+        annotations = {}
+        if is_cs or is_python_object:
             substitutions = dict(zip(parameters, type_args))
             annotations = {
                 name: TS[_substitute_typevars(tp, substitutions)]
@@ -2222,6 +2237,12 @@ class _TSBMeta(type):
                     else _python_object_python_field_types(origin)
                 ).items()
             }
+        else:
+            # hgraph parity: schema INHERITANCE - base-class fields first
+            # (MRO reversed), subclass fields after; later duplicates
+            # override.
+            for klass in reversed(origin.__mro__):
+                annotations.update(_evaluated_annotations(klass))
 
         field_names = []
         field_patterns = []

--- a/python/py_type_system.cpp
+++ b/python/py_type_system.cpp
@@ -924,6 +924,9 @@ namespace hgraph::python_bridge
         }
         return PyTsType{TypeRegistry::instance().tsb(name, entries)};
     });
+    m.def("tsb", [](PyValueType bundle) {
+        return PyTsType{TypeRegistry::instance().tsb(bundle.meta)};
+    });
 
     m.def("scalar_pattern_var", [](const std::string &name) {
         return PyScalarPattern{ScalarPattern::var(name)};

--- a/python/tests/test_python_owned_structured_scalar.py
+++ b/python/tests/test_python_owned_structured_scalar.py
@@ -1,6 +1,7 @@
 import json
-from dataclasses import dataclass, field
-from typing import Generic, Optional, TypeVar
+from collections.abc import Mapping
+from dataclasses import InitVar, dataclass, field
+from typing import ClassVar, Generic, Optional, TypeVar
 
 import pytest
 
@@ -503,6 +504,60 @@ def test_time_series_schema_can_be_lifted_from_python_owned_dataclass():
     assert schema.scalar_type() is Quote
     assert schema.__annotations__ == {"bid": TS[float], "ask": TS[float]}
     assert TSB[schema].handle.is_tsb
+    assert TSB[schema].handle == TSB[Quote].handle
+
+
+def test_dataclass_bundle_derivation_is_conservative_and_interned():
+    @dataclass(frozen=True)
+    class Child:
+        value: int
+
+    @dataclass(frozen=True)
+    class Model:
+        number: int
+        values: tuple[int, ...]
+        lookup: Mapping[str, float]
+        child: Child
+        constructor_only: InitVar[str] = "ignored"
+        class_value: ClassVar[int] = 1
+
+        @property
+        def computed(self):
+            return self.number * 2
+
+    first = TSB[Model]
+    second = TSB[Model]
+    explicit = TSB[TimeSeriesSchema.from_scalar_schema(Model)]
+
+    assert first.handle == second.handle == explicit.handle
+    assert fields(first) == {
+        "number": TS[int],
+        "values": TS[tuple[int, ...]],
+        "lookup": TS[Mapping[str, float]],
+        "child": TS[Child],
+    }
+
+
+def test_dataclass_bundle_rejects_non_scalar_and_unresolved_fields():
+    @dataclass(frozen=True)
+    class TimeSeriesField:
+        value: TS[int]
+
+    with pytest.raises(
+        TypeError,
+        match="field 'value' must resolve to a supported scalar type",
+    ):
+        TSB[TimeSeriesField]
+
+    @dataclass(frozen=True)
+    class UnresolvedField:
+        value: "MissingBundleField"
+
+    with pytest.raises(
+        TypeError,
+        match="field 'value' must resolve to a supported scalar type",
+    ):
+        TSB[UnresolvedField]
 
 
 def test_generic_typevar_resolution_and_nested_container_substitution():

--- a/src/hgraph/types/metadata/type_registry.cpp
+++ b/src/hgraph/types/metadata/type_registry.cpp
@@ -1760,6 +1760,33 @@ namespace hgraph
         return &meta;
     }
 
+    const TSValueTypeMetaData *TypeRegistry::tsb(const ValueTypeMetaData *bundle_value)
+    {
+        if (bundle_value == nullptr ||
+            bundle_value->try_value_kind() != ValueTypeKind::Bundle ||
+            (!bundle_value->is_named_bundle() && !bundle_value->is_un_named_bundle()))
+        {
+            throw std::invalid_argument(
+                "tsb(Bundle) requires a named or structural Bundle value schema");
+        }
+
+        std::vector<std::pair<std::string, const TSValueTypeMetaData *>> fields;
+        fields.reserve(bundle_value->field_count);
+        for (std::size_t index = 0; index < bundle_value->field_count; ++index)
+        {
+            const ValueFieldMetaData &field = bundle_value->fields[index];
+            if (field.name == nullptr || field.type == nullptr)
+            {
+                throw std::invalid_argument(
+                    "tsb(Bundle) requires named fields with concrete scalar schemas");
+            }
+            fields.emplace_back(field.name, ts(field.type));
+        }
+
+        return bundle_value->is_named_bundle() ? tsb(bundle_value->name(), fields)
+                                               : un_named_tsb(fields);
+    }
+
     const TSValueTypeMetaData *TypeRegistry::ref(const TSValueTypeMetaData *referenced_ts)
     {
         const std::lock_guard lock(mutex_);

--- a/tests/cpp/test_eval_node.cpp
+++ b/tests/cpp/test_eval_node.cpp
@@ -226,6 +226,19 @@ namespace
             }
         }
     };
+
+    using LiftedPriceValue =
+        Bundle<"LiftedPriceValue", Field<"price", Float>, Field<"currency", Str>>;
+    using LiftedPriceBundle = TSBFromScalar<LiftedPriceValue>;
+
+    struct PassThroughLiftedPrice
+    {
+        static constexpr auto name = "eval_pass_through_lifted_price";
+        static void eval(In<"price", LiftedPriceBundle> price, Out<LiftedPriceBundle> out)
+        {
+            apply_delta(out.base(), price.delta());
+        }
+    };
 }  // namespace
 
 TEST_CASE("eval_node: maps each input tick through a compute node")
@@ -397,4 +410,15 @@ TEST_CASE("eval_node: a node can inspect its prior TSB output before emitting a 
                                    tsb_delta<OutputAccessBundle>(Int{2}, Str{"c"}))),
                  values<Value>(tsb_delta<OutputAccessBundle>(Int{1}, Str{"a"}), none,
                                tsb_delta<OutputAccessBundle>(Int{2}, Str{"c"})));
+}
+
+TEST_CASE("eval_node: TSBFromScalar is a first-class native wiring schema")
+{
+    using namespace hgraph;
+    CHECK_OUTPUT(
+        testing::eval_node<PassThroughLiftedPrice>(
+            values<Value>(tsb_delta<LiftedPriceBundle>(Float{1.25}, Str{"USD"}),
+                          tsb_delta<LiftedPriceBundle>(Float{2.5}, Str{"EUR"}))),
+        values<Value>(tsb_delta<LiftedPriceBundle>(Float{1.25}, Str{"USD"}),
+                      tsb_delta<LiftedPriceBundle>(Float{2.5}, Str{"EUR"})));
 }

--- a/tests/cpp/test_static_schema.cpp
+++ b/tests/cpp/test_static_schema.cpp
@@ -213,6 +213,33 @@ TEST_CASE("static_schema: Bundle<\"Name\", ...> resolves to registry.bundle(name
     REQUIRE(got == registry.bundle("LabelledPoint", {{"x", int_meta}, {"label", str_meta}}));
 }
 
+TEST_CASE("static_schema: TSBFromScalar lifts named and structural Bundle fields")
+{
+    using namespace hgraph;
+    auto &registry = TypeRegistry::instance();
+
+    using Child = Bundle<"LiftedChild", Field<"label", Str>>;
+    using Model = Bundle<"LiftedModel",
+                         Field<"number", Int>,
+                         Field<"items", HomogeneousTuple<Int>>,
+                         Field<"child", Child>>;
+    using Lifted = TSBFromScalar<Model>;
+    using Expected = TSB<"LiftedModel",
+                         Field<"number", TS<Int>>,
+                         Field<"items", TS<HomogeneousTuple<Int>>>,
+                         Field<"child", TS<Child>>>;
+    STATIC_REQUIRE(std::is_same_v<Lifted, Expected>);
+
+    using Structural = UnNamedBundle<Field<"number", Int>, Field<"label", Str>>;
+    using StructuralLifted = TSBFromScalar<Structural>;
+    using StructuralExpected =
+        UnNamedTSB<Field<"number", TS<Int>>, Field<"label", TS<Str>>>;
+    STATIC_REQUIRE(std::is_same_v<StructuralLifted, StructuralExpected>);
+
+    const auto *model = value_schema_descriptor<Model>::value_meta();
+    REQUIRE(schema_descriptor<Lifted>::ts_meta() == registry.tsb(model));
+}
+
 TEST_CASE("static_schema: TsVar / ScalarVar render schemas non-concrete")
 {
     using namespace hgraph;

--- a/tests/cpp/test_type_registry.cpp
+++ b/tests/cpp/test_type_registry.cpp
@@ -1037,6 +1037,40 @@ TEST_CASE("TypeRegistry::tsb reuses a qualified CompoundScalar value schema") {
   REQUIRE(std::string{tsb->name()} == std::string{bundle->name()});
 }
 
+TEST_CASE("TypeRegistry::tsb lifts Bundle value fields without inferring "
+          "time-series containers") {
+  using namespace hgraph;
+  auto &registry = TypeRegistry::instance();
+  const auto *integer = registry.value_type("int");
+  const auto *string = registry.value_type("str");
+  const auto *items = registry.list(integer);
+  const auto *child =
+      registry.bundle("tests.tsb", "LiftedChild", {{"label", string}});
+  const auto *model = registry.bundle(
+      "tests.tsb", "LiftedModel",
+      {{"number", integer}, {"items", items}, {"child", child}});
+
+  const auto *lifted = registry.tsb(model);
+
+  REQUIRE(lifted == registry.tsb(model));
+  REQUIRE(lifted->is_named_tsb());
+  REQUIRE(lifted->value_schema == model);
+  REQUIRE(lifted->field_count() == 3);
+  REQUIRE(lifted->fields()[0].type == registry.ts(integer));
+  REQUIRE(lifted->fields()[1].type == registry.ts(items));
+  REQUIRE(lifted->fields()[2].type == registry.ts(child));
+  REQUIRE_FALSE(lifted->fields()[1].type->kind == TSTypeKind::TSL);
+  REQUIRE_FALSE(lifted->fields()[2].type->kind == TSTypeKind::TSB);
+
+  const auto *structural =
+      registry.un_named_bundle({{"number", integer}, {"items", items}});
+  REQUIRE(registry.tsb(structural)->is_un_named_tsb());
+  REQUIRE_THROWS_AS(registry.tsb(integer), std::invalid_argument);
+  REQUIRE_THROWS_AS(
+      registry.tsb(static_cast<const ValueTypeMetaData *>(nullptr)),
+      std::invalid_argument);
+}
+
 TEST_CASE("TypeRegistry: un_named_tsb and tsb distinguish structural vs "
           "nominal identity") {
   using namespace hgraph;

--- a/tests/install_consumer/main.cpp
+++ b/tests/install_consumer/main.cpp
@@ -24,6 +24,12 @@ int main()
     static_assert(std::is_trivially_copyable_v<TypeRecord>);
     static_assert(std::is_standard_layout_v<AnyPtr>);
     static_assert(std::is_trivially_copyable_v<AnyPtr>);
+    using ConsumerScalar =
+        Bundle<"consumer::Scalar", Field<"number", Int>, Field<"label", Str>>;
+    using ConsumerBundle = TSBFromScalar<ConsumerScalar>;
+    static_assert(std::is_same_v<ConsumerBundle,
+                                 TSB<"consumer::Scalar", Field<"number", TS<Int>>,
+                                     Field<"label", TS<Str>>>>);
 
     auto &registry = TypeRegistry::instance();
     registry.register_scalar<std::int32_t>("int32");

--- a/tools/parity/catalog.py
+++ b/tools/parity/catalog.py
@@ -696,19 +696,42 @@ def _stream_dataclass(hg, recipe):
 
     from hgraph.reflection import fields, scalar_type
     from hgraph.stream import Stream
+    from hgraph.test import eval_node
 
     @dataclass(frozen=True)
     class Payload:
-        value: int
+        value: bool
 
     stream_fields = fields(hg.TSB[Stream[Payload]])
+    payload_fields = fields(hg.TSB[Payload])
+
+    @hg.graph
+    def round_trip(value: hg.TS[Payload]) -> hg.TS[Payload]:
+        return hg.convert[hg.TS[Payload]](hg.convert[hg.TSB](value))
+
+    values = eval_node(
+        round_trip,
+        [Payload(value) if value is not None else None
+         for value in decoded_inputs(hg, recipe)["probe"]],
+    )
     return {
-        name: (
-            scalar_type(field_type).__module__
-            + "."
-            + scalar_type(field_type).__qualname__
-        )
-        for name, field_type in sorted(stream_fields.items())
+        "stream_fields": {
+            name: (
+                scalar_type(field_type).__module__
+                + "."
+                + scalar_type(field_type).__qualname__
+            )
+            for name, field_type in sorted(stream_fields.items())
+        },
+        "payload_fields": {
+            name: (
+                scalar_type(field_type).__module__
+                + "."
+                + scalar_type(field_type).__qualname__
+            )
+            for name, field_type in sorted(payload_fields.items())
+        },
+        "round_trip": values,
     }
 
 
@@ -1018,8 +1041,13 @@ CATALOG = {
     "stream_dataclass": TemplateSpec(
         name="stream_dataclass",
         required_inputs=("probe",),
-        features=("boundary:python-owned", "shape:TSB", "type:dataclass"),
-        operators=(),
+        features=(
+            "boundary:python-owned",
+            "shape:TSB",
+            "type:dataclass",
+            "conversion:round-trip",
+        ),
+        operators=("convert",),
         execute=_stream_dataclass,
     ),
 }

--- a/tools/parity/corpus/issue-90-dataclass-tsb.json
+++ b/tools/parity/corpus/issue-90-dataclass-tsb.json
@@ -1,0 +1,22 @@
+{
+  "schema_version": 1,
+  "id": "issue-90-dataclass-tsb",
+  "description": "Plain dataclasses derive a direct TSB schema and round-trip through the bundle form.",
+  "template": "stream_dataclass",
+  "inputs": {
+    "probe": [
+      true,
+      false,
+      null,
+      true
+    ]
+  },
+  "parameters": {},
+  "features": [
+    "boundary:python-owned",
+    "shape:TSB",
+    "type:dataclass",
+    "conversion:round-trip"
+  ],
+  "source_issue": "https://github.com/hhenson/hg_cpp/issues/90"
+}


### PR DESCRIPTION
## Summary

- Add native runtime `Bundle -> TSB` lifting and the public compile-time `TSBFromScalar` contract.
- Route Python dataclass and helper schema construction through the native registry so both surfaces share one canonical interned type.
- Preserve exact conservative semantics: each scalar field becomes `TS<T>`; collections and nested bundles remain scalar values; invalid fields fail early.
- Add native, Python, installed-SDK, documentation, and differential parity coverage.

## Why

The Python layer previously expanded dataclass fields before calling the registry, so C++ had no equivalent first-class path and downstream projects had to maintain peer bundle schemas.

## Impact

C++ and Python now share the same schema-lifting contract without automatic upcasting, downcasting, or inferred collection/nested-bundle topology.

## Validation

- Fresh CMake configure, clean build, and complete native suite — 1,280/1,280 tests passed.
- Stable-ABI wheel built with Python 3.12 and complete non-WIP suite run under a fresh Python 3.14 environment — 1,687 passed, 10 skipped. An initial unrelated real-time catalogue timeout passed in isolation and on the full rerun.
- Sphinx documentation build with warnings as errors passed.
- Installed C++ SDK consumer passed.
- Wheel-installed Python extension consumer passed.
- Differential PR campaign — 76 attempted, 70 matched, 6 known, 0 new mismatches, 0 quarantined.
- Linux VM validation was not run because the VM is unavailable in the current environment.

Closes #90

Related reference implementation: https://github.com/hhenson/hgraph/pull/355