### PR TITLE
Publish __start_time__ on the evaluate_graph path

### DIFF
--- a/python/hgraph/_wiring/_runner.py
+++ b/python/hgraph/_wiring/_runner.py
@@ -233,6 +233,14 @@ def _evaluate_graph(graph_fn, config, args, kwargs):
         _wiring_stack.append(w)
         wiring_pushed = True
         wiring_started = time.perf_counter()
+        # Python-readable mirror of the run start (the C++ run bounds have no
+        # wiring-time getter), exactly as eval_node publishes it: start-time-
+        # aware wiring — the DATA_FRAME replay overloads' upstream
+        # `_api.start_time` filter — reads this. Without it a stored frame
+        # carrying rows before start_time replays them into the native
+        # generator and the stream aborts empty.
+        state["__start_time__"] = (
+            config.start_time if config.start_time is not None else _hgraph.MIN_ST)
         config.graph_logger.debug("Wiring graph: %s", getattr(graph_fn, "__name__", graph_fn))
         out = graph_fn(*args, **kwargs)
         if out is not None:

--- a/python/hgraph/_wiring/_runner.py
+++ b/python/hgraph/_wiring/_runner.py
@@ -218,6 +218,7 @@ def _evaluate_graph(graph_fn, config, args, kwargs):
     missing = object()
     previous_logger = state.get(_GRAPH_LOGGER_KEY, missing)
     previous_formatter = state.get(_GRAPH_LOGGER_FORMATTER_KEY, missing)
+    previous_start_time = state.get("__start_time__", missing)
     state[_GRAPH_LOGGER_KEY] = config.graph_logger
     if config.logger_formatter is None:
         state.pop(_GRAPH_LOGGER_FORMATTER_KEY, None)
@@ -278,6 +279,13 @@ def _evaluate_graph(graph_fn, config, args, kwargs):
             state.pop(_GRAPH_LOGGER_FORMATTER_KEY, None)
         else:
             state[_GRAPH_LOGGER_FORMATTER_KEY] = previous_formatter
+        # Restore the enclosing run's start mirror (a nested evaluate_graph
+        # during an outer wiring must not leak its bound into replay wired
+        # later by the outer graph).
+        if previous_start_time is missing:
+            state.pop("__start_time__", None)
+        else:
+            state["__start_time__"] = previous_start_time
     if profiler is not None:
         _log_evaluation_profile(config.graph_logger, profiler.snapshot())
     if out is None:

--- a/python/tests/test_data_frame_replay_window.py
+++ b/python/tests/test_data_frame_replay_window.py
@@ -56,3 +56,20 @@ def test_data_frame_replay_keyed_history_before_start_via_evaluate_graph():
         # (removed/modified/removed_strict), not eval_node's friendly dict.
         assert [value["modified"] for _, value in out] == [{"a": 3.0}, {"a": 4.0}]
         assert all(not value["removed"] for _, value in out)
+
+
+def test_nested_evaluate_graph_restores_the_enclosing_start_mirror():
+    # A nested evaluate_graph (e.g. invoked synchronously while an outer
+    # graph is still wiring) must not leak its run start into replay wired
+    # later by the outer graph — the mirror restores like the logger keys.
+    with hg.GlobalState():
+        state = hg.GlobalState.instance()
+        outer = MIN_ST + 7 * MIN_TD
+        state["__start_time__"] = outer
+
+        @hg.graph
+        def g() -> TS[int]:
+            return hg.const(1)
+
+        hg.evaluate_graph(g, hg.GraphConfiguration(start_time=MIN_ST + 2 * MIN_TD))
+        assert state["__start_time__"] == outer

