### PR TITLE
Compose the valid-subset relations with the catch-up elision

### DIFF
--- a/docs/source/developer_guide/roadmap.rst
+++ b/docs/source/developer_guide/roadmap.rst
@@ -642,11 +642,17 @@ The following are intentional unless separately re-opened:
   stalls on the invalid input while hg_cpp recomputes the remaining valid
   subset). hg_cpp may publish the valid-subset aggregate — down to the
   reduce identity — while released hgraph holds; subsequent complete
-  aggregates agree. The parity families are scoped to the service-backed
-  inners (subscription startup; request-reply switch flips) — only a
-  service round trip opens the in-flight invalid window, so an extra tick
-  on a pure-arithmetic pipeline stays reportable — and permit only those
-  extra candidate emissions; every released-hgraph emission must match.
+  aggregates agree. The early emission COMPOSES with the no-change ruling:
+  when released hgraph later emits exactly the value hg_cpp already
+  published (e.g. a phantom map key's removal empties upstream's dict one
+  cycle after hg_cpp reduced without it), hg_cpp elides the equal re-tick,
+  so the value can appear one cycle earlier here (issues
+  #98/#102/#110/#150). The parity families are scoped to the
+  service-backed inners (subscription startup; request-reply switch
+  flips) — only a service round trip opens the in-flight invalid window,
+  so an extra tick on a pure-arithmetic pipeline stays reportable — and
+  permit only those extra candidate emissions and their exact-value
+  catch-up elisions; every other released-hgraph emission must match.
 - Python ``REF`` is an opaque value and does not expose ``.output``.
 - ``None`` in CompoundScalar/Bundle construction means an unset field.
 - TSB deltas are canonically dense; sparse-bundle delta parity is not required.

--- a/python/tests/test_parity_harness.py
+++ b/python/tests/test_parity_harness.py
@@ -1209,6 +1209,13 @@ def test_valid_subset_reduce_relation_is_narrowly_bounded():
     assert not classify([None, None, 26, 14], [None, 9, 25, 14])
     assert not classify([None, None, 26, 14], [None, None, None, 14])
     assert not classify([None, None, 26, 14], [None, 9, 26])
+    # CATCH-UP composition (issues #98/#102/#110/#150): upstream later
+    # emits exactly the value the candidate published early; the candidate
+    # elides the equal re-tick. The value must match exactly, and a missed
+    # emission with nothing published stays reportable.
+    assert classify([None, 0], [0, None])
+    assert not classify([None, 7], [0, None])
+    assert not classify([None, 0], [None, None])
 
 
 def test_switch_flip_valid_subset_relation_is_windowed():
@@ -1252,6 +1259,11 @@ def test_switch_flip_valid_subset_relation_is_windowed():
     # Payload mismatches and missing emissions stay reportable everywhere.
     assert not classify([3, None, None, -6], [3, 0, None, -7])
     assert not classify([3, None, None, -6], [3, None, None, None])
+    # CATCH-UP composition: upstream's later emission of exactly the
+    # candidate's in-window early value is the elided equal re-tick;
+    # a different later value stays reportable.
+    assert classify([None, 0], [0, None])
+    assert not classify([None, 7], [0, None])
 
     # A spurious tick with the selector PARKED on the arithmetic branch —
     # the t0 emission closes the only window, so nothing later is covered.

--- a/tools/parity/known.py
+++ b/tools/parity/known.py
@@ -280,10 +280,15 @@ def _valid_subset_reduce_relation(
     mapped values while released hgraph remains invalid because another live
     keyed slot is still a phantom.
 
-    Only additional candidate emissions are admitted. Every tick emitted by
-    released hgraph must match exactly, so payload corruption, missing
-    aggregates, shifted eventual values, and trace-length differences remain
-    reportable.
+    Only additional candidate emissions are admitted, plus the CATCH-UP
+    elision they compose with: when released hgraph later emits exactly the
+    value the candidate already published early, the candidate's silent
+    position is the ruled no-change elision of an equal re-tick (the two
+    Accepted Deviations composing, e.g. a phantom map key whose removal
+    empties upstream's dict one cycle after hg_cpp already reduced without
+    it). Any other reference emission must match exactly, so payload
+    corruption, missing aggregates, changed eventual values, and
+    trace-length differences remain reportable.
     """
     if difference.get("classification") != "value":
         return False
@@ -297,11 +302,18 @@ def _valid_subset_reduce_relation(
         return False
 
     extra = 0
+    candidate_last: Any = object()   # nothing published yet
     for ref, cand in zip(reference_trace, candidate_trace):
+        if cand is not None:
+            candidate_last = cand
         if ref == cand:
             continue
         if ref is None and cand is not None:
             extra += 1
+            continue
+        if cand is None and ref == candidate_last:
+            # Upstream catching up to the candidate's earlier emission;
+            # the candidate elides the equal re-tick (no-change ruling).
             continue
         return False
     return extra >= 1
@@ -343,16 +355,25 @@ def _switch_flip_valid_subset_relation(
 
     extra = 0
     window = False
+    candidate_last: Any = object()   # nothing published yet
     for index, (ref, cand) in enumerate(
         zip(reference_trace, candidate_trace)
     ):
         if index in disturbed:
             window = True
+        if cand is not None:
+            candidate_last = cand
         if ref is not None:
-            if ref != cand:
-                return False
-            window = False
-            continue
+            if ref == cand:
+                window = False
+                continue
+            if cand is None and ref == candidate_last:
+                # Upstream catching up to the candidate's earlier in-window
+                # emission; the candidate elides the equal re-tick (the
+                # no-change ruling composing with the valid-subset one).
+                window = False
+                continue
+            return False
         if cand is None:
             continue
         if not window:

--- a/tools/parity/known_divergences.json
+++ b/tools/parity/known_divergences.json
@@ -104,7 +104,7 @@
       "parameters_not_equal": {},
       "relation": "valid-subset-reduce",
       "issue": "https://github.com/hhenson/hg_cpp/issues/95",
-      "reason": "Accepted reduce deviation (issue #95, roadmap.rst): reduction is over currently-valid values \u2014 a mapped subscription child can exist before its output first validates, and hg_cpp may publish the valid-subset aggregate while released hgraph waits for every live keyed slot. Suppress only extra candidate emissions while every released-hgraph emission remains exactly equal.",
+      "reason": "Accepted reduce deviation (issue #95, roadmap.rst): reduction is over currently-valid values \u2014 a mapped subscription child can exist before its output first validates, and hg_cpp may publish the valid-subset aggregate while released hgraph waits for every live keyed slot. Suppress only extra candidate emissions while every released-hgraph emission remains exactly equal. When released hgraph later emits exactly the value the candidate published early, the candidate's silent position is the composed no-change elision of the equal re-tick (issues #98/#102/#110/#150); any other released-hgraph emission must match exactly.",
       "review_after": "2027-07-28"
     },
     {
@@ -117,7 +117,7 @@
       "parameters_not_equal": {},
       "relation": "switch-flip-valid-subset-reduce",
       "issue": "https://github.com/hhenson/hg_cpp/issues/95",
-      "reason": "The same issue #95 semantics reached through a per-key switch_ flip: flipping to the request-reply-backed branch invalidates the switch output on both runtimes (upstream's own value=None reset) while the round trip is in flight; upstream's reduce tree stalls on the invalid input, hg_cpp recomputes the remaining valid subset down to the identity (issues #99/#101/#104/#108/#115/#130/#131/#147/#152/#154/#155). Scoped to the request_reply inner \u2014 only a service round trip opens the in-flight invalid window; a pure-arithmetic branch evaluates same-cycle under sampled semantics, so its extra ticks stay reportable. Suppress only extra candidate emissions inside a disturbance window (from a selector/values input tick until the next agreeing reference emission \u2014 the span a flip or in-flight round trip can cover) while every released-hgraph emission remains exactly equal.",
+      "reason": "The same issue #95 semantics reached through a per-key switch_ flip: flipping to the request-reply-backed branch invalidates the switch output on both runtimes (upstream's own value=None reset) while the round trip is in flight; upstream's reduce tree stalls on the invalid input, hg_cpp recomputes the remaining valid subset down to the identity (issues #99/#101/#104/#108/#115/#130/#131/#147/#152/#154/#155). Scoped to the request_reply inner \u2014 only a service round trip opens the in-flight invalid window; a pure-arithmetic branch evaluates same-cycle under sampled semantics, so its extra ticks stay reportable. Suppress only extra candidate emissions inside a disturbance window (from a selector/values input tick until the next agreeing reference emission \u2014 the span a flip or in-flight round trip can cover) while every released-hgraph emission remains exactly equal. When released hgraph later emits exactly the value the candidate published early, the candidate's silent position is the composed no-change elision of the equal re-tick (issues #98/#102/#110/#150); any other released-hgraph emission must match exactly.",
       "review_after": "2027-07-28"
     }
   ]


### PR DESCRIPTION
## Summary

Disposition of the map half of the missing-first-emission group, after PR #167 fixed the mesh half. Probing both runtimes showed upstream is *asymmetric*: a `map_` key materializes eagerly (invalid child blocks its reduce), while a `mesh_` key waits for the child's first tick (empty dict → reduce emits its zero). hg_cpp is self-consistent (invalid ⇒ absent), so on these recipes the divergence is exactly the two Accepted Deviations composing:

- hg_cpp publishes the reduce identity **early** (valid-subset ruling, issue #95 — the roadmap wording literally describes the phantom *map* child);
- upstream emits the same value one cycle later when the key's removal empties its dict, and hg_cpp elides that equal re-tick (no-change ruling).

Traces: candidate `[0, null]` vs reference `[null, 0]` — same value, one cycle earlier. Neither relation admitted the composite alone. Both valid-subset relations now track the candidate's last published value and admit a reference emission against a silent candidate **only when it exactly equals that value**. A different later value and a missed emission with nothing published stay reportable (pinned in both harness relation tests). Roadmap + family reasons record the composition.

## Verification

- Harness selection: 35 passed.
- Differential sweep: #98, #102, #110, #150 all classify as family-covered; the catch-up requires the exact value.

Closes #98. Closes #102. Closes #110. Closes #150.

🤖 Generated with [Claude Code](https://claude.com/claude-code)