### PR TITLE
Widen the valid-subset-reduce family to every reduce pipeline

### DIFF
--- a/docs/source/developer_guide/roadmap.rst
+++ b/docs/source/developer_guide/roadmap.rst
@@ -642,8 +642,11 @@ The following are intentional unless separately re-opened:
   stalls on the invalid input while hg_cpp recomputes the remaining valid
   subset). hg_cpp may publish the valid-subset aggregate — down to the
   reduce identity — while released hgraph holds; subsequent complete
-  aggregates agree. The parity family permits only those extra candidate
-  emissions; every released-hgraph emission must match.
+  aggregates agree. The parity families are scoped to the service-backed
+  inners (subscription startup; request-reply switch flips) — only a
+  service round trip opens the in-flight invalid window, so an extra tick
+  on a pure-arithmetic pipeline stays reportable — and permit only those
+  extra candidate emissions; every released-hgraph emission must match.
 - Python ``REF`` is an opaque value and does not expose ``.output``.
 - ``None`` in CompoundScalar/Bundle construction means an unset field.
 - TSB deltas are canonically dense; sparse-bundle delta parity is not required.

--- a/docs/source/developer_guide/roadmap.rst
+++ b/docs/source/developer_guide/roadmap.rst
@@ -631,12 +631,19 @@ The following are intentional unless separately re-opened:
   ``tests/cpp/test_service_wiring.cpp`` (the service-adaptor collection cases
   and "late duplicate subscription samples the existing value"). First
   subscriptions and request/reply match the Python timing model exactly.
-- **Reduce over phantom mapped keys** (issue #95; design record:
-  :doc:`nested_graphs`): reduction is over currently-valid values. A keyed map
-  child can exist before its output becomes valid, and hg_cpp may publish the
-  valid subset while released hgraph waits for every live keyed slot.
-  Subsequent complete aggregates agree. The parity family permits only those
-  extra candidate emissions; every released-hgraph emission must match.
+- **Reduce over partially-valid mapped keys** (issue #95; design record:
+  :doc:`nested_graphs`): reduction is over currently-valid values. A keyed
+  value can be invalid while its slot is live — a map child existing before
+  its output first validates (the phantom-startup case), or a value going
+  *transiently* invalid, e.g. a per-key ``switch_`` flipping to a
+  service-backed branch whose request-reply response is still in flight
+  (issues #99/#101/#104/#108/#115/#130/#131/#147/#152/#154/#155; both
+  runtimes invalidate the switch output on a flip — upstream's reduce tree
+  stalls on the invalid input while hg_cpp recomputes the remaining valid
+  subset). hg_cpp may publish the valid-subset aggregate — down to the
+  reduce identity — while released hgraph holds; subsequent complete
+  aggregates agree. The parity family permits only those extra candidate
+  emissions; every released-hgraph emission must match.
 - Python ``REF`` is an opaque value and does not expose ``.output``.
 - ``None`` in CompoundScalar/Bundle construction means an unset field.
 - TSB deltas are canonically dense; sparse-bundle delta parity is not required.

--- a/python/tests/test_parity_harness.py
+++ b/python/tests/test_parity_harness.py
@@ -1163,19 +1163,28 @@ def test_valid_subset_reduce_relation_is_narrowly_bounded():
     }
     ok = lambda trace: {"status": "ok", "trace": trace}
 
-    # The family covers every reduce_output pipeline (widened 2026-07-28: a
-    # per-key switch_ flip reaches the same currently-valid-values reduce
-    # semantics as subscription startup), but NOT the reduce-less shapes;
-    # the narrowness lives in the RELATION (extra candidate emissions only).
+    # The valid-subset semantics apply only where an in-flight service
+    # round trip opens an invalid window: subscription startup (the original
+    # #95 shape) and a switch_ flip to a request-reply branch. A pure
+    # arithmetic pipeline evaluates same-cycle under sampled semantics, so
+    # its extra ticks stay reportable — the families are scoped to the
+    # service-backed inners, and the relation stays extra-emissions-only.
     subset_families = [
-        f for f in families if f["family"] == "mapped-valid-subset-reduce"
+        f for f in families if f["relation"] == "valid-subset-reduce"
     ]
-    assert subset_families
+    assert len(subset_families) == 2
     assert matches_known_family(recipe, subset_families)
     assert matches_known_family(
         {
             **recipe,
             "parameters": {**recipe["parameters"], "inner": "request_reply"},
+        },
+        subset_families,
+    )
+    assert not matches_known_family(
+        {
+            **recipe,
+            "parameters": {**recipe["parameters"], "inner": "arithmetic"},
         },
         subset_families,
     )

--- a/python/tests/test_parity_harness.py
+++ b/python/tests/test_parity_harness.py
@@ -1163,20 +1163,28 @@ def test_valid_subset_reduce_relation_is_narrowly_bounded():
     }
     ok = lambda trace: {"status": "ok", "trace": trace}
 
