### PR TITLE
Present the original frame API at every user boundary

### DIFF
--- a/docs/source/developer_guide/roadmap.rst
+++ b/docs/source/developer_guide/roadmap.rst
@@ -635,7 +635,18 @@ The following are intentional unless separately re-opened:
   ``polars.DataFrame``/``polars.Series`` (``pl.from_arrow``, zero-copy) to
   reduce migration cost for polars-era user code.  Default off; polars stays
   a lazy optional dependency (a clear error if the switch is on without it);
-  the runtime substrate and record/replay artifacts remain Arrow either way.  Upstream tests asserting polars-native values against
+  the runtime substrate and record/replay artifacts remain Arrow either way.
+  The same boundary presents **naive UTC timestamps** (upstream parity — the
+  Python convention is tz-free datetimes throughout): version-2 Instant
+  columns (``timestamp[us, UTC]``) strip their timezone on the way out and
+  drop the ``hgraph.temporal.version`` marker, so the presented frame IS the
+  version-1 form and re-ingests cleanly; zoned frames (``hgraph.tzdb.version``
+  — ZonedDateTime columns) keep their timezone semantics.  Stored artifacts
+  stay version-2 tz-aware.  The presentation is a single Python-side hook
+  pair (``hgraph._frame._present_frame``/``_present_series``, called from
+  the bridge's outbound converters); user-facing framework returns route
+  through ``as_user_frame`` and shipped internals normalize back through
+  ``as_arrow_table``.  Upstream tests asserting polars-native values against
   frame reads (pyarrow scalars do not compare equal to python scalars, and
   arrow schema iteration yields ``Field`` objects, not names) are ported with
   that boundary conversion; the conversions themselves are exercised

--- a/python/hgraph/_frame.py
+++ b/python/hgraph/_frame.py
@@ -73,13 +73,14 @@ def _strip_utc_timestamps(table):
     the instants are UTC either way. The ``hgraph.temporal.version`` marker
     drops with the timezone — the result IS the version-1 form, which the
     codec re-ingests (a naive column under a version-2 marker is rejected).
-    Zoned frames (``hgraph.tzdb.version`` present — ZonedDateTime columns)
-    keep their timezone semantics untouched, as do non-UTC zones."""
+    Zoned values keep their timezone semantics untouched: ZonedDateTime and
+    the range kinds are STRUCT columns whose nested timestamps this
+    top-level strip never reaches, and the ``hgraph.tzdb.version`` marker
+    their ingest validation requires is preserved. Non-UTC zones are never
+    stripped."""
     import pyarrow as pa
 
     metadata = dict(table.schema.metadata or {})
-    if b"hgraph.tzdb.version" in metadata:
-        return table
     fields = [
         field.with_type(pa.timestamp(field.type.unit))
         if pa.types.is_timestamp(field.type) and field.type.tz == "UTC"

--- a/python/hgraph/_frame.py
+++ b/python/hgraph/_frame.py
@@ -31,10 +31,12 @@ def without_frame_metadata(table):
 def as_arrow_table(frame):
     """The canonical ``pyarrow.Table`` form of a frame value.
 
-    Shipped frame-consuming Python nodes normalize their inputs through
-    this so the polars_frames compatibility switch (issue #80) never
-    changes their internals: a pyarrow table passes through; a polars
-    ``DataFrame`` (or any ``__arrow_c_stream__`` carrier) converts on the
+    Shipped frame-consuming code (adaptor internals, the record/replay
+    machinery) normalizes inputs through this so neither the polars_frames
+    compatibility switch (issue #80) nor a user-supplied polars frame ever
+    changes their internals: a pyarrow table passes through; a
+    ``RecordBatch``/``RecordBatchReader``, a polars ``DataFrame``, or any
+    other ``__arrow_c_stream__``/``to_arrow`` carrier converts on the
     zero-copy Arrow stream. Polars' native ``string_view``/``binary_view``
     layouts cast to the standard string/binary types — several pyarrow
     compute kernels (e.g. ``filter``) have no view-type kernels."""
@@ -42,8 +44,15 @@ def as_arrow_table(frame):
 
     if isinstance(frame, pa.Table):
         return frame
+    if isinstance(frame, pa.RecordBatch):
+        return pa.Table.from_batches([frame])
+    if isinstance(frame, pa.RecordBatchReader):
+        return frame.read_all()
     if not hasattr(frame, "__arrow_c_stream__"):
-        return frame
+        to_arrow = getattr(frame, "to_arrow", None)
+        if to_arrow is None:
+            return frame
+        return as_arrow_table(to_arrow())
     table = pa.table(frame)
     fields = [
         field.with_type(pa.string()) if pa.types.is_string_view(field.type)
@@ -55,10 +64,80 @@ def as_arrow_table(frame):
     return table.cast(target) if target != table.schema else table
 
 
+def _strip_utc_timestamps(table):
+    """Naive-UTC presentation of a table's timestamp columns.
+
+    The v2 table codec stamps engine-time columns ``timestamp[us, UTC]``;
+    hgraph's Python convention is NAIVE UTC datetimes throughout (upstream
+    parity), so the user boundary presents timezone-free columns. Lossless:
+    the instants are UTC either way. The ``hgraph.temporal.version`` marker
+    drops with the timezone — the result IS the version-1 form, which the
+    codec re-ingests (a naive column under a version-2 marker is rejected).
+    Zoned frames (``hgraph.tzdb.version`` present — ZonedDateTime columns)
+    keep their timezone semantics untouched, as do non-UTC zones."""
+    import pyarrow as pa
+
+    metadata = dict(table.schema.metadata or {})
+    if b"hgraph.tzdb.version" in metadata:
+        return table
+    fields = [
+        field.with_type(pa.timestamp(field.type.unit))
+        if pa.types.is_timestamp(field.type) and field.type.tz == "UTC"
+        else field
+        for field in table.schema
+    ]
+    target = pa.schema(fields, metadata=table.schema.metadata)
+    if target == table.schema:
+        return table
+    metadata.pop(b"hgraph.temporal.version", None)
+    return table.cast(pa.schema(fields, metadata=metadata or None))
+
+
+def as_user_frame(frame):
+    """A frame in the USER-FACING form (the original hgraph API).
+
+    Timestamp columns present naive (tz-free) UTC, and with the
+    polars_frames compatibility switch on (issue #80) the result is a
+    ``polars.DataFrame``. Every framework surface that hands a frame to
+    user code — the bridge conversion boundary, ``DataFrameStorage``
+    reads, the frame store — returns through this."""
+    table = _strip_utc_timestamps(as_arrow_table(frame))
+    if not _hgraph.polars_frames():
+        return table
+    try:
+        import polars
+    except ImportError as error:
+        raise RuntimeError(
+            "the polars_frames feature switch is enabled (HGRAPH_POLARS_FRAMES) "
+            "but polars is not installed; install polars or disable the switch"
+        ) from error
+    return polars.from_arrow(table)
+
+
+def _present_frame(table):
+    """Bridge hook: the outbound frame presentation (called by frame_to_py)."""
+    return as_user_frame(table)
+
+
+def _present_series(array):
+    """Bridge hook: the outbound series presentation (called by series_to_py)."""
+    if not _hgraph.polars_frames():
+        return array
+    try:
+        import polars
+    except ImportError as error:
+        raise RuntimeError(
+            "the polars_frames feature switch is enabled (HGRAPH_POLARS_FRAMES) "
+            "but polars is not installed; install polars or disable the switch"
+        ) from error
+    return polars.from_arrow(array)
+
+
 __all__ = [
     "with_frame_metadata",
     "frame_metadata",
     "has_frame_metadata",
     "without_frame_metadata",
     "as_arrow_table",
+    "as_user_frame",
 ]

--- a/python/hgraph/adaptors/data_frame/_data_frame_record_replay.py
+++ b/python/hgraph/adaptors/data_frame/_data_frame_record_replay.py
@@ -164,6 +164,8 @@ class BaseDataFrameStorage(DataFrameStorage, ABC):
         self._schema = {}
 
     def read_frame(self, path, start_time=None, end_time=None, as_of=None):
+        from hgraph._frame import as_user_frame
+
         frame = self._read(path)
         date_col, as_of_col = self._schema_info(path)
         mask = None
@@ -178,7 +180,10 @@ class BaseDataFrameStorage(DataFrameStorage, ABC):
         if as_of is not None and as_of_col is not None:
             as_of_mask = pc.less_equal(frame[as_of_col], pa.scalar(as_of))
             mask = as_of_mask if mask is None else pc.and_(mask, as_of_mask)
-        return frame.filter(mask) if mask is not None else frame
+        # A framework surface: user code reads recordings through this, so
+        # the result presents in the user-facing form (issue #80); internal
+        # replay normalizes back through _as_arrow.
+        return as_user_frame(frame.filter(mask) if mask is not None else frame)
 
     def write_frame(self, path, frame, mode=WriteMode.OVERWRITE, as_of=None):
         frame = _as_arrow(frame)
@@ -262,14 +267,12 @@ class MemoryDataFrameStorage(BaseDataFrameStorage):
 
 
 def _as_arrow(value):
-    if isinstance(value, pa.Table):
-        return value
-    if isinstance(value, pa.RecordBatch):
-        return pa.Table.from_batches([value])
-    to_arrow = getattr(value, "to_arrow", None)
-    if to_arrow is not None:
-        return _as_arrow(to_arrow())
-    raise TypeError(f"dataframe storage requires an Arrow-compatible frame, got {type(value)!r}")
+    from hgraph._frame import as_arrow_table
+
+    table = as_arrow_table(value)
+    if not isinstance(table, pa.Table):
+        raise TypeError(f"dataframe storage requires an Arrow-compatible frame, got {type(value)!r}")
+    return table
 
 
 # --------------------------------------------------------------------------
@@ -342,13 +345,16 @@ _LITERAL_FRAMES = {}
 
 
 def _storage_frame(key, recordable_id):
+    # Internal replay consumption: a user-implemented storage (or a
+    # user-supplied literal frame) may return the user-facing form —
+    # normalize back to the canonical Arrow representation (issue #80).
     literal = _LITERAL_FRAMES.get((key, recordable_id))
     if literal is not None:
-        return literal
+        return _as_arrow(literal)
     storage = DataFrameStorage.instance()
     if storage is None:
         raise RuntimeError("data-frame record/replay requires an active DataFrameStorage")
-    return storage.read_frame(f"{recordable_id}.{key}", as_of=_configured_as_of())
+    return _as_arrow(storage.read_frame(f"{recordable_id}.{key}", as_of=_configured_as_of()))
 
 
 _REPLAY_SCHEMAS = {}

--- a/python/hgraph/adaptors/data_frame/_data_frame_source.py
+++ b/python/hgraph/adaptors/data_frame/_data_frame_source.py
@@ -18,18 +18,12 @@ __all__ = (
 
 
 def _as_arrow_table(value) -> pa.Table:
-    if isinstance(value, pa.Table):
-        return value
-    if isinstance(value, pa.RecordBatch):
-        return pa.Table.from_batches([value])
-    if isinstance(value, pa.RecordBatchReader):
-        return value.read_all()
-    to_arrow = getattr(value, "to_arrow", None)
-    if to_arrow is not None:
-        table = to_arrow()
-        if isinstance(table, pa.Table):
-            return table
-    raise TypeError(f"dataframe sources must produce an Arrow Table, got {type(value)!r}")
+    from hgraph._frame import as_arrow_table
+
+    table = as_arrow_table(value)
+    if not isinstance(table, pa.Table):
+        raise TypeError(f"dataframe sources must produce an Arrow Table, got {type(value)!r}")
+    return table
 
 
 class DataFrameSource(ABC):

--- a/python/tests/ported/_operators/test_data_frame_operators.py
+++ b/python/tests/ported/_operators/test_data_frame_operators.py
@@ -4,10 +4,11 @@
 #    pa.concat_tables, .sort(...) -> .sort_by(...), assert_frame_equal ->
 #    Table.equals. The empty frame gets explicit column types (pyarrow cannot
 #    infer from []).
-#  - deviation: RFC 0002 version-2 Instant columns are timestamp[us, "UTC"],
-#    so Arrow returns timezone-aware UTC datetime values.
+#  - the user boundary presents NAIVE UTC datetimes (upstream-verbatim,
+#    issue #80): version-2 Instant columns strip their UTC timezone on the
+#    way out, so date expectations are upstream's naive values.
 from dataclasses import dataclass
-from datetime import datetime, timezone
+from datetime import datetime
 from typing import Tuple
 
 import pyarrow as pa
@@ -21,7 +22,8 @@ from hgraph.test import eval_node
 
 
 def _instant(value: datetime) -> datetime:
-    return value.replace(tzinfo=timezone.utc)
+    # Upstream-verbatim: engine dates surface as naive UTC datetimes.
+    return value
 
 
 def test_data_frame_ts():

--- a/python/tests/ported/_wiring/test_lower.py
+++ b/python/tests/ported/_wiring/test_lower.py
@@ -1,10 +1,8 @@
-from datetime import timezone
-
 import pyarrow as pa
 import pytest
 
-# deviation: RFC 0002 version-2 Instant columns are timestamp[us, "UTC"];
-# Arrow therefore returns timezone-aware UTC datetime values.
+# The user boundary presents NAIVE UTC datetimes (upstream-verbatim, issue
+# #80): version-2 Instant columns strip their UTC timezone on the way out.
 from hgraph import (
     GlobalContext,
     GlobalState,
@@ -38,9 +36,9 @@ def test_lower_replays_arrow_frames_through_native_graph():
 
     assert result.to_pydict() == {
         "date": [
-            MIN_ST.replace(tzinfo=timezone.utc),
-            (MIN_ST + MIN_TD).replace(tzinfo=timezone.utc),
-            (MIN_ST + MIN_TD * 2).replace(tzinfo=timezone.utc),
+            MIN_ST,
+            MIN_ST + MIN_TD,
+            MIN_ST + MIN_TD * 2,
         ],
         "value": [4, 5, 6],
     }
@@ -102,5 +100,5 @@ def test_lower_preserves_polars_boundary_compatibility():
 
     assert isinstance(result, pl.DataFrame)
     assert result.equals(
-        pl.DataFrame({"date": [MIN_ST.replace(tzinfo=timezone.utc)], "value": [2]})
+        pl.DataFrame({"date": [MIN_ST], "value": [2]})
     )

--- a/python/tests/test_polars_frames.py
+++ b/python/tests/test_polars_frames.py
@@ -137,6 +137,42 @@ def test_frame_store_read_presents_naive_utc_timestamps():
         hg.set_record_replay_config(hg.IN_MEMORY)
 
 
+def test_strip_presents_engine_columns_naive_even_in_zoned_frames():
+    # A frame carrying ZonedDateTime values (a STRUCT column + the
+    # hgraph.tzdb.version marker) still presents its top-level engine
+    # timestamp columns naive; the zoned struct's nested timestamp and the
+    # tzdb marker are untouched, and the temporal marker drops (v1 form).
+    from datetime import datetime, timezone
+
+    from hgraph._frame import _strip_utc_timestamps
+
+    zoned_type = pa.struct([
+        pa.field("instant", pa.timestamp("us", tz="UTC")),
+        pa.field("zone", pa.string()),
+        pa.field("offset_seconds", pa.int32()),
+    ])
+    when = datetime(2026, 7, 27, 12, 0, tzinfo=timezone.utc)
+    table = pa.table(
+        {
+            "__date_time__": pa.array([when], pa.timestamp("us", tz="UTC")),
+            "value": pa.array(
+                [{"instant": when, "zone": "Europe/London", "offset_seconds": 3600}],
+                zoned_type,
+            ),
+        },
+    ).replace_schema_metadata({
+        b"hgraph.temporal.version": b"2",
+        b"hgraph.tzdb.version": b"2026a",
+    })
+
+    stripped = _strip_utc_timestamps(table)
+    assert stripped.schema.field("__date_time__").type == pa.timestamp("us")
+    assert stripped.schema.field("value").type == zoned_type
+    metadata = stripped.schema.metadata
+    assert b"hgraph.temporal.version" not in metadata
+    assert metadata[b"hgraph.tzdb.version"] == b"2026a"
+
+
 def test_data_frame_storage_read_presents_user_form(polars_frames):
     # RecorderAPI/DataFrameStorage reads are a user-facing framework
     # surface: with the switch on the user reads polars, while internal

--- a/python/tests/test_polars_frames.py
+++ b/python/tests/test_polars_frames.py
@@ -103,6 +103,65 @@ def test_shipped_frame_consumers_survive_the_switch(polars_frames):
     assert result["instrument"].to_list() == ["A"]
 
 
+def test_frame_store_read_presents_naive_utc_timestamps():
+    # The v2 table codec stamps engine-time columns timestamp[us, UTC];
+    # the user boundary presents them NAIVE (upstream parity) and drops the
+    # version marker so the frame re-ingests as the v1 form.
+    from datetime import datetime
+
+    import hgraph as hg
+    from hgraph import graph
+    from hgraph.test import eval_node
+
+    hg.set_record_replay_config(hg.DATA_FRAME)
+    try:
+        @hg.component
+        def snap(x: TS[int]) -> TS[int]:
+            return x + x
+
+        @graph
+        def recording(x: TS[int]) -> TS[int]:
+            with hg.record_replay_scope(hg.RecordReplayEnum.RECORD):
+                return snap(x)
+
+        eval_node(recording, [1, 2, 3])
+        table = hg.frame_store_read("snap.__out__")
+        assert isinstance(table, pa.Table)
+        for field in table.schema:
+            if pa.types.is_timestamp(field.type):
+                assert field.type.tz is None, field
+        first = table.to_pylist()[0]["__date_time__"]
+        assert isinstance(first, datetime) and first.tzinfo is None
+        assert b"hgraph.temporal.version" not in (table.schema.metadata or {})
+    finally:
+        hg.set_record_replay_config(hg.IN_MEMORY)
+
+
+def test_data_frame_storage_read_presents_user_form(polars_frames):
+    # RecorderAPI/DataFrameStorage reads are a user-facing framework
+    # surface: with the switch on the user reads polars, while internal
+    # replay keeps working (it normalizes back to Arrow).
+    from datetime import datetime
+
+    import hgraph as hg
+    from hgraph import GlobalState, MIN_ST, MIN_TD, record, replay, set_as_of, set_record_replay_model
+    from hgraph.adaptors.data_frame import DATA_FRAME_RECORD_REPLAY, MemoryDataFrameStorage
+    from hgraph.test import eval_node
+
+    with GlobalState(), MemoryDataFrameStorage() as storage:
+        set_record_replay_model(DATA_FRAME_RECORD_REPLAY)
+        set_as_of(MIN_ST + MIN_TD * 30)
+        eval_node(record[TS[int]], ts=[1, 2, 3], key="ts", recordable_id="test")
+
+        frame = storage.read_frame("test.ts")
+        assert isinstance(frame, polars.DataFrame)
+        assert frame["value"].to_list() == [1, 2, 3]
+        assert frame["__date_time__"].dtype.time_zone is None
+
+        # Internal replay consumes the same storage unaffected.
+        assert eval_node(replay[TS[int]], key="ts", recordable_id="test") == [1, 2, 3]
+
+
 def test_enabled_without_polars_raises_clearly(polars_frames):
     saved = {name: module for name, module in sys.modules.items()
              if name == "polars" or name.startswith("polars.")}

--- a/python/value_conversion.cpp
+++ b/python/value_conversion.cpp
@@ -552,18 +552,22 @@ namespace hgraph::python_bridge
 
     namespace
     {
-        [[nodiscard]] nb::object import_polars()
+        /* The user-boundary frame/series presentation lives PYTHON-side
+           (hgraph._frame): naive-UTC timestamp columns and the optional
+           polars form (issue #80). The bridge stays usable without the
+           hgraph package (raw pyarrow passthrough). */
+        [[nodiscard]] nb::object present_through(const char *hook, nb::object value)
         {
+            nb::object presenter;
             try
             {
-                return nb::module_::import_("polars");
+                presenter = nb::module_::import_("hgraph._frame").attr(hook);
             }
             catch (nb::python_error &)
             {
-                throw std::runtime_error(
-                    "the polars_frames feature switch is enabled (HGRAPH_POLARS_FRAMES) "
-                    "but polars is not installed; install polars or disable the switch");
+                return value;
             }
+            return presenter(value);
         }
     }  // namespace
 
@@ -572,8 +576,7 @@ namespace hgraph::python_bridge
         if (!frame.has_value()) { return nb::none(); }
         nb::object stream = nb::cast(PyArrowStream{frame});
         nb::object table  = nb::module_::import_("pyarrow").attr("table")(stream);
-        if (!polars_frames_enabled()) { return table; }
-        return import_polars().attr("from_arrow")(table);
+        return present_through("_present_frame", std::move(table));
     }
 
     Value py_arrow_to_frame(nb::handle object)
@@ -619,8 +622,7 @@ namespace hgraph::python_bridge
         if (!series.has_value()) { return nb::none(); }
         nb::object holder = nb::cast(PySeriesArray{series});
         nb::object array  = nb::module_::import_("pyarrow").attr("array")(holder);
-        if (!polars_frames_enabled()) { return array; }
-        return import_polars().attr("from_arrow")(array);
+        return present_through("_present_series", std::move(array));
     }
 
     Value py_arrow_to_series(nb::handle object)


### PR DESCRIPTION
## Summary

Follow-on to PR #89 (merged before this landed on the branch), covering the two related compatibility requirements:

**Record/replay + frameworks present the original API.** Wherever Python user code interacts with frames it gets the original hgraph API. The outbound presentation is consolidated into a single Python-side hook pair (`hgraph._frame._present_frame`/`_present_series`) called from the bridge's `frame_to_py`/`series_to_py` (raw-pyarrow fallback keeps `_hgraph` usable standalone; the C++ polars wrap is superseded). `BaseDataFrameStorage.read_frame` — the RecorderAPI surface — returns the user form via the public `as_user_frame`; internal replay (`_storage_frame`) normalizes user-implemented storages and literal-frame overrides back to Arrow through the consolidated `as_arrow_table` (which now also absorbs `RecordBatch`/`RecordBatchReader`/`to_arrow` carriers — the two adaptor-local copies delegate to it). Rule for future surfaces: outbound to users → `as_user_frame`; inbound to shipped internals → `as_arrow_table`.

**Naive UTC timestamps (the tz-aware leak).** The v2 table codec stamps engine-time columns `timestamp[us, UTC]`, so `frame_store_read` and TABLE-protocol frames handed user code timezone-aware datetimes where upstream — and every hgraph scalar path — is naive. The boundary now strips UTC timestamp columns to tz-free and drops the `hgraph.temporal.version` marker: the presented frame IS the version-1 form, which the codec re-ingests (a naive column under a v2 marker is rejected by `validate_versioned_array_type`). Zoned frames (`hgraph.tzdb.version` — ZonedDateTime) and non-UTC zones keep their timezone semantics; stored artifacts stay version-2 tz-aware. The ported-test adaptations that had encoded the tz-aware behaviour (`test_lower`, `test_data_frame_operators` `_instant`) are reverted to upstream-verbatim naive expectations.

Doc record: the Arrow/polars boundary entry in roadmap.rst Accepted Deviations.

## Test plan

- [x] `test_polars_frames.py` — 8 cases incl. `frame_store_read` naive presentation + v1-marker drop, `DataFrameStorage.read_frame` user form under the switch with internal replay unaffected
- [x] Un-adapted ported suites green (`test_lower`, `test_data_frame_operators`)
- [x] Full Python tree excl. adaptors — 1573 passed, 10 skipped
- [x] Complete adaptor suite — 114 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)