--- a/python/tests/test_data_frame_replay_window.py
+++ b/python/tests/test_data_frame_replay_window.py
@@ -1,0 +1,58 @@
+"""The DATA_FRAME replay start-time filter must apply on EVERY run entry
+point. ``__start_time__`` (the Python-readable mirror of the run start) was
+only published by ``eval_node``, so on the ``evaluate_graph``/``run_graph``
+path the replay overloads' pre-start filter was inert: a stored frame
+carrying rows dated before ``start_time`` fed them to the native replay
+generator and the whole stream came out empty. The sibling of the
+wiring/GlobalState seeding fix (d809ff63) — same subsystem, different entry
+point.
+"""
+
+import hgraph as hg
+from hgraph import MIN_ST, MIN_TD, TS, TSD
+from hgraph.adaptors.data_frame import (
+    DATA_FRAME_RECORD_REPLAY,
+    MemoryDataFrameStorage,
+)
+from hgraph.test import eval_node
+
+
+def _record(ts_type, key, values):
+    hg.set_record_replay_model(DATA_FRAME_RECORD_REPLAY)
+    hg.set_as_of(MIN_ST + MIN_TD * 30)
+    eval_node(hg.record[ts_type], ts=values, key=key, recordable_id="test")
+
+
+def test_data_frame_replay_drops_pre_start_rows_via_evaluate_graph():
+    with hg.GlobalState(), MemoryDataFrameStorage():
+        _record(TS[float], "ts", [1.0, 2.0, 3.0])
+
+        @hg.graph
+        def replay_g() -> TS[float]:
+            return hg.replay[TS[float]](key="ts", recordable_id="test")
+
+        # The first two recorded rows predate the run: they must be DROPPED
+        # (not crash the stream into emptiness).
+        start = MIN_ST + 2 * MIN_TD
+        out = hg.evaluate_graph(replay_g, hg.GraphConfiguration(start_time=start))
+        assert [value for _, value in out] == [3.0]
+        assert [when for when, _ in out] == [start]
+
+
+def test_data_frame_replay_keyed_history_before_start_via_evaluate_graph():
+    # The reported shape: a keyed series backfilled with history long before
+    # the run start, replayed as TSD[str, TS[float]].
+    with hg.GlobalState(), MemoryDataFrameStorage():
+        _record(TSD[str, TS[float]], "prices",
+                [{"a": 1.0}, {"a": 2.0}, {"a": 3.0}, {"a": 4.0}])
+
+        @hg.graph
+        def replay_g() -> TSD[str, TS[float]]:
+            return hg.replay[TSD[str, TS[float]]](key="prices", recordable_id="test")
+
+        start = MIN_ST + 2 * MIN_TD
+        out = hg.evaluate_graph(replay_g, hg.GraphConfiguration(start_time=start))
+        # evaluate_graph's sparse recording presents the canonical TSD delta
+        # (removed/modified/removed_strict), not eval_node's friendly dict.
+        assert [value["modified"] for _, value in out] == [{"a": 3.0}, {"a": 4.0}]
+        assert all(not value["removed"] for _, value in out)


### PR DESCRIPTION
## Summary

Fixes the reported DATA_FRAME replay bug on the `evaluate_graph`/`run_graph` entry point: the replay overloads' pre-start row filter reads the GlobalState `__start_time__` mirror at wiring time, but only `eval_node` ever published that key. Through `evaluate_graph` the filter resolved to `None`, pre-start rows flowed into the native replay generator, and the stream aborted empty — any frame with history before `start_time` produced all-null output.

`_evaluate_graph` now publishes the run start (or `MIN_ST`) on the bound GlobalState after the wiring stack is pushed and before the graph function wires — mirroring `eval_node` exactly. This is the `evaluate_graph`-path sibling of the wiring/GlobalState seeding fix (d809ff63).

## Verification

- New `python/tests/test_data_frame_replay_window.py`: scalar `TS[float]` and keyed `TSD[str, TS[float]]` frames recorded with rows predating the run start, replayed through `evaluate_graph` — in-window rows tick, pre-start rows drop. Both tests fail without the one-line fix (verified by stashing it) and pass with it.
- Full python tree: 1601 passed / 10 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)