### PR TITLE
Land the valid-subset family scoping on main

### DIFF
--- a/docs/source/developer_guide/roadmap.rst
+++ b/docs/source/developer_guide/roadmap.rst
@@ -642,8 +642,11 @@ The following are intentional unless separately re-opened:
   stalls on the invalid input while hg_cpp recomputes the remaining valid
   subset). hg_cpp may publish the valid-subset aggregate — down to the
   reduce identity — while released hgraph holds; subsequent complete
-  aggregates agree. The parity family permits only those extra candidate
-  emissions; every released-hgraph emission must match.
+  aggregates agree. The parity families are scoped to the service-backed
+  inners (subscription startup; request-reply switch flips) — only a
+  service round trip opens the in-flight invalid window, so an extra tick
+  on a pure-arithmetic pipeline stays reportable — and permit only those
+  extra candidate emissions; every released-hgraph emission must match.
 - Python ``REF`` is an opaque value and does not expose ``.output``.
 - ``None`` in CompoundScalar/Bundle construction means an unset field.
 - TSB deltas are canonically dense; sparse-bundle delta parity is not required.

--- a/docs/source/developer_guide/roadmap.rst
+++ b/docs/source/developer_guide/roadmap.rst
@@ -631,12 +631,19 @@ The following are intentional unless separately re-opened:
   ``tests/cpp/test_service_wiring.cpp`` (the service-adaptor collection cases
   and "late duplicate subscription samples the existing value"). First
   subscriptions and request/reply match the Python timing model exactly.
-- **Reduce over phantom mapped keys** (issue #95; design record:
-  :doc:`nested_graphs`): reduction is over currently-valid values. A keyed map
-  child can exist before its output becomes valid, and hg_cpp may publish the
-  valid subset while released hgraph waits for every live keyed slot.
-  Subsequent complete aggregates agree. The parity family permits only those
-  extra candidate emissions; every released-hgraph emission must match.
+- **Reduce over partially-valid mapped keys** (issue #95; design record:
+  :doc:`nested_graphs`): reduction is over currently-valid values. A keyed
+  value can be invalid while its slot is live — a map child existing before
+  its output first validates (the phantom-startup case), or a value going
+  *transiently* invalid, e.g. a per-key ``switch_`` flipping to a
+  service-backed branch whose request-reply response is still in flight
+  (issues #99/#101/#104/#108/#115/#130/#131/#147/#152/#154/#155; both
+  runtimes invalidate the switch output on a flip — upstream's reduce tree
+  stalls on the invalid input while hg_cpp recomputes the remaining valid
+  subset). hg_cpp may publish the valid-subset aggregate — down to the
+  reduce identity — while released hgraph holds; subsequent complete
+  aggregates agree. The parity family permits only those extra candidate
+  emissions; every released-hgraph emission must match.
 - Python ``REF`` is an opaque value and does not expose ``.output``.
 - ``None`` in CompoundScalar/Bundle construction means an unset field.
 - TSB deltas are canonically dense; sparse-bundle delta parity is not required.

--- a/python/tests/test_parity_harness.py
+++ b/python/tests/test_parity_harness.py
@@ -1163,19 +1163,28 @@ def test_valid_subset_reduce_relation_is_narrowly_bounded():
     }
     ok = lambda trace: {"status": "ok", "trace": trace}
 
-    # The family covers every reduce_output pipeline (widened 2026-07-28: a
-    # per-key switch_ flip reaches the same currently-valid-values reduce
-    # semantics as subscription startup), but NOT the reduce-less shapes;
-    # the narrowness lives in the RELATION (extra candidate emissions only).
+    # The valid-subset semantics apply only where an in-flight service
+    # round trip opens an invalid window: subscription startup (the original
+    # #95 shape) and a switch_ flip to a request-reply branch. A pure
+    # arithmetic pipeline evaluates same-cycle under sampled semantics, so
+    # its extra ticks stay reportable — the families are scoped to the
+    # service-backed inners, and the relation stays extra-emissions-only.
     subset_families = [
-        f for f in families if f["family"] == "mapped-valid-subset-reduce"
+        f for f in families if f["relation"] == "valid-subset-reduce"
     ]
