### PR TITLE
Fix mapped-service reduction parity gaps

### DIFF
--- a/docs/source/developer_guide/nested_graphs.rst
+++ b/docs/source/developer_guide/nested_graphs.rst
@@ -272,6 +272,15 @@ values**, not a collection's capacity, determines the result:
    slots do not participate. Code that requires an empty value must supply one
    explicitly and account for its documented singleton application.
 
+   The same valid-value rule applies to dynamic ``TSD`` inputs. A mapped key
+   can be live before its child has produced a valid value (a phantom slot).
+   hg_cpp reduces the valid subset and may therefore publish an intermediate
+   aggregate; released hgraph can remain invalid until every live keyed slot
+   has a value. Once those values are valid, the aggregates are identical.
+   This avoids making results depend on keyed capacity or service latency and
+   is an accepted deviation (issue #95), pinned by the mapped-service tests and
+   the bounded ``valid-subset-reduce`` parity-family relation.
+
 ``reduce(func, ts, zero_ts, is_associative=false)`` selects the ordered form.
 It requires a live time-series ``zero_ts`` and always lays out a left fold,
 including for four or more elements. Invalid positions still use

--- a/docs/source/developer_guide/parity_matrix.rst
+++ b/docs/source/developer_guide/parity_matrix.rst
@@ -551,6 +551,14 @@ Wiring and node-authoring surface
        issue #44; pinned by ``python/tests/test_reduce_zero_semantics.py`` and
        ``tests/cpp/test_reduce.cpp`` (issue-44 recipe case), suppressed by
        fingerprint in ``tools/parity/known_divergences.json``.
+       A second accepted reduce deviation concerns **phantom mapped keys**:
+       hg_cpp reduces the currently-valid values and may publish an
+       intermediate aggregate while another live keyed slot is still invalid;
+       released hgraph waits for that slot. Subsequent aggregates agree. This
+       is the capacity- and latency-independent contract documented in
+       :doc:`nested_graphs`; issue #95 is pinned by the mapped-service Python
+       and C++ regressions and the bounded ``valid-subset-reduce`` parity
+       family.
    * - ``dispatch_``
      - Full for Bundle values
      - Native ``dispatch_cases`` / ``dispatch_case`` wiring builds a closed

--- a/docs/source/developer_guide/roadmap.rst
+++ b/docs/source/developer_guide/roadmap.rst
@@ -619,6 +619,12 @@ The following are intentional unless separately re-opened:
   ``tests/cpp/test_service_wiring.cpp`` (the service-adaptor collection cases
   and "late duplicate subscription samples the existing value"). First
   subscriptions and request/reply match the Python timing model exactly.
+- **Reduce over phantom mapped keys** (issue #95; design record:
+  :doc:`nested_graphs`): reduction is over currently-valid values. A keyed map
+  child can exist before its output becomes valid, and hg_cpp may publish the
+  valid subset while released hgraph waits for every live keyed slot.
+  Subsequent complete aggregates agree. The parity family permits only those
+  extra candidate emissions; every released-hgraph emission must match.
 - Python ``REF`` is an opaque value and does not expose ``.output``.
 - ``None`` in CompoundScalar/Bundle construction means an unset field.
 - TSB deltas are canonically dense; sparse-bundle delta parity is not required.

--- a/python/tests/test_parity_harness.py
+++ b/python/tests/test_parity_harness.py
@@ -1143,6 +1143,48 @@ def test_empty_family_parameter_map_matches_the_whole_template():
     )
 
 
+def test_valid_subset_reduce_relation_is_narrowly_bounded():
+    from tools.parity.known import (
+        is_known_family_failure,
+        load_known_divergences,
+        matches_known_family,
+    )
+
+    _fingerprints, families = load_known_divergences()
+    recipe = {
+        "template": "nested_higher_order",
+        "parameters": {
+            "inner": "subscription",
+            "outer": "map",
+            "wrap_switch": False,
+            "reduce_output": True,
+            "increment": 2,
+        },
+    }
+    ok = lambda trace: {"status": "ok", "trace": trace}
+
+    assert matches_known_family(recipe, families)
+    assert not matches_known_family(
+        {
+            **recipe,
+            "parameters": {**recipe["parameters"], "inner": "request_reply"},
+        },
+        families,
+    )
+
+    def classify(reference, candidate):
+        difference = compare_outcomes(ok(reference), ok(candidate))
+        assert difference is not None
+        return is_known_family_failure(
+            recipe, difference.to_dict(), ok(reference), ok(candidate), families
+        )
+
+    assert classify([None, None, 26, 14], [None, 9, 26, 14])
+    assert not classify([None, None, 26, 14], [None, 9, 25, 14])
+    assert not classify([None, None, 26, 14], [None, None, None, 14])
+    assert not classify([None, None, 26, 14], [None, 9, 26])
+
+
 def test_generated_subscription_recipes_never_resubscribe():
     # Re-subscribing a previously computed symbol is the designed same-cycle
     # sampling deviation (issue #66): the generator must not explore it.

