### PR TITLE
Honor explicit zero for invalid forwarded reduce slots

### DIFF
--- a/python/tests/ported/_wiring/test_service.py
+++ b/python/tests/ported/_wiring/test_service.py
@@ -375,7 +375,7 @@ def test_mapped_subscription_result_uses_the_declared_value_schema():
         client,
         ["instrument"],
         __end_time__=hg.MIN_ST + 5 * hg.MIN_TD,
-    ) == [None, 3.0]
+    ) == [0.0, 3.0]
 
 
 def test_mapped_request_reply_service_can_call_itself_recursively():

--- a/python/tests/test_reduce_zero_semantics.py
+++ b/python/tests/test_reduce_zero_semantics.py
@@ -22,13 +22,17 @@ output is INVALID: it never becomes valid if the collection never ticks, and
 it is invalidated (not merely left un-ticked) when the collection empties.
 For any non-empty input both produce identical results.
 
-With an identity ``zero`` the two implementations agree everywhere. These
-tests pin the hg_cpp behaviour for both arities. See issue #44 and the
-documented reduce deviation in ``docs/source/developer_guide/parity_matrix.rst``.
+With an identity ``zero`` the implementations agree once the same values are
+valid. During mapped phantom-slot startup, hg_cpp reduces the currently-valid
+subset (which can be empty and therefore publishes the explicit zero), while
+released hgraph may wait; that accepted #95 timing deviation is documented in
+``nested_graphs.rst``. These tests pin the hg_cpp behaviour for both arities.
+See issue #44 and the documented reduce deviations in
+``docs/source/developer_guide/parity_matrix.rst``.
 """
 
 import hgraph as hg
-from hgraph import TS, TSD, graph
+from hgraph import TS, TSD, TSS, graph
 from hgraph.test import eval_node
 
 
@@ -83,6 +87,49 @@ def test_identity_zero_matches_upstream():
         [{"a": 1, "b": 2, "c": 3}, {"a": hg.REMOVE, "b": hg.REMOVE, "c": hg.REMOVE}],
     )
     assert out == [6, 0]
+
+
+def test_explicit_zero_tracks_valid_values_through_forwarded_mesh_slots():
+    @graph
+    def double(value: TS[int]) -> TS[int]:
+        return value * 2
+
+    @graph
+    def negate(value: TS[int]) -> TS[int]:
+        return value * -1
+
+    @graph
+    def switched_child(key: TS[str], selector: TS[str]) -> TS[int]:
+        return hg.switch_(
+            selector,
+            {"double": double, "negate": negate},
+            hg.len_(key),
+        )
+
+    @graph
+    def mesh_reduce(keys: TSS[str], selector: TS[str]) -> TS[int]:
+        meshed = hg.mesh_(
+            switched_child,
+            selector,
+            __keys__=keys,
+            __key_arg__="key",
+        )
+        return hg.reduce(lambda lhs, rhs: lhs + rhs, meshed, 0)
+
+    # A live mesh slot whose forwarded switch target is still invalid is not a
+    # live reduction value. The explicit zero therefore publishes first; the
+    # child joins once selected and removing its key returns to zero.
+    out = eval_node(
+        mesh_reduce,
+        [
+            hg.set_delta(added={"k"}, tp=str),
+            None,
+            None,
+            hg.set_delta(removed={"k"}, tp=str),
+        ],
+        [None, "double", "negate", None],
+    )
+    assert out == [0, 2, -1, 0]
 
 
 def _map_reduce_no_zero(increment: int):

--- a/python/tests/test_service_timing_semantics.py
+++ b/python/tests/test_service_timing_semantics.py
@@ -98,7 +98,7 @@ def test_request_reply_inside_a_mapped_switch_keeps_late_keys():
         [{"k1": 3}, {"k2": 4}, None, {"k1": hg.REMOVE}],
         ["alpha", None, "beta", None],
         __end_time__=hg.MIN_ST + 10 * hg.MIN_TD,
-    ) == [None, None, 10, 6]
+    ) == [0, None, 10, 6]
 
 
 def test_subscription_inside_a_mapped_switch_keeps_late_keys():
@@ -132,12 +132,13 @@ def test_subscription_inside_a_mapped_switch_keeps_late_keys():
         mapped = hg.map_(per_key, values, selector)
         return hg.reduce(lambda lhs, rhs: lhs + rhs, mapped, 0)
 
-    # Issue #95: k1's first response is already valid while k2 is a phantom
-    # mapped slot. hg_cpp publishes that valid subset (9); released hgraph
-    # waits one cycle. Once k2 becomes valid, both publish 26 and then 14.
+    # Issue #95: reduction is over the currently-valid subset. Its explicit
+    # identity is observable while every mapped switch terminal is invalid,
+    # then k1 publishes 9 while k2 is still a phantom slot. Released hgraph
+    # waits at those points; once k2 is valid, both publish 26 and then 14.
     assert eval_node(
         app,
         [{"k1": 3}, {"k2": 4}, None, {"k1": hg.REMOVE}],
         ["alpha", None, "beta", None],
         __end_time__=hg.MIN_ST + 10 * hg.MIN_TD,
-    ) == [None, 9, 26, 14]
+    ) == [0, 9, 26, 14]

--- a/src/hgraph/runtime/reduce_node.cpp
+++ b/src/hgraph/runtime/reduce_node.cpp
@@ -447,7 +447,9 @@ namespace hgraph
             if (leaf != last) { storage.structural_leaves.push_back(last); }
         }
 
-        [[nodiscard]] bool reconcile_leaf_state(ReduceNodeStorage &storage, const TSDDataView &dict, bool full)
+        [[nodiscard]] bool reconcile_leaf_state(ReduceNodeStorage &storage,
+                                                const TSDOutputView &output,
+                                                const TSDDataView &dict, bool full)
         {
             if (full)
             {
@@ -458,12 +460,18 @@ namespace hgraph
                 storage.key_to_leaf.reserve(dict.size());
                 for (std::size_t slot = 0; slot < dict.slot_capacity(); ++slot)
                 {
-                    if (!dict.slot_live(slot) || !dict.at_slot(slot).valid()) { continue; }
+                    if (!dict.slot_live(slot)) { continue; }
+                    // A map/mesh forwarding slot can be structurally live
+                    // before its child terminal has a value. Reduction
+                    // membership follows the resolved terminal, not the link
+                    // endpoint that owns the slot.
+                    TSOutputView source = resolve_forwarding_source(output.at_slot(slot));
+                    if (!source.valid()) { continue; }
                     Value key{dict.key_at_slot(slot)};
                     storage.key_to_leaf.emplace(key, storage.dense_to_key.size());
                     storage.dense_to_key.push_back(std::move(key));
                     storage.dense_to_source_slot.push_back(slot);
-                    storage.dense_to_source_handle.emplace_back();
+                    storage.dense_to_source_handle.push_back(source.handle());
                 }
                 return true;
             }
@@ -500,15 +508,15 @@ namespace hgraph
             for (std::size_t slot = dict.next_added_slot(); slot != TS_DATA_NO_CHILD_ID;
                  slot = dict.next_added_slot(slot))
             {
-                auto child = dict.at_slot(slot);
-                if (!child.valid()) { continue; }
+                TSOutputView source = resolve_forwarding_source(output.at_slot(slot));
+                if (!source.valid()) { continue; }
                 Value typed_key{dict.key_at_slot(slot)};
                 if (storage.key_to_leaf.find(typed_key) != storage.key_to_leaf.end()) { continue; }
                 storage.structural_leaves.push_back(storage.dense_to_key.size());
                 storage.key_to_leaf.emplace(typed_key, storage.dense_to_key.size());
                 storage.dense_to_key.push_back(std::move(typed_key));
                 storage.dense_to_source_slot.push_back(slot);
-                storage.dense_to_source_handle.emplace_back();
+                storage.dense_to_source_handle.push_back(source.handle());
                 structural = true;
             }
 
@@ -518,8 +526,8 @@ namespace hgraph
                 if (!dict.slot_live(slot)) { continue; }
                 const ValueView key = dict.key_at_slot(slot);
                 const auto found = storage.key_to_leaf.find(key);
-                auto child = dict.at_slot(slot);
-                if (!child.valid())
+                TSOutputView source = resolve_forwarding_source(output.at_slot(slot));
+                if (!source.valid())
                 {
                     if (found != storage.key_to_leaf.end())
                     {
@@ -538,7 +546,15 @@ namespace hgraph
                     storage.key_to_leaf.emplace(typed_key, leaf);
                     storage.dense_to_key.push_back(std::move(typed_key));
                     storage.dense_to_source_slot.push_back(slot);
-                    storage.dense_to_source_handle.emplace_back();
+                    storage.dense_to_source_handle.push_back(source.handle());
+                    structural = true;
+                    continue;
+                }
+
+                if (!source.handle().same_as(storage.dense_to_source_handle[found->second]))
+                {
+                    storage.structural_leaves.push_back(found->second);
+                    storage.dense_to_source_handle[found->second] = source.handle();
                     structural = true;
                 }
             }
@@ -640,10 +656,10 @@ namespace hgraph
 
         [[nodiscard]] bool reconcile_dict_collection(ReduceNodeStorage &storage, TSInputView &input, bool full)
         {
-            static_cast<void>(input);
-            auto data = storage.collection_source.data_view();
-            auto dict = data.as_dict();
-            return reconcile_leaf_state(storage, dict, full);
+            auto root = storage.collection_source.view(input.evaluation_time());
+            auto output = root.as_dict();
+            auto data = output.data_view();
+            return reconcile_leaf_state(storage, output, data, full);
         }
 
         [[nodiscard]] bool reconcile_list_collection(ReduceNodeStorage &storage, TSInputView &input, bool full)
@@ -699,7 +715,7 @@ namespace hgraph
         {
             auto dict = source.as_dict();
             return source_slot < dict.slot_capacity() && dict.slot_live(source_slot)
-                       ? dict.at_slot(source_slot)
+                       ? resolve_forwarding_source(dict.at_slot(source_slot))
                        : TSOutputView{};
         }
 

--- a/tests/cpp/test_map.cpp
+++ b/tests/cpp/test_map.cpp
@@ -1313,16 +1313,19 @@ TEST_CASE("map_: a downstream map binds when an upstream phantom slot becomes va
                       dict_delta<Str, TS<Int>>({{"key"s, 43}})));
 }
 
-TEST_CASE("map_: reduce observes a chained map phantom slot becoming valid")
+TEST_CASE("map_: reduce publishes explicit zero before a chained phantom becomes valid")
 {
     using namespace hgraph;
     stdlib::register_standard_operators();
 
+    // Reduction is over currently-valid values. The first mapped slot is only
+    // a forwarding placeholder, so the explicit zero publishes until its
+    // child terminal acquires 43.
     CHECK_OUTPUT(
         eval_node<ReducedChainedLateMappedIdentityG>(
             values<Value>(set_delta<Str>({"key"s}, {}), none),
             values<Value>(none, dict_delta<Str, TS<Int>>({{"key"s, 42}}))),
-        values<Int>(none, 43));
+        values<Int>(0, 43));
 }
 
 TEST_CASE("map_: reduce observes multiple phantom slots becoming valid together")
@@ -1331,6 +1334,8 @@ TEST_CASE("map_: reduce observes multiple phantom slots becoming valid together"
     using namespace std::string_literals;
     stdlib::register_standard_operators();
 
+    // Both forwarding placeholders are initially invalid, so their valid
+    // subset is empty and the supplied identity publishes.
     CHECK_OUTPUT(
         eval_node<ReducedChainedLateMappedIdentityG>(
             values<Value>(
@@ -1340,7 +1345,7 @@ TEST_CASE("map_: reduce observes multiple phantom slots becoming valid together"
                 none,
                 dict_delta<Str, TS<Int>>(
                     {{"first"s, 42}, {"second"s, 43}}))),
-        values<Int>(none, 87));
+        values<Int>(0, 87));
 }
 
 TEST_CASE("map_: multiplexed dict add and remove rebind existing explicit-key children")

--- a/tests/cpp/test_mesh.cpp
+++ b/tests/cpp/test_mesh.cpp
@@ -176,6 +176,37 @@ struct SwitchInMeshG {
   }
 };
 
+struct InvalidSwitchInMeshG {
+  static constexpr auto name = "invalid_switch_in_mesh_g";
+
+  static Port<TS<Int>> compose(Wiring &w,
+                               NamedPort<"key", TS<Str>> key,
+                               Port<TS<Str>> mode) {
+    auto size = wire<stdlib::len_>(w, key).as<TS<Int>>();
+    return wire<stdlib::switch_>(
+               w, mode,
+               stdlib::switch_cases(
+                   {{Value{Str{"double"}}, fn<SwitchDoubleG>()},
+                    {Value{Str{"negate"}}, fn<SwitchNegateG>()}}),
+               size)
+        .as<TS<Int>>();
+  }
+};
+
+struct ReduceInvalidSwitchMeshG {
+  static constexpr auto name = "reduce_invalid_switch_mesh_g";
+
+  static Port<TS<Int>> compose(Wiring &w, Port<TSS<Str>> keys,
+                               Port<TS<Str>> mode) {
+    auto meshed =
+        wire<stdlib::mesh_>(w, fn<InvalidSwitchInMeshG>(), mode,
+                            arg<"__keys__">(keys))
+            .as<TSD<Str, TS<Int>>>();
+    return wire<stdlib::reduce_>(w, fn<stdlib::add_>(), meshed, Int{0})
+        .as<TS<Int>>();
+  }
+};
+
 struct MeshSwitchZeroG {
   static constexpr auto name = "mesh_switch_zero_g";
   static Port<TS<Int>> compose(Wiring &w, Port<TS<Int>>) {
@@ -411,6 +442,19 @@ TEST_CASE("mesh_: a switch_ terminal writes through to the mesh element") {
               dict_delta<Str, TS<Str>>({{"a"s, "double"s}, {"b"s, "negate"s}})),
           values<Value>(dict_delta<Str, TS<Int>>({{"a"s, 3}, {"b"s, 4}})))),
       values<Value>(dict_delta<Str, TS<Int>>({{"a"s, 6}, {"b"s, -4}})));
+}
+
+TEST_CASE(
+    "mesh_: reduce publishes an explicit zero while switch children are invalid") {
+  using namespace hgraph;
+  stdlib::register_standard_operators();
+
+  CHECK_OUTPUT(
+      eval_node<ReduceInvalidSwitchMeshG>(
+          values<Value>(set_delta<Str>({Str{"k"}}, {}), none, none,
+                        set_delta<Str>({}, {Str{"k"}})),
+          values<Str>(none, Str{"double"}, Str{"negate"}, none)),
+      values<Int>(0, 2, -1, 0));
 }
 
 TEST_CASE("mesh_: a pass-through child output forwards the mapped element") {

--- a/tests/cpp/test_service_wiring.cpp
+++ b/tests/cpp/test_service_wiring.cpp
@@ -1641,9 +1641,12 @@ TEST_CASE("service wiring: mapped subscription results retain their declared val
 {
     hgraph::stdlib::register_standard_operators();
 
+    // The mapped subscription slot exists before its forwarded value is valid.
+    // Reduction is over the currently-valid subset, so its explicit identity is
+    // published until the first price arrives.
     CHECK_OUTPUT(eval_node<MappedPriceReductionClientGraph>(
                      values<Value>(set_delta<Int>({7}, {}))),
-                 values<Int>(none, 70));
+                 values<Int>(0, 70));
 }
 
 TEST_CASE("service wiring: late duplicate subscription samples the existing value")
@@ -1781,6 +1784,8 @@ TEST_CASE("service wiring: request/reply under map switch retains late keys")
 {
     hgraph::stdlib::register_standard_operators();
 
+    // The explicit reduction identity is observable while all mapped switch
+    // terminals are invalid.
     CHECK_OUTPUT(
         eval_node<MappedRequestReplySwitchGraph>(
             values<Value>(
@@ -1789,16 +1794,17 @@ TEST_CASE("service wiring: request/reply under map switch retains late keys")
                 none,
                 dict_delta<Int, TS<Int>>({}, {1})),
             values<Str>(Str{"alpha"}, none, Str{"beta"}, none)),
-        values<Int>(none, none, 10, 6));
+        values<Int>(0, none, 10, 6));
 }
 
 TEST_CASE("service wiring: subscription under map switch retains late keys")
 {
     hgraph::stdlib::register_standard_operators();
 
-    // Issue #95: key 1 becomes valid while key 2 is still a phantom mapped
-    // slot. Reduction is over the currently-valid subset, so the first quote
-    // publishes 15; later complete aggregates still match released hgraph.
+    // Issue #95: reduction is over the currently-valid subset. Its explicit
+    // identity is therefore observable while every mapped switch terminal is
+    // invalid, and key 1 publishes 15 while key 2 is still a phantom slot.
+    // Later complete aggregates still match released hgraph.
     CHECK_OUTPUT(
         eval_node<MappedSubscriptionSwitchGraph>(
             values<Value>(
@@ -1807,7 +1813,7 @@ TEST_CASE("service wiring: subscription under map switch retains late keys")
                 none,
                 dict_delta<Int, TS<Int>>({}, {1})),
             values<Str>(Str{"alpha"}, none, Str{"beta"}, none)),
-        values<Int>(none, 15, 70, 46));
+        values<Int>(0, 15, 70, 46));
 }
 
 TEST_CASE("service wiring: a mapped request/reply implementation can call itself recursively")

--- a/tools/parity/corpus/coverage-mesh-reduce-explicit-zero-invalid-child.json
+++ b/tools/parity/corpus/coverage-mesh-reduce-explicit-zero-invalid-child.json
@@ -1,0 +1,34 @@
+{
+  "description": "An explicit identity zero seeds reduction while a mesh child remains invalid.",
+  "features": [
+    "binding:non-peered",
+    "lifecycle:multi-cycle",
+    "nested-leaf:arithmetic",
+    "nested:mesh",
+    "reference:REF",
+    "shape:TSD",
+    "topology:nested-higher-order",
+    "topology:reduce",
+    "type:int"
+  ],
+  "id": "coverage-mesh-reduce-explicit-zero-invalid-child",
+  "inputs": {
+    "selector": [
+      null
+    ],
+    "values": [
+      {
+        "k": 1
+      }
+    ]
+  },
+  "parameters": {
+    "increment": 0,
+    "inner": "arithmetic",
+    "outer": "mesh",
+    "reduce_output": true,
+    "wrap_switch": false
+  },
+  "schema_version": 1,
+  "template": "nested_higher_order"
+}

--- a/tools/parity/corpus/issue-100-mesh-reduce-explicit-zero-subscription.json
+++ b/tools/parity/corpus/issue-100-mesh-reduce-explicit-zero-subscription.json
@@ -1,0 +1,36 @@
+{
+  "description": "Issue #100: an explicit identity zero must seed reduction over a mesh whose children remain invalid.",
+  "features": [
+    "binding:non-peered",
+    "lifecycle:multi-cycle",
+    "nested-leaf:subscription",
+    "nested:mesh",
+    "reference:REF",
+    "shape:TSD",
+    "topology:nested-higher-order",
+    "topology:reduce",
+    "type:int"
+  ],
+  "id": "issue-100-mesh-reduce-explicit-zero-subscription",
+  "inputs": {
+    "selector": [
+      null,
+      null
+    ],
+    "values": [
+      {
+        "k2": -3
+      },
+      null
+    ]
+  },
+  "parameters": {
+    "increment": -1,
+    "inner": "subscription",
+    "outer": "mesh",
+    "reduce_output": true,
+    "wrap_switch": false
+  },
+  "schema_version": 1,
+  "template": "nested_higher_order"
+}

--- a/tools/parity/corpus/issue-103-mesh-reduce-explicit-zero-request-reply.json
+++ b/tools/parity/corpus/issue-103-mesh-reduce-explicit-zero-request-reply.json
@@ -1,0 +1,34 @@
+{
+  "description": "Issue #103: an explicit identity zero must seed reduction over a mesh whose children remain invalid.",
+  "features": [
+    "binding:non-peered",
+    "lifecycle:multi-cycle",
+    "nested-leaf:request_reply",
+    "nested:mesh",
+    "reference:REF",
+    "shape:TSD",
+    "topology:nested-higher-order",
+    "topology:reduce",
+    "type:int"
+  ],
+  "id": "issue-103-mesh-reduce-explicit-zero-request-reply",
+  "inputs": {
+    "selector": [
+      null
+    ],
+    "values": [
+      {
+        "k3": -10
+      }
+    ]
+  },
+  "parameters": {
+    "increment": -1,
+    "inner": "request_reply",
+    "outer": "mesh",
+    "reduce_output": true,
+    "wrap_switch": false
+  },
+  "schema_version": 1,
+  "template": "nested_higher_order"
+}

--- a/tools/parity/corpus/issue-123-mesh-reduce-explicit-zero-request-reply.json
+++ b/tools/parity/corpus/issue-123-mesh-reduce-explicit-zero-request-reply.json
@@ -1,0 +1,36 @@
+{
+  "description": "Issue #123: an explicit identity zero must remain published while a mesh child stays invalid.",
+  "features": [
+    "binding:non-peered",
+    "lifecycle:multi-cycle",
+    "nested-leaf:request_reply",
+    "nested:mesh",
+    "reference:REF",
+    "shape:TSD",
+    "topology:nested-higher-order",
+    "topology:reduce",
+    "type:int"
+  ],
+  "id": "issue-123-mesh-reduce-explicit-zero-request-reply",
+  "inputs": {
+    "selector": [
+      null,
+      null
+    ],
+    "values": [
+      {
+        "k1": -5
+      },
+      null
+    ]
+  },
+  "parameters": {
+    "increment": 2,
+    "inner": "request_reply",
+    "outer": "mesh",
+    "reduce_output": true,
+    "wrap_switch": false
+  },
+  "schema_version": 1,
+  "template": "nested_higher_order"
+}

--- a/tools/parity/corpus/issue-156-mesh-reduce-explicit-zero-subscription.json
+++ b/tools/parity/corpus/issue-156-mesh-reduce-explicit-zero-subscription.json
@@ -1,0 +1,34 @@
+{
+  "description": "Issue #156: an explicit identity zero must seed reduction over a mesh whose children remain invalid.",
+  "features": [
+    "binding:non-peered",
+    "lifecycle:multi-cycle",
+    "nested-leaf:subscription",
+    "nested:mesh",
+    "reference:REF",
+    "shape:TSD",
+    "topology:nested-higher-order",
+    "topology:reduce",
+    "type:int"
+  ],
+  "id": "issue-156-mesh-reduce-explicit-zero-subscription",
+  "inputs": {
+    "selector": [
+      null
+    ],
+    "values": [
+      {
+        "k3": -7
+      }
+    ]
+  },
+  "parameters": {
+    "increment": -5,
+    "inner": "subscription",
+    "outer": "mesh",
+    "reduce_output": true,
+    "wrap_switch": false
+  },
+  "schema_version": 1,
+  "template": "nested_higher_order"
+}


### PR DESCRIPTION
## Summary

- track resolved map/mesh forwarding terminals as TSD reduce leaves
- exclude invalid forwarded children and publish an explicit identity zero for an empty valid subset
- add native, Python, service-timing, and parity regression coverage

## Root cause

The reducer used the structurally live forwarding slot as the leaf even when its resolved child terminal was invalid. That built a combiner tree containing an invalid operand instead of treating the currently valid subset as empty.

## Impact

Explicit-zero reductions over mapped or meshed switch and service children now follow the same contract as other TSD reductions. Omitted-zero behavior remains unchanged.

## Validation

- macOS native: 1,286 passed
- macOS Python 3.14 non-WIP: 1,712 passed, 10 skipped
- OrbStack x86_64 Linux native: 1,286 passed
- OrbStack x86_64 Linux Python 3.14 non-WIP with Polars rtcompat: 1,712 passed, 10 skipped
- parity corpus validation: 47 recipes
- parity harness: 34 passed
- issue recipes #100, #103, #123, and #156 match released hgraph 0.5.31

Closes #100
Closes #103
Closes #123
Closes #156