-    assert subset_families
+    assert len(subset_families) == 2
     assert matches_known_family(recipe, subset_families)
     assert matches_known_family(
         {
             **recipe,
             "parameters": {**recipe["parameters"], "inner": "request_reply"},
+        },
+        subset_families,
+    )
+    assert not matches_known_family(
+        {
+            **recipe,
+            "parameters": {**recipe["parameters"], "inner": "arithmetic"},
         },
         subset_families,
     )

--- a/python/tests/test_parity_harness.py
+++ b/python/tests/test_parity_harness.py
@@ -1170,7 +1170,9 @@ def test_valid_subset_reduce_relation_is_narrowly_bounded():
     # its extra ticks stay reportable — the families are scoped to the
     # service-backed inners, and the relation stays extra-emissions-only.
     subset_families = [
-        f for f in families if f["relation"] == "valid-subset-reduce"
+        f for f in families
+        if f["family"] in ("mapped-subscription-valid-subset-reduce",
+                           "switch-flip-valid-subset-reduce")
     ]
     assert len(subset_families) == 2
     assert matches_known_family(recipe, subset_families)
@@ -1207,6 +1209,61 @@ def test_valid_subset_reduce_relation_is_narrowly_bounded():
     assert not classify([None, None, 26, 14], [None, 9, 25, 14])
     assert not classify([None, None, 26, 14], [None, None, None, 14])
     assert not classify([None, None, 26, 14], [None, 9, 26])
+
+
+def test_switch_flip_valid_subset_relation_is_windowed():
+    from tools.parity.known import (
+        is_known_family_failure,
+        load_known_divergences,
+    )
+
+    _fingerprints, families = load_known_divergences()
+    ok = lambda trace: {"status": "ok", "trace": trace}
+    # The issue #99 shape: beta at t0, flip to the request-reply alpha at
+    # t1, response lands at t3.
+    recipe = {
+        "template": "nested_higher_order",
+        "inputs": {
+            "selector": ["beta", "alpha", None, None],
+            "values": [{"k1": -1}, None, None, None],
+        },
+        "parameters": {
+            "inner": "request_reply",
+            "outer": "map",
+            "wrap_switch": False,
+            "reduce_output": True,
+            "increment": -5,
+        },
+    }
+
+    def classify(reference, candidate, with_recipe=None):
+        difference = compare_outcomes(ok(reference), ok(candidate))
+        assert difference is not None
+        return is_known_family_failure(
+            with_recipe or recipe, difference.to_dict(), ok(reference),
+            ok(candidate), families,
+        )
+
+    # The flip-cycle valid-subset emission is inside the window.
+    assert classify([3, None, None, -6], [3, 0, None, -6])
+    # An extra tick AFTER the pipeline settled (no input tick since the
+    # last agreeing reference emission) is NOT covered (PR #165 review).
+    assert not classify([3, None, None, -6, None], [3, 0, None, -6, 99])
+    # Payload mismatches and missing emissions stay reportable everywhere.
+    assert not classify([3, None, None, -6], [3, 0, None, -7])
+    assert not classify([3, None, None, -6], [3, None, None, None])
+
+    # A spurious tick with the selector PARKED on the arithmetic branch —
+    # the t0 emission closes the only window, so nothing later is covered.
+    parked = {
+        **recipe,
+        "inputs": {
+            "selector": ["beta", None, None, None],
+            "values": [{"k1": -1}, None, None, None],
+        },
+    }
+    assert not classify([3, None, None, None], [3, None, None, 99],
+                        with_recipe=parked)
 
 
 def test_nested_no_change_retick_family_is_elision_only():

--- a/python/tests/test_parity_harness.py
+++ b/python/tests/test_parity_harness.py
@@ -1163,20 +1163,28 @@ def test_valid_subset_reduce_relation_is_narrowly_bounded():
     }
     ok = lambda trace: {"status": "ok", "trace": trace}
 