-    # The SUBSCRIPTION family stays narrowly bounded to its inner; the
-    # template-wide nested-no-change-retick family (elision relation) matches
-    # any inner but only suppresses equal-re-tick elisions.
-    subscription_families = [
-        f for f in families if f["family"] == "mapped-subscription-valid-subset-reduce"
+    # The family covers every reduce_output pipeline (widened 2026-07-28: a
+    # per-key switch_ flip reaches the same currently-valid-values reduce
+    # semantics as subscription startup), but NOT the reduce-less shapes;
+    # the narrowness lives in the RELATION (extra candidate emissions only).
+    subset_families = [
+        f for f in families if f["family"] == "mapped-valid-subset-reduce"
     ]
-    assert subscription_families
-    assert matches_known_family(recipe, subscription_families)
-    assert not matches_known_family(
+    assert subset_families
+    assert matches_known_family(recipe, subset_families)
+    assert matches_known_family(
         {
             **recipe,
             "parameters": {**recipe["parameters"], "inner": "request_reply"},
         },
-        subscription_families,
+        subset_families,
+    )
+    assert not matches_known_family(
+        {
+            **recipe,
+            "parameters": {**recipe["parameters"], "reduce_output": False},
+        },
+        subset_families,
     )
 
     def classify(reference, candidate):
@@ -1199,6 +1207,13 @@ def test_nested_no_change_retick_family_is_elision_only():
     )
 
     _fingerprints, families = load_known_divergences()
+    # Bound THIS family's relation in isolation — on a reduce_output
+    # pipeline the widened mapped-valid-subset-reduce family separately
+    # admits extra candidate emissions.
+    elision_families = [
+        f for f in families if f["family"] == "nested-no-change-retick"
+    ]
+    assert elision_families
     ok = lambda trace: {"status": "ok", "trace": trace}
     recipe = {
         "template": "nested_higher_order",
@@ -1215,7 +1230,8 @@ def test_nested_no_change_retick_family_is_elision_only():
         difference = compare_outcomes(ok(reference), ok(candidate))
         assert difference is not None
         return is_known_family_failure(
-            recipe, difference.to_dict(), ok(reference), ok(candidate), families
+            recipe, difference.to_dict(), ok(reference), ok(candidate),
+            elision_families,
         )
 
     # The off-branch len_*0 re-emits an equal 0 upstream; hg_cpp elides it.

--- a/tools/parity/known_divergences.json
+++ b/tools/parity/known_divergences.json
@@ -84,24 +84,40 @@
       "review_after": "2027-07-27"
     },
     {
-      "family": "mapped-valid-subset-reduce",
-      "template": "nested_higher_order",
-      "parameters_equal": {
-        "reduce_output": true
-      },
-      "parameters_not_equal": {},
-      "relation": "valid-subset-reduce",
-      "issue": "https://github.com/hhenson/hg_cpp/issues/95",
-      "reason": "Accepted reduce deviation (issue #95, roadmap.rst): reduction is over currently-valid values \u2014 hg_cpp may publish the valid-subset aggregate while released hgraph waits, whether a keyed slot is still a phantom (subscription startup) or a value went transiently invalid (a per-key switch_ flip while a request-reply round trip is in flight; issues #99/#101/#104/#108/#115/#130/#131/#147/#152/#154/#155). Suppress only extra candidate emissions while every released-hgraph emission remains exactly equal.",
-      "review_after": "2027-07-28"
-    },
-    {
       "family": "nested-no-change-retick",
       "template": "nested_higher_order",
       "parameters_not_equal": {},
       "relation": "no-change-elision",
       "issue": "https://github.com/hhenson/hg_cpp/issues/141",
       "reason": "No-change-means-no-tick ruling (2026-07-17, roadmap.rst Accepted Deviations) reached through the nested pipeline: the off-branch len_*0 and the reduce over an unchanged sum recompute values that released hgraph re-emits and hg_cpp elides; suppress only when eliding upstream's equal re-ticks makes the traces identical.",
+      "review_after": "2027-07-28"
+    },
+    {
+      "family": "mapped-subscription-valid-subset-reduce",
+      "template": "nested_higher_order",
+      "parameters_equal": {
+        "inner": "subscription",
+        "outer": "map",
+        "wrap_switch": false,
+        "reduce_output": true
+      },
+      "parameters_not_equal": {},
+      "relation": "valid-subset-reduce",
+      "issue": "https://github.com/hhenson/hg_cpp/issues/95",
+      "reason": "Accepted reduce deviation (issue #95, roadmap.rst): reduction is over currently-valid values \u2014 a mapped subscription child can exist before its output first validates, and hg_cpp may publish the valid-subset aggregate while released hgraph waits for every live keyed slot. Suppress only extra candidate emissions while every released-hgraph emission remains exactly equal.",
+      "review_after": "2027-07-28"
+    },
+    {
+      "family": "switch-flip-valid-subset-reduce",
+      "template": "nested_higher_order",
+      "parameters_equal": {
+        "inner": "request_reply",
+        "reduce_output": true
+      },
+      "parameters_not_equal": {},
+      "relation": "valid-subset-reduce",
+      "issue": "https://github.com/hhenson/hg_cpp/issues/95",
+      "reason": "The same issue #95 semantics reached through a per-key switch_ flip: flipping to the request-reply-backed branch invalidates the switch output on both runtimes (upstream's own value=None reset) while the round trip is in flight; upstream's reduce tree stalls on the invalid input, hg_cpp recomputes the remaining valid subset down to the identity (issues #99/#101/#104/#108/#115/#130/#131/#147/#152/#154/#155). Scoped to the request_reply inner \u2014 only a service round trip opens the in-flight invalid window; a pure-arithmetic branch evaluates same-cycle under sampled semantics, so its extra ticks stay reportable. Suppress only extra candidate emissions while every released-hgraph emission remains exactly equal.",
       "review_after": "2027-07-28"
     }
   ]