--- a/python/tests/test_service_timing_semantics.py
+++ b/python/tests/test_service_timing_semantics.py
@@ -1,4 +1,4 @@
-"""Service-boundary timing semantics (documented upstream deviations).
+"""Service-boundary and mapped-service reduction timing semantics.
 
 The scheduling matrix in ``docs/source/developer_guide/services.rst`` is the
 design record: request stubs forward next cycle by design, and a late or
@@ -6,6 +6,10 @@ duplicate subscription samples the existing shared output in the same cycle.
 Released hgraph observably differs on both edges (same-cycle adaptor round
 trips; one-cycle re-subscription re-delivery). See the Accepted Deviations
 list in ``roadmap.rst`` and parity issues #64 / #66.
+
+Issue #95 is a separate reduce boundary: released hgraph waits when a keyed
+mapped slot is live but not yet valid, whereas hg_cpp reduces the currently
+valid values. The eventual service payloads and aggregates remain identical.
 """
 
 import hgraph as hg
@@ -60,3 +64,80 @@ def test_resubscription_samples_existing_value_in_the_same_cycle():
         __end_time__=hg.MIN_ST + 7 * hg.MIN_TD,
     )
     assert out == [None, 35, None, 35]
+
+
+def test_request_reply_inside_a_mapped_switch_keeps_late_keys():
+    @hg.request_reply_service
+    def adjust(path: str, request: TS[int]) -> TS[int]: ...
+
+    @hg.service_impl(interfaces=adjust)
+    def adjust_impl(request: TSD[int, TS[int]]) -> TSD[int, TS[int]]:
+        return hg.map_(lambda value: value + 2, request)
+
+    @graph
+    def alpha(value: TS[int]) -> TS[int]:
+        return adjust("mapped-request-reply", value)
+
+    @graph
+    def beta(value: TS[int]) -> TS[int]:
+        return value * 2 - 2
+
+    @graph
+    def per_key(key: TS[str], value: TS[int], selector: TS[str]) -> TS[int]:
+        del key
+        return hg.switch_(selector, {"alpha": alpha, "beta": beta}, value)
+
+    @graph
+    def app(values: TSD[str, TS[int]], selector: TS[str]) -> TS[int]:
+        hg.register_service("mapped-request-reply", adjust_impl)
+        mapped = hg.map_(per_key, values, selector)
+        return hg.reduce(lambda lhs, rhs: lhs + rhs, mapped, 0)
+
+    assert eval_node(
+        app,
+        [{"k1": 3}, {"k2": 4}, None, {"k1": hg.REMOVE}],
+        ["alpha", None, "beta", None],
+        __end_time__=hg.MIN_ST + 10 * hg.MIN_TD,
+    ) == [None, None, 10, 6]
+
+
+def test_subscription_inside_a_mapped_switch_keeps_late_keys():
+    @hg.subscription_service
+    def quote(path: str, symbol: TS[str]) -> TS[int]: ...
+
+    @graph
+    def quote_value(symbol: TS[str]) -> TS[int]:
+        return hg.len_(symbol) * 2
+
+    @hg.service_impl(interfaces=quote)
+    def quote_impl(symbol: TSS[str]) -> TSD[str, TS[int]]:
+        return hg.map_(quote_value, __keys__=symbol, __key_arg__="symbol")
+
+    @graph
+    def alpha(value: TS[int]) -> TS[int]:
+        return value + 2
+
+    @graph
+    def beta(value: TS[int]) -> TS[int]:
+        return value * 2 - 2
+
+    @graph
+    def per_key(key: TS[str], value: TS[int], selector: TS[str]) -> TS[int]:
+        quoted = quote("mapped-subscription", key) + value
+        return hg.switch_(selector, {"alpha": alpha, "beta": beta}, quoted)
+
+    @graph
+    def app(values: TSD[str, TS[int]], selector: TS[str]) -> TS[int]:
+        hg.register_service("mapped-subscription", quote_impl)
+        mapped = hg.map_(per_key, values, selector)
+        return hg.reduce(lambda lhs, rhs: lhs + rhs, mapped, 0)
+
+    # Issue #95: k1's first response is already valid while k2 is a phantom
+    # mapped slot. hg_cpp publishes that valid subset (9); released hgraph
+    # waits one cycle. Once k2 becomes valid, both publish 26 and then 14.
+    assert eval_node(
+        app,
+        [{"k1": 3}, {"k2": 4}, None, {"k1": hg.REMOVE}],
+        ["alpha", None, "beta", None],
+        __end_time__=hg.MIN_ST + 10 * hg.MIN_TD,
+    ) == [None, 9, 26, 14]

--- a/src/hgraph/runtime/reduce_node.cpp
+++ b/src/hgraph/runtime/reduce_node.cpp
@@ -654,7 +654,12 @@ namespace hgraph
         [[nodiscard]] bool dict_structure_modified(const TSInputView &input, DateTime evaluation_time)
         {
             static_cast<void>(evaluation_time);
-            return input.as_dict().structure_modified();
+            // A live TSD slot can acquire or lose its first value without a
+            // key-set change. Reduction is over currently-valid values, so
+            // every dictionary tick needs the sparse add/remove/modified
+            // reconciliation below; ordinary value updates return
+            // ``structural == false`` and do not rebuild the combiner tree.
+            return input.modified();
         }
 
         [[nodiscard]] bool list_structure_modified(const TSInputView &input, DateTime)

--- a/tests/cpp/test_map.cpp
+++ b/tests/cpp/test_map.cpp
@@ -1325,6 +1325,24 @@ TEST_CASE("map_: reduce observes a chained map phantom slot becoming valid")
         values<Int>(none, 43));
 }
 
+TEST_CASE("map_: reduce observes multiple phantom slots becoming valid together")
+{
+    using namespace hgraph;
+    using namespace std::string_literals;
+    stdlib::register_standard_operators();
+
+    CHECK_OUTPUT(
+        eval_node<ReducedChainedLateMappedIdentityG>(
+            values<Value>(
+                set_delta<Str>({"first"s, "second"s}, {}),
+                none),
+            values<Value>(
+                none,
+                dict_delta<Str, TS<Int>>(
+                    {{"first"s, 42}, {"second"s, 43}}))),
+        values<Int>(none, 87));
+}
+
 TEST_CASE("map_: multiplexed dict add and remove rebind existing explicit-key children")
 {
     using namespace hgraph;

--- a/tests/cpp/test_service_wiring.cpp
+++ b/tests/cpp/test_service_wiring.cpp
@@ -1141,6 +1141,128 @@ namespace
         }
     };
 
+    struct MappedServiceSwitchAlpha
+    {
+        [[maybe_unused]] static constexpr auto name =
+            "mapped_service_switch_alpha";
+
+        static Port<TS<Int>> compose(Wiring &w, Port<TS<Int>> value)
+        {
+            return wire<AddOneService>(
+                w, service::path("mapped_switch_request_reply"), value);
+        }
+    };
+
+    struct MappedServiceSwitchBeta
+    {
+        [[maybe_unused]] static constexpr auto name =
+            "mapped_service_switch_beta";
+
+        static Port<TS<Int>> compose(Wiring &, Port<TS<Int>> value)
+        {
+            using namespace hgraph::stdlib::syntax;
+            return (value * Int{2} - Int{2}).as<TS<Int>>();
+        }
+    };
+
+    struct MappedServiceSwitchAddTwo
+    {
+        [[maybe_unused]] static constexpr auto name =
+            "mapped_service_switch_add_two";
+
+        static Port<TS<Int>> compose(Wiring &, Port<TS<Int>> value)
+        {
+            using namespace hgraph::stdlib::syntax;
+            return (value + Int{2}).as<TS<Int>>();
+        }
+    };
+
+    struct MappedRequestReplySwitchFunction
+    {
+        [[maybe_unused]] static constexpr auto name =
+            "mapped_request_reply_switch_function";
+
+        static Port<TS<Int>> compose(
+            Wiring &w, NamedPort<"key", TS<Int>>,
+            Port<TS<Int>> value, Port<TS<Str>> selector)
+        {
+            return wire<stdlib::switch_>(
+                       w, selector,
+                       stdlib::switch_cases(
+                           {{Value{Str{"alpha"}}, fn<MappedServiceSwitchAlpha>()},
+                            {Value{Str{"beta"}}, fn<MappedServiceSwitchBeta>()}}),
+                       value)
+                .as<TS<Int>>();
+        }
+    };
+
+    struct MappedRequestReplySwitchGraph
+    {
+        [[maybe_unused]] static constexpr auto name =
+            "mapped_request_reply_switch_graph";
+
+        static Port<TS<Int>> compose(
+            Wiring &w, Port<TSD<Int, TS<Int>>> values,
+            Port<TS<Str>> selector)
+        {
+            service::register_request_reply_service<AddOneService, AddOneImplNode>(
+                w, service::path("mapped_switch_request_reply"));
+            auto mapped = wire<stdlib::map_>(
+                              w, fn<MappedRequestReplySwitchFunction>(),
+                              values, selector)
+                              .as<TSD<Int, TS<Int>>>();
+            return wire<stdlib::reduce_>(
+                       w, fn<stdlib::add_>(), mapped, Int{0})
+                .as<TS<Int>>();
+        }
+    };
+
+    struct MappedSubscriptionSwitchFunction
+    {
+        [[maybe_unused]] static constexpr auto name =
+            "mapped_subscription_switch_function";
+
+        static Port<TS<Int>> compose(
+            Wiring &w, NamedPort<"key", TS<Int>> key,
+            Port<TS<Int>> value, Port<TS<Str>> selector)
+        {
+            using namespace hgraph::stdlib::syntax;
+            auto quoted =
+                (wire<PricesService>(
+                     w, service::path("mapped_switch_subscription"), key) +
+                 value)
+                    .as<TS<Int>>();
+            return wire<stdlib::switch_>(
+                       w, selector,
+                       stdlib::switch_cases(
+                           {{Value{Str{"alpha"}}, fn<MappedServiceSwitchAddTwo>()},
+                            {Value{Str{"beta"}}, fn<MappedServiceSwitchBeta>()}}),
+                       quoted)
+                .as<TS<Int>>();
+        }
+    };
+
+    struct MappedSubscriptionSwitchGraph
+    {
+        [[maybe_unused]] static constexpr auto name =
+            "mapped_subscription_switch_graph";
+
+        static Port<TS<Int>> compose(
+            Wiring &w, Port<TSD<Int, TS<Int>>> values,
+            Port<TS<Str>> selector)
+        {
+            service::register_subscription_service<PricesService, MappedPricesImpl>(
+                w, service::path("mapped_switch_subscription"));
+            auto mapped = wire<stdlib::map_>(
+                              w, fn<MappedSubscriptionSwitchFunction>(),
+                              values, selector)
+                              .as<TSD<Int, TS<Int>>>();
+            return wire<stdlib::reduce_>(
+                       w, fn<stdlib::add_>(), mapped, Int{0})
+                .as<TS<Int>>();
+        }
+    };
+
     struct RecursiveAddOneMappedFunction
     {
         [[maybe_unused]] static constexpr auto name = "recursive_add_one_mapped_function";
@@ -1653,6 +1775,39 @@ TEST_CASE("service wiring: map and mesh children call an outer request/reply ser
         dict_delta<Int, TS<Int>>({{1, 12}, {2, 22}}));
     CHECK_OUTPUT(eval_node<MappedServiceClientGraph>(requests), expected);
     CHECK_OUTPUT(eval_node<MeshedServiceClientGraph>(requests), expected);
+}
+
+TEST_CASE("service wiring: request/reply under map switch retains late keys")
+{
+    hgraph::stdlib::register_standard_operators();
+
+    CHECK_OUTPUT(
+        eval_node<MappedRequestReplySwitchGraph>(
+            values<Value>(
+                dict_delta<Int, TS<Int>>({{1, 3}}),
+                dict_delta<Int, TS<Int>>({{2, 4}}),
+                none,
+                dict_delta<Int, TS<Int>>({}, {1})),
+            values<Str>(Str{"alpha"}, none, Str{"beta"}, none)),
+        values<Int>(none, none, 10, 6));
+}
+
+TEST_CASE("service wiring: subscription under map switch retains late keys")
+{
+    hgraph::stdlib::register_standard_operators();
+
+    // Issue #95: key 1 becomes valid while key 2 is still a phantom mapped
+    // slot. Reduction is over the currently-valid subset, so the first quote
+    // publishes 15; later complete aggregates still match released hgraph.
+    CHECK_OUTPUT(
+        eval_node<MappedSubscriptionSwitchGraph>(
+            values<Value>(
+                dict_delta<Int, TS<Int>>({{1, 3}}),
+                dict_delta<Int, TS<Int>>({{2, 4}}),
+                none,
+                dict_delta<Int, TS<Int>>({}, {1})),
+            values<Str>(Str{"alpha"}, none, Str{"beta"}, none)),
+        values<Int>(none, 15, 70, 46));
 }
 
 TEST_CASE("service wiring: a mapped request/reply implementation can call itself recursively")

--- a/tools/parity/corpus/issue-94-request-reply-map-switch.json
+++ b/tools/parity/corpus/issue-94-request-reply-map-switch.json
@@ -1,0 +1,23 @@
+{
+  "schema_version": 1,
+  "id": "issue-94-request-reply-map-switch",
+  "description": "Request-reply service in a per-key switch under map_ with key churn",
+  "template": "nested_higher_order",
+  "inputs": {
+    "values": [
+      {"k1": 3},
+      {"k2": 4},
+      null,
+      {"k1": {"$remove": true}}
+    ],
+    "selector": ["alpha", null, "beta", null]
+  },
+  "parameters": {
+    "inner": "request_reply",
+    "outer": "map",
+    "wrap_switch": false,
+    "reduce_output": true,
+    "increment": 2
+  },
+  "features": ["topology:nested-higher-order"]
+}

--- a/tools/parity/corpus/issue-95-subscription-map-churn.json
+++ b/tools/parity/corpus/issue-95-subscription-map-churn.json
@@ -1,0 +1,23 @@
+{
+  "schema_version": 1,
+  "id": "issue-95-subscription-map-churn",
+  "description": "Subscription service under map_ with key churn and per-key switching",
+  "template": "nested_higher_order",
+  "inputs": {
+    "values": [
+      {"k1": 3},
+      {"k2": 4},
+      null,
+      {"k1": {"$remove": true}}
+    ],
+    "selector": ["alpha", null, "beta", null]
+  },
+  "parameters": {
+    "inner": "subscription",
+    "outer": "map",
+    "wrap_switch": false,
+    "reduce_output": true,
+    "increment": 2
+  },
+  "features": ["topology:nested-higher-order"]
+}

--- a/tools/parity/known.py
+++ b/tools/parity/known.py
@@ -3,10 +3,11 @@
 ``known_divergences.json`` carries two suppression shapes:
 
 - ``divergences``: exact failure fingerprints.
-- ``families``: a template plus a ``parameters_not_equal`` map matching every
-  recipe of that template whose named parameters all differ from the stated
-  identity. An empty map matches every recipe of the template (used when a
-  documented deviation applies to every recipe of a template).
+- ``families``: a template plus optional ``parameters_equal`` and required
+  ``parameters_not_equal`` maps. Named parameters must respectively equal the
+  stated value or differ from the stated identity. Empty maps match every
+  recipe of the template (used when a documented deviation applies to every
+  recipe of a template).
 
 Each family names a bounded ``relation`` which proves the observed traces are
 the documented deviation.  Parameter membership alone is insufficient: a
@@ -29,6 +30,7 @@ SERVICE_ADAPTOR_ONE_CYCLE = "service-adaptor-one-cycle"
 KEY_SET_SIZE_NO_RETICK = "key-set-size-no-retick"
 SUBSCRIPTION_RESAMPLE_ONE_CYCLE = "subscription-resample-one-cycle"
 NO_CHANGE_ELISION = "no-change-elision"
+VALID_SUBSET_REDUCE = "valid-subset-reduce"
 
 
 def load_known_divergences(
@@ -62,6 +64,9 @@ def _matches_family_parameters(
     # deviation family. An empty parameters_not_equal map matches the whole
     # template.
     return recipe.get("template") == family["template"] and all(
+        parameters.get(name, object()) == expected
+        for name, expected in family.get("parameters_equal", {}).items()
+    ) and all(
         parameters.get(name, identity) != identity
         for name, identity in family["parameters_not_equal"].items()
     )
@@ -264,9 +269,48 @@ def _no_change_elision_relation(
     return elided >= 1
 
 
+def _valid_subset_reduce_relation(
+    _recipe: dict[str, Any],
+    difference: dict[str, Any],
+    reference: dict[str, Any],
+    candidate: dict[str, Any],
+    _family: dict[str, Any],
+) -> bool:
+    """Issue #95: hg_cpp may publish an aggregate of the currently-valid
+    mapped values while released hgraph remains invalid because another live
+    keyed slot is still a phantom.
+
+    Only additional candidate emissions are admitted. Every tick emitted by
+    released hgraph must match exactly, so payload corruption, missing
+    aggregates, shifted eventual values, and trace-length differences remain
+    reportable.
+    """
+    if difference.get("classification") != "value":
+        return False
+    reference_trace = reference.get("trace")
+    candidate_trace = candidate.get("trace")
+    if (
+        not isinstance(reference_trace, list)
+        or not isinstance(candidate_trace, list)
+        or len(reference_trace) != len(candidate_trace)
+    ):
+        return False
+
+    extra = 0
+    for ref, cand in zip(reference_trace, candidate_trace):
+        if ref == cand:
+            continue
+        if ref is None and cand is not None:
+            extra += 1
+            continue
+        return False
+    return extra >= 1
+
+
 RELATIONS = {
     TRACE_VALUE: _trace_value_relation,
     NO_CHANGE_ELISION: _no_change_elision_relation,
+    VALID_SUBSET_REDUCE: _valid_subset_reduce_relation,
     SERVICE_ADAPTOR_ONE_CYCLE: _service_adaptor_one_cycle_relation,
     KEY_SET_SIZE_NO_RETICK: _key_set_size_no_retick_relation,
     SUBSCRIPTION_RESAMPLE_ONE_CYCLE: (

--- a/tools/parity/known_divergences.json
+++ b/tools/parity/known_divergences.json
@@ -82,6 +82,21 @@
       "issue": "https://github.com/hhenson/hg_cpp/issues/65",
       "reason": "No-change-means-no-tick ruling (2026-07-17, roadmap.rst Accepted Deviations): a size/emptiness/membership recompute equal to the previously emitted value does not re-tick in hg_cpp where released hgraph re-emits it; suppress only when eliding upstream's equal re-ticks makes the traces identical.",
       "review_after": "2027-07-27"
+    },
+    {
+      "family": "mapped-subscription-valid-subset-reduce",
+      "template": "nested_higher_order",
+      "parameters_equal": {
+        "inner": "subscription",
+        "outer": "map",
+        "wrap_switch": false,
+        "reduce_output": true
+      },
+      "parameters_not_equal": {},
+      "relation": "valid-subset-reduce",
+      "issue": "https://github.com/hhenson/hg_cpp/issues/95",
+      "reason": "Accepted reduce deviation: hg_cpp reduces currently-valid mapped values and may publish while another live keyed slot is still a phantom; released hgraph waits. Suppress only extra candidate emissions while every released-hgraph emission remains exactly equal.",
+      "review_after": "2027-07-27"
     }
   ]
 }


### PR DESCRIPTION
## Summary

- reconcile dynamic `TSD` reductions whenever the input ticks, so live phantom slots are incorporated when they first become valid
- add first-class C++ and Python regressions for request/reply and subscription services nested under `map_` and `switch_`
- add replayable parity corpus cases for issues #94 and #95
- document the remaining issue #95 valid-subset timing difference and constrain it with a bounded parity-family relation

## Root cause

The associative dictionary reducer used key-set changes as its only signal to reconcile sparse additions and removals. A live keyed slot can acquire its first valid value without changing the key set, so that value could be omitted from subsequent aggregates. The reducer now reconciles on every dictionary input tick; ordinary value-only updates still avoid rebuilding the combiner tree.

## Impact

Issue #94 now matches released hgraph exactly. Issue #95 no longer drops late keyed values: all released-hgraph emissions match, while hg_cpp may additionally publish the aggregate of the currently valid subset before another live mapped slot becomes valid. That C++-first behavior is documented as an accepted deviation, and the parity rule permits only those extra emissions.

## Validation

- macOS fresh native acceptance suite: 1,283 passed
- macOS stable-ABI wheel in fresh Python 3.14 environment: 1,697 passed, 10 skipped
- `hg-linux` native acceptance suite: 1,283 passed
- `hg-linux` stable-ABI wheel in fresh Python 3.14 environment with `polars[rtcompat]`: 1,697 passed, 10 skipped
- parity campaign including both issue recipes: 49 matched, one bounded known deviation, zero new behavioral differences
- Sphinx HTML build with warnings as errors

Closes #94
Closes #95