-    # The SUBSCRIPTION family stays narrowly bounded to its inner; the
-    # template-wide nested-no-change-retick family (elision relation) matches
-    # any inner but only suppresses equal-re-tick elisions.
-    subscription_families = [
-        f for f in families if f["family"] == "mapped-subscription-valid-subset-reduce"
+    # The family covers every reduce_output pipeline (widened 2026-07-28: a
+    # per-key switch_ flip reaches the same currently-valid-values reduce
+    # semantics as subscription startup), but NOT the reduce-less shapes;
+    # the narrowness lives in the RELATION (extra candidate emissions only).
+    subset_families = [
+        f for f in families if f["family"] == "mapped-valid-subset-reduce"
     ]
-    assert subscription_families
-    assert matches_known_family(recipe, subscription_families)
-    assert not matches_known_family(
+    assert subset_families
+    assert matches_known_family(recipe, subset_families)
+    assert matches_known_family(
         {
             **recipe,
             "parameters": {**recipe["parameters"], "inner": "request_reply"},
         },
-        subscription_families,
+        subset_families,
+    )
+    assert not matches_known_family(
+        {
+            **recipe,
+            "parameters": {**recipe["parameters"], "reduce_output": False},
+        },
+        subset_families,
     )
 
     def classify(reference, candidate):
@@ -1199,6 +1207,13 @@ def test_nested_no_change_retick_family_is_elision_only():
     )
 
     _fingerprints, families = load_known_divergences()
+    # Bound THIS family's relation in isolation — on a reduce_output
+    # pipeline the widened mapped-valid-subset-reduce family separately
+    # admits extra candidate emissions.
+    elision_families = [
+        f for f in families if f["family"] == "nested-no-change-retick"
+    ]
+    assert elision_families
     ok = lambda trace: {"status": "ok", "trace": trace}
     recipe = {
         "template": "nested_higher_order",
@@ -1215,7 +1230,8 @@ def test_nested_no_change_retick_family_is_elision_only():
         difference = compare_outcomes(ok(reference), ok(candidate))
         assert difference is not None
         return is_known_family_failure(
-            recipe, difference.to_dict(), ok(reference), ok(candidate), families
+            recipe, difference.to_dict(), ok(reference), ok(candidate),
+            elision_families,
         )
 
     # The off-branch len_*0 re-emits an equal 0 upstream; hg_cpp elides it.

--- a/tools/parity/known.py
+++ b/tools/parity/known.py
@@ -307,10 +307,67 @@ def _valid_subset_reduce_relation(
     return extra >= 1
 
 
+def _switch_flip_valid_subset_relation(
+    recipe: dict[str, Any],
+    difference: dict[str, Any],
+    reference: dict[str, Any],
+    candidate: dict[str, Any],
+    _family: dict[str, Any],
+) -> bool:
+    """The switch-flip route of the issue #95 deviation, WINDOWED (PR #165
+    review): an extra candidate emission is admitted only inside a
+    disturbance window — from a driving-input tick (``selector`` /
+    ``outer_selector`` / ``values``, the events that can flip a branch or
+    put a request round trip in flight) until the next agreeing reference
+    emission. Outside a window every position must match exactly, so a
+    spurious candidate tick on a settled request-reply pipeline stays
+    reportable, as do payload mismatches and missing emissions anywhere."""
+    if difference.get("classification") != "value":
+        return False
+    reference_trace = reference.get("trace")
+    candidate_trace = candidate.get("trace")
+    if (
+        not isinstance(reference_trace, list)
+        or not isinstance(candidate_trace, list)
+        or len(reference_trace) != len(candidate_trace)
+    ):
+        return False
+
+    inputs = recipe.get("inputs") or {}
+    disturbed = set()
+    for name in ("selector", "outer_selector", "values"):
+        ticks = inputs.get(name) or ()
+        for index, tick in enumerate(ticks):
+            if tick is not None:
+                disturbed.add(index)
+
+    extra = 0
+    window = False
+    for index, (ref, cand) in enumerate(
+        zip(reference_trace, candidate_trace)
+    ):
+        if index in disturbed:
+            window = True
+        if ref is not None:
+            if ref != cand:
+                return False
+            window = False
+            continue
+        if cand is None:
+            continue
+        if not window:
+            return False
+        extra += 1
+    return extra >= 1
+
+
+SWITCH_FLIP_VALID_SUBSET = "switch-flip-valid-subset-reduce"
+
 RELATIONS = {
     TRACE_VALUE: _trace_value_relation,
     NO_CHANGE_ELISION: _no_change_elision_relation,
     VALID_SUBSET_REDUCE: _valid_subset_reduce_relation,
+    SWITCH_FLIP_VALID_SUBSET: _switch_flip_valid_subset_relation,
     SERVICE_ADAPTOR_ONE_CYCLE: _service_adaptor_one_cycle_relation,
     KEY_SET_SIZE_NO_RETICK: _key_set_size_no_retick_relation,
     SUBSCRIPTION_RESAMPLE_ONE_CYCLE: (

--- a/tools/parity/known_divergences.json
+++ b/tools/parity/known_divergences.json
@@ -84,24 +84,40 @@
       "review_after": "2027-07-27"
     },
     {
-      "family": "mapped-valid-subset-reduce",
-      "template": "nested_higher_order",
-      "parameters_equal": {
-        "reduce_output": true
-      },
-      "parameters_not_equal": {},
-      "relation": "valid-subset-reduce",
-      "issue": "https://github.com/hhenson/hg_cpp/issues/95",
-      "reason": "Accepted reduce deviation (issue #95, roadmap.rst): reduction is over currently-valid values \u2014 hg_cpp may publish the valid-subset aggregate while released hgraph waits, whether a keyed slot is still a phantom (subscription startup) or a value went transiently invalid (a per-key switch_ flip while a request-reply round trip is in flight; issues #99/#101/#104/#108/#115/#130/#131/#147/#152/#154/#155). Suppress only extra candidate emissions while every released-hgraph emission remains exactly equal.",
-      "review_after": "2027-07-28"
-    },
-    {
       "family": "nested-no-change-retick",
       "template": "nested_higher_order",
       "parameters_not_equal": {},
       "relation": "no-change-elision",
       "issue": "https://github.com/hhenson/hg_cpp/issues/141",
       "reason": "No-change-means-no-tick ruling (2026-07-17, roadmap.rst Accepted Deviations) reached through the nested pipeline: the off-branch len_*0 and the reduce over an unchanged sum recompute values that released hgraph re-emits and hg_cpp elides; suppress only when eliding upstream's equal re-ticks makes the traces identical.",
+      "review_after": "2027-07-28"
+    },
+    {
+      "family": "mapped-subscription-valid-subset-reduce",
+      "template": "nested_higher_order",
+      "parameters_equal": {
+        "inner": "subscription",
+        "outer": "map",
+        "wrap_switch": false,
+        "reduce_output": true
+      },
+      "parameters_not_equal": {},
+      "relation": "valid-subset-reduce",
+      "issue": "https://github.com/hhenson/hg_cpp/issues/95",
+      "reason": "Accepted reduce deviation (issue #95, roadmap.rst): reduction is over currently-valid values \u2014 a mapped subscription child can exist before its output first validates, and hg_cpp may publish the valid-subset aggregate while released hgraph waits for every live keyed slot. Suppress only extra candidate emissions while every released-hgraph emission remains exactly equal.",
+      "review_after": "2027-07-28"
+    },
+    {
+      "family": "switch-flip-valid-subset-reduce",
+      "template": "nested_higher_order",
+      "parameters_equal": {
+        "inner": "request_reply",
+        "reduce_output": true
+      },
+      "parameters_not_equal": {},
+      "relation": "valid-subset-reduce",
+      "issue": "https://github.com/hhenson/hg_cpp/issues/95",
+      "reason": "The same issue #95 semantics reached through a per-key switch_ flip: flipping to the request-reply-backed branch invalidates the switch output on both runtimes (upstream's own value=None reset) while the round trip is in flight; upstream's reduce tree stalls on the invalid input, hg_cpp recomputes the remaining valid subset down to the identity (issues #99/#101/#104/#108/#115/#130/#131/#147/#152/#154/#155). Scoped to the request_reply inner \u2014 only a service round trip opens the in-flight invalid window; a pure-arithmetic branch evaluates same-cycle under sampled semantics, so its extra ticks stay reportable. Suppress only extra candidate emissions while every released-hgraph emission remains exactly equal.",
       "review_after": "2027-07-28"
     }
   ]

--- a/tools/parity/known_divergences.json
+++ b/tools/parity/known_divergences.json
@@ -115,9 +115,9 @@
         "reduce_output": true
       },
       "parameters_not_equal": {},
-      "relation": "valid-subset-reduce",
+      "relation": "switch-flip-valid-subset-reduce",
       "issue": "https://github.com/hhenson/hg_cpp/issues/95",
-      "reason": "The same issue #95 semantics reached through a per-key switch_ flip: flipping to the request-reply-backed branch invalidates the switch output on both runtimes (upstream's own value=None reset) while the round trip is in flight; upstream's reduce tree stalls on the invalid input, hg_cpp recomputes the remaining valid subset down to the identity (issues #99/#101/#104/#108/#115/#130/#131/#147/#152/#154/#155). Scoped to the request_reply inner \u2014 only a service round trip opens the in-flight invalid window; a pure-arithmetic branch evaluates same-cycle under sampled semantics, so its extra ticks stay reportable. Suppress only extra candidate emissions while every released-hgraph emission remains exactly equal.",
+      "reason": "The same issue #95 semantics reached through a per-key switch_ flip: flipping to the request-reply-backed branch invalidates the switch output on both runtimes (upstream's own value=None reset) while the round trip is in flight; upstream's reduce tree stalls on the invalid input, hg_cpp recomputes the remaining valid subset down to the identity (issues #99/#101/#104/#108/#115/#130/#131/#147/#152/#154/#155). Scoped to the request_reply inner \u2014 only a service round trip opens the in-flight invalid window; a pure-arithmetic branch evaluates same-cycle under sampled semantics, so its extra ticks stay reportable. Suppress only extra candidate emissions inside a disturbance window (from a selector/values input tick until the next agreeing reference emission \u2014 the span a flip or in-flight round trip can cover) while every released-hgraph emission remains exactly equal.",
       "review_after": "2027-07-28"
     }
   ]

