### PR TITLE
None means nothing ticked, consistently across all keyed structures

### DIFF
--- a/docs/source/developer_guide/python_integration.rst
+++ b/docs/source/developer_guide/python_integration.rst
@@ -189,8 +189,12 @@ the ``_hgraph`` bridge module (built from ``python/module.cpp``):
   ``__end_time__=)`` with schema-directed test vectors (TSS from sets —
   removals via ``set_delta(...)``/``Removed(...)`` markers; a dict is NEVER
   a TSS value/delta and rejects loudly, except the empty ``{}`` which is
-  upstream's empty-set stand-in — TSD from ``{key: value}`` dicts with
-  ``None`` = lenient removal, TSL from per-index lists) and friendly delta
+  upstream's empty-set stand-in — TSD from ``{key: value}`` dicts where a
+  ``None`` value means NOTHING ticked for that key (the per-key analogue
+  of the top-level no-tick, consistent across keyed structures — TSD
+  keys, TSL indices, TSB fields — and matching upstream; removals are the
+  explicit ``REMOVE``/``REMOVE_IF_EXISTS`` sentinels; ruling 2026-07-28),
+  TSL from per-index lists) and friendly delta
   read-back (``REMOVE`` sentinel). A generic ``TSL[..., SIZE]`` parameter
   annotation resolves its size from the samples (int-keyed dict → max key
   + 1; list → length) and wires the REAL dynamic list shape (issue #81);

--- a/docs/source/developer_guide/roadmap.rst
+++ b/docs/source/developer_guide/roadmap.rst
@@ -610,21 +610,20 @@ The following are intentional unless separately re-opened:
   TSS/TSD delta that nets to no change does not tick. Explicit writes are
   unaffected and match upstream exactly: a python node returning the same
   scalar each evaluation ticks each time, as do repeated TSD entry writes.
-- **TSD removals are invisible to upstream's len family** (issues
-  #120/#129, 2026-07-28): released hgraph never subtracts a removed key
-  from ``len_``/``is_empty``/``contains_`` over a TSD — a removal-only
-  delta does not re-evaluate at all, and even a MIXED delta that does
-  re-evaluate still counts the removed key (reference probes:
-  ``{a:1,b:2}`` then ``{a:None,b:5}`` leaves upstream ``len_`` at 2;
-  ``{a:None,c:3}`` reads 3).  hg_cpp re-evaluates and publishes the
-  correct size.  Correctness over the upstream quirk: pinned by
-  ``test_tsd_removal_reticks_are_the_ruled_deviation`` and the native
-  container matrix, the failure fingerprints (removal-only AND mixed
-  shapes) are pinned in ``known_divergences.json``, the corpus tracks the
-  space (``coverage-tsd-removal-*``), and generation excludes TSD
-  removals entirely — mixed deltas diverge too, so there is no
-  upstream-agreeing removal space to fuzz.  TSS removals agree with
-  upstream and stay generated.
+- **The lenient-None TSD convention diverges observably in the len
+  family** (issues #120/#129, 2026-07-28; a manifestation of the
+  None-removal convention above, NOT an upstream ``len_`` defect):
+  released hgraph's ``eval_node`` SILENTLY IGNORES a ``{key: None}``
+  TSD tick (no removal, no value, no error — reported upstream as
+  hhenson/hgraph#363), so derived ``len_``/``is_empty``/``contains_``
+  values appear stale; hg_cpp's harness treats ``None`` as the lenient
+  removal and re-evaluates.  With explicit ``REMOVE`` deltas the two
+  runtimes agree exactly (verified by reference-env probes; the native
+  container matrix pins the removal re-ticks as plain correct
+  behaviour).  The campaign keeps out of the divergent convention space:
+  the ``collection_size`` generator emits no ``None`` values for TSD,
+  the corpus tracks the shapes (``coverage-tsd-removal-*``), and their
+  failure fingerprints are pinned in ``known_divergences.json``.
 - **Service-boundary timing** (design record: the scheduling matrix in
   :doc:`services`): request stubs forward next cycle by design, so a
   ``service_adaptor`` round trip observably lands one cycle after released

--- a/docs/source/developer_guide/roadmap.rst
+++ b/docs/source/developer_guide/roadmap.rst
@@ -610,20 +610,6 @@ The following are intentional unless separately re-opened:
   TSS/TSD delta that nets to no change does not tick. Explicit writes are
   unaffected and match upstream exactly: a python node returning the same
   scalar each evaluation ticks each time, as do repeated TSD entry writes.
-- **The lenient-None TSD convention diverges observably in the len
-  family** (issues #120/#129, 2026-07-28; a manifestation of the
-  None-removal convention above, NOT an upstream ``len_`` defect):
-  released hgraph's ``eval_node`` SILENTLY IGNORES a ``{key: None}``
-  TSD tick (no removal, no value, no error — reported upstream as
-  hhenson/hgraph#363), so derived ``len_``/``is_empty``/``contains_``
-  values appear stale; hg_cpp's harness treats ``None`` as the lenient
-  removal and re-evaluates.  With explicit ``REMOVE`` deltas the two
-  runtimes agree exactly (verified by reference-env probes; the native
-  container matrix pins the removal re-ticks as plain correct
-  behaviour).  The campaign keeps out of the divergent convention space:
-  the ``collection_size`` generator emits no ``None`` values for TSD,
-  the corpus tracks the shapes (``coverage-tsd-removal-*``), and their
-  failure fingerprints are pinned in ``known_divergences.json``.
 - **Service-boundary timing** (design record: the scheduling matrix in
   :doc:`services`): request stubs forward next cycle by design, so a
   ``service_adaptor`` round trip observably lands one cycle after released

--- a/docs/source/developer_guide/roadmap.rst
+++ b/docs/source/developer_guide/roadmap.rst
@@ -596,13 +596,17 @@ Accepted Deviations
 
 The following are intentional unless separately re-opened:
 
-- The harness ``None``-removal convention for TSD inputs applies leniently
-  (``REMOVE``/``REMOVE_IF_EXISTS`` honour upstream semantics exactly:
-  ``REMOVE`` raises when the key is absent at delta application,
+- A ``None`` value in a keyed delta means **nothing ticked for that key**
+  (ruling 2026-07-28) — the per-key analogue of the top-level no-tick,
+  applied consistently across keyed structures (TSD keys, TSL indices,
+  TSB fields) and to Python node RESULTS, matching upstream exactly (its
+  TSD setter skips ``None`` values; hhenson/hgraph#363 analysis).
+  Removals are the explicit sentinels, honouring upstream semantics
+  exactly: ``REMOVE`` raises when the key is absent at delta application,
   ``REMOVE_IF_EXISTS`` does not; the canonical TSD delta carries strict
-  removals in a dedicated ``removed_strict`` field that only user-authored
-  Python dicts populate — captured/replicated deltas stay lenient).  TSS
-  element removals are lenient in upstream and here alike.
+  removals in a dedicated ``removed_strict`` field that only
+  user-authored Python dicts populate — captured/replicated deltas stay
+  lenient.  TSS element removals are lenient in upstream and here alike.
 - **No-change means no tick** (ruling 2026-07-17): operators that derive a
   value from a collection do not re-tick when the recomputed value is
   unchanged — e.g. ``len_`` over a TSS whose delta nets to no length change

--- a/python/py_nodes.cpp
+++ b/python/py_nodes.cpp
@@ -97,9 +97,12 @@ void apply_py_result(nb::handle result, Out<TsVar<"O">> &out) {
         key_value.view().assign_from_python(key);
         const bool strict_remove = removed_sentinel_slot().is_valid() &&
                                    item.is(removed_sentinel_slot());
+        // None = nothing ticked for this key (ruling 2026-07-28) —
+        // the keyed-delta contract applies to node RESULTS too.
+        if (item.is_none()) { continue; }
         const bool lenient_remove =
-            item.is_none() || (remove_if_exists_sentinel_slot().is_valid() &&
-                               item.is(remove_if_exists_sentinel_slot()));
+            remove_if_exists_sentinel_slot().is_valid() &&
+            item.is(remove_if_exists_sentinel_slot());
         if (strict_remove || lenient_remove) {
           // Membership is pre-checked: an ineffective erase would
           // touch-validate the output (the replay empty-tick rule),
@@ -126,9 +129,10 @@ void apply_py_result(nb::handle result, Out<TsVar<"O">> &out) {
       Value key_value = py_to_value_as(key, key_meta);
       const bool strict_remove = removed_sentinel_slot().is_valid() &&
                                  item.is(removed_sentinel_slot());
+      if (item.is_none()) { continue; }   // per-key no-tick (2026-07-28)
       const bool lenient_remove =
-          item.is_none() || (remove_if_exists_sentinel_slot().is_valid() &&
-                             item.is(remove_if_exists_sentinel_slot()));
+          remove_if_exists_sentinel_slot().is_valid() &&
+          item.is(remove_if_exists_sentinel_slot());
       if (strict_remove || lenient_remove) {
         // See above: pre-check membership so a skipped lenient
         // removal produces no tick and a strict one raises.

--- a/python/tests/test_hgraph_api.py
+++ b/python/tests/test_hgraph_api.py
@@ -203,8 +203,12 @@ def test_tsd_key_removal():
     def keys(d: TSD[str, TS[int]]) -> TSD[str, TS[int]]:
         return hg.map_("add_", d, d)
 
-    out = eval_node(keys, [{"a": 1, "b": 2}, {"a": None}])
+    # None = nothing ticked for the key (ruling 2026-07-28); removals are
+    # the explicit sentinels.
+    out = eval_node(keys, [{"a": 1, "b": 2}, {"a": hg.REMOVE_IF_EXISTS}])
     check(out == [{"a": 2, "b": 4}, {"a": hg.REMOVE}], f"removal: {out}")
+    out = eval_node(keys, [{"a": 1, "b": 2}, {"a": None}])
+    check(out == [{"a": 2, "b": 4}, None], f"None no-op: {out}")
 
 
 def test_tss_deltas():
@@ -775,7 +779,7 @@ def test_time_series_view_api():
     def g(d: TSD[str, TS[int]]) -> TS[int]:
         return observe(d)
 
-    out = eval_node(g, [{"a": 1, "b": 2}, {"a": None}])
+    out = eval_node(g, [{"a": 1, "b": 2}, {"a": hg.REMOVE_IF_EXISTS}])
     check(out == [2, 1], f"sizes: {out}")
     check(observations[0][0] == {"a": 1, "b": 2}, f"value: {observations[0]}")
     check(observations[0][3] == ["a", "b"] and observations[0][4] == [], "first delta keys")

--- a/python/tests/test_len_sized_types.py
+++ b/python/tests/test_len_sized_types.py
@@ -102,28 +102,36 @@ def test_len_family_never_valid_input_never_ticks():
     assert eval_node(tsd_empty, [None, None]) == [True, None]
 
 
-def test_tsd_none_removal_convention_drives_len_family_reticks():
-    # The lenient-None convention (recorded deviation; issues #120/#129,
-    # fingerprints pinned in known_divergences.json): a {key: None} tick is
-    # a lenient removal in hg_cpp's eval_node, so the len family
-    # re-evaluates — upstream's eval_node silently ignores the tick
-    # entirely (reported as hhenson/hgraph#363). With explicit REMOVE both
-    # runtimes agree. These pins are the hg_cpp convention contract.
+def test_tsd_removal_reticks_and_none_is_a_per_key_no_op():
+    # Ruling 2026-07-28: None means NOTHING ticked for that key — the
+    # per-key analogue of the top-level no-tick, consistent across all
+    # keyed structures and matching upstream. Removals are the explicit
+    # sentinels, and the len family re-evaluates on them (both runtimes
+    # agree).
     @hg.graph
     def tsd_len(ts: hg.TSD[str, hg.TS[int]]) -> TS[int]:
         return hg.len_(ts)
 
-    assert eval_node(tsd_len, [{"a": 1, "b": 2}, {"a": None}]) == [2, 1]
+    assert eval_node(tsd_len, [{"a": 1, "b": 2}, {"a": hg.REMOVE_IF_EXISTS}]) == [2, 1]
+    assert eval_node(tsd_len, [{"a": 1, "b": 2}, {"a": None}]) == [2, None]
 
     @hg.graph
     def tsd_empty(ts: hg.TSD[str, hg.TS[int]]) -> TS[bool]:
         return hg.is_empty(ts)
 
-    assert eval_node(tsd_empty, [{"a": 1}, {"a": None}, {"b": 2}]) == [
+    assert eval_node(tsd_empty, [{"a": 1}, {"a": hg.REMOVE_IF_EXISTS}, {"b": 2}]) == [
         False, True, False]
 
     @hg.graph
     def tsd_contains(ts: hg.TSD[str, hg.TS[int]]) -> TS[bool]:
         return hg.contains_(ts, "c")
 
-    assert eval_node(tsd_contains, [{"c": 0}, {"c": None}]) == [True, False]
+    assert eval_node(tsd_contains, [{"c": 0}, {"c": hg.REMOVE_IF_EXISTS}]) == [True, False]
+
+    # Consistency across keyed structures: a None entry per TSL index is
+    # likewise a no-tick for that index.
+    @hg.graph
+    def tsl_first(ts: hg.TSL[TS[int], hg.Size[2]]) -> TS[int]:
+        return ts[0]
+
+    assert eval_node(tsl_first, [[1, 2], [None, 5]]) == [1, None]

--- a/python/tests/test_len_sized_types.py
+++ b/python/tests/test_len_sized_types.py
@@ -102,12 +102,13 @@ def test_len_family_never_valid_input_never_ticks():
     assert eval_node(tsd_empty, [None, None]) == [True, None]
 
 
-def test_tsd_removal_reticks_are_the_ruled_deviation():
-    # Ruled deviation (issues #120/#129, fingerprints pinned in
-    # known_divergences.json): released hgraph does NOT re-evaluate the len
-    # family on a TSD removal-only delta, leaving stale values (a partial
-    # removal leaves upstream len_ at the old size); hg_cpp re-evaluates and
-    # publishes the correct value. These pins are the hg_cpp contract.
+def test_tsd_none_removal_convention_drives_len_family_reticks():
+    # The lenient-None convention (recorded deviation; issues #120/#129,
+    # fingerprints pinned in known_divergences.json): a {key: None} tick is
+    # a lenient removal in hg_cpp's eval_node, so the len family
+    # re-evaluates — upstream's eval_node silently ignores the tick
+    # entirely (reported as hhenson/hgraph#363). With explicit REMOVE both
+    # runtimes agree. These pins are the hg_cpp convention contract.
     @hg.graph
     def tsd_len(ts: hg.TSD[str, hg.TS[int]]) -> TS[int]:
         return hg.len_(ts)

--- a/python/tests/test_tsd_removal_semantics.py
+++ b/python/tests/test_tsd_removal_semantics.py
@@ -10,7 +10,19 @@
 import pytest
 
 import hgraph as hg
-from hgraph import TS, TSD, TSS, Removed, graph, compute_node, set_delta
+from hgraph import (
+    TS,
+    TSB,
+    TSD,
+    TSL,
+    TSS,
+    Removed,
+    Size,
+    TimeSeriesSchema,
+    compute_node,
+    graph,
+    set_delta,
+)
 from hgraph.test import eval_node
 
 
@@ -32,6 +44,12 @@ def test_remove_absent_key_raises():
 def test_remove_if_exists_absent_key_is_silent():
     out = eval_node(_ident, [{"a": 1}, {"zzz": hg.REMOVE_IF_EXISTS}])
     assert out == [{"a": 2}, None]
+
+
+def test_first_tsd_tick_preserves_no_tick_and_empty_tick_distinction():
+    assert eval_node(_ident, [{"zzz": None}]) is None
+    assert eval_node(_ident, [{"zzz": hg.REMOVE_IF_EXISTS}]) is None
+    assert eval_node(_ident, [{}]) == [{}]
 
 
 def test_remove_if_exists_existing_key_removes():
@@ -62,6 +80,45 @@ def test_none_in_a_python_node_result_is_a_per_key_no_op():
         return _emit_none_for_a(ts)
 
     assert eval_node(g, [True]) == [{"b": 7}]
+
+
+def test_none_only_python_node_result_is_no_tick_for_nested_tsd():
+    @compute_node
+    def emit(ts: TS[bool]) -> TSD[str, TSL[TS[int], Size[2]]]:
+        return {"outer": None}
+
+    assert eval_node(emit, [True]) is None
+
+
+class _Pair(TimeSeriesSchema):
+    a: TS[int]
+    b: TS[int]
+
+
+def test_none_only_python_node_result_is_no_tick_for_fixed_structures():
+    @compute_node
+    def emit_bundle(ts: TS[bool]) -> TSB[_Pair]:
+        return {"a": None, "b": None}
+
+    @compute_node
+    def emit_list(ts: TS[bool]) -> TSL[TS[int], Size[2]]:
+        return [None, None]
+
+    assert eval_node(emit_bundle, [True]) is None
+    assert eval_node(emit_list, [True]) is None
+
+
+def test_fixed_structure_python_node_result_keeps_real_child_updates():
+    @compute_node
+    def emit_bundle(ts: TS[bool]) -> TSB[_Pair]:
+        return {"a": None, "b": 7}
+
+    @compute_node
+    def emit_list(ts: TS[bool]) -> TSL[TS[int], Size[2]]:
+        return [None, 7]
+
+    assert eval_node(emit_bundle, [True]) == [{"b": 7}]
+    assert eval_node(emit_list, [True]) == [{1: 7}]
 
 
 def test_python_node_result_remove_absent_key_raises():

--- a/python/tests/test_tsd_removal_semantics.py
+++ b/python/tests/test_tsd_removal_semantics.py
@@ -3,7 +3,8 @@
 - ``REMOVE`` is STRICT: removing a key that is not present raises at delta
   application (upstream raises through the node as a NodeException).
 - ``REMOVE_IF_EXISTS`` is LENIENT: an absent key is silently ignored.
-- The harness ``None``-removal convenience applies leniently.
+- A ``None`` value means NOTHING ticked for that key (ruling 2026-07-28):
+  a per-key no-op, never a removal.
 - TSS element removals are lenient in upstream and here alike.
 """
 import pytest
@@ -38,9 +39,29 @@ def test_remove_if_exists_existing_key_removes():
     assert out == [{"a": 2, "b": 4}, {"b": hg.REMOVE}]
 
 
-def test_none_removal_convention_is_lenient():
+def test_none_value_is_a_per_key_no_op():
+    # Absent key: nothing happens.
     out = eval_node(_ident, [{"a": 1}, {"zzz": None}])
     assert out == [{"a": 2}, None]
+    # EXISTING key: nothing happens either — the key survives and keeps
+    # updating afterwards (None is never a removal).
+    out = eval_node(_ident, [{"a": 1}, {"a": None}, {"a": 5}])
+    assert out == [{"a": 2}, None, {"a": 10}]
+
+
+@compute_node
+def _emit_none_for_a(ts: TS[bool]) -> TSD[str, TS[int]]:
+    return {"a": None, "b": 7}
+
+
+def test_none_in_a_python_node_result_is_a_per_key_no_op():
+    # The keyed-delta contract applies to node RESULTS too: the returned
+    # None entry must not remove (or write) key "a".
+    @graph
+    def g(ts: TS[bool]) -> TSD[str, TS[int]]:
+        return _emit_none_for_a(ts)
+
+    assert eval_node(g, [True]) == [{"b": 7}]
 
 
 def test_python_node_result_remove_absent_key_raises():

--- a/python/value_conversion.cpp
+++ b/python/value_conversion.cpp
@@ -892,8 +892,11 @@ namespace hgraph::python_bridge
                 SetBuilder  removed{delta_binding(key_meta)};
                 SetBuilder  removed_strict{delta_binding(key_meta)};
                 MapBuilder  modified{delta_binding(key_meta), delta_binding(child->delta_value_schema)};
+                bool        saw_item     = false;
+                bool        saw_non_none = false;
                 for (auto [key, item] : nb::cast<nb::dict>(object))
                 {
+                    saw_item = true;
                     // Upstream convention (ruling 2026-07-28): a None value
                     // means NOTHING happens for that key — the per-key
                     // analogue of the top-level None no-tick. Removals are
@@ -901,6 +904,7 @@ namespace hgraph::python_bridge
                     // key is absent at application; REMOVE_IF_EXISTS is
                     // lenient.
                     if (item.is_none()) { continue; }
+                    saw_non_none = true;
                     Value key_value = py_to_value_as(key, key_meta);
                     const bool strict_remove =
                         removed_sentinel_slot().is_valid() && item.is(removed_sentinel_slot());
@@ -912,9 +916,15 @@ namespace hgraph::python_bridge
                     else
                     {
                         Value child_delta = py_to_delta(item, child);
+                        if (!child_delta.has_value()) { continue; }
                         modified.set_item_copy(key_value.view().data(), child_delta.view().data());
                     }
                 }
+                // A non-empty mapping whose entries are all None is the
+                // keyed equivalent of a top-level None: no delta at all.
+                // Keep {} distinct because it explicitly validates a fresh
+                // TSD as an empty collection.
+                if (saw_item && !saw_non_none) { return Value{*ts->delta_value_schema}; }
                 BundleBuilder bundle{delta_binding(ts->delta_value_schema)};
                 bundle.set("removed", removed.build());
                 bundle.set("modified", modified.build());
@@ -933,6 +943,7 @@ namespace hgraph::python_bridge
                         if (item.is_none()) { continue; }
                         const auto index = nb::cast<std::int64_t>(key);
                         Value child_delta = py_to_delta(item, ts->element_ts());
+                        if (!child_delta.has_value()) { continue; }
                         builder.set_item_copy(std::addressof(index), child_delta.view().data());
                     }
                     return builder.build();
@@ -943,6 +954,11 @@ namespace hgraph::python_bridge
                     if (!item.is_none())
                     {
                         Value child_delta = py_to_delta(item, ts->element_ts());
+                        if (!child_delta.has_value())
+                        {
+                            ++index;
+                            continue;
+                        }
                         builder.set_item_copy(std::addressof(index), child_delta.view().data());
                     }
                     ++index;
@@ -984,7 +1000,9 @@ namespace hgraph::python_bridge
                                           ? nb::borrow<nb::object>(fields[key])
                                           : nb::getattr(object, key);
                     if (item.is_none()) { continue; }
-                    builder.set(index, py_to_delta(item, field.type).view());
+                    Value child_delta = py_to_delta(item, field.type);
+                    if (!child_delta.has_value()) { continue; }
+                    builder.set(index, child_delta.view());
                 }
                 return builder.build();
             }

--- a/python/value_conversion.cpp
+++ b/python/value_conversion.cpp
@@ -894,16 +894,19 @@ namespace hgraph::python_bridge
                 MapBuilder  modified{delta_binding(key_meta), delta_binding(child->delta_value_schema)};
                 for (auto [key, item] : nb::cast<nb::dict>(object))
                 {
+                    // Upstream convention (ruling 2026-07-28): a None value
+                    // means NOTHING happens for that key — the per-key
+                    // analogue of the top-level None no-tick. Removals are
+                    // the explicit sentinels only: REMOVE raises when the
+                    // key is absent at application; REMOVE_IF_EXISTS is
+                    // lenient.
+                    if (item.is_none()) { continue; }
                     Value key_value = py_to_value_as(key, key_meta);
-                    // hgraph's removal contract: REMOVE raises when the key is
-                    // absent at application; REMOVE_IF_EXISTS and the harness
-                    // None convention are lenient.
                     const bool strict_remove =
                         removed_sentinel_slot().is_valid() && item.is(removed_sentinel_slot());
                     const bool lenient_remove =
-                        item.is_none() ||
-                        (remove_if_exists_sentinel_slot().is_valid() &&
-                         item.is(remove_if_exists_sentinel_slot()));
+                        remove_if_exists_sentinel_slot().is_valid() &&
+                        item.is(remove_if_exists_sentinel_slot());
                     if (strict_remove) { (void)removed_strict.insert_copy(key_value.view().data()); }
                     else if (lenient_remove) { (void)removed.insert_copy(key_value.view().data()); }
                     else
@@ -925,6 +928,9 @@ namespace hgraph::python_bridge
                 {
                     for (auto [key, item] : nb::cast<nb::dict>(object))
                     {
+                        // None = nothing ticked for this index (the keyed-
+                        // structure convention, ruling 2026-07-28).
+                        if (item.is_none()) { continue; }
                         const auto index = nb::cast<std::int64_t>(key);
                         Value child_delta = py_to_delta(item, ts->element_ts());
                         builder.set_item_copy(std::addressof(index), child_delta.view().data());

--- a/src/hgraph/types/metadata/ts_data_fixed_structured_ops.cpp
+++ b/src/hgraph/types/metadata/ts_data_fixed_structured_ops.cpp
@@ -1647,12 +1647,13 @@ namespace hgraph::ts_data_plan_factory_detail
                     fmt::format("{} expects {} elements, got {}", what, state->element_count(), count));
             }
 
+            bool touched = false;
             for (std::size_t index = 0; index < count; ++index)
             {
                 nb::object child_source = sequence[index];
-                static_cast<void>(fixed_child_update_from_python(state, memory, index, child_source, modified_time));
+                touched |= fixed_child_update_from_python(state, memory, index, child_source, modified_time);
             }
-            return true;
+            return touched;
         }
 
         [[nodiscard]] static bool fixed_from_python_bundle(const FixedTSDataContext *state,
@@ -1663,7 +1664,7 @@ namespace hgraph::ts_data_plan_factory_detail
             nb::object object = nb::borrow<nb::object>(source);
             if (is_python_mapping(source))
             {
-                bool touched = true;
+                bool touched = false;
                 for_each_python_mapping_item(source, "TSB from_python", [&](nb::handle key, nb::handle value) {
                     const auto field = nb::cast<std::string>(key);
                     const auto index = field_index_by_name(state, field);
@@ -1671,7 +1672,7 @@ namespace hgraph::ts_data_plan_factory_detail
                     {
                         throw std::invalid_argument(fmt::format("TSB from_python unknown field '{}'", field));
                     }
-                    static_cast<void>(fixed_child_update_from_python(state, memory, index, value, modified_time));
+                    touched |= fixed_child_update_from_python(state, memory, index, value, modified_time);
                 });
                 return touched;
             }
@@ -1682,6 +1683,7 @@ namespace hgraph::ts_data_plan_factory_detail
             }
 
             bool saw_field = false;
+            bool touched   = false;
             for (std::size_t index = 0; index < state->element_count(); ++index)
             {
                 const char *name = state->schema->fields()[index].name;
@@ -1692,13 +1694,13 @@ namespace hgraph::ts_data_plan_factory_detail
                 if (!nb::hasattr(object, name)) { continue; }
                 saw_field = true;
                 nb::object child_source = nb::getattr(object, name);
-                static_cast<void>(fixed_child_update_from_python(state, memory, index, child_source, modified_time));
+                touched |= fixed_child_update_from_python(state, memory, index, child_source, modified_time);
             }
             if (!saw_field)
             {
                 throw std::invalid_argument("TSB from_python expects a mapping, sequence, or field attributes");
             }
-            return true;
+            return touched;
         }
 
         [[nodiscard]] static bool fixed_from_python_list_mapping(const FixedTSDataContext *state,
@@ -1706,15 +1708,16 @@ namespace hgraph::ts_data_plan_factory_detail
                                                                  nb::handle                source,
                                                                  DateTime             modified_time)
         {
+            bool touched = false;
             for_each_python_mapping_item(source, "fixed TSL from_python", [&](nb::handle key, nb::handle value) {
                 const auto index = nb::cast<std::size_t>(key);
                 if (index >= state->element_count())
                 {
                     throw std::out_of_range("fixed TSL from_python index out of range");
                 }
-                static_cast<void>(fixed_child_update_from_python(state, memory, index, value, modified_time));
+                touched |= fixed_child_update_from_python(state, memory, index, value, modified_time);
             });
-            return true;
+            return touched;
         }
 
         [[nodiscard]] static bool fixed_from_python(const void *context,

--- a/src/hgraph/types/time_series/ts_delta.cpp
+++ b/src/hgraph/types/time_series/ts_delta.cpp
@@ -546,12 +546,26 @@ namespace hgraph
         {
             if (!delta.has_value()) { return false; }
             const auto bundle = delta.as_bundle();
-            if (bundle.field("removed").as_indexed_view().size() != 0 ||
-                bundle.field("modified").as_map().size() != 0 ||
-                bundle.field("removed_strict").as_indexed_view().size() != 0)
+            const auto modified       = bundle.field("modified").as_map();
+            const auto removed_strict = bundle.field("removed_strict").as_indexed_view();
+            if (modified.size() != 0 || removed_strict.size() != 0)
             {
                 return true;
             }
+
+            const auto removed = bundle.field("removed").as_indexed_view();
+            if (removed.size() != 0)
+            {
+                const auto dict_out = out.as_dict();
+                for (std::size_t index = 0; index < removed.size(); ++index)
+                {
+                    if (dict_out.contains(removed.at(index))) { return true; }
+                }
+                // Lenient removals of absent keys are not an empty
+                // validating tick, even when the TSD is still fresh.
+                return false;
+            }
+
             // The empty-tick validation rule, as for TSS.
             return !out.valid();
         }

--- a/tests/cpp/test_std_operators.cpp
+++ b/tests/cpp/test_std_operators.cpp
@@ -1837,10 +1837,11 @@ TEST_CASE("std operators: collection container operators support TSS TSD and fix
                      values<Value>(set_delta<Int>({1}, {}), none))),
                  values<Bool>(none, true));
 
-    // The ruled TSD-removal deviation (issues #120/#129): hg_cpp
-    // re-evaluates on removals — a partial removal shrinks len_, emptying
-    // flips is_empty, removing the probed key flips contains_ — where
-    // released hgraph never subtracts a removed key (mixed deltas included).
+    // Removal-driven re-ticks over EXPLICIT removal deltas — plain correct
+    // behaviour on which both runtimes agree (the #120/#129 divergences were
+    // the harness None-convention, hhenson/hgraph#363, not len semantics):
+    // a partial removal shrinks len_, emptying flips is_empty, removing the
+    // probed key flips contains_.
     CHECK_OUTPUT((eval_node<stdlib::len_, TSD<Int, TS<Int>>>(
                      values<Value>(dict_delta<Int, TS<Int>>({{1, 1}, {2, 2}}),
                                    dict_delta<Int, TS<Int>>({}, {1})))),

--- a/tests/cpp/test_ts_delta.cpp
+++ b/tests/cpp/test_ts_delta.cpp
@@ -231,6 +231,29 @@ TEST_CASE("ts_delta: capture/apply round-trip a TSD-of-scalar dict delta") {
                 dict_delta<Str, TS<Int>>({{"b"s, 9}})});
 }
 
+TEST_CASE("ts_delta: TSD lenient removals tick only when a key exists") {
+  using namespace std::string_literals;
+
+  (void)TypeRegistry::instance().register_scalar<Int>("int");
+  (void)TypeRegistry::instance().register_scalar<Str>("str");
+  const std::vector<std::optional<Value>> deltas{
+      dict_delta<Str, TS<Int>>({}, {"missing"s}),
+      dict_delta<Str, TS<Int>>({}),
+      dict_delta<Str, TS<Int>>({{"a"s, 1}}),
+      dict_delta<Str, TS<Int>>({}, {"a"s}),
+      dict_delta<Str, TS<Int>>({}, {"a"s}),
+      dict_delta<Str, TS<Int>>({{"b"s, 2}}),
+  };
+
+  auto app = run_graph<ApplyGraph<TSD<Str, TS<Int>>>>(
+      [&](const GlobalStateView &gs) { set_replay_deltas(gs, "in", deltas); });
+  CHECK_OUTPUT(get_recorded_deltas(app.view().graph().global_state(), "out"),
+               {none, dict_delta<Str, TS<Int>>({}),
+                dict_delta<Str, TS<Int>>({{"a"s, 1}}),
+                dict_delta<Str, TS<Int>>({}, {"a"s}), none,
+                dict_delta<Str, TS<Int>>({{"b"s, 2}})});
+}
+
 TEST_CASE("TSD output slots use the graph's closed Bundle realization") {
   auto &registry = TypeRegistry::instance();
   const auto *integer = registry.register_scalar<Int>("int");

--- a/tools/parity/corpus/coverage-tsd-removal-contains.json
+++ b/tools/parity/corpus/coverage-tsd-removal-contains.json
@@ -1,5 +1,5 @@
 {
-  "description": "Ruled deviation: a TSD removal-only delta re-evaluates the len family in hg_cpp (correct) where released hgraph leaves a stale value; the failure fingerprint is pinned in known_divergences.json.",
+  "description": "Recorded lenient-None deviation (len-family manifestation): upstream eval_node silently ignores {key: None} TSD ticks (hhenson/hgraph#363); hg_cpp removes leniently and re-evaluates. Fingerprint pinned in known_divergences.json.",
   "features": [
     "binding:non-peered",
     "domain:collection-size",

--- a/tools/parity/corpus/coverage-tsd-removal-contains.json
+++ b/tools/parity/corpus/coverage-tsd-removal-contains.json
@@ -1,5 +1,5 @@
 {
-  "description": "Recorded lenient-None deviation (len-family manifestation): upstream eval_node silently ignores {key: None} TSD ticks (hhenson/hgraph#363); hg_cpp removes leniently and re-evaluates. Fingerprint pinned in known_divergences.json.",
+  "description": "TSD removal re-ticks (agreeing space): removing the probed key flips contains_ on both runtimes.",
   "features": [
     "binding:non-peered",
     "domain:collection-size",
@@ -15,7 +15,9 @@
         "c": 0
       },
       {
-        "c": null
+        "c": {
+          "$remove_if_exists": true
+        }
       }
     ]
   },

--- a/tools/parity/corpus/coverage-tsd-removal-is-empty.json
+++ b/tools/parity/corpus/coverage-tsd-removal-is-empty.json
@@ -1,5 +1,5 @@
 {
-  "description": "Ruled deviation: a TSD removal-only delta re-evaluates the len family in hg_cpp (correct) where released hgraph leaves a stale value; the failure fingerprint is pinned in known_divergences.json.",
+  "description": "Recorded lenient-None deviation (len-family manifestation): upstream eval_node silently ignores {key: None} TSD ticks (hhenson/hgraph#363); hg_cpp removes leniently and re-evaluates. Fingerprint pinned in known_divergences.json.",
   "features": [
     "binding:non-peered",
     "domain:collection-size",

--- a/tools/parity/corpus/coverage-tsd-removal-is-empty.json
+++ b/tools/parity/corpus/coverage-tsd-removal-is-empty.json
@@ -1,5 +1,5 @@
 {
-  "description": "Recorded lenient-None deviation (len-family manifestation): upstream eval_node silently ignores {key: None} TSD ticks (hhenson/hgraph#363); hg_cpp removes leniently and re-evaluates. Fingerprint pinned in known_divergences.json.",
+  "description": "TSD removal re-ticks (agreeing space): removing the last key flips is_empty on both runtimes; None values are per-key no-ticks (ruling 2026-07-28).",
   "features": [
     "binding:non-peered",
     "domain:collection-size",
@@ -15,7 +15,9 @@
         "b": 4
       },
       {
-        "b": null
+        "b": {
+          "$remove_if_exists": true
+        }
       }
     ]
   },

--- a/tools/parity/corpus/coverage-tsd-removal-mixed-add.json
+++ b/tools/parity/corpus/coverage-tsd-removal-mixed-add.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
   "id": "coverage-tsd-removal-mixed-add",
-  "description": "Recorded lenient-None deviation (len-family manifestation): upstream eval_node silently ignores {key: None} TSD ticks (hhenson/hgraph#363); hg_cpp removes leniently and re-evaluates. Fingerprint pinned in known_divergences.json.",
+  "description": "Mixed removal+add TSD delta plus a None per-key no-tick. The size stays 2 across the mixed tick: upstream re-publishes the unchanged length while hg_cpp elides it \u2014 the ruled no-change-means-no-tick deviation, classified known by the no-change-elision family (a permanently known mismatch).",
   "template": "collection_size",
   "inputs": {
     "ts": [
@@ -10,8 +10,13 @@
         "b": 2
       },
       {
-        "a": null,
+        "a": {
+          "$remove_if_exists": true
+        },
         "c": 3
+      },
+      {
+        "d": null
       }
     ]
   },

--- a/tools/parity/corpus/coverage-tsd-removal-mixed-add.json
+++ b/tools/parity/corpus/coverage-tsd-removal-mixed-add.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
   "id": "coverage-tsd-removal-mixed-add",
-  "description": "Ruled deviation: upstream's TSD len family never subtracts removed keys, even on mixed deltas that re-evaluate; hg_cpp publishes the correct size. Fingerprint pinned in known_divergences.json.",
+  "description": "Recorded lenient-None deviation (len-family manifestation): upstream eval_node silently ignores {key: None} TSD ticks (hhenson/hgraph#363); hg_cpp removes leniently and re-evaluates. Fingerprint pinned in known_divergences.json.",
   "template": "collection_size",
   "inputs": {
     "ts": [

--- a/tools/parity/corpus/coverage-tsd-removal-mixed-update.json
+++ b/tools/parity/corpus/coverage-tsd-removal-mixed-update.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
   "id": "coverage-tsd-removal-mixed-update",
-  "description": "Recorded lenient-None deviation (len-family manifestation): upstream eval_node silently ignores {key: None} TSD ticks (hhenson/hgraph#363); hg_cpp removes leniently and re-evaluates. Fingerprint pinned in known_divergences.json.",
+  "description": "Mixed removal+update TSD delta (agreeing space): len_ shrinks while the surviving key updates.",
   "template": "collection_size",
   "inputs": {
     "ts": [
@@ -10,7 +10,9 @@
         "b": 2
       },
       {
-        "a": null,
+        "a": {
+          "$remove_if_exists": true
+        },
         "b": 5
       }
     ]

--- a/tools/parity/corpus/coverage-tsd-removal-mixed-update.json
+++ b/tools/parity/corpus/coverage-tsd-removal-mixed-update.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
   "id": "coverage-tsd-removal-mixed-update",
-  "description": "Ruled deviation: upstream's TSD len family never subtracts removed keys, even on mixed deltas that re-evaluate; hg_cpp publishes the correct size. Fingerprint pinned in known_divergences.json.",
+  "description": "Recorded lenient-None deviation (len-family manifestation): upstream eval_node silently ignores {key: None} TSD ticks (hhenson/hgraph#363); hg_cpp removes leniently and re-evaluates. Fingerprint pinned in known_divergences.json.",
   "template": "collection_size",
   "inputs": {
     "ts": [

--- a/tools/parity/generate.py
+++ b/tools/parity/generate.py
@@ -522,13 +522,17 @@ def recipe_payload_strategy(*, min_ticks: int = 8, max_ticks: int = 32,
             if operation == "contains":
                 parameters["probe"] = draw(small)
         elif shape == "tsd":
-            # No removals (None values): TSD removal-driven len-family
-            # re-ticks are a RULED deviation (released hgraph leaves stale
-            # values; hg_cpp re-evaluates) — the corpus tracks that space
-            # with pinned fingerprints, generation stays out of it.
+            # Full delta space: values, explicit lenient removals, and None
+            # per-key no-ticks (ruling 2026-07-28: None means nothing
+            # happened for that key — both runtimes agree).
+            entry_value = st.one_of(
+                small,
+                st.just({"$remove_if_exists": True}),
+                st.none(),
+            )
             def tick():
                 entries = draw(st.lists(
-                    st.tuples(keys, small),
+                    st.tuples(keys, entry_value),
                     min_size=1, max_size=3, unique_by=lambda kv: kv[0]))
                 return {key: value for key, value in entries}
             inputs = {"ts": [tick() for _ in range(count)]}

--- a/tools/parity/known_divergences.json
+++ b/tools/parity/known_divergences.json
@@ -30,30 +30,6 @@
       "issue": "https://github.com/hhenson/hg_cpp/pull/67",
       "reason": "No-change-means-no-tick ruling (2026-07-17, roadmap.rst): a mesh over an initially empty key set emits no tick in hg_cpp where released hgraph ticks an empty map. Fingerprint pinned by test_parity_harness.py against the corpus recipe mesh-empty-initial-no-tick.",
       "review_after": "2027-07-26"
-    },
-    {
-      "fingerprint": "0708a2d7d8227adae475652e3d559744555a9e979fab7adc4cc8d29e848460d8",
-      "issue": "https://github.com/hhenson/hg_cpp/issues/129",
-      "reason": "Recorded lenient-None deviation, len-family manifestation: released hgraph's eval_node silently ignores a {key: None} TSD tick (reported upstream as hhenson/hgraph#363), so its len_/is_empty/contains_ appear stale; hg_cpp's harness treats None as the lenient removal and re-evaluates. With explicit REMOVE deltas both runtimes agree. See the roadmap.rst Accepted Deviations None-convention entries.",
-      "review_after": "2027-07-28"
-    },
-    {
-      "fingerprint": "79b21651093f2a52ac1eb73e5ac3d4cf0f86e73b2094e466f5653d709c2167fc",
-      "issue": "https://github.com/hhenson/hg_cpp/issues/120",
-      "reason": "Recorded lenient-None deviation, len-family manifestation: released hgraph's eval_node silently ignores a {key: None} TSD tick (reported upstream as hhenson/hgraph#363), so its len_/is_empty/contains_ appear stale; hg_cpp's harness treats None as the lenient removal and re-evaluates. With explicit REMOVE deltas both runtimes agree. See the roadmap.rst Accepted Deviations None-convention entries.",
-      "review_after": "2027-07-28"
-    },
-    {
-      "fingerprint": "88e2181815d7034510ee3179c90a5295611dc572ef95f4b6941d303ad029817f",
-      "issue": "https://github.com/hhenson/hg_cpp/issues/129",
-      "reason": "Recorded lenient-None deviation, len-family manifestation: released hgraph's eval_node silently ignores a {key: None} TSD tick (reported upstream as hhenson/hgraph#363), so its len_/is_empty/contains_ appear stale; hg_cpp's harness treats None as the lenient removal and re-evaluates. With explicit REMOVE deltas both runtimes agree. See the roadmap.rst Accepted Deviations None-convention entries.",
-      "review_after": "2027-07-28"
-    },
-    {
-      "fingerprint": "4c3658dcf2fd97f59b8af5975fc31648da38c12ff68a55a85d5e1d4d4913ac3c",
-      "issue": "https://github.com/hhenson/hg_cpp/issues/129",
-      "reason": "Recorded lenient-None deviation, len-family manifestation: released hgraph's eval_node silently ignores a {key: None} TSD tick (reported upstream as hhenson/hgraph#363), so its len_/is_empty/contains_ appear stale; hg_cpp's harness treats None as the lenient removal and re-evaluates. With explicit REMOVE deltas both runtimes agree. See the roadmap.rst Accepted Deviations None-convention entries.",
-      "review_after": "2027-07-28"
     }
   ],
   "families": [

--- a/tools/parity/known_divergences.json
+++ b/tools/parity/known_divergences.json
@@ -34,25 +34,25 @@
     {
       "fingerprint": "0708a2d7d8227adae475652e3d559744555a9e979fab7adc4cc8d29e848460d8",
       "issue": "https://github.com/hhenson/hg_cpp/issues/129",
-      "reason": "Accepted deviation (TSD removal-driven len-family re-ticks): released hgraph does not re-evaluate len_/is_empty/contains_ over a TSD on a removal-only delta, leaving stale values (a partial removal leaves upstream len_ at the old size forever); hg_cpp re-evaluates and publishes the correct value. Correctness over upstream quirk \u2014 see the roadmap.rst Accepted Deviations entry.",
+      "reason": "Recorded lenient-None deviation, len-family manifestation: released hgraph's eval_node silently ignores a {key: None} TSD tick (reported upstream as hhenson/hgraph#363), so its len_/is_empty/contains_ appear stale; hg_cpp's harness treats None as the lenient removal and re-evaluates. With explicit REMOVE deltas both runtimes agree. See the roadmap.rst Accepted Deviations None-convention entries.",
       "review_after": "2027-07-28"
     },
     {
       "fingerprint": "79b21651093f2a52ac1eb73e5ac3d4cf0f86e73b2094e466f5653d709c2167fc",
       "issue": "https://github.com/hhenson/hg_cpp/issues/120",
-      "reason": "Accepted deviation (TSD removal-driven len-family re-ticks): released hgraph does not re-evaluate len_/is_empty/contains_ over a TSD on a removal-only delta, leaving stale values (a partial removal leaves upstream len_ at the old size forever); hg_cpp re-evaluates and publishes the correct value. Correctness over upstream quirk \u2014 see the roadmap.rst Accepted Deviations entry.",
+      "reason": "Recorded lenient-None deviation, len-family manifestation: released hgraph's eval_node silently ignores a {key: None} TSD tick (reported upstream as hhenson/hgraph#363), so its len_/is_empty/contains_ appear stale; hg_cpp's harness treats None as the lenient removal and re-evaluates. With explicit REMOVE deltas both runtimes agree. See the roadmap.rst Accepted Deviations None-convention entries.",
       "review_after": "2027-07-28"
     },
     {
       "fingerprint": "88e2181815d7034510ee3179c90a5295611dc572ef95f4b6941d303ad029817f",
       "issue": "https://github.com/hhenson/hg_cpp/issues/129",
-      "reason": "Accepted deviation (TSD removals invisible to upstream's len family): released hgraph never subtracts a removed key \u2014 a removal-only delta does not re-evaluate, and even a MIXED delta that does re-evaluate still counts the removed key (reference probes: {a:1,b:2} then {a:None,b:5} -> upstream len stays 2; {a:None,c:3} -> upstream len 3). hg_cpp re-evaluates and publishes the correct size. See the roadmap.rst Accepted Deviations entry.",
+      "reason": "Recorded lenient-None deviation, len-family manifestation: released hgraph's eval_node silently ignores a {key: None} TSD tick (reported upstream as hhenson/hgraph#363), so its len_/is_empty/contains_ appear stale; hg_cpp's harness treats None as the lenient removal and re-evaluates. With explicit REMOVE deltas both runtimes agree. See the roadmap.rst Accepted Deviations None-convention entries.",
       "review_after": "2027-07-28"
     },
     {
       "fingerprint": "4c3658dcf2fd97f59b8af5975fc31648da38c12ff68a55a85d5e1d4d4913ac3c",
       "issue": "https://github.com/hhenson/hg_cpp/issues/129",
-      "reason": "Accepted deviation (TSD removals invisible to upstream's len family): released hgraph never subtracts a removed key \u2014 a removal-only delta does not re-evaluate, and even a MIXED delta that does re-evaluate still counts the removed key (reference probes: {a:1,b:2} then {a:None,b:5} -> upstream len stays 2; {a:None,c:3} -> upstream len 3). hg_cpp re-evaluates and publishes the correct size. See the roadmap.rst Accepted Deviations entry.",
+      "reason": "Recorded lenient-None deviation, len-family manifestation: released hgraph's eval_node silently ignores a {key: None} TSD tick (reported upstream as hhenson/hgraph#363), so its len_/is_empty/contains_ appear stale; hg_cpp's harness treats None as the lenient removal and re-evaluates. With explicit REMOVE deltas both runtimes agree. See the roadmap.rst Accepted Deviations None-convention entries.",
       "review_after": "2027-07-28"
     }
   ],


### PR DESCRIPTION
## Summary

Follow-on to PR #139 (merged before these two commits reached the branch) — **this also fixes the currently-failing Differential-parity-smoke on main** (`coverage-tsd-removal-mixed-update` diverging in the interim state).

**The ruling (2026-07-28), superseding the lenient-None convention**: a `None` value in a keyed delta means **nothing ticked for that key** — the per-key analogue of the top-level no-tick — applied consistently across keyed structures (TSD keys, TSL indices, TSB fields) and matching upstream exactly (its TSD setter deliberately skips `None`; the hhenson/hgraph#363 analysis, closed as working-as-designed). Removals are the explicit `REMOVE`/`REMOVE_IF_EXISTS` sentinels only.

- `py_to_delta`: TSD `None` values skip (was: lenient removal); the TSL dict form skips `None` items (list form and TSB fields already did).
- With the conventions aligned, the #120/#129 divergences **vanish** — their minimized recipes now MATCH the recorded reference traces (verified), so they were genuinely fixed, not ruled: the interim fingerprint pins are removed and the interim roadmap deviation bullet is deleted; the original None-convention bullet now states the ruling.
- The `coverage-tsd-removal-*` corpus recipes are repurposed to explicit-removal coverage of the agreeing space (differentially verified MATCHing; the mixed-add case rides the existing no-change-elision family), and the `collection_size` generator fuzzes the full delta space again — values, explicit lenient removals, and `None` per-key no-ticks.
- Includes the intermediate attribution correction: upstream `len_` handles explicit removals correctly; the earlier "stale upstream len" reading was the convention mismatch.

## Test plan

- [x] #120/#129 minimized recipes MATCH the recorded reference traces
- [x] Repurposed corpus recipes differentially verified against the reference env
- [x] C++ suite clean; full Python tree 1589 passed, 10 skipped; harness 33 passed; corpus 41 valid
- [x] Local pr-profile smoke of the corpus passes with these changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)