### PR TITLE
A mesh with never-valid keys must not touch-validate its output

### DIFF
--- a/python/tests/test_parity_fixes.py
+++ b/python/tests/test_parity_fixes.py
@@ -188,3 +188,17 @@ def test_contains_seeds_false_before_the_container_ticks():
         return hg.contains_(ts, 1)
 
     assert eval_node(tss_contains, [None, None]) == [False, None]
+
+
+def test_mesh_with_never_valid_keys_never_ticks():
+    # Issues #128/#132/#151: a mesh_ whose __keys__ source never validates
+    # must not touch-validate its owned output — upstream emits nothing.
+    @graph
+    def keyed(key: TS[str]) -> TS[int]:
+        return hg.len_(key)
+
+    @graph
+    def g(keys: hg.TSS[str]) -> hg.TSD[str, TS[int]]:
+        return hg.mesh_(keyed, __keys__=keys, __key_arg__="key")
+
+    assert eval_node(g, [None, None]) is None

--- a/src/hgraph/runtime/mesh_node.cpp
+++ b/src/hgraph/runtime/mesh_node.cpp
@@ -710,10 +710,18 @@ bool mesh_evaluate_impl(const void *, const NodeView &view,
   if (!keys_input.valid()) {
     storage.unsubscribe_requested_keys_noexcept();
     auto output = view.output(evaluation_time);
-    auto output_dict = output.as_dict();
-    auto output_mutation = output_dict.begin_mutation(evaluation_time);
-    stop_and_clear_all_instances(view, context, storage, evaluation_time);
-    output_mutation.clear();
+    // Only tear down what was ever published: clear() on a never-valid
+    // dict would touch-VALIDATE it (the empty-tick rule), making a mesh
+    // whose __keys__ never validated tick a valid empty dict at start
+    // where released hgraph stays silent (issues #128/#132/#151).
+    if (output.valid()) {
+      auto output_dict = output.as_dict();
+      auto output_mutation = output_dict.begin_mutation(evaluation_time);
+      stop_and_clear_all_instances(view, context, storage, evaluation_time);
+      output_mutation.clear();
+    } else {
+      stop_and_clear_all_instances(view, context, storage, evaluation_time);
+    }
     return true;
   }
 

--- a/tests/cpp/test_mesh.cpp
+++ b/tests/cpp/test_mesh.cpp
@@ -440,6 +440,21 @@ TEST_CASE("mesh_: invalid explicit keys clear children and output") {
                     dict_delta<Str, TS<Int>>({}, {"a"s, "b"s})));
 }
 
+TEST_CASE("mesh_: never-valid keys never tick the output") {
+  using namespace hgraph;
+  stdlib::register_standard_operators();
+
+  // issues #128/#132/#151: a mesh whose __keys__ NEVER validates must not
+  // touch-validate its owned output — released hgraph emits nothing, and a
+  // valid empty dict at start is an observable extra tick. (Keys that
+  // BECOME invalid after publishing still clear with removals — the cases
+  // around this one pin that.)
+  CHECK_OUTPUT((eval_node<MeshInvalidKeysGraph>(
+                   values<Value>(dict_delta<Str, TS<Int>>({{"a"s, 1}}), none),
+                   values<Str>(Str{"none"}, none))),
+               values<Value>(none, none));
+}
+
 TEST_CASE(
     "mesh_: replacing the explicit key-set source reconciles full membership") {
   using namespace hgraph;

--- a/tools/parity/corpus/issue-132-mesh-never-valid-keys-silent.json
+++ b/tools/parity/corpus/issue-132-mesh-never-valid-keys-silent.json
@@ -1,0 +1,35 @@
+{
+  "description": "Issue #128/#132/#151: a mesh whose __keys__ never validates must not touch-validate its owned output \u2014 released hgraph emits nothing; hg_cpp used to tick a valid empty dict at start.",
+  "features": [
+    "binding:non-peered",
+    "lifecycle:multi-cycle",
+    "nested-leaf:request_reply",
+    "nested:mesh",
+    "reference:REF",
+    "shape:TSD",
+    "topology:nested-higher-order",
+    "type:int"
+  ],
+  "id": "issue-132-mesh-never-valid-keys-silent",
+  "inputs": {
+    "selector": [
+      null,
+      null
+    ],
+    "values": [
+      null,
+      null
+    ]
+  },
+  "parameters": {
+    "increment": 1,
+    "inner": "request_reply",
+    "outer": "mesh",
+    "reduce_output": false,
+    "wrap_switch": false
+  },
+  "schema_version": 1,
+  "seed": 7,
+  "source_issue": "https://github.com/hhenson/hg_cpp/issues/132",
+  "template": "nested_higher_order"
+}


### PR DESCRIPTION
## Summary

Fixes the mesh empty-start group from the nightly batch: `mesh_evaluate`'s invalid-`__keys__` branch unconditionally began a mutation and `clear()`ed the owned TSD. Under the empty-tick rule that touch **validates** a never-valid dict, so a mesh whose keys source never ticked published a valid empty dict at start (`[{}, None]`) where released hgraph emits nothing. The teardown now only runs the output mutation when the output has ever published (`output.valid()`); keys that *become* invalid after publishing still clear with removals — the neighbouring `MeshInvalidKeysGraph` pins cover that path unchanged.

## Verification

- C++ suite: 253,418 assertions / 1,282 cases green, incl. the new "never-valid keys never tick the output" pin.
- Full python tree: 1,598 passed / 10 skipped, incl. the new `mesh_` python pin.
- Corpus (43 recipes incl. the #132 minimized case) validates; differential replays of #128, #132, #151 all report no difference.

Closes #128. Closes #132. Closes #151.

🤖 Generated with [Claude Code](https://claude.com/claude-code)