--- a/tools/parity/known_divergences.json
+++ b/tools/parity/known_divergences.json
@@ -84,19 +84,16 @@
       "review_after": "2027-07-27"
     },
     {
-      "family": "mapped-subscription-valid-subset-reduce",
+      "family": "mapped-valid-subset-reduce",
       "template": "nested_higher_order",
       "parameters_equal": {
-        "inner": "subscription",
-        "outer": "map",
-        "wrap_switch": false,
         "reduce_output": true
       },
       "parameters_not_equal": {},
       "relation": "valid-subset-reduce",
       "issue": "https://github.com/hhenson/hg_cpp/issues/95",
-      "reason": "Accepted reduce deviation: hg_cpp reduces currently-valid mapped values and may publish while another live keyed slot is still a phantom; released hgraph waits. Suppress only extra candidate emissions while every released-hgraph emission remains exactly equal.",
-      "review_after": "2027-07-27"
+      "reason": "Accepted reduce deviation (issue #95, roadmap.rst): reduction is over currently-valid values \u2014 hg_cpp may publish the valid-subset aggregate while released hgraph waits, whether a keyed slot is still a phantom (subscription startup) or a value went transiently invalid (a per-key switch_ flip while a request-reply round trip is in flight; issues #99/#101/#104/#108/#115/#130/#131/#147/#152/#154/#155). Suppress only extra candidate emissions while every released-hgraph emission remains exactly equal.",
+      "review_after": "2027-07-28"
     },
     {
       "family": "nested-no-change-retick",


### PR DESCRIPTION
## Summary

PR #164 was merged at 07:20 into `agent/tss-overlap-contains` — eight minutes after that branch itself had merged to main via #163 — so its two commits (the valid-subset-reduce family widening and the service-backed-inner scoping from the review follow-up) never reached main. This PR carries exactly those commits.

Content recap: the issue #95 valid-subset-reduce deviation now has two constrained family entries — the original subscription-startup shape, and `switch-flip-valid-subset-reduce` (inner=request_reply, reduce_output) for the branch-flip route — with the arithmetic-inner exclusion pinned in the harness bounds test and the roadmap bullet retitled to "Reduce over partially-valid mapped keys". Covers the already-closed issues #99/#101/#104/#108/#115/#130/#131/#147/#152/#154/#155.

🤖 Generated with [Claude Code](https://claude.com/claude-code)