### PR TITLE
Target the nightly parity campaign at the 2026-07 compat-issue classes

### DIFF
--- a/docs/source/developer_guide/parity_testing.rst
+++ b/docs/source/developer_guide/parity_testing.rst
@@ -143,7 +143,19 @@ production triage has actually produced (the 2026-07 batch, issues #74-#92):
   a changed frame surface is a trace difference (the PR #92 class);
 - ``postponed_annotations`` is a generation MODE on the source-built
   templates: the generated module opts into PEP 563, so string annotations
-  exercise signature resolution on both distributions (the #83 class).
+  exercise signature resolution on both distributions (the #83 class);
+- ``nested_higher_order`` targets the composition breeding ground directly:
+  a key set GROWING AND SHRINKING under ``map_``/``mesh_``, a per-key
+  ``switch_`` FLIPPING branches (nested graphs start/stop), request-reply
+  and subscription services and adaptors living inside that structure, and
+  optionally the whole pipeline under an outer ``switch_`` that tears it
+  down and rebuilds it. Weighted double in the generator. Composition is
+  restricted to upstream-supported space (a per-key adaptor client cycles
+  released hgraph's toposort, so the adaptor consumes the reduced pipeline
+  output; subscriptions subscribe per key outside the flipping switch), and
+  the subscription variant stays out of the ruled re-subscription timing
+  space (no key re-adds, no outer switch). Its first differential replays
+  surfaced issues #94 and #95.
 
 When a new compatibility issue is fixed, extend this list: either an
 existing template's generated space must provably contain the issue's

--- a/docs/source/developer_guide/parity_testing.rst
+++ b/docs/source/developer_guide/parity_testing.rst
@@ -122,6 +122,34 @@ events, tick lengths, and feature pairs.  They also compare the template
 catalogue with the runtime's public operator inventory, so unsupported
 generation surface remains visible.
 
+The catalogue is deliberately targeted at the compatibility-issue classes
+production triage has actually produced (the 2026-07 batch, issues #74-#92):
+
+- ``scalar_expression`` const arguments exercise scalar auto-const overload
+  selection (the #74/#78 exact-matching class);
+- ``temporal_expression`` drives date/datetime arithmetic into the upstream
+  ``getattr_`` accessor tables — properties and method-call spellings, the
+  ``(date - date).days`` shape included (the #82 class);
+- ``collection_size`` covers ``len_``/``is_empty``/``contains_`` over every
+  upstream-supported sized shape (the #81 class); its no-change re-tick
+  elision is the ruled deviation, bounded by the ``no-change-elision``
+  relation in ``known_divergences.json``;
+- ``lifecycle_state`` generates start/stop lifecycle functions across the
+  accepted signature spellings — strict, bare-injectable, and unannotated
+  name-match (the #79 class);
+- ``data_frame_recording`` records through the DATA_FRAME model and emits
+  the frame a ``DataFrameStorage`` hands back to user code — column names,
+  **timezone presentation**, and row values — so a tz-aware engine column or
+  a changed frame surface is a trace difference (the PR #92 class);
+- ``postponed_annotations`` is a generation MODE on the source-built
+  templates: the generated module opts into PEP 563, so string annotations
+  exercise signature resolution on both distributions (the #83 class).
+
+When a new compatibility issue is fixed, extend this list: either an
+existing template's generated space must provably contain the issue's
+minimized shape, or a new template/mode is added alongside a
+``coverage-*`` corpus recipe pinning it.
+
 Add a template when a behavior cannot be represented by the existing bounded
 language:
 

--- a/python/tests/test_parity_harness.py
+++ b/python/tests/test_parity_harness.py
@@ -169,7 +169,7 @@ def test_generated_framework_recipes_prioritize_ref_and_non_peered_paths():
     pytest.importorskip("hypothesis")
     from tools.parity.generate import generate_recipes
 
-    recipes = generate_recipes(480, seed=29)
+    recipes = generate_recipes(640, seed=29)
     templates = {recipe.template for recipe in recipes}
     assert {
         "service_reference",
@@ -1196,7 +1196,7 @@ def test_generator_covers_the_2026_07_compat_issue_classes():
         postponed = postponed or recipe.parameters.get(
             "postponed_annotations", False)
     assert {"temporal_expression", "collection_size", "lifecycle_state",
-            "data_frame_recording"} <= templates
+            "data_frame_recording", "nested_higher_order"} <= templates
     assert postponed
 
 
@@ -1209,6 +1209,8 @@ def test_coverage_corpus_recipes_execute_on_the_candidate():
         "coverage-lifecycle-spellings",
         "coverage-frame-recording",
         "coverage-postponed-annotations",
+        "coverage-nested-adaptor-pipeline",
+        "coverage-nested-outer-switch",
     ):
         raw = json.loads(
             (CORPUS / f"{name}.json").read_text(encoding="utf-8"))
@@ -1302,4 +1304,23 @@ def test_new_template_validators_reject_malformed_recipes():
             "parameters": {"as_of_offset": 0},
         },
         "as_of_offset",
+    )
+    rejects(
+        {
+            "template": "nested_higher_order",
+            "inputs": {"values": [{"k1": 1}], "selector": ["alpha"]},
+            "parameters": {"inner": "adaptor", "outer": "map",
+                           "wrap_switch": False, "reduce_output": False},
+        },
+        "adaptor inner requires reduce_output",
+    )
+    rejects(
+        {
+            "template": "nested_higher_order",
+            "inputs": {"values": [{"k1": 1}, {"k1": {"$remove": True}}, {"k1": 2}],
+                       "selector": ["alpha", None, None]},
+            "parameters": {"inner": "subscription", "outer": "map",
+                           "wrap_switch": False, "reduce_output": True},
+        },
+        "must not re-add removed keys",
     )

--- a/python/tests/test_parity_harness.py
+++ b/python/tests/test_parity_harness.py
@@ -169,7 +169,7 @@ def test_generated_framework_recipes_prioritize_ref_and_non_peered_paths():
     pytest.importorskip("hypothesis")
     from tools.parity.generate import generate_recipes
 
-    recipes = generate_recipes(320, seed=29)
+    recipes = generate_recipes(480, seed=29)
     templates = {recipe.template for recipe in recipes}
     assert {
         "service_reference",
@@ -1091,7 +1091,7 @@ def test_generated_key_set_recipes_avoid_ruled_no_tick_space():
     pytest.importorskip("hypothesis")
     from tools.parity.generate import generate_recipes
 
-    recipes = generate_recipes(320, seed=29)
+    recipes = generate_recipes(480, seed=29)
     keyed = [
         r
         for r in recipes
@@ -1180,3 +1180,126 @@ def test_wheel_fingerprint_excludes_parity_tooling(tmp_path):
     )
     after = hg_cpp_source_fingerprint(tmp_path, python_version="3.12")
     assert before == after
+
+
+def test_generator_covers_the_2026_07_compat_issue_classes():
+    # The nightly generator must keep producing recipes in the spaces where
+    # the 2026-07 compatibility issues lived: temporal accessors (#82),
+    # collection sizes (#81), lifecycle signature spellings (#79), the
+    # recorded-frame surface (PR #92), and postponed annotations (#83).
+    from tools.parity.generate import generate_recipes
+
+    templates = set()
+    postponed = False
+    for recipe in generate_recipes(480, seed=29):
+        templates.add(recipe.template)
+        postponed = postponed or recipe.parameters.get(
+            "postponed_annotations", False)
+    assert {"temporal_expression", "collection_size", "lifecycle_state",
+            "data_frame_recording"} <= templates
+    assert postponed
+
+
+def test_coverage_corpus_recipes_execute_on_the_candidate():
+    from tools.parity.runner import run_recipe
+
+    for name in (
+        "coverage-temporal-accessors",
+        "coverage-collection-sizes",
+        "coverage-lifecycle-spellings",
+        "coverage-frame-recording",
+        "coverage-postponed-annotations",
+    ):
+        raw = json.loads(
+            (CORPUS / f"{name}.json").read_text(encoding="utf-8"))
+        result = run_recipe(raw)
+        assert result["status"] == "ok", (name, result)
+    # The recorded-frame surface reports column timezone presentation: the
+    # naive-UTC user boundary must hold (a tz-aware column is a trace diff).
+    raw = json.loads(
+        (CORPUS / "coverage-frame-recording.json").read_text(encoding="utf-8"))
+    frame = dict(run_recipe(raw)["trace"]["$map"])["frame"]
+    columns = dict(frame["$map"])["columns"]
+    assert all(dict(column["$map"])["tz"] is None for column in columns)
+
+
+def test_no_change_elision_relation_bounds_the_ruled_deviation():
+    from tools.parity.known import (
+        is_known_family_failure,
+        load_known_divergences,
+    )
+
+    _fingerprints, families = load_known_divergences()
+    ok = lambda trace: {"status": "ok", "trace": trace}
+    recipe = {
+        "template": "collection_size",
+        "inputs": {"ts": [None]},
+        "parameters": {"shape": "tss", "operation": "len"},
+    }
+
+    def classify(reference, candidate):
+        difference = compare_outcomes(ok(reference), ok(candidate))
+        assert difference is not None
+        return is_known_family_failure(
+            recipe, difference.to_dict(), ok(reference), ok(candidate),
+            families)
+
+    # The ruled shape: upstream re-ticks the unchanged size, hg_cpp elides.
+    assert classify([2, 2, 3], [2, None, 3])
+    # A changed value is NOT elidable.
+    assert not classify([2, 3, 3], [2, None, 3])
+    assert not classify([2, 2, 3], [2, None, 4])
+    # An extra candidate tick is reportable.
+    assert not classify([2, None, 3], [2, 2, 3])
+    # A first-tick difference is reportable (nothing emitted yet).
+    assert not classify([2, 3], [None, 3])
+    # Length differences remain reportable.
+    difference = compare_outcomes(ok([2, 2]), ok([2]))
+    assert not is_known_family_failure(
+        recipe, difference.to_dict(), ok([2, 2]), ok([2]), families)
+
+
+def test_new_template_validators_reject_malformed_recipes():
+    def rejects(raw, match):
+        with pytest.raises(RecipeError, match=match):
+            validate_recipe(Recipe.from_dict({
+                "schema_version": 1,
+                "id": "generated-validator-check",
+                "description": "validator check",
+                **raw,
+            }))
+
+    rejects(
+        {
+            "template": "temporal_expression",
+            "inputs": {"lhs": [None]},
+            "parameters": {
+                "input_type": "date", "target": "input", "accessor": "hour",
+            },
+        },
+        "accessor",
+    )
+    rejects(
+        {
+            "template": "collection_size",
+            "inputs": {"a": [1], "b": [2]},
+            "parameters": {"shape": "tsl", "operation": "contains"},
+        },
+        "tsl covers len only",
+    )
+    rejects(
+        {
+            "template": "lifecycle_state",
+            "inputs": {"value": [1]},
+            "parameters": {"start_spelling": "banana"},
+        },
+        "start_spelling",
+    )
+    rejects(
+        {
+            "template": "data_frame_recording",
+            "inputs": {"ts": [1]},
+            "parameters": {"as_of_offset": 0},
+        },
+        "as_of_offset",
+    )

--- a/python/tests/test_parity_harness.py
+++ b/python/tests/test_parity_harness.py
@@ -1281,6 +1281,48 @@ def test_new_template_validators_reject_malformed_recipes():
         },
         "accessor",
     )
+    # Malformed temporal tick encodings reject at the trusted boundary
+    # (PR #93 review): never deferred to a runtime decode failure.
+    rejects(
+        {
+            "template": "temporal_expression",
+            "inputs": {"lhs": [{"$date": 123}]},
+            "parameters": {
+                "input_type": "date", "target": "input", "accessor": "year",
+            },
+        },
+        "iso-string",
+    )
+    rejects(
+        {
+            "template": "temporal_expression",
+            "inputs": {"lhs": [{"$datetime": "2026-07-27T12:00:00+02:00"}]},
+            "parameters": {
+                "input_type": "datetime", "target": "input", "accessor": "hour",
+            },
+        },
+        "must be naive",
+    )
+    rejects(
+        {
+            "template": "temporal_expression",
+            "inputs": {"lhs": [{"$date": "not-a-date"}]},
+            "parameters": {
+                "input_type": "date", "target": "input", "accessor": "year",
+            },
+        },
+        "not a valid ISO",
+    )
+    rejects(
+        {
+            "template": "temporal_expression",
+            "inputs": {"lhs": [{"$datetime": "2026-07-27T12:00:00"}]},
+            "parameters": {
+                "input_type": "date", "target": "input", "accessor": "year",
+            },
+        },
+        "ticks must be",
+    )
     rejects(
         {
             "template": "collection_size",

--- a/tools/parity/catalog.py
+++ b/tools/parity/catalog.py
@@ -42,6 +42,14 @@ def _decode_value(hg, value):
         return [_decode_value(hg, item) for item in value]
     if not isinstance(value, dict):
         return value
+    if set(value) == {"$date"}:
+        import datetime as _dt
+
+        return _dt.date.fromisoformat(value["$date"])
+    if set(value) == {"$datetime"}:
+        import datetime as _dt
+
+        return _dt.datetime.fromisoformat(value["$datetime"])
     if set(value) == {"$remove"} and value["$remove"] is True:
         return hg.REMOVE
     if set(value) == {"$remove_if_exists"} and value["$remove_if_exists"] is True:
@@ -181,6 +189,9 @@ def _validate_scalar_expression(recipe):
         raise RecipeError(
             f"declared output_type {declared_output!r} does not match {output_type!r}"
         )
+    postponed = recipe.parameters.get("postponed_annotations", False)
+    if not isinstance(postponed, bool):
+        raise RecipeError("postponed_annotations must be a boolean")
 
 
 def _scalar_expression(hg, recipe):
@@ -191,7 +202,12 @@ def _scalar_expression(hg, recipe):
     arguments = ", ".join(
         f"{name}: hg.TS[{type_name}]" for name, type_name in input_types.items()
     )
+    # mode:postponed-annotations (issue #83 class): the generated module opts
+    # into PEP 563, so every annotation reaches the wiring layer as a STRING.
+    prefix = ("from __future__ import annotations\n"
+              if recipe.parameters.get("postponed_annotations", False) else "")
     source = (
+        f"{prefix}"
         "@hg.graph\n"
         f"def parity_graph({arguments}) -> hg.TS[{output_type}]:\n"
         f"    return {_expression_source(recipe.parameters['expression'])}\n"
@@ -203,6 +219,302 @@ def _scalar_expression(hg, recipe):
         namespace["parity_graph"],
         *(inputs[name] for name in input_types),
     )
+
+
+# --------------------------------------------------------------------------
+# Temporal accessor expressions (issue #82 class): date/datetime arithmetic
+# feeding the upstream getattr_ property/method tables.
+
+_TEMPORAL_PROPERTIES = {
+    "date": {"year": "int", "month": "int", "day": "int"},
+    "datetime": {
+        "year": "int", "month": "int", "day": "int",
+        "hour": "int", "minute": "int", "second": "int", "microsecond": "int",
+    },
+    "timedelta": {"days": "int", "seconds": "int", "microseconds": "int"},
+}
+
+_TEMPORAL_METHODS = {
+    "date": {"weekday": "int", "isoweekday": "int"},
+    "datetime": {"weekday": "int", "isoweekday": "int"},
+    "timedelta": {"total_seconds": "float"},
+}
+
+
+def _temporal_accessor_kind(recipe):
+    target = recipe.parameters.get("target")
+    if target == "difference":
+        return "timedelta"
+    return recipe.parameters.get("input_type")
+
+
+def _validate_temporal_expression(recipe):
+    parameters = recipe.parameters
+    input_type = parameters.get("input_type")
+    if input_type not in ("date", "datetime"):
+        raise RecipeError("temporal_expression input_type must be date or datetime")
+    target = parameters.get("target")
+    if target not in ("difference", "shifted", "input"):
+        raise RecipeError("temporal_expression target must be difference/shifted/input")
+    if set(recipe.inputs) != ({"lhs", "rhs"} if target == "difference" else {"lhs"}):
+        raise RecipeError("temporal_expression inputs do not match its target")
+    delta = parameters.get("delta")
+    if target == "shifted":
+        if (not isinstance(delta, dict)
+                or set(delta) - {"days", "seconds", "microseconds"}
+                or not all(isinstance(v, int) and not isinstance(v, bool)
+                           and -10_000 <= v <= 10_000 for v in delta.values())):
+            raise RecipeError("temporal_expression shifted target needs a bounded delta")
+    elif delta is not None:
+        raise RecipeError("temporal_expression delta applies to the shifted target only")
+    kind = _temporal_accessor_kind(recipe)
+    accessor = parameters.get("accessor")
+    table = {**_TEMPORAL_PROPERTIES[kind], **_TEMPORAL_METHODS[kind]}
+    if accessor not in table:
+        raise RecipeError(f"temporal_expression accessor {accessor!r} not valid for {kind}")
+    if parameters.get("output_type", table[accessor]) != table[accessor]:
+        raise RecipeError("temporal_expression output_type does not match the accessor")
+    postponed = parameters.get("postponed_annotations", False)
+    if not isinstance(postponed, bool):
+        raise RecipeError("postponed_annotations must be a boolean")
+
+
+def _temporal_expression(hg, recipe):
+    import datetime as dt_module
+
+    from hgraph.test import eval_node
+
+    parameters = recipe.parameters
+    input_type = parameters["input_type"]
+    target = parameters["target"]
+    accessor = parameters["accessor"]
+    kind = _temporal_accessor_kind(recipe)
+    output_type = {**_TEMPORAL_PROPERTIES[kind], **_TEMPORAL_METHODS[kind]}[accessor]
+    call = "()" if accessor in _TEMPORAL_METHODS[kind] else ""
+    if target == "difference":
+        arguments = f"lhs: hg.TS[{input_type}], rhs: hg.TS[{input_type}]"
+        base = "(lhs - rhs)"
+    elif target == "shifted":
+        arguments = f"lhs: hg.TS[{input_type}]"
+        base = f"(lhs + timedelta(**{parameters['delta']!r}))"
+    else:
+        arguments = f"lhs: hg.TS[{input_type}]"
+        base = "lhs"
+    prefix = ("from __future__ import annotations\n"
+              if parameters.get("postponed_annotations", False) else "")
+    source = (
+        f"{prefix}"
+        "@hg.graph\n"
+        f"def parity_graph({arguments}) -> hg.TS[{output_type}]:\n"
+        "    lhs = hg.getitem_(hg.TSL.from_ts(lhs, lhs), 0)\n"
+        f"    return {base}.{accessor}{call}\n"
+    )
+    namespace = {
+        "hg": hg,
+        "date": dt_module.date,
+        "datetime": dt_module.datetime,
+        "timedelta": dt_module.timedelta,
+    }
+    exec(compile(source, f"<parity:{recipe.id}>", "exec"), namespace)
+    inputs = decoded_inputs(hg, recipe)
+    ordered = ("lhs", "rhs") if target == "difference" else ("lhs",)
+    return eval_node(namespace["parity_graph"], *(inputs[name] for name in ordered))
+
+
+# --------------------------------------------------------------------------
+# Collection sizes (issue #81 class): len_/is_empty/contains_ over every
+# upstream-supported sized shape.
+
+_COLLECTION_SHAPES = ("str", "tss", "tsd", "tsl")
+_COLLECTION_OPERATIONS = ("len", "is_empty", "contains")
+
+
+def _validate_collection_size(recipe):
+    parameters = recipe.parameters
+    shape = parameters.get("shape")
+    if shape not in _COLLECTION_SHAPES:
+        raise RecipeError(f"collection_size shape must be one of {_COLLECTION_SHAPES}")
+    operation = parameters.get("operation")
+    if operation not in _COLLECTION_OPERATIONS:
+        raise RecipeError(
+            f"collection_size operation must be one of {_COLLECTION_OPERATIONS}")
+    if shape == "tsl":
+        if operation != "len":
+            raise RecipeError("collection_size tsl covers len only")
+        if set(recipe.inputs) != {"a", "b"}:
+            raise RecipeError("collection_size tsl requires inputs a and b")
+    elif set(recipe.inputs) != {"ts"}:
+        raise RecipeError("collection_size requires the ts input")
+    probe = parameters.get("probe")
+    if operation == "contains":
+        expected = str if shape in ("str", "tsd") else int
+        if not isinstance(probe, expected) or isinstance(probe, bool):
+            raise RecipeError("collection_size contains needs a matching probe scalar")
+    elif probe is not None:
+        raise RecipeError("collection_size probe applies to contains only")
+
+
+def _collection_size(hg, recipe):
+    from hgraph.test import eval_node
+
+    parameters = recipe.parameters
+    shape = parameters["shape"]
+    operation = parameters["operation"]
+    probe = parameters.get("probe")
+    inputs = decoded_inputs(hg, recipe)
+    if shape == "tsl":
+        @hg.graph
+        def parity_graph(a: hg.TS[int], b: hg.TS[int]) -> hg.TS[int]:
+            return hg.len_(hg.TSL.from_ts(_via_non_peered_ref(hg, a), b))
+
+        return eval_node(parity_graph, inputs["a"], inputs["b"])
+
+    annotation = {
+        "str": hg.TS[str],
+        "tss": hg.TSS[int],
+        "tsd": hg.TSD[str, hg.TS[int]],
+    }[shape]
+
+    if operation == "len":
+        @hg.graph
+        def parity_graph(ts: annotation) -> hg.TS[int]:
+            return hg.len_(_via_non_peered_ref(hg, ts))
+    elif operation == "is_empty":
+        @hg.graph
+        def parity_graph(ts: annotation) -> hg.TS[bool]:
+            return hg.is_empty(_via_non_peered_ref(hg, ts))
+    else:
+        @hg.graph
+        def parity_graph(ts: annotation) -> hg.TS[bool]:
+            return hg.contains_(_via_non_peered_ref(hg, ts), probe)
+
+    return eval_node(parity_graph, inputs["ts"])
+
+
+# --------------------------------------------------------------------------
+# Lifecycle signature spellings (issue #79 class): start/stop parameters
+# match the eval signature by name; every accepted spelling behaves alike.
+
+_LIFECYCLE_SPELLINGS = {
+    "default": "_state: hg.STATE = None",
+    "bare": "_state: hg.STATE",
+    "unannotated": "_state",
+}
+
+
+def _validate_lifecycle_state(recipe):
+    parameters = recipe.parameters
+    for phase in ("start_spelling", "stop_spelling"):
+        spelling = parameters.get(phase)
+        if spelling is not None and spelling not in _LIFECYCLE_SPELLINGS:
+            raise RecipeError(
+                f"lifecycle_state {phase} must be one of {tuple(_LIFECYCLE_SPELLINGS)}")
+    if parameters.get("start_spelling") is None:
+        raise RecipeError("lifecycle_state requires a start_spelling (state seeding)")
+    seed = parameters.get("seed", 0)
+    if not isinstance(seed, int) or isinstance(seed, bool) or not -100 <= seed <= 100:
+        raise RecipeError("lifecycle_state seed must be a bounded integer")
+    if set(recipe.inputs) != {"value"}:
+        raise RecipeError("lifecycle_state requires the value input")
+
+
+def _lifecycle_state(hg, recipe):
+    from hgraph.test import eval_node
+
+    parameters = recipe.parameters
+    seed = parameters.get("seed", 0)
+    start_signature = _LIFECYCLE_SPELLINGS[parameters["start_spelling"]]
+    stop_spelling = parameters.get("stop_spelling")
+    stop_block = ""
+    if stop_spelling is not None:
+        stop_block = (
+            "@lifecycle_node.stop\n"
+            f"def lifecycle_stop({_LIFECYCLE_SPELLINGS[stop_spelling]}):\n"
+            "    pass\n"
+        )
+    source = (
+        "@hg.compute_node\n"
+        "def lifecycle_node(value: hg.TS[int], _state: hg.STATE = None) -> hg.TS[int]:\n"
+        "    _state.total = _state.total + value.value\n"
+        "    return _state.total\n"
+        "@lifecycle_node.start\n"
+        f"def lifecycle_start({start_signature}):\n"
+        f"    _state.total = {seed}\n"
+        f"{stop_block}"
+        "@hg.graph\n"
+        "def parity_graph(value: hg.TS[int]) -> hg.TS[int]:\n"
+        "    value = hg.getitem_(hg.TSL.from_ts(value, value), 0)\n"
+        "    return lifecycle_node(value)\n"
+    )
+    namespace = {"hg": hg}
+    exec(compile(source, f"<parity:{recipe.id}>", "exec"), namespace)
+    inputs = decoded_inputs(hg, recipe)
+    return eval_node(namespace["parity_graph"], inputs["value"])
+
+
+# --------------------------------------------------------------------------
+# Data-frame recording surface (issue #92 class): the frames the recorder
+# frameworks hand back to user code — column timezone presentation included.
+
+
+def _validate_data_frame_recording(recipe):
+    if set(recipe.inputs) != {"ts"}:
+        raise RecipeError("data_frame_recording requires the ts input")
+    as_of_offset = recipe.parameters.get("as_of_offset", 30)
+    if (not isinstance(as_of_offset, int) or isinstance(as_of_offset, bool)
+            or not 1 <= as_of_offset <= 10_000):
+        raise RecipeError("data_frame_recording as_of_offset must be a bounded integer")
+
+
+def _canonical_frame_surface(frame):
+    """A frame in a distribution-independent canonical shape.
+
+    Works for both boundary forms (upstream polars DataFrame, hg_cpp
+    pyarrow Table): column names with their timezone presentation, plus the
+    row values (datetimes canonicalize downstream via isoformat — a
+    tz-aware value renders with its offset, so an aware/naive divergence is
+    a trace difference)."""
+    if hasattr(frame, "to_pylist"):   # pyarrow.Table
+        columns = []
+        for field in frame.schema:
+            tz = getattr(field.type, "tz", None)
+            columns.append({"name": field.name, "tz": tz})
+        rows = [
+            [row[column["name"]] for column in columns]
+            for row in frame.to_pylist()
+        ]
+        return {"columns": columns, "rows": rows}
+    if hasattr(frame, "to_dicts"):   # polars.DataFrame
+        columns = []
+        for name, dtype in frame.schema.items():
+            tz = getattr(dtype, "time_zone", None)
+            columns.append({"name": name, "tz": tz})
+        rows = [
+            [row[column["name"]] for column in columns]
+            for row in frame.to_dicts()
+        ]
+        return {"columns": columns, "rows": rows}
+    raise RecipeError(f"unsupported frame surface {type(frame)!r}")
+
+
+def _data_frame_recording(hg, recipe):
+    from hgraph.test import eval_node
+    from hgraph.adaptors.data_frame import (
+        DATA_FRAME_RECORD_REPLAY,
+        MemoryDataFrameStorage,
+    )
+
+    as_of_offset = recipe.parameters.get("as_of_offset", 30)
+    inputs = decoded_inputs(hg, recipe)
+    with hg.GlobalState(), MemoryDataFrameStorage() as storage:
+        hg.set_record_replay_model(DATA_FRAME_RECORD_REPLAY)
+        hg.set_as_of(hg.MIN_ST + hg.MIN_TD * as_of_offset)
+        eval_node(hg.record[hg.TS[int]], ts=inputs["ts"], key="ts",
+                  recordable_id="parity")
+        frame = storage.read_frame("parity.ts")
+        replayed = eval_node(hg.replay[hg.TS[int]], key="ts",
+                             recordable_id="parity")
+    return {"frame": _canonical_frame_surface(frame), "replayed": replayed}
 
 
 def _feedback_accumulate(hg, recipe):
@@ -1050,6 +1362,58 @@ CATALOG = {
         operators=("convert",),
         execute=_stream_dataclass,
     ),
+    "temporal_expression": TemplateSpec(
+        name="temporal_expression",
+        required_inputs=None,
+        features=(
+            "shape:TS",
+            "topology:expression",
+            "domain:temporal",
+            "reference:REF",
+            "binding:non-peered",
+        ),
+        operators=("sub_", "add_", "getattr_"),
+        execute=_temporal_expression,
+    ),
+    "collection_size": TemplateSpec(
+        name="collection_size",
+        required_inputs=None,
+        features=(
+            "topology:expression",
+            "domain:collection-size",
+            "reference:REF",
+            "binding:non-peered",
+        ),
+        operators=("len_", "is_empty", "contains_"),
+        execute=_collection_size,
+    ),
+    "lifecycle_state": TemplateSpec(
+        name="lifecycle_state",
+        required_inputs=("value",),
+        features=(
+            "shape:TS",
+            "type:int",
+            "boundary:python-owned",
+            "domain:lifecycle-signature",
+            "reference:REF",
+            "binding:non-peered",
+        ),
+        operators=(),
+        execute=_lifecycle_state,
+    ),
+    "data_frame_recording": TemplateSpec(
+        name="data_frame_recording",
+        required_inputs=("ts",),
+        features=(
+            "shape:TS",
+            "type:int",
+            "boundary:python-owned",
+            "domain:frame-surface",
+            "topology:record-replay",
+        ),
+        operators=("record", "replay"),
+        execute=_data_frame_recording,
+    ),
 }
 
 
@@ -1092,6 +1456,14 @@ def validate_recipe(recipe):
         )
     if recipe.template == "scalar_expression":
         _validate_scalar_expression(recipe)
+    elif recipe.template == "temporal_expression":
+        _validate_temporal_expression(recipe)
+    elif recipe.template == "collection_size":
+        _validate_collection_size(recipe)
+    elif recipe.template == "lifecycle_state":
+        _validate_lifecycle_state(recipe)
+    elif recipe.template == "data_frame_recording":
+        _validate_data_frame_recording(recipe)
     elif recipe.template == "feedback_accumulate":
         initial = recipe.parameters.get("initial", 0)
         if not isinstance(initial, int) or isinstance(initial, bool):

--- a/tools/parity/catalog.py
+++ b/tools/parity/catalog.py
@@ -453,6 +453,236 @@ def _lifecycle_state(hg, recipe):
 
 
 # --------------------------------------------------------------------------
+# Deeply nested higher-order structures: map_/mesh_ over a CHURNING key set,
+# a per-key switch_ FLIPPING branches (nested graphs start/stop), services
+# (request-reply / subscription) and adaptors living INSIDE those branches,
+# optionally the whole pipeline under an outer switch_ that tears it down and
+# rebuilds it. This composition space is where production issues breed.
+
+_NESTED_INNER = ("arithmetic", "request_reply", "subscription", "adaptor")
+_NESTED_OUTER = ("map", "mesh")
+
+
+def _keys_re_added(ticks):
+    removed = set()
+    for tick in ticks:
+        if not isinstance(tick, dict):
+            continue
+        for key, value in tick.items():
+            if isinstance(value, dict) and value.get("$remove") is True:
+                removed.add(key)
+            elif key in removed:
+                return True
+    return False
+
+
+def _validate_nested_higher_order(recipe):
+    parameters = recipe.parameters
+    inner = parameters.get("inner")
+    if inner not in _NESTED_INNER:
+        raise RecipeError(f"nested_higher_order inner must be one of {_NESTED_INNER}")
+    outer = parameters.get("outer")
+    if outer not in _NESTED_OUTER:
+        raise RecipeError(f"nested_higher_order outer must be one of {_NESTED_OUTER}")
+    wrap_switch = parameters.get("wrap_switch", False)
+    reduce_output = parameters.get("reduce_output", True)
+    if not isinstance(wrap_switch, bool) or not isinstance(reduce_output, bool):
+        raise RecipeError("nested_higher_order wrap_switch/reduce_output must be booleans")
+    if wrap_switch and not reduce_output:
+        raise RecipeError(
+            "nested_higher_order wrap_switch requires reduce_output (one output shape)")
+    increment = parameters.get("increment", 1)
+    if (not isinstance(increment, int) or isinstance(increment, bool)
+            or not -20 <= increment <= 20):
+        raise RecipeError("nested_higher_order increment must be a bounded integer")
+    expected = {"values", "selector"}
+    if wrap_switch:
+        expected.add("outer_selector")
+    if set(recipe.inputs) != expected:
+        raise RecipeError(f"nested_higher_order requires inputs {sorted(expected)}")
+    for name, allowed in (("selector", ("alpha", "beta")),
+                          ("outer_selector", ("on", "off"))):
+        for tick in recipe.inputs.get(name, ()):
+            if tick is not None and tick not in allowed:
+                raise RecipeError(f"nested_higher_order {name} ticks must be in {allowed}")
+    if inner == "adaptor" and not reduce_output:
+        raise RecipeError(
+            "nested_higher_order adaptor inner requires reduce_output "
+            "(the adaptor consumes the reduced pipeline output)")
+    if inner == "subscription":
+        # The service re-subscription timing deviation is RULED (roadmap.rst):
+        # generated recipes stay out of that space — a removed key is never
+        # re-added, and the outer switch (which would re-subscribe every key
+        # on re-entry) is excluded.
+        if wrap_switch:
+            raise RecipeError(
+                "nested_higher_order subscription inner excludes wrap_switch")
+        if _keys_re_added(recipe.inputs["values"]):
+            raise RecipeError(
+                "nested_higher_order subscription inner must not re-add removed keys")
+
+
+def _nested_higher_order(hg, recipe):
+    from hgraph.test import eval_node
+
+    parameters = recipe.parameters
+    inner = parameters["inner"]
+    outer = parameters["outer"]
+    wrap_switch = parameters.get("wrap_switch", False)
+    reduce_output = parameters.get("reduce_output", True)
+    increment = parameters.get("increment", 1)
+    path = f"nested_{inner}"
+
+    # ---- the service/adaptor leaf living inside the alpha branch ----
+    if inner == "request_reply":
+        @hg.request_reply_service
+        def adjust(path: str, request: hg.TS[int]) -> hg.TS[int]: ...
+
+        @hg.service_impl(interfaces=adjust)
+        def adjust_impl(request: hg.TSD[int, hg.TS[int]]) -> hg.TSD[int, hg.TS[int]]:
+            return hg.map_(lambda value: value + increment, request)
+
+        def register(): hg.register_service(path, adjust_impl)
+        def alpha_leaf(value): return adjust(path, value)
+    elif inner == "subscription":
+        @hg.subscription_service
+        def quote(path: str, symbol: hg.TS[str]) -> hg.TS[int]: ...
+
+        @hg.graph
+        def quote_value(symbol: hg.TS[str]) -> hg.TS[int]:
+            return hg.len_(symbol) * increment
+
+        @hg.service_impl(interfaces=quote)
+        def quote_impl(symbol: hg.TSS[str]) -> hg.TSD[str, hg.TS[int]]:
+            return hg.map_(quote_value, __keys__=symbol, __key_arg__="symbol")
+
+        def register(): hg.register_service(path, quote_impl)
+        def alpha_leaf(value, key): return quote(path, key) + value
+    elif inner == "adaptor":
+        @hg.adaptor
+        def loopback(path: str, value: hg.TS[int]) -> hg.TS[int]: ...
+
+        @hg.adaptor_impl(interfaces=loopback)
+        def loopback_impl(path: str, value: hg.TS[int]) -> hg.TS[int]:
+            return value + increment
+
+        def register(): hg.register_adaptor(path, loopback_impl)
+        def alpha_leaf(value): return loopback(path, value)
+    else:
+        def register(): pass
+        def alpha_leaf(value): return value + increment
+
+    # ---- the per-key graph: a switch_ flipping between the service-backed
+    #      alpha branch and plain arithmetic (branch flips start/stop the
+    #      nested graphs and their service/adaptor clients) ----
+    # Upstream-supported composition space only (the generator does not
+    # explore upstream-broken shapes): a per-key ADAPTOR client cycles
+    # released hgraph's toposort, so the adaptor consumes the reduced
+    # pipeline output instead; the SUBSCRIPTION subscribes per key OUTSIDE
+    # the switch (key churn still subscribes/unsubscribes) while the switch
+    # flips the arithmetic around it.
+    if inner == "subscription":
+        @hg.graph
+        def alpha_branch(value: hg.TS[int]) -> hg.TS[int]:
+            return value + increment
+
+        @hg.graph
+        def beta_branch(value: hg.TS[int]) -> hg.TS[int]:
+            return value * 2 - increment
+
+        @hg.graph
+        def per_key_graph(key: hg.TS[str], value: hg.TS[int],
+                          selector: hg.TS[str]) -> hg.TS[int]:
+            quoted = alpha_leaf(value, key)
+            return hg.switch_(
+                selector,
+                {"alpha": alpha_branch, "beta": beta_branch},
+                quoted,
+            )
+    else:
+        if inner == "adaptor":
+            @hg.graph
+            def alpha_branch(value: hg.TS[int]) -> hg.TS[int]:
+                return value + increment
+        else:
+            @hg.graph
+            def alpha_branch(value: hg.TS[int]) -> hg.TS[int]:
+                return alpha_leaf(value)
+
+        @hg.graph
+        def beta_branch(value: hg.TS[int]) -> hg.TS[int]:
+            return value * 2 - increment
+
+        @hg.graph
+        def per_key_graph(key: hg.TS[str], value: hg.TS[int],
+                          selector: hg.TS[str]) -> hg.TS[int]:
+            del key
+            return hg.switch_(
+                selector,
+                {"alpha": alpha_branch, "beta": beta_branch},
+                value,
+            )
+
+    @hg.graph
+    def mesh_keyed(key: hg.TS[str], selector: hg.TS[str]) -> hg.TS[int]:
+        return per_key_graph(key, hg.len_(key), selector)
+
+    def pipeline(values, selector):
+        if outer == "mesh":
+            mapped = hg.mesh_(
+                mesh_keyed, selector,
+                __keys__=hg.keys_(values), __key_arg__="key",
+            )
+        else:
+            mapped = hg.map_(per_key_graph, values, selector)
+        if reduce_output:
+            reduced = hg.reduce(lambda lhs, rhs: lhs + rhs, mapped, 0)
+            if inner == "adaptor":
+                # The adaptor consumes the churning nested pipeline's output.
+                return alpha_leaf(reduced)
+            return reduced
+        return mapped
+
+    if wrap_switch:
+        @hg.graph
+        def parity_graph(values: hg.TSD[str, hg.TS[int]], selector: hg.TS[str],
+                         outer_selector: hg.TS[str]) -> hg.TS[int]:
+            register()
+            values = _via_non_peered_ref(hg, values)
+            return hg.switch_(
+                outer_selector,
+                {
+                    "on": lambda values, selector: pipeline(values, selector),
+                    "off": lambda values, selector: hg.len_(values) * 0,
+                },
+                values,
+                selector,
+            )
+    elif reduce_output:
+        @hg.graph
+        def parity_graph(values: hg.TSD[str, hg.TS[int]],
+                         selector: hg.TS[str]) -> hg.TS[int]:
+            register()
+            values = _via_non_peered_ref(hg, values)
+            return pipeline(values, selector)
+    else:
+        @hg.graph
+        def parity_graph(values: hg.TSD[str, hg.TS[int]],
+                         selector: hg.TS[str]) -> hg.TSD[str, hg.TS[int]]:
+            register()
+            values = _via_non_peered_ref(hg, values)
+            return pipeline(values, selector)
+
+    inputs = decoded_inputs(hg, recipe)
+    ordered = ["values", "selector"] + (["outer_selector"] if wrap_switch else [])
+    return eval_node(
+        parity_graph,
+        *(inputs[name] for name in ordered),
+        __end_time__=hg.MIN_ST + (recipe.tick_count + 6) * hg.MIN_TD,
+    )
+
+
+# --------------------------------------------------------------------------
 # Data-frame recording surface (issue #92 class): the frames the recorder
 # frameworks hand back to user code — column timezone presentation included.
 
@@ -1401,6 +1631,20 @@ CATALOG = {
         operators=(),
         execute=_lifecycle_state,
     ),
+    "nested_higher_order": TemplateSpec(
+        name="nested_higher_order",
+        required_inputs=None,
+        features=(
+            "topology:nested-higher-order",
+            "shape:TSD",
+            "type:int",
+            "reference:REF",
+            "binding:non-peered",
+            "lifecycle:multi-cycle",
+        ),
+        operators=("map_", "mesh_", "switch_", "reduce", "len_", "keys_"),
+        execute=_nested_higher_order,
+    ),
     "data_frame_recording": TemplateSpec(
         name="data_frame_recording",
         required_inputs=("ts",),
@@ -1462,6 +1706,8 @@ def validate_recipe(recipe):
         _validate_collection_size(recipe)
     elif recipe.template == "lifecycle_state":
         _validate_lifecycle_state(recipe)
+    elif recipe.template == "nested_higher_order":
+        _validate_nested_higher_order(recipe)
     elif recipe.template == "data_frame_recording":
         _validate_data_frame_recording(recipe)
     elif recipe.template == "feedback_accumulate":

--- a/tools/parity/catalog.py
+++ b/tools/parity/catalog.py
@@ -248,6 +248,39 @@ def _temporal_accessor_kind(recipe):
     return recipe.parameters.get("input_type")
 
 
+def _validate_temporal_ticks(recipe, name):
+    """Reject malformed temporal tick encodings at the trusted boundary.
+
+    A curated or model-proposed recipe must not defer ``{"$date": 123}`` to
+    a runtime decode failure: every non-null tick carries exactly the tag
+    matching ``input_type`` and a valid ISO string (datetimes NAIVE — the
+    UTC convention)."""
+    import datetime as dt_module
+
+    input_type = recipe.parameters.get("input_type")
+    tag = "$date" if input_type == "date" else "$datetime"
+    decoder = (dt_module.date.fromisoformat if input_type == "date"
+               else dt_module.datetime.fromisoformat)
+    for tick in recipe.inputs.get(name, ()):
+        if tick is None:
+            continue
+        if (not isinstance(tick, dict) or set(tick) != {tag}
+                or not isinstance(tick[tag], str)):
+            raise RecipeError(
+                f"temporal_expression {name} ticks must be "
+                f'{{"{tag}": "<iso-string>"}} or null')
+        try:
+            decoded = decoder(tick[tag])
+        except ValueError as error:
+            raise RecipeError(
+                f"temporal_expression {name} tick {tick[tag]!r} is not a "
+                f"valid ISO {input_type}") from error
+        if input_type == "datetime" and decoded.tzinfo is not None:
+            raise RecipeError(
+                f"temporal_expression {name} datetime ticks must be naive "
+                "(the UTC convention)")
+
+
 def _validate_temporal_expression(recipe):
     parameters = recipe.parameters
     input_type = parameters.get("input_type")
@@ -258,6 +291,8 @@ def _validate_temporal_expression(recipe):
         raise RecipeError("temporal_expression target must be difference/shifted/input")
     if set(recipe.inputs) != ({"lhs", "rhs"} if target == "difference" else {"lhs"}):
         raise RecipeError("temporal_expression inputs do not match its target")
+    for name in recipe.inputs:
+        _validate_temporal_ticks(recipe, name)
     delta = parameters.get("delta")
     if target == "shifted":
         if (not isinstance(delta, dict)

--- a/tools/parity/corpus/coverage-collection-sizes.json
+++ b/tools/parity/corpus/coverage-collection-sizes.json
@@ -1,0 +1,25 @@
+{
+  "schema_version": 1,
+  "id": "coverage-collection-sizes",
+  "description": "The issue #81 class: len_ over a TSS whose deltas net growth and no-change ticks.",
+  "template": "collection_size",
+  "inputs": {
+    "ts": [
+      {"$set_delta": {"added": [1, 2], "removed": []}},
+      {"$set_delta": {"added": [2], "removed": []}},
+      {"$set_delta": {"added": [3], "removed": [1]}},
+      {"$set_delta": {"added": [], "removed": [2, 3]}}
+    ]
+  },
+  "parameters": {
+    "shape": "tss",
+    "operation": "len"
+  },
+  "features": [
+    "topology:expression",
+    "domain:collection-size",
+    "shape:TSS",
+    "operator:len"
+  ],
+  "source_issue": "https://github.com/hhenson/hg_cpp/issues/81"
+}

--- a/tools/parity/corpus/coverage-frame-recording.json
+++ b/tools/parity/corpus/coverage-frame-recording.json
@@ -1,0 +1,20 @@
+{
+  "schema_version": 1,
+  "id": "coverage-frame-recording",
+  "description": "The PR #92 class: the frame a recorder hands back to user code, including the timezone presentation of engine timestamp columns.",
+  "template": "data_frame_recording",
+  "inputs": {
+    "ts": [1, null, 2, 3]
+  },
+  "parameters": {
+    "as_of_offset": 30
+  },
+  "features": [
+    "shape:TS",
+    "type:int",
+    "boundary:python-owned",
+    "domain:frame-surface",
+    "topology:record-replay"
+  ],
+  "source_issue": "https://github.com/hhenson/hg_cpp/pull/92"
+}

--- a/tools/parity/corpus/coverage-lifecycle-spellings.json
+++ b/tools/parity/corpus/coverage-lifecycle-spellings.json
@@ -1,0 +1,23 @@
+{
+  "schema_version": 1,
+  "id": "coverage-lifecycle-spellings",
+  "description": "The issue #79 class: start/stop lifecycle parameters spelled without the strict '= None' form match the eval signature by name.",
+  "template": "lifecycle_state",
+  "inputs": {
+    "value": [1, null, 2, 3]
+  },
+  "parameters": {
+    "start_spelling": "bare",
+    "stop_spelling": "unannotated",
+    "seed": 10
+  },
+  "features": [
+    "shape:TS",
+    "type:int",
+    "boundary:python-owned",
+    "domain:lifecycle-signature",
+    "lifecycle:start-bare",
+    "lifecycle:stop-unannotated"
+  ],
+  "source_issue": "https://github.com/hhenson/hg_cpp/issues/79"
+}

--- a/tools/parity/corpus/coverage-nested-adaptor-pipeline.json
+++ b/tools/parity/corpus/coverage-nested-adaptor-pipeline.json
@@ -1,0 +1,38 @@
+{
+  "schema_version": 1,
+  "id": "coverage-nested-adaptor-pipeline",
+  "description": "Adaptor consuming the reduced output of a churning map+switch pipeline (verified matching released hgraph).",
+  "template": "nested_higher_order",
+  "inputs": {
+    "values": [
+      {
+        "k1": 3
+      },
+      {
+        "k2": 4
+      },
+      null,
+      {
+        "k1": {
+          "$remove": true
+        }
+      }
+    ],
+    "selector": [
+      "alpha",
+      null,
+      "beta",
+      null
+    ]
+  },
+  "parameters": {
+    "inner": "adaptor",
+    "outer": "map",
+    "wrap_switch": false,
+    "reduce_output": true,
+    "increment": 2
+  },
+  "features": [
+    "topology:nested-higher-order"
+  ]
+}

--- a/tools/parity/corpus/coverage-nested-outer-switch.json
+++ b/tools/parity/corpus/coverage-nested-outer-switch.json
@@ -1,0 +1,52 @@
+{
+  "schema_version": 1,
+  "id": "coverage-nested-outer-switch",
+  "description": "Outer switch tearing down and rebuilding a map+switch+reduce pipeline over a churning key set (verified matching released hgraph).",
+  "template": "nested_higher_order",
+  "inputs": {
+    "values": [
+      {
+        "k1": 3
+      },
+      {
+        "k2": 4
+      },
+      null,
+      {
+        "k1": {
+          "$remove": true
+        }
+      },
+      {
+        "k3": 5
+      },
+      null
+    ],
+    "selector": [
+      "alpha",
+      null,
+      "beta",
+      null,
+      "alpha",
+      null
+    ],
+    "outer_selector": [
+      "on",
+      null,
+      "off",
+      null,
+      "on",
+      null
+    ]
+  },
+  "parameters": {
+    "inner": "arithmetic",
+    "outer": "map",
+    "wrap_switch": true,
+    "reduce_output": true,
+    "increment": 2
+  },
+  "features": [
+    "topology:nested-higher-order"
+  ]
+}

--- a/tools/parity/corpus/coverage-postponed-annotations.json
+++ b/tools/parity/corpus/coverage-postponed-annotations.json
@@ -1,0 +1,27 @@
+{
+  "schema_version": 1,
+  "id": "coverage-postponed-annotations",
+  "description": "The issue #83 class: the generated module opts into PEP 563, so string annotations exercise signature resolution on both distributions.",
+  "template": "scalar_expression",
+  "inputs": {
+    "lhs": [1, null, 3],
+    "rhs": [2, 4, null]
+  },
+  "parameters": {
+    "input_types": {"lhs": "int", "rhs": "int"},
+    "output_type": "int",
+    "expression": {
+      "op": "add",
+      "args": [{"input": "lhs"}, {"input": "rhs"}]
+    },
+    "postponed_annotations": true
+  },
+  "features": [
+    "shape:TS",
+    "topology:expression",
+    "type:int",
+    "operator:add",
+    "mode:postponed-annotations"
+  ],
+  "source_issue": "https://github.com/hhenson/hg_cpp/issues/83"
+}

--- a/tools/parity/corpus/coverage-temporal-accessors.json
+++ b/tools/parity/corpus/coverage-temporal-accessors.json
@@ -1,0 +1,34 @@
+{
+  "schema_version": 1,
+  "id": "coverage-temporal-accessors",
+  "description": "The issue #82 class: (date - date).days through the upstream getattr_ accessor tables.",
+  "template": "temporal_expression",
+  "inputs": {
+    "lhs": [
+      {"$date": "2026-07-27"},
+      null,
+      {"$date": "2026-08-03"}
+    ],
+    "rhs": [
+      {"$date": "2026-07-20"},
+      {"$date": "2026-07-21"},
+      null
+    ]
+  },
+  "parameters": {
+    "input_type": "date",
+    "target": "difference",
+    "accessor": "days",
+    "output_type": "int",
+    "postponed_annotations": false
+  },
+  "features": [
+    "shape:TS",
+    "topology:expression",
+    "domain:temporal",
+    "type:date",
+    "operator:days",
+    "temporal:difference"
+  ],
+  "source_issue": "https://github.com/hhenson/hg_cpp/issues/82"
+}

--- a/tools/parity/generate.py
+++ b/tools/parity/generate.py
@@ -570,6 +570,79 @@ def recipe_payload_strategy(*, min_ticks: int = 8, max_ticks: int = 32):
         }
 
     @st.composite
+    def nested_higher_order(draw):
+        # The composition breeding ground: churning key sets under map_/mesh_,
+        # per-key switch_ branches flipping (nested graphs start/stop),
+        # services/adaptors INSIDE the branches, optionally the whole
+        # pipeline under an outer switch_ tearing it down and rebuilding it.
+        inner = draw(st.sampled_from(
+            ("arithmetic", "request_reply", "request_reply",
+             "subscription", "adaptor")))
+        outer = draw(st.sampled_from(("map", "map", "mesh")))
+        subscription = inner == "subscription"
+        wrap = False if subscription else draw(st.booleans())
+        reduce_output = (True if wrap or inner == "adaptor"
+                         else draw(st.sampled_from((True, True, False))))
+        count = draw(st.integers(min_value=min_ticks, max_value=max_ticks))
+        keys = ("k1", "k2", "k3")
+        active: set = set()
+        retired: set = set()
+        first_key = draw(st.sampled_from(keys))
+        active.add(first_key)
+        values: list = [{first_key: draw(st.integers(-10, 10))}]
+        for _ in range(count - 1):
+            action = draw(st.sampled_from(("none", "update", "add", "remove")))
+            if action == "none" or (action != "add" and not active):
+                values.append(None)
+                continue
+            if action == "remove":
+                key = draw(st.sampled_from(sorted(active)))
+                values.append({key: {"$remove": True}})
+                active.remove(key)
+                retired.add(key)
+                continue
+            if action == "add":
+                # The re-subscription timing deviation is ruled: with a
+                # subscription leaf a removed key is never re-added.
+                pool = [key for key in keys if key not in active
+                        and not (subscription and key in retired)]
+                if not pool:
+                    values.append(None)
+                    continue
+                key = draw(st.sampled_from(pool))
+                active.add(key)
+            else:
+                key = draw(st.sampled_from(sorted(active)))
+            values.append({key: draw(st.integers(-10, 10))})
+        selector = ["alpha"] + [
+            draw(st.sampled_from((None, "alpha", "beta", "beta")))
+            for _ in range(count - 1)]
+        inputs = {"values": values, "selector": selector}
+        parameters = {
+            "inner": inner,
+            "outer": outer,
+            "wrap_switch": wrap,
+            "reduce_output": reduce_output,
+            "increment": draw(st.integers(min_value=-5, max_value=5)),
+        }
+        if wrap:
+            inputs["outer_selector"] = ["on"] + [
+                draw(st.sampled_from((None, "on", "off")))
+                for _ in range(count - 1)]
+        return {
+            "template": "nested_higher_order",
+            "inputs": inputs,
+            "parameters": parameters,
+            "features": [
+                *CATALOG["nested_higher_order"].features,
+                f"nested:{outer}",
+                f"nested-leaf:{inner}",
+                *(("nested:outer-switch",) if wrap else ()),
+                *(("topology:reduce",) if reduce_output else ()),
+            ],
+        }
+
+    @st.composite
     def data_frame_recording(draw):
         count = draw(st.integers(min_value=min_ticks, max_value=max_ticks))
         small = st.integers(min_value=-20, max_value=20)
@@ -602,6 +675,8 @@ def recipe_payload_strategy(*, min_ticks: int = 8, max_ticks: int = 32):
         collection_size(),
         lifecycle_state(),
         data_frame_recording(),
+        nested_higher_order(),
+        nested_higher_order(),
     )
 
 

--- a/tools/parity/generate.py
+++ b/tools/parity/generate.py
@@ -90,6 +90,10 @@ def recipe_payload_strategy(*, min_ticks: int = 8, max_ticks: int = 32):
                     visit(argument)
 
         visit(expression)
+        # mode:postponed-annotations (issue #83 class): the same expression
+        # occasionally runs from a PEP 563 module, so string annotations
+        # exercise the signature-resolution path on both distributions.
+        postponed = draw(st.sampled_from((False, False, False, True)))
         return {
             "template": "scalar_expression",
             "inputs": {"lhs": lhs, "rhs": rhs},
@@ -97,12 +101,14 @@ def recipe_payload_strategy(*, min_ticks: int = 8, max_ticks: int = 32):
                 "input_types": {"lhs": type_name, "rhs": type_name},
                 "output_type": type_name,
                 "expression": expression,
+                "postponed_annotations": postponed,
             },
             "features": [
                 *CATALOG["scalar_expression"].features,
                 f"type:{type_name}",
                 f"ticks:{'long' if count > 16 else 'medium'}",
                 *(f"operator:{operation}" for operation in sorted(operations)),
+                *(("mode:postponed-annotations",) if postponed else ()),
             ],
         }
 
@@ -413,6 +419,171 @@ def recipe_payload_strategy(*, min_ticks: int = 8, max_ticks: int = 32):
             "features": [*CATALOG["mesh_key_set"].features],
         }
 
+    # ---- templates targeted at the 2026-07 compatibility-issue classes ----
+
+    _TEMPORAL_PROPERTIES = {
+        "date": ("year", "month", "day"),
+        "datetime": ("year", "month", "day", "hour", "minute", "second",
+                     "microsecond"),
+        "timedelta": ("days", "seconds", "microseconds"),
+    }
+    _TEMPORAL_METHODS = {
+        "date": ("weekday", "isoweekday"),
+        "datetime": ("weekday", "isoweekday"),
+        "timedelta": ("total_seconds",),
+    }
+    _TEMPORAL_OUTPUT = {"total_seconds": "float"}
+
+    @st.composite
+    def temporal_expression(draw):
+        import datetime as dt
+
+        input_type = draw(st.sampled_from(("date", "datetime")))
+        target = draw(st.sampled_from(("difference", "shifted", "input")))
+        kind = "timedelta" if target == "difference" else input_type
+        accessor = draw(st.sampled_from(
+            _TEMPORAL_PROPERTIES[kind] + _TEMPORAL_METHODS[kind]))
+        count = draw(st.integers(min_value=min_ticks, max_value=max_ticks))
+        day = st.integers(min_value=0, max_value=36_500)
+        micro = st.integers(min_value=0, max_value=86_399_999_999)
+
+        def sample(with_none):
+            base = dt.datetime(1990, 1, 1)
+            offset = base + dt.timedelta(days=draw(day),
+                                         microseconds=draw(micro))
+            if input_type == "date":
+                encoded = {"$date": offset.date().isoformat()}
+            else:
+                encoded = {"$datetime": offset.isoformat()}
+            if with_none and draw(st.booleans()):
+                return None
+            return encoded
+
+        lhs = [sample(False)] + [sample(True) for _ in range(count - 1)]
+        inputs = {"lhs": lhs}
+        parameters = {
+            "input_type": input_type,
+            "target": target,
+            "accessor": accessor,
+            "output_type": _TEMPORAL_OUTPUT.get(accessor, "int"),
+            "postponed_annotations": draw(
+                st.sampled_from((False, False, False, True))),
+        }
+        if target == "difference":
+            inputs["rhs"] = [sample(False)] + [
+                sample(True) for _ in range(count - 1)]
+        elif target == "shifted":
+            parameters["delta"] = {
+                "days": draw(st.integers(min_value=-3_650, max_value=3_650)),
+                "seconds": draw(st.integers(min_value=-10_000, max_value=10_000)),
+                "microseconds": draw(
+                    st.integers(min_value=-10_000, max_value=10_000)),
+            }
+        return {
+            "template": "temporal_expression",
+            "inputs": inputs,
+            "parameters": parameters,
+            "features": [
+                *CATALOG["temporal_expression"].features,
+                f"type:{input_type}",
+                f"operator:{accessor}",
+                f"temporal:{target}",
+                *(("mode:postponed-annotations",)
+                  if parameters["postponed_annotations"] else ()),
+            ],
+        }
+
+    @st.composite
+    def collection_size(draw):
+        shape = draw(st.sampled_from(("str", "tss", "tsd", "tsl")))
+        operation = ("len" if shape == "tsl"
+                     else draw(st.sampled_from(("len", "is_empty", "contains"))))
+        count = draw(st.integers(min_value=min_ticks, max_value=max_ticks))
+        parameters = {"shape": shape, "operation": operation}
+        keys = st.sampled_from(("a", "b", "c", "d"))
+        small = st.integers(min_value=-5, max_value=5)
+        if shape == "str":
+            text = st.text(
+                alphabet="abcdef", min_size=0, max_size=6)
+            series = [draw(text)] + [
+                draw(st.one_of(st.none(), text)) for _ in range(count - 1)]
+            inputs = {"ts": series}
+            if operation == "contains":
+                parameters["probe"] = draw(st.sampled_from(("a", "cd", "")))
+        elif shape == "tss":
+            def delta():
+                added = draw(st.lists(small, max_size=3))
+                removed = draw(st.lists(small, max_size=2))
+                return {"$set_delta": {"added": added, "removed": removed}}
+            inputs = {"ts": [delta()] + [
+                None if draw(st.booleans()) else delta()
+                for _ in range(count - 1)]}
+            if operation == "contains":
+                parameters["probe"] = draw(small)
+        elif shape == "tsd":
+            def tick():
+                entries = draw(st.lists(
+                    st.tuples(keys, st.one_of(st.none(), small)),
+                    min_size=1, max_size=3, unique_by=lambda kv: kv[0]))
+                return {key: value for key, value in entries}
+            inputs = {"ts": [tick() for _ in range(count)]}
+            if operation == "contains":
+                parameters["probe"] = draw(keys)
+        else:
+            series = st.one_of(st.none(), small)
+            inputs = {
+                "a": [draw(small)] + [draw(series) for _ in range(count - 1)],
+                "b": [draw(small)] + [draw(series) for _ in range(count - 1)],
+            }
+        return {
+            "template": "collection_size",
+            "inputs": inputs,
+            "parameters": parameters,
+            "features": [
+                *CATALOG["collection_size"].features,
+                f"shape:{shape.upper() if shape != 'str' else 'TS'}",
+                f"operator:{operation}",
+            ],
+        }
+
+    @st.composite
+    def lifecycle_state(draw):
+        count = draw(st.integers(min_value=min_ticks, max_value=max_ticks))
+        small = st.integers(min_value=-10, max_value=10)
+        values = [draw(small)] + [
+            draw(st.one_of(st.none(), small)) for _ in range(count - 1)]
+        spellings = ("default", "bare", "unannotated")
+        parameters = {
+            "start_spelling": draw(st.sampled_from(spellings)),
+            "stop_spelling": draw(st.sampled_from((None,) + spellings)),
+            "seed": draw(st.integers(min_value=-50, max_value=50)),
+        }
+        return {
+            "template": "lifecycle_state",
+            "inputs": {"value": values},
+            "parameters": parameters,
+            "features": [
+                *CATALOG["lifecycle_state"].features,
+                f"lifecycle:start-{parameters['start_spelling']}",
+                f"lifecycle:stop-{parameters['stop_spelling'] or 'absent'}",
+            ],
+        }
+
+    @st.composite
+    def data_frame_recording(draw):
+        count = draw(st.integers(min_value=min_ticks, max_value=max_ticks))
+        small = st.integers(min_value=-20, max_value=20)
+        values = [draw(small)] + [
+            draw(st.one_of(st.none(), small)) for _ in range(count - 1)]
+        return {
+            "template": "data_frame_recording",
+            "inputs": {"ts": values},
+            "parameters": {
+                "as_of_offset": draw(st.integers(min_value=1, max_value=100)),
+            },
+            "features": [*CATALOG["data_frame_recording"].features],
+        }
+
     return st.one_of(
         scalar_expression(),
         feedback_accumulate(),
@@ -427,6 +598,10 @@ def recipe_payload_strategy(*, min_ticks: int = 8, max_ticks: int = 32):
         operator_pipeline(),
         tsd_key_set_pipeline(),
         mesh_key_set(),
+        temporal_expression(),
+        collection_size(),
+        lifecycle_state(),
+        data_frame_recording(),
     )
 
 

--- a/tools/parity/generate.py
+++ b/tools/parity/generate.py
@@ -32,7 +32,8 @@ def _recipe_from_payload(payload: dict[str, Any], seed: int) -> Recipe:
     return recipe
 
 
-def recipe_payload_strategy(*, min_ticks: int = 8, max_ticks: int = 32):
+def recipe_payload_strategy(*, min_ticks: int = 8, max_ticks: int = 32,
+                            templates: tuple[str, ...] | None = None):
     from hypothesis import strategies as st
 
     if not 1 <= min_ticks <= max_ticks <= 256:
@@ -657,27 +658,42 @@ def recipe_payload_strategy(*, min_ticks: int = 8, max_ticks: int = 32):
             "features": [*CATALOG["data_frame_recording"].features],
         }
 
-    return st.one_of(
-        scalar_expression(),
-        feedback_accumulate(),
-        switch_arithmetic(),
-        tsd_map_reduce(),
-        service_reference(),
-        service_request_reply(),
-        service_subscription(),
-        adaptor_loopback(),
-        service_adaptor_roundtrip(),
-        context_switch(),
-        operator_pipeline(),
-        tsd_key_set_pipeline(),
-        mesh_key_set(),
-        temporal_expression(),
-        collection_size(),
-        lifecycle_state(),
-        data_frame_recording(),
-        nested_higher_order(),
-        nested_higher_order(),
+    # (name, factory) pairs; a repeated name WEIGHTS that template in the
+    # unrestricted draw (nested_higher_order is the composition breeding
+    # ground and draws double).
+    weighted = (
+        ("scalar_expression", scalar_expression),
+        ("feedback_accumulate", feedback_accumulate),
+        ("switch_arithmetic", switch_arithmetic),
+        ("tsd_map_reduce", tsd_map_reduce),
+        ("service_reference", service_reference),
+        ("service_request_reply", service_request_reply),
+        ("service_subscription", service_subscription),
+        ("adaptor_loopback", adaptor_loopback),
+        ("service_adaptor_roundtrip", service_adaptor_roundtrip),
+        ("context_switch", context_switch),
+        ("operator_pipeline", operator_pipeline),
+        ("tsd_key_set_pipeline", tsd_key_set_pipeline),
+        ("mesh_key_set", mesh_key_set),
+        ("temporal_expression", temporal_expression),
+        ("collection_size", collection_size),
+        ("lifecycle_state", lifecycle_state),
+        ("data_frame_recording", data_frame_recording),
+        ("nested_higher_order", nested_higher_order),
+        ("nested_higher_order", nested_higher_order),
     )
+    if templates is None:
+        return st.one_of(*(factory() for _, factory in weighted))
+    # A restricted profile draws ONLY the allowed strategies — selecting at
+    # the source, never filtering the union (a post-hoc filter discards most
+    # draws and trips hypothesis's filter_too_much health check).
+    allowed = frozenset(templates)
+    unknown = allowed - {name for name, _ in weighted}
+    if unknown:
+        raise ValueError(
+            f"unknown generated template(s): {', '.join(sorted(unknown))}")
+    return st.one_of(*(factory() for name, factory in weighted
+                       if name in allowed))
 
 
 def generate_recipes(
@@ -698,18 +714,8 @@ def generate_recipes(
         payloads.append(payload)
 
     strategy = recipe_payload_strategy(
-        min_ticks=min_ticks, max_ticks=max_ticks
+        min_ticks=min_ticks, max_ticks=max_ticks, templates=templates
     )
-    if templates is not None:
-        allowed = frozenset(templates)
-        unknown = allowed - frozenset(CATALOG)
-        if unknown:
-            raise ValueError(
-                f"unknown generated template(s): {', '.join(sorted(unknown))}"
-            )
-        strategy = strategy.filter(
-            lambda payload: payload["template"] in allowed
-        )
     generated = given(strategy)(collect)
     generated = settings(
         max_examples=count,

--- a/tools/parity/known.py
+++ b/tools/parity/known.py
@@ -28,6 +28,7 @@ TRACE_VALUE = "trace-value"
 SERVICE_ADAPTOR_ONE_CYCLE = "service-adaptor-one-cycle"
 KEY_SET_SIZE_NO_RETICK = "key-set-size-no-retick"
 SUBSCRIPTION_RESAMPLE_ONE_CYCLE = "subscription-resample-one-cycle"
+NO_CHANGE_ELISION = "no-change-elision"
 
 
 def load_known_divergences(
@@ -225,8 +226,47 @@ def _subscription_resample_one_cycle_relation(
     return j == len(reference_trace) and inserted >= 1
 
 
+def _no_change_elision_relation(
+    _recipe: dict[str, Any],
+    difference: dict[str, Any],
+    reference: dict[str, Any],
+    candidate: dict[str, Any],
+    _family: dict[str, Any],
+) -> bool:
+    """No-change-means-no-tick (ruling 2026-07-17): the candidate trace is
+    the reference trace with re-ticks of an UNCHANGED value elided. Every
+    position must either match exactly, or be a candidate ``None`` where the
+    reference re-emitted the value it had already emitted; at least one
+    elision must account for the difference. Extra candidate ticks, changed
+    values, and length differences remain reportable."""
+    if difference.get("classification") != "value":
+        return False
+    reference_trace = reference.get("trace")
+    candidate_trace = candidate.get("trace")
+    if (
+        not isinstance(reference_trace, list)
+        or not isinstance(candidate_trace, list)
+        or len(reference_trace) != len(candidate_trace)
+    ):
+        return False
+    last: Any = object()   # nothing emitted yet — never equal to a value
+    elided = 0
+    for ref, cand in zip(reference_trace, candidate_trace):
+        unchanged = ref is not None and ref == last
+        if ref is not None:
+            last = ref
+        if cand == ref:
+            continue
+        if cand is None and unchanged:
+            elided += 1
+            continue
+        return False
+    return elided >= 1
+
+
 RELATIONS = {
     TRACE_VALUE: _trace_value_relation,
+    NO_CHANGE_ELISION: _no_change_elision_relation,
     SERVICE_ADAPTOR_ONE_CYCLE: _service_adaptor_one_cycle_relation,
     KEY_SET_SIZE_NO_RETICK: _key_set_size_no_retick_relation,
     SUBSCRIPTION_RESAMPLE_ONE_CYCLE: (

--- a/tools/parity/known_divergences.json
+++ b/tools/parity/known_divergences.json
@@ -73,6 +73,15 @@
       "issue": "https://github.com/hhenson/hg_cpp/issues/44",
       "reason": "Released hgraph applies a non-identity reduce zero a capacity-history-dependent number of times; any mismatch with zero != 0 is the documented reduce deviation, not a candidate defect.",
       "review_after": "2027-07-26"
+    },
+    {
+      "family": "collection-size-no-retick",
+      "template": "collection_size",
+      "parameters_not_equal": {},
+      "relation": "no-change-elision",
+      "issue": "https://github.com/hhenson/hg_cpp/issues/65",
+      "reason": "No-change-means-no-tick ruling (2026-07-17, roadmap.rst Accepted Deviations): a size/emptiness/membership recompute equal to the previously emitted value does not re-tick in hg_cpp where released hgraph re-emits it; suppress only when eliding upstream's equal re-ticks makes the traces identical.",
+      "review_after": "2027-07-27"
     }
   ]
 }


### PR DESCRIPTION
## Summary

Uses the 2026-07 compatibility-issue batch (#74–#92) as the coverage guide: every class a production issue actually came from now has generated nightly coverage.

| Issue class | New coverage |
|---|---|
| #74/#78 scalar auto-const overload selection | already covered (`scalar_expression` const args caught #74–#76) |
| #82 temporal accessors | **`temporal_expression`**: date/datetime arithmetic into the upstream `getattr_` tables — property and method-call spellings, `(date - date).days` included |
| #81 sized types | **`collection_size`**: `len_`/`is_empty`/`contains_` over str/TSS/TSD/fixed-TSL |
| #79 lifecycle signatures | **`lifecycle_state`**: start/stop across the accepted spellings (strict / bare / unannotated name-match), stop optionally absent |
| #83 postponed annotations | **`postponed_annotations` mode** on the source-built templates — the generated module opts into PEP 563 (~1 in 4 draws) |
| PR #92 frame boundary | **`data_frame_recording`**: DATA_FRAME record → `DataFrameStorage.read_frame` → canonical frame surface (column names, **timezone presentation**, row values) + the replay leg — a tz-aware engine column is a trace difference |

Noise control, per the triage-deviations-first rule: `collection_size` deliberately generates into the ruled **no-change-means-no-tick** space, bounded by a new `no-change-elision` relation + `collection-size-no-retick` family — suppression applies only when eliding upstream's equal re-ticks makes the traces identical; changed values, extra candidate ticks, first-tick differences, and length changes remain reportable.

All new templates route through the non-peered REF hop, preserving the ≥80% REF/non-peered framework-priority invariant. Recipe inputs gain `$date`/`$datetime` decoding. `parity_testing.rst` records the class-to-template map and the standing rule: every future compat fix either provably lands inside an existing template's generated space or adds a template/mode with a `coverage-*` corpus recipe.

## Test plan

- [x] `test_parity_harness.py` — 32 passed (new: generator produces all templates + the mode; the five `coverage-*` corpus recipes execute on the candidate with the frame surface asserted tz-free; the elision relation accepts exactly the ruled shape and rejects corruption/extra ticks/first-tick/length differences; validators reject malformed recipes)
- [x] `python -m tools.parity validate tools/parity/corpus` — 33 recipes valid
- [x] Full Python tree excl. adaptors on merged main — 1580 passed, 10 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)