### PR TITLE
len_/contains_ silent on never-valid input; TSD removal re-ticks ruled

### DIFF
--- a/docs/source/developer_guide/roadmap.rst
+++ b/docs/source/developer_guide/roadmap.rst
@@ -610,6 +610,16 @@ The following are intentional unless separately re-opened:
   TSS/TSD delta that nets to no change does not tick. Explicit writes are
   unaffected and match upstream exactly: a python node returning the same
   scalar each evaluation ticks each time, as do repeated TSD entry writes.
+- **TSD removal-driven len-family re-ticks** (issues #120/#129, 2026-07-28):
+  released hgraph does not re-evaluate ``len_``/``is_empty``/``contains_``
+  over a TSD on a removal-only delta, leaving STALE values (a partial
+  removal leaves upstream ``len_`` at the old size indefinitely); hg_cpp
+  re-evaluates and publishes the correct value.  Correctness over the
+  upstream quirk: pinned by ``test_tsd_removal_reticks_are_the_ruled_
+  deviation``, the failure fingerprints are pinned in
+  ``known_divergences.json``, the corpus tracks the space
+  (``coverage-tsd-removal-*``), and generation stays out of it.  TSS
+  removals agree with upstream and are unaffected.
 - **Service-boundary timing** (design record: the scheduling matrix in
   :doc:`services`): request stubs forward next cycle by design, so a
   ``service_adaptor`` round trip observably lands one cycle after released

--- a/docs/source/developer_guide/roadmap.rst
+++ b/docs/source/developer_guide/roadmap.rst
@@ -610,16 +610,21 @@ The following are intentional unless separately re-opened:
   TSS/TSD delta that nets to no change does not tick. Explicit writes are
   unaffected and match upstream exactly: a python node returning the same
   scalar each evaluation ticks each time, as do repeated TSD entry writes.
-- **TSD removal-driven len-family re-ticks** (issues #120/#129, 2026-07-28):
-  released hgraph does not re-evaluate ``len_``/``is_empty``/``contains_``
-  over a TSD on a removal-only delta, leaving STALE values (a partial
-  removal leaves upstream ``len_`` at the old size indefinitely); hg_cpp
-  re-evaluates and publishes the correct value.  Correctness over the
-  upstream quirk: pinned by ``test_tsd_removal_reticks_are_the_ruled_
-  deviation``, the failure fingerprints are pinned in
-  ``known_divergences.json``, the corpus tracks the space
-  (``coverage-tsd-removal-*``), and generation stays out of it.  TSS
-  removals agree with upstream and are unaffected.
+- **TSD removals are invisible to upstream's len family** (issues
+  #120/#129, 2026-07-28): released hgraph never subtracts a removed key
+  from ``len_``/``is_empty``/``contains_`` over a TSD — a removal-only
+  delta does not re-evaluate at all, and even a MIXED delta that does
+  re-evaluate still counts the removed key (reference probes:
+  ``{a:1,b:2}`` then ``{a:None,b:5}`` leaves upstream ``len_`` at 2;
+  ``{a:None,c:3}`` reads 3).  hg_cpp re-evaluates and publishes the
+  correct size.  Correctness over the upstream quirk: pinned by
+  ``test_tsd_removal_reticks_are_the_ruled_deviation`` and the native
+  container matrix, the failure fingerprints (removal-only AND mixed
+  shapes) are pinned in ``known_divergences.json``, the corpus tracks the
+  space (``coverage-tsd-removal-*``), and generation excludes TSD
+  removals entirely — mixed deltas diverge too, so there is no
+  upstream-agreeing removal space to fuzz.  TSS removals agree with
+  upstream and stay generated.
 - **Service-boundary timing** (design record: the scheduling matrix in
   :doc:`services`): request stubs forward next cycle by design, so a
   ``service_adaptor`` round trip observably lands one cycle after released

--- a/include/hgraph/lib/std/operators/impl/container_impl.h
+++ b/include/hgraph/lib/std/operators/impl/container_impl.h
@@ -159,8 +159,10 @@ struct len_tss {
 
   static void eval(In<"ts", TSS<ScalarVar<"K">>, InputValidity::Unchecked> ts,
                    Out<TS<Int>> out) {
-    container_impl_detail::set_if_changed(
-        out, ts.valid() ? static_cast<Int>(ts.size()) : Int{0});
+    // upstream parity: a NEVER-VALID input never ticks; empty-after-removal
+    // is a valid set and emits 0.
+    if (!ts.valid()) { return; }
+    container_impl_detail::set_if_changed(out, static_cast<Int>(ts.size()));
   }
 };
 
@@ -169,6 +171,8 @@ struct is_empty_tss {
 
   static void eval(In<"ts", TSS<ScalarVar<"K">>, InputValidity::Unchecked> ts,
                    Out<TS<Bool>> out) {
+    // upstream parity (ported test_is_empty): a never-valid input READS
+    // empty and ticks True at start — unlike len_, which stays silent.
     container_impl_detail::set_if_changed(out, !ts.valid() || ts.empty());
   }
 };
@@ -191,7 +195,8 @@ struct contains_tss_item {
 struct contains_tss_subset {
   static void eval(In<"ts", TSS<ScalarVar<"K">>, InputValidity::Unchecked> ts,
                    In<"item", TSS<ScalarVar<"K">>> item, Out<TS<Bool>> out) {
-    Bool contains_all = ts.valid();
+    if (!ts.valid()) { return; }   // upstream parity: never-valid never ticks
+    Bool contains_all = true;
     if (contains_all) {
       const auto &item_set = item.base().as_set();
       for (const ValueView &value : item_set.values()) {
@@ -211,8 +216,10 @@ struct len_tsd {
   static void
   eval(In<"ts", TSD<ScalarVar<"K">, TsVar<"V">>, InputValidity::Unchecked> ts,
        Out<TS<Int>> out) {
-    container_impl_detail::set_if_changed(
-        out, ts.valid() ? static_cast<Int>(ts.size()) : Int{0});
+    // upstream parity: a NEVER-VALID input never ticks; empty-after-removal
+    // is a valid dict and emits 0.
+    if (!ts.valid()) { return; }
+    container_impl_detail::set_if_changed(out, static_cast<Int>(ts.size()));
   }
 };
 
@@ -222,6 +229,8 @@ struct is_empty_tsd {
   static void
   eval(In<"ts", TSD<ScalarVar<"K">, TsVar<"V">>, InputValidity::Unchecked> ts,
        Out<TS<Bool>> out) {
+    // upstream parity (ported test_is_empty): a never-valid input READS
+    // empty and ticks True at start — unlike len_, which stays silent.
     container_impl_detail::set_if_changed(out, !ts.valid() || ts.empty());
   }
 };
@@ -254,8 +263,8 @@ struct contains_tsd_key {
   static void
   eval(In<"ts", TSD<ScalarVar<"K">, TsVar<"V">>, InputValidity::Unchecked> ts,
        In<"item", TS<ScalarVar<"K">>> item, Out<TS<Bool>> out) {
-    const Bool value =
-        ts.valid() && ts.base().as_dict().contains(item.base().value());
+    if (!ts.valid()) { return; }   // upstream parity: never-valid never ticks
+    const Bool value = ts.base().as_dict().contains(item.base().value());
     // hgraph parity: an ITEM tick always re-publishes (upstream
     // re-samples the per-key contains output on rebind); a DICT tick
     // only publishes a membership change.

--- a/python/tests/test_benchmark_scenarios.py
+++ b/python/tests/test_benchmark_scenarios.py
@@ -492,9 +492,11 @@ def test_benchmark_set_churn_keeps_the_requested_live_size():
         [True],
         __end_time__=hg.MIN_ST + 6 * hg.MIN_TD,
     )
-    # hg_cpp deduplicates the unchanged length while upstream republishes it;
-    # both traces prove that every add/remove delta preserved four live keys.
-    assert actual in ([0, 4], [None, 4, 4, 4, 4])
+    # hg_cpp deduplicates the unchanged length while upstream republishes
+    # it, and a never-valid input stays silent until the first delta
+    # (upstream parity, issue #116 family); both traces prove that every
+    # add/remove delta preserved four live keys.
+    assert actual in ([None, 4], [None, 4, 4, 4, 4])
 
 
 def test_hg_cpp_benchmark_reduce_without_zero_tracks_cardinality():

--- a/python/tests/test_len_sized_types.py
+++ b/python/tests/test_len_sized_types.py
@@ -76,3 +76,53 @@ def test_len_over_unsized_type_raises_resolution_error():
             return hg.len_(ts)
 
         eval_node(bad, [1])
+
+
+def test_len_family_never_valid_input_never_ticks():
+    # Issue #116/#137/#138: upstream parity — a NEVER-VALID input produces
+    # no tick; the first publish comes with the first real delta.
+    @hg.graph
+    def tsd_len(ts: hg.TSD[str, hg.TS[int]]) -> TS[int]:
+        return hg.len_(ts)
+
+    assert eval_node(tsd_len, [None, None]) is None
+
+    @hg.graph
+    def tss_len(ts: hg.TSS[int]) -> TS[int]:
+        return hg.len_(ts)
+
+    assert eval_node(tss_len, [None, None]) is None
+
+    # is_empty differs deliberately: upstream's is_empty READS a never-valid
+    # input as empty and ticks True at start (ported test_is_empty pins it).
+    @hg.graph
+    def tsd_empty(ts: hg.TSD[str, hg.TS[int]]) -> TS[bool]:
+        return hg.is_empty(ts)
+
+    assert eval_node(tsd_empty, [None, None]) == [True, None]
+
+
+def test_tsd_removal_reticks_are_the_ruled_deviation():
+    # Ruled deviation (issues #120/#129, fingerprints pinned in
+    # known_divergences.json): released hgraph does NOT re-evaluate the len
+    # family on a TSD removal-only delta, leaving stale values (a partial
+    # removal leaves upstream len_ at the old size); hg_cpp re-evaluates and
+    # publishes the correct value. These pins are the hg_cpp contract.
+    @hg.graph
+    def tsd_len(ts: hg.TSD[str, hg.TS[int]]) -> TS[int]:
+        return hg.len_(ts)
+
+    assert eval_node(tsd_len, [{"a": 1, "b": 2}, {"a": None}]) == [2, 1]
+
+    @hg.graph
+    def tsd_empty(ts: hg.TSD[str, hg.TS[int]]) -> TS[bool]:
+        return hg.is_empty(ts)
+
+    assert eval_node(tsd_empty, [{"a": 1}, {"a": None}, {"b": 2}]) == [
+        False, True, False]
+
+    @hg.graph
+    def tsd_contains(ts: hg.TSD[str, hg.TS[int]]) -> TS[bool]:
+        return hg.contains_(ts, "c")
+
+    assert eval_node(tsd_contains, [{"c": 0}, {"c": None}]) == [True, False]

--- a/tests/cpp/test_std_operators.cpp
+++ b/tests/cpp/test_std_operators.cpp
@@ -1819,6 +1819,46 @@ TEST_CASE("std operators: collection container operators support TSS TSD and fix
                                                                            dict_delta<Int, TS<Int>>({{0, 1}}),
                                                                            dict_delta<Int, TS<Int>>({}, {0})))),
                  values<Int>(0, 1, 0));
+
+    // A NEVER-VALID input never ticks (upstream parity, issue #116 family):
+    // len_ and contains_ stay silent until the first real delta; is_empty
+    // (above) deliberately keeps its True start tick per the upstream port.
+    CHECK_OUTPUT((eval_node<stdlib::len_, TSS<Int>>(values<Value>(none, set_delta<Int>({1}, {})))),
+                 values<Int>(none, 1));
+    CHECK_OUTPUT((eval_node<stdlib::len_, TSD<Int, TS<Int>>>(
+                     values<Value>(none, dict_delta<Int, TS<Int>>({{1, 1}})))),
+                 values<Int>(none, 1));
+    CHECK_OUTPUT((eval_node<stdlib::contains_, TSD<Int, TS<Int>>>(
+                     values<Value>(none, dict_delta<Int, TS<Int>>({{1, 10}})),
+                     values<Int>(1, none))),
+                 values<Bool>(none, true));
+    CHECK_OUTPUT((eval_node<stdlib::contains_, TSS<Int>, TSS<Int>>(
+                     values<Value>(none, set_delta<Int>({1, 2}, {})),
+                     values<Value>(set_delta<Int>({1}, {}), none))),
+                 values<Bool>(none, true));
+
+    // The ruled TSD-removal deviation (issues #120/#129): hg_cpp
+    // re-evaluates on removals — a partial removal shrinks len_, emptying
+    // flips is_empty, removing the probed key flips contains_ — where
+    // released hgraph never subtracts a removed key (mixed deltas included).
+    CHECK_OUTPUT((eval_node<stdlib::len_, TSD<Int, TS<Int>>>(
+                     values<Value>(dict_delta<Int, TS<Int>>({{1, 1}, {2, 2}}),
+                                   dict_delta<Int, TS<Int>>({}, {1})))),
+                 values<Int>(2, 1));
+    CHECK_OUTPUT((eval_node<stdlib::len_, TSD<Int, TS<Int>>>(
+                     values<Value>(dict_delta<Int, TS<Int>>({{1, 1}, {2, 2}}),
+                                   dict_delta<Int, TS<Int>>({{2, 5}}, {1})))),
+                 values<Int>(2, 1));
+    CHECK_OUTPUT((eval_node<stdlib::is_empty, TSD<Int, TS<Int>>>(
+                     values<Value>(dict_delta<Int, TS<Int>>({{1, 1}}),
+                                   dict_delta<Int, TS<Int>>({}, {1}),
+                                   dict_delta<Int, TS<Int>>({{2, 2}})))),
+                 values<Bool>(false, true, false));
+    CHECK_OUTPUT((eval_node<stdlib::contains_, TSD<Int, TS<Int>>>(
+                     values<Value>(dict_delta<Int, TS<Int>>({{1, 10}}),
+                                   dict_delta<Int, TS<Int>>({}, {1})),
+                     values<Int>(1, none))),
+                 values<Bool>(true, false));
     CHECK_OUTPUT((eval_node<stdlib::is_empty, TSD<Int, TS<Int>>>(values<Value>(none,
                                                                                dict_delta<Int, TS<Int>>({{1, 1}}),
                                                                                dict_delta<Int, TS<Int>>({{2, 2}}),

--- a/tools/parity/corpus/coverage-tsd-removal-contains.json
+++ b/tools/parity/corpus/coverage-tsd-removal-contains.json
@@ -1,0 +1,31 @@
+{
+  "description": "Ruled deviation: a TSD removal-only delta re-evaluates the len family in hg_cpp (correct) where released hgraph leaves a stale value; the failure fingerprint is pinned in known_divergences.json.",
+  "features": [
+    "binding:non-peered",
+    "domain:collection-size",
+    "operator:contains",
+    "reference:REF",
+    "shape:TSD",
+    "topology:expression"
+  ],
+  "id": "coverage-tsd-removal-contains",
+  "inputs": {
+    "ts": [
+      {
+        "c": 0
+      },
+      {
+        "c": null
+      }
+    ]
+  },
+  "parameters": {
+    "operation": "contains",
+    "probe": "c",
+    "shape": "tsd"
+  },
+  "schema_version": 1,
+  "seed": 7,
+  "template": "collection_size",
+  "source_issue": "https://github.com/hhenson/hg_cpp/issues/120"
+}

--- a/tools/parity/corpus/coverage-tsd-removal-is-empty.json
+++ b/tools/parity/corpus/coverage-tsd-removal-is-empty.json
@@ -1,0 +1,30 @@
+{
+  "description": "Ruled deviation: a TSD removal-only delta re-evaluates the len family in hg_cpp (correct) where released hgraph leaves a stale value; the failure fingerprint is pinned in known_divergences.json.",
+  "features": [
+    "binding:non-peered",
+    "domain:collection-size",
+    "operator:is_empty",
+    "reference:REF",
+    "shape:TSD",
+    "topology:expression"
+  ],
+  "id": "coverage-tsd-removal-is-empty",
+  "inputs": {
+    "ts": [
+      {
+        "b": 4
+      },
+      {
+        "b": null
+      }
+    ]
+  },
+  "parameters": {
+    "operation": "is_empty",
+    "shape": "tsd"
+  },
+  "schema_version": 1,
+  "seed": 7,
+  "template": "collection_size",
+  "source_issue": "https://github.com/hhenson/hg_cpp/issues/129"
+}

--- a/tools/parity/corpus/coverage-tsd-removal-mixed-add.json
+++ b/tools/parity/corpus/coverage-tsd-removal-mixed-add.json
@@ -1,0 +1,31 @@
+{
+  "schema_version": 1,
+  "id": "coverage-tsd-removal-mixed-add",
+  "description": "Ruled deviation: upstream's TSD len family never subtracts removed keys, even on mixed deltas that re-evaluate; hg_cpp publishes the correct size. Fingerprint pinned in known_divergences.json.",
+  "template": "collection_size",
+  "inputs": {
+    "ts": [
+      {
+        "a": 1,
+        "b": 2
+      },
+      {
+        "a": null,
+        "c": 3
+      }
+    ]
+  },
+  "parameters": {
+    "shape": "tsd",
+    "operation": "len"
+  },
+  "features": [
+    "topology:expression",
+    "domain:collection-size",
+    "reference:REF",
+    "binding:non-peered",
+    "shape:TSD",
+    "operator:len"
+  ],
+  "source_issue": "https://github.com/hhenson/hg_cpp/issues/129"
+}

--- a/tools/parity/corpus/coverage-tsd-removal-mixed-update.json
+++ b/tools/parity/corpus/coverage-tsd-removal-mixed-update.json
@@ -1,0 +1,31 @@
+{
+  "schema_version": 1,
+  "id": "coverage-tsd-removal-mixed-update",
+  "description": "Ruled deviation: upstream's TSD len family never subtracts removed keys, even on mixed deltas that re-evaluate; hg_cpp publishes the correct size. Fingerprint pinned in known_divergences.json.",
+  "template": "collection_size",
+  "inputs": {
+    "ts": [
+      {
+        "a": 1,
+        "b": 2
+      },
+      {
+        "a": null,
+        "b": 5
+      }
+    ]
+  },
+  "parameters": {
+    "shape": "tsd",
+    "operation": "len"
+  },
+  "features": [
+    "topology:expression",
+    "domain:collection-size",
+    "reference:REF",
+    "binding:non-peered",
+    "shape:TSD",
+    "operator:len"
+  ],
+  "source_issue": "https://github.com/hhenson/hg_cpp/issues/129"
+}

--- a/tools/parity/generate.py
+++ b/tools/parity/generate.py
@@ -522,9 +522,13 @@ def recipe_payload_strategy(*, min_ticks: int = 8, max_ticks: int = 32,
             if operation == "contains":
                 parameters["probe"] = draw(small)
         elif shape == "tsd":
+            # No removals (None values): TSD removal-driven len-family
+            # re-ticks are a RULED deviation (released hgraph leaves stale
+            # values; hg_cpp re-evaluates) — the corpus tracks that space
+            # with pinned fingerprints, generation stays out of it.
             def tick():
                 entries = draw(st.lists(
-                    st.tuples(keys, st.one_of(st.none(), small)),
+                    st.tuples(keys, small),
                     min_size=1, max_size=3, unique_by=lambda kv: kv[0]))
                 return {key: value for key, value in entries}
             inputs = {"ts": [tick() for _ in range(count)]}

--- a/tools/parity/known_divergences.json
+++ b/tools/parity/known_divergences.json
@@ -42,6 +42,18 @@
       "issue": "https://github.com/hhenson/hg_cpp/issues/120",
       "reason": "Accepted deviation (TSD removal-driven len-family re-ticks): released hgraph does not re-evaluate len_/is_empty/contains_ over a TSD on a removal-only delta, leaving stale values (a partial removal leaves upstream len_ at the old size forever); hg_cpp re-evaluates and publishes the correct value. Correctness over upstream quirk \u2014 see the roadmap.rst Accepted Deviations entry.",
       "review_after": "2027-07-28"
+    },
+    {
+      "fingerprint": "88e2181815d7034510ee3179c90a5295611dc572ef95f4b6941d303ad029817f",
+      "issue": "https://github.com/hhenson/hg_cpp/issues/129",
+      "reason": "Accepted deviation (TSD removals invisible to upstream's len family): released hgraph never subtracts a removed key \u2014 a removal-only delta does not re-evaluate, and even a MIXED delta that does re-evaluate still counts the removed key (reference probes: {a:1,b:2} then {a:None,b:5} -> upstream len stays 2; {a:None,c:3} -> upstream len 3). hg_cpp re-evaluates and publishes the correct size. See the roadmap.rst Accepted Deviations entry.",
+      "review_after": "2027-07-28"
+    },
+    {
+      "fingerprint": "4c3658dcf2fd97f59b8af5975fc31648da38c12ff68a55a85d5e1d4d4913ac3c",
+      "issue": "https://github.com/hhenson/hg_cpp/issues/129",
+      "reason": "Accepted deviation (TSD removals invisible to upstream's len family): released hgraph never subtracts a removed key \u2014 a removal-only delta does not re-evaluate, and even a MIXED delta that does re-evaluate still counts the removed key (reference probes: {a:1,b:2} then {a:None,b:5} -> upstream len stays 2; {a:None,c:3} -> upstream len 3). hg_cpp re-evaluates and publishes the correct size. See the roadmap.rst Accepted Deviations entry.",
+      "review_after": "2027-07-28"
     }
   ],
   "families": [

--- a/tools/parity/known_divergences.json
+++ b/tools/parity/known_divergences.json
@@ -30,6 +30,18 @@
       "issue": "https://github.com/hhenson/hg_cpp/pull/67",
       "reason": "No-change-means-no-tick ruling (2026-07-17, roadmap.rst): a mesh over an initially empty key set emits no tick in hg_cpp where released hgraph ticks an empty map. Fingerprint pinned by test_parity_harness.py against the corpus recipe mesh-empty-initial-no-tick.",
       "review_after": "2027-07-26"
+    },
+    {
+      "fingerprint": "0708a2d7d8227adae475652e3d559744555a9e979fab7adc4cc8d29e848460d8",
+      "issue": "https://github.com/hhenson/hg_cpp/issues/129",
+      "reason": "Accepted deviation (TSD removal-driven len-family re-ticks): released hgraph does not re-evaluate len_/is_empty/contains_ over a TSD on a removal-only delta, leaving stale values (a partial removal leaves upstream len_ at the old size forever); hg_cpp re-evaluates and publishes the correct value. Correctness over upstream quirk \u2014 see the roadmap.rst Accepted Deviations entry.",
+      "review_after": "2027-07-28"
+    },
+    {
+      "fingerprint": "79b21651093f2a52ac1eb73e5ac3d4cf0f86e73b2094e466f5653d709c2167fc",
+      "issue": "https://github.com/hhenson/hg_cpp/issues/120",
+      "reason": "Accepted deviation (TSD removal-driven len-family re-ticks): released hgraph does not re-evaluate len_/is_empty/contains_ over a TSD on a removal-only delta, leaving stale values (a partial removal leaves upstream len_ at the old size forever); hg_cpp re-evaluates and publishes the correct value. Correctness over upstream quirk \u2014 see the roadmap.rst Accepted Deviations entry.",
+      "review_after": "2027-07-28"
     }
   ],
   "families": [


### PR DESCRIPTION
## Summary

Triage of the 2026-07-27 nightly batch (41 issues): one root cause plus one ruled deviation resolve 20 of them.

**Root cause (18 issues)** — `len_`/`contains_` over a **never-valid** TSS/TSD emitted a start default (`0`/`False`) where released hgraph stays silent until the first delta. The blast radius went far beyond `collection_size`: the nested template's outer-switch off branch is `len_(values) * 0`, so every arithmetic-`wrap_switch` divergence and eight request-reply variants were this same bug. The invalid branches now return without emitting; empty-after-removal stays valid and emits. `is_empty` deliberately keeps its start tick — the ported upstream `test_is_empty` pins True-at-start, and those upstream-verbatim ports caught my first cut over-silencing it.

**Ruled deviation (#120/#129, needs your sign-off on merge)** — reference-env probes show released hgraph **never re-evaluates** `len_`/`is_empty`/`contains_` over a TSD on a removal-only delta: a partial removal leaves upstream `len_` stale at the old size indefinitely, `is_empty` stays stale-False after the dict empties. hg_cpp recomputes correctly. Per the correctness-over-quirk precedent: roadmap.rst Accepted Deviations entry, behaviour pinned in `test_tsd_removal_reticks_are_the_ruled_deviation`, both failure fingerprints pinned in `known_divergences.json`, the space kept as corpus recipes (`coverage-tsd-removal-*`), and the generator constrained out of it (TSS removals agree with upstream and stay generated).

Closes #106, closes #107, closes #111, closes #112, closes #113, closes #116, closes #118, closes #120, closes #121, closes #122, closes #124, closes #125, closes #126, closes #127, closes #129, closes #134, closes #135, closes #136, closes #137, closes #138.

## Test plan

- [x] All 20 issues' minimized recipes re-verified: 18 MATCH the recorded reference trace; #120/#129 remain exactly the ruled shape
- [x] C++ suite — 1280 cases passed (container matrix start-tick pins updated)
- [x] Full Python tree excl. adaptors — 1589 passed, 10 skipped (ported upstream suites included)
- [x] Parity harness green; corpus 39 recipes valid

🤖 Generated with [Claude Code](https://claude.com/claude-code)