### PR TITLE
Wiring reads the live selected GlobalState; run copies at graph build

### DIFF
--- a/docs/source/developer_guide/record_replay_table.rst
+++ b/docs/source/developer_guide/record_replay_table.rst
@@ -139,12 +139,13 @@ function; a const source is ``const_``. For the two roles that remain:
 
 **P2 — configuration in graph GlobalState.** The record/replay model,
 date/as-of keys, and as-of override are one typed **RecordReplayConfig** value
-in the top-level graph's ``GlobalState``.  Operator resolution receives the
-wiring state's copy, while runtime nodes receive the root graph's normal copy.
-Configuration is installed before wiring and must not change between wiring
-and execution.  Python's imperative setters update its thread-local seed; the
-normal bridge copy-in/copy-out lifecycle carries that configuration without a
-second process-global store.
+in the top-level graph's ``GlobalState``.  Operator resolution reads the LIVE
+selected state during wiring (ruling 2026-07-27) — the same store Python's
+imperative setters write, so configuration applied during wiring, including
+inside a graph function, is honoured — while runtime nodes receive the root
+graph's isolation copy, captured at graph build.  Configuration must not
+change between graph build and execution.  There is no second process-global
+store.
 
 **P3 — modes via the context machinery, folded into identity.** The
 ``RecordReplayContext`` maps onto the landed wiring-scope machinery (a

--- a/docs/source/developer_guide/roadmap.rst
+++ b/docs/source/developer_guide/roadmap.rst
@@ -687,9 +687,18 @@ The following are intentional unless separately re-opened:
   ``from_data_frame`` / ``to_data_frame`` operators. The Python facade is a
   value adapter: PyArrow remains the default result and a Polars input selects
   a Polars result without introducing a Polars runtime dependency.
-- ``GlobalState`` keeps C++ copy-in/copy-out ownership.  Python's thread-local
+- ``GlobalState`` keeps C++ copy ownership, with the copy taken at **graph
+  build** (ruling 2026-07-27): the WIRING phase reads/writes the LIVE selected
+  state — the same store the configuration setters
+  (``set_record_replay_model``/``set_as_of``/...) write, so configuration
+  applied during wiring (including inside a graph function) is honoured — and
+  the run's isolation copy is captured when the graph is built, with results
+  copied back at run end.  A construction-time copy previously split the two
+  stores and silently ignored in-graph configuration.  Python's thread-local
   seed and ``GlobalContext`` are authoring adapters, not alternate runtime
-  global state.
+  global state; nested ``GlobalState`` activation is a modeling error and
+  raises (upstream's layer-chaining is not emulated — configuration belongs
+  on the scope that owns the evaluation).
 - The ``Hg*TypeMetaData`` **type-reflection family is not supported** —
   ``HgTypeMetaData`` and every ``Hg*TypeMetaData`` subclass, plus
   ``parse_type``/``parse_value``, ``resolve``/``build_resolution_dict``,

--- a/include/hgraph/runtime/global_state.h
+++ b/include/hgraph/runtime/global_state.h
@@ -107,9 +107,17 @@ namespace hgraph
     };
 
     /**
-     * Selects a pre-wiring seed on the current thread. New top-level Wiring
-     * and GraphBuilder instances copy the selected state using normal
-     * GlobalState value semantics. The context is not retained by a graph.
+     * Selects the LIVE global state on the current thread (lifecycle ruling
+     * 2026-07-27). A top-level Wiring created inside the context reads and
+     * writes the selected state THROUGH the context for the duration of the
+     * wiring — nothing copies it and nothing retains a pointer to it. The
+     * wiring end (graph build) FIXES the seed: the state is copied then, as
+     * it stands, into the graph as its initial state; the run works on that
+     * isolation copy (global to the runtime graph and all nested graphs)
+     * and results copy back at run end, after which no reference to the
+     * selected state is held anywhere. The selected state must span the
+     * wiring process — a wiring whose context exited early fails its build
+     * loudly rather than dereferencing a dead state.
      */
     class HGRAPH_EXPORT GlobalContext
     {

--- a/python/hgraph/notebook.py
+++ b/python/hgraph/notebook.py
@@ -116,6 +116,14 @@ class NotebookSession:
     def run(self):
         """Evaluate the whole graph as it currently stands (simulation)."""
         self._require_open()
+        # Each eval re-runs the grown graph from the configured start time,
+        # and the wiring seeds from the LIVE session state (the 2026-07-27
+        # GlobalState lifecycle) — so the prior run's recordings, copied back
+        # into the session state, must not re-seed and accumulate.
+        for _, key in self._recorded.values():
+            state_key = _RECORD_STATE_PREFIX + key
+            if state_key in self._state:
+                del self._state[state_key]
         return self._wiring.run(
             start_time=self._start_time, end_time=self._end_time, snapshot=True
         )

--- a/python/tests/test_global_state_wiring.py
+++ b/python/tests/test_global_state_wiring.py
@@ -1,0 +1,93 @@
+"""Pin the GlobalState wiring lifecycle (ruling 2026-07-27).
+
+The wiring phase reads the LIVE selected GlobalState — the same store the
+configuration setters (set_record_replay_model, set_as_of, ...) write — so
+configuration set during wiring, including inside a graph function, is
+honoured. The run takes its isolation copy at graph build; results copy back
+at run end. A construction-time copy previously split the two stores and
+silently ignored in-graph configuration (a client's replay defaulted to
+IN_MEMORY). Nested GlobalState activation remains a loud modeling error.
+"""
+
+import pyarrow as pa
+import pytest
+
+import hgraph as hg
+from hgraph import GlobalState, TS, set_as_of, set_record_replay_model
+from hgraph.adaptors.data_frame import (
+    DATA_FRAME_RECORD_REPLAY,
+    MemoryDataFrameStorage,
+)
+from hgraph.test import eval_node
+
+
+def _frame(values):
+    stamps = [hg.MIN_ST + i * hg.MIN_TD for i in range(len(values))]
+    return pa.table({
+        "__date_time__": stamps,
+        "__as_of__": stamps,
+        "value": values,
+    })
+
+
+def test_record_replay_model_set_inside_the_graph_is_honoured():
+    # The client scenario: configuration applied DURING WIRING, inside the
+    # graph function, on the selected state — no nested GlobalState.
+    @hg.graph
+    def wired(ts: TS[int]) -> TS[int]:
+        set_record_replay_model(DATA_FRAME_RECORD_REPLAY)
+        set_as_of(hg.MIN_ST + hg.MIN_TD * 30)
+        return hg.replay[TS[int]](key="ts", recordable_id="client")
+
+    with GlobalState(), MemoryDataFrameStorage() as storage:
+        storage.write_frame("client.ts", _frame([7, 8]))
+        assert eval_node(wired, [None, None]) == [7, 8]
+
+
+def test_record_replay_model_set_in_graph_with_implicit_state():
+    with MemoryDataFrameStorage() as storage:
+        storage.write_frame("implicit.ts", _frame([42]))
+
+        @hg.graph
+        def wired(ts: TS[int]) -> TS[int]:
+            set_record_replay_model(DATA_FRAME_RECORD_REPLAY)
+            set_as_of(hg.MIN_ST + hg.MIN_TD * 30)
+            return hg.replay[TS[int]](key="ts", recordable_id="implicit")
+
+        assert eval_node(wired, [None]) == [42]
+
+
+def test_wiring_time_state_entries_reach_the_run_and_copy_back():
+    # An entry written at wiring time lives on the SELECTED state, seeds the
+    # run's isolation copy, and the state remains the user's afterwards.
+    @hg.compute_node
+    def read_marker(ts: TS[int]) -> TS[str]:
+        return GlobalState.instance()["marker"]
+
+    @hg.graph
+    def wired(ts: TS[int]) -> TS[str]:
+        GlobalState.instance()["marker"] = "set-at-wiring"
+        return read_marker(ts)
+
+    with GlobalState() as state:
+        assert eval_node(wired, [1]) == ["set-at-wiring"]
+        assert state["marker"] == "set-at-wiring"
+
+
+def test_nested_global_state_activation_stays_a_loud_error():
+    # Nested activation is a modeling failure, not layering: configuration
+    # belongs on the scope that owns the evaluation.
+    with GlobalState():
+        with pytest.raises(RuntimeError, match="nested"):
+            with GlobalState():
+                pass
+
+    @hg.graph
+    def wired(ts: TS[int]) -> TS[int]:
+        with GlobalState():
+            set_record_replay_model(DATA_FRAME_RECORD_REPLAY)
+        return ts
+
+    with GlobalState():
+        with pytest.raises(RuntimeError, match="nested"):
+            eval_node(wired, [1])

--- a/src/hgraph/types/graph_wiring.cpp
+++ b/src/hgraph/types/graph_wiring.cpp
@@ -987,9 +987,12 @@ struct Wiring::Impl {
       : observers(std::move(observer_registry)),
         wiring_path(std::move(observer_path)), kind(wiring_kind) {
     if (kind == WiringKind::TopLevel) {
-      if (const GlobalState *state = GlobalContext::active_state()) {
-        global_state = *state;
-      }
+      // The LIVE selected state, not a copy (ruling 2026-07-27): setters
+      // invoked during wiring (set_record_replay_model, set_as_of, ...)
+      // write into the selected GlobalState, and wiring-time reads must see
+      // the same store — a construction-time copy silently ignored them.
+      // The run's isolation copy is taken at graph build instead.
+      live_state = GlobalContext::active_state();
     }
   }
 
@@ -1048,7 +1051,8 @@ struct Wiring::Impl {
   std::vector<ServiceImplementationScopeState> implementation_scopes{};
   bool building_services{false};
   std::string service_materialization_path{};
-  GlobalState global_state{};
+  GlobalState global_state{};  // stateless-wiring fallback (no live context)
+  GlobalState *live_state{nullptr};
   std::shared_ptr<WiringObserverRegistry> observers{};
   std::vector<std::string> wiring_path{};
   WiringKind kind{WiringKind::TopLevel};
@@ -2200,6 +2204,9 @@ Wiring::activate_error_capture(const WiringInstance *node,
 }
 
 GlobalStateView Wiring::global_state() noexcept {
+  if (impl_->live_state != nullptr) {
+    return impl_->live_state->view();
+  }
   return impl_->global_state.view();
 }
 
@@ -2209,7 +2216,7 @@ GlobalStateView Wiring::operator_state() noexcept {
       return state->view();
     }
   }
-  return impl_->global_state.view();
+  return global_state();
 }
 
 void Wiring::apply_service_rank_dependencies() {
@@ -2256,12 +2263,16 @@ GraphBuilder Wiring::finish_top_level(bool consume_state) {
   RankedGraphBuild build = build_ranked_graph(impl_->instances, nullptr);
   validate_same_cycle_pairs(build.index_of);
   build.graph_builder.type_realization(realization);
-  // Carry wiring-time entries onto the graph: moved on the consuming
-  // finish() path, copied on the snapshot() path so the wiring stays live
-  // (GlobalState is copy-in/copy-out by contract).
-  build.graph_builder.global_state(consume_state
-                                       ? std::move(impl_->global_state)
-                                       : GlobalState{impl_->global_state});
+  // The run's ISOLATION COPY is taken here, at graph build (ruling
+  // 2026-07-27): a live-seeded wiring copies the selected GlobalState as it
+  // stands NOW — wiring-time configuration and entries included — and the
+  // user's state object stays theirs (results copy back at run end). A
+  // stateless wiring keeps the internal store: moved on the consuming
+  // finish() path, copied on the snapshot() path so the wiring stays live.
+  build.graph_builder.global_state(
+      impl_->live_state != nullptr ? GlobalState{*impl_->live_state}
+      : consume_state              ? std::move(impl_->global_state)
+                                   : GlobalState{impl_->global_state});
   const ValueView traits_value = impl_->traits.as_value().view();
   const auto traits_map = traits_value.as_map();
   for (const auto [key, boxed] : traits_map) {

--- a/src/hgraph/types/graph_wiring.cpp
+++ b/src/hgraph/types/graph_wiring.cpp
@@ -991,8 +991,12 @@ struct Wiring::Impl {
       // invoked during wiring (set_record_replay_model, set_as_of, ...)
       // write into the selected GlobalState, and wiring-time reads must see
       // the same store — a construction-time copy silently ignored them.
-      // The run's isolation copy is taken at graph build instead.
-      live_state = GlobalContext::active_state();
+      // NOTHING is retained: reads resolve through the active context per
+      // call, the seed is FIXED by copy at wiring end (graph build), and
+      // the selected state must span the wiring process (finish fails
+      // loudly if it exited early). Only whether this wiring was live-
+      // seeded is remembered.
+      live_seeded = GlobalContext::active_state() != nullptr;
     }
   }
 
@@ -1052,7 +1056,7 @@ struct Wiring::Impl {
   bool building_services{false};
   std::string service_materialization_path{};
   GlobalState global_state{};  // stateless-wiring fallback (no live context)
-  GlobalState *live_state{nullptr};
+  bool live_seeded{false};
   std::shared_ptr<WiringObserverRegistry> observers{};
   std::vector<std::string> wiring_path{};
   WiringKind kind{WiringKind::TopLevel};
@@ -2204,8 +2208,13 @@ Wiring::activate_error_capture(const WiringInstance *node,
 }
 
 GlobalStateView Wiring::global_state() noexcept {
-  if (impl_->live_state != nullptr) {
-    return impl_->live_state->view();
+  // Resolved LIVE through the wiring context on every call — never a
+  // retained pointer (which would dangle when a short-lived GlobalContext
+  // exits before the wiring is done).
+  if (impl_->kind == WiringKind::TopLevel && impl_->live_seeded) {
+    if (GlobalState *state = GlobalContext::active_state()) {
+      return state->view();
+    }
   }
   return impl_->global_state.view();
 }
@@ -2263,16 +2272,25 @@ GraphBuilder Wiring::finish_top_level(bool consume_state) {
   RankedGraphBuild build = build_ranked_graph(impl_->instances, nullptr);
   validate_same_cycle_pairs(build.index_of);
   build.graph_builder.type_realization(realization);
-  // The run's ISOLATION COPY is taken here, at graph build (ruling
-  // 2026-07-27): a live-seeded wiring copies the selected GlobalState as it
-  // stands NOW — wiring-time configuration and entries included — and the
-  // user's state object stays theirs (results copy back at run end). A
-  // stateless wiring keeps the internal store: moved on the consuming
-  // finish() path, copied on the snapshot() path so the wiring stays live.
+  // The wiring end FIXES the seed (ruling 2026-07-27): a live-seeded wiring
+  // copies the selected GlobalState as it stands NOW — wiring-time
+  // configuration and entries included — into the graph as its initial
+  // state; the user's state object stays theirs (results copy back at run
+  // end). The selected state must span the wiring process. A stateless
+  // wiring keeps the internal store: moved on the consuming finish() path,
+  // copied on the snapshot() path so the wiring stays live.
+  GlobalState *live = impl_->kind == WiringKind::TopLevel && impl_->live_seeded
+                          ? GlobalContext::active_state()
+                          : nullptr;
+  if (impl_->live_seeded && live == nullptr) {
+    throw std::logic_error(
+        "Wiring: the selected GlobalState exited before wiring finished — "
+        "the global state must span the wiring process");
+  }
   build.graph_builder.global_state(
-      impl_->live_state != nullptr ? GlobalState{*impl_->live_state}
-      : consume_state              ? std::move(impl_->global_state)
-                                   : GlobalState{impl_->global_state});
+      live != nullptr    ? GlobalState{*live}
+      : consume_state    ? std::move(impl_->global_state)
+                         : GlobalState{impl_->global_state});
   const ValueView traits_value = impl_->traits.as_value().view();
   const auto traits_map = traits_value.as_map();
   for (const auto [key, boxed] : traits_map) {

--- a/tests/cpp/test_global_state.cpp
+++ b/tests/cpp/test_global_state.cpp
@@ -316,3 +316,26 @@ TEST_CASE("global context: seeds builders by copy and does not nest")
     // the graph's isolation copy taken at build and never reaches the seed.
     CHECK(seed.view().get_as<std::int32_t>("counter") == 100);
 }
+
+TEST_CASE("global context: the selected state must span the wiring process")
+{
+    using namespace hgraph;
+    auto &registry = TypeRegistry::instance();
+    (void)registry.register_scalar<std::int32_t>("int32");
+
+    // A wiring whose selecting context exits early holds NO retained
+    // pointer: reads fall back to the internal store (no dangling), and
+    // fixing the seed at build fails loudly.
+    Wiring wiring;
+    {
+        GlobalState  seed;
+        seed.view().set("seed", Value{std::int32_t{7}});
+        GlobalContext context{seed};
+        Wiring        live_wiring;
+        CHECK(live_wiring.global_state().get_as<std::int32_t>("seed") == 7);
+        wiring = std::move(live_wiring);
+    }
+    CHECK_FALSE(wiring.global_state().contains("seed"));
+    CounterGraph::compose(wiring);
+    CHECK_THROWS_AS(std::move(wiring).finish(), std::logic_error);
+}

--- a/tests/cpp/test_global_state.cpp
+++ b/tests/cpp/test_global_state.cpp
@@ -311,5 +311,8 @@ TEST_CASE("global context: seeds builders by copy and does not nest")
     executor.view().run();
 
     CHECK(executor.view().graph().global_state().get_as<std::int32_t>("counter") == 101);
-    CHECK_FALSE(seed.view().contains("counter"));
+    // The WIRING write ("counter" = 100 in compose) lands on the LIVE
+    // selected seed (ruling 2026-07-27); the RUNTIME bump to 101 happens on
+    // the graph's isolation copy taken at build and never reaches the seed.
+    CHECK(seed.view().get_as<std::int32_t>("counter") == 100);
 }


### PR DESCRIPTION
## Summary

Fixes the client-reported failure where `set_record_replay_model(DATA_FRAME)` applied during wiring was silently ignored (replay defaulted to IN_MEMORY). Per the ruling: the setters write configuration into the selected GlobalState, but wiring read a **construction-time copy** instead of the global state information — a design failure, corrected here.

- **One source of truth during wiring**: `Wiring` (TopLevel) captures the live `GlobalContext::active_state()` as a pointer; `global_state()`/`operator_state()` read through it. Configuration set during wiring — including inside a graph function, with an explicit *or* the implicit thread state — is now honoured by both the python model gates and the native `requires_` gates.
- **Isolation moves to graph build**: a live-seeded finish copies the selected state as it stands *then* (wiring-time entries included); the user's state object stays theirs and results copy back at run end. The C++ contract pin now asserts exactly this: the wiring write is visible on the seed, the runtime bump is isolated.
- **Stateless wirings unchanged** (internal store + dense-harness default). **Nested `GlobalState` activation stays a loud error** — upstream's layer-chaining is deliberately not emulated; configuration belongs on the scope that owns the evaluation (recorded in roadmap.rst).
- **Notebook follow-through**: the session clears its recorded keys before each re-run — prior recordings copy back into the live session state and must not re-seed and accumulate. Component RECOVER (which deliberately extends the prior recording) is untouched.

Docs: roadmap.rst GlobalState lifecycle entry; record_replay_table.rst P2.

## Test plan

- [x] C++ suite — 1276 cases passed (contract pin updated to the new lifecycle)
- [x] `test_global_state_wiring.py` — the client scenario with explicit and implicit state, wiring-time entries reaching the run and copying back, nested activation loud
- [x] Full Python tree excl. adaptors — 1580 passed, 10 skipped (notebook + component recovery suites included)
- [x] Adaptors — 114 passed; parity harness — 28 passed; corpus valid

🤖 Generated with [Claude Code](https://claude.com/claude-code)