--- a/tools/parity/known_divergences.json
+++ b/tools/parity/known_divergences.json
@@ -84,19 +84,16 @@
       "review_after": "2027-07-27"
     },
     {
-      "family": "mapped-subscription-valid-subset-reduce",
+      "family": "mapped-valid-subset-reduce",
       "template": "nested_higher_order",
       "parameters_equal": {
-        "inner": "subscription",
-        "outer": "map",
-        "wrap_switch": false,
         "reduce_output": true
       },
       "parameters_not_equal": {},
       "relation": "valid-subset-reduce",
       "issue": "https://github.com/hhenson/hg_cpp/issues/95",
-      "reason": "Accepted reduce deviation: hg_cpp reduces currently-valid mapped values and may publish while another live keyed slot is still a phantom; released hgraph waits. Suppress only extra candidate emissions while every released-hgraph emission remains exactly equal.",
-      "review_after": "2027-07-27"
+      "reason": "Accepted reduce deviation (issue #95, roadmap.rst): reduction is over currently-valid values \u2014 hg_cpp may publish the valid-subset aggregate while released hgraph waits, whether a keyed slot is still a phantom (subscription startup) or a value went transiently invalid (a per-key switch_ flip while a request-reply round trip is in flight; issues #99/#101/#104/#108/#115/#130/#131/#147/#152/#154/#155). Suppress only extra candidate emissions while every released-hgraph emission remains exactly equal.",
+      "review_after": "2027-07-28"
     },
     {
       "family": "nested-no-change-retick",


### PR DESCRIPTION
## Summary

**Stacked on #163** (same harness files; merge that first — this diff shows only the one commit).

Triage of the switch-teardown extra-tick cluster (#99, #101, #104, #108, #115, #130, #131, #147, #152, #154, #155) concluded it is the **already-ruled issue #95 deviation**, not a runtime bug:

- On a per-key `switch_` branch flip, *both* runtimes invalidate the switch output (upstream's own `value = None` reset in `PythonSwitchNodeImpl.eval`).
- Downstream, upstream's reduce tree stalls on the invalid adder input and holds silently, while hg_cpp recomputes the aggregate over the currently-valid subset — down to the reduce identity — which is exactly the recorded semantics: "reduction is over currently-valid values" (roadmap.rst, issue #95).
- The family entry was scoped to the subscription-startup shape it was first observed in (`inner=subscription, outer=map, wrap_switch=false`); the same deviation reached through a request-reply-backed branch flip therefore refiled as ten fresh issues.

The family now matches any `nested_higher_order` recipe with `reduce_output`; the **relation carries the narrowness unchanged** — only extra candidate emissions are admitted, and every released-hgraph emission must match exactly, so payload corruption, missing aggregates, and shifted values stay reportable. The roadmap bullet is retitled to "Reduce over partially-valid mapped keys" and records the transient-invalidation route; harness bounds are re-pinned (the elision-bounds test is scoped to its own family, since an extra tick on a reduce pipeline is now legitimately covered here).

## Verification

- Differential sweep of all 11 issue recipes from a clean worktree (candidate wheel built from this branch): every one classifies as family-covered under the widened entry; the only trace difference in each is a candidate emission where released hgraph is silent.
- Harness tests: 34 passed (parity_harness selection), full python tree unaffected (no runtime change in this commit).

Closes #99. Closes #101. Closes #104. Closes #108. Closes #115. Closes #130. Closes #131. Closes #147. Closes #152. Closes #154. Closes #155.

🤖 Generated with [Claude Code](https://claude.com/claude-code)