### PR TITLE
Document valid-output removals for mapped switch flips

### DIFF
--- a/docs/source/developer_guide/nested_graphs.rst
+++ b/docs/source/developer_guide/nested_graphs.rst
@@ -603,6 +603,15 @@ input(s) — an operator like the rest of the family
   On node stop, ``map_`` stops every child, erases the owned TSD elements, and
   clears the output, while entry destruction remains part of node-storage
   disposal after graph-wide subscriptions have been released.
+- **Only valid child outputs are map elements.** If a live child's terminal
+  becomes invalid — for example, ``switch_`` flips from an arithmetic branch
+  to a request/reply-backed branch whose response is still in flight — the
+  owned TSD publishes a removal for that key. The response adds the key again
+  when the terminal validates. Released hgraph instead publishes an empty TSD
+  delta during this switch flip and retains the stale element. hg_cpp's
+  valid-child-set behavior is the accepted deviation for issues
+  #105/#117/#119/#133/#145, pinned by the mapped request/reply tests and the
+  bounded ``switch-flip-map-removal`` parity relation.
 - **Storage-plan ordering is load-bearing**: the map field is placed *after*
   ``output`` in the node storage plan (``node_storage_plan_for``'s
   ``extra_fields_after_output``) so reverse-order destruction tears the

--- a/docs/source/developer_guide/parity_matrix.rst
+++ b/docs/source/developer_guide/parity_matrix.rst
@@ -559,6 +559,14 @@ Wiring and node-authoring surface
        :doc:`nested_graphs`; issue #95 is pinned by the mapped-service Python
        and C++ regressions and the bounded ``valid-subset-reduce`` parity
        family.
+       The related unreduced-map deviation is also intentional: when a
+       mapped ``switch_`` flips to a request/reply branch whose response is
+       still in flight, hg_cpp removes the transiently invalid child output
+       and adds it again when the response arrives. Released hgraph publishes
+       an empty delta and retains the stale value. Issues
+       #105/#117/#119/#133/#145 are pinned by the mapped request/reply Python
+       and C++ regressions and the bounded ``switch-flip-map-removal`` parity
+       family.
    * - ``dispatch_``
      - Full for Bundle values
      - Native ``dispatch_cases`` / ``dispatch_case`` wiring builds a closed

--- a/docs/source/developer_guide/parity_testing.rst
+++ b/docs/source/developer_guide/parity_testing.rst
@@ -214,12 +214,16 @@ way:
 * ``service-adaptor-one-cycle`` requires the candidate trace to equal one
   leading no-tick cycle followed by the complete reference trace;
 * ``key-set-size-no-retick`` removes only ``size`` fields and then requires
-  every remaining field to compare within the template's float tolerance; and
+  every remaining field to compare within the template's float tolerance;
 * ``subscription-resample-one-cycle`` requires repeated non-null subscription
   keys and proves that delaying the **subset** of repeats that actually emit
   an existing value — a repeat that emits nothing shifts nothing — makes the
   complete payload traces equal, with at least one repeat accounting for the
-  mismatch.
+  mismatch; and
+* ``switch-flip-map-removal`` requires the candidate to remove exactly every
+  currently-live mapped output, opposite the reference's canonical empty-map
+  delta, on the exact ``beta``-to-request/reply-``alpha`` switch flip. Later
+  response payloads and every other tick must still match.
 
 An unknown relation, payload corruption, unrelated missing field, candidate
 crash, or status difference does not match and therefore continues through

--- a/docs/source/developer_guide/roadmap.rst
+++ b/docs/source/developer_guide/roadmap.rst
@@ -647,6 +647,15 @@ The following are intentional unless separately re-opened:
   service round trip opens the in-flight invalid window, so an extra tick
   on a pure-arithmetic pipeline stays reportable — and permit only those
   extra candidate emissions; every released-hgraph emission must match.
+- **Map output contains only valid child outputs** (issues
+  #105/#117/#119/#133/#145; design record: :doc:`nested_graphs`): a
+  request/reply-backed ``switch_`` branch is transiently invalid while its
+  response is in flight. hg_cpp removes the previously valid mapped element
+  during that interval and adds it again when the response arrives. Released
+  hgraph publishes an empty TSD delta and retains the stale element. The
+  ``switch-flip-map-removal`` parity relation admits only an all-live-key,
+  removal-only candidate delta on the exact ``beta``-to-``alpha`` flip;
+  subsequent payloads and every other tick must match.
 - Python ``REF`` is an opaque value and does not expose ``.output``.
 - ``None`` in CompoundScalar/Bundle construction means an unset field.
 - TSB deltas are canonically dense; sparse-bundle delta parity is not required.

--- a/python/tests/test_parity_harness.py
+++ b/python/tests/test_parity_harness.py
@@ -1266,6 +1266,107 @@ def test_switch_flip_valid_subset_relation_is_windowed():
                         with_recipe=parked)
 
 
+def test_switch_flip_map_removal_relation_is_narrowly_bounded():
+    from tools.parity.known import (
+        is_known_family_failure,
+        load_known_divergences,
+        matches_known_family,
+    )
+
+    _fingerprints, families = load_known_divergences()
+    removal_families = [
+        family
+        for family in families
+        if family["family"] == "request-reply-switch-map-removal"
+    ]
+    assert len(removal_families) == 1
+    recipe = {
+        "template": "nested_higher_order",
+        "inputs": {
+            "selector": ["beta", "alpha", None, None],
+            "values": [{"k1": 1, "k2": 2}, None, None, None],
+        },
+        "parameters": {
+            "inner": "request_reply",
+            "outer": "map",
+            "wrap_switch": False,
+            "reduce_output": False,
+            "increment": 3,
+        },
+    }
+    assert matches_known_family(recipe, removal_families)
+    assert not matches_known_family(
+        {
+            **recipe,
+            "parameters": {**recipe["parameters"], "reduce_output": True},
+        },
+        removal_families,
+    )
+
+    mapped = lambda entries: {"$map": entries}
+    removed = lambda key: [key, {"$remove": True}]
+    initial = mapped([["k1", -1], ["k2", 1]])
+    response = mapped([["k1", 4], ["k2", 5]])
+    reference = [initial, mapped([]), None, response]
+    candidate = [
+        initial,
+        mapped([removed("k1"), removed("k2")]),
+        None,
+        response,
+    ]
+    ok = lambda trace: {"status": "ok", "trace": trace}
+
+    def classify(ref, cand, with_recipe=None):
+        difference = compare_outcomes(ok(ref), ok(cand))
+        assert difference is not None
+        return is_known_family_failure(
+            with_recipe or recipe,
+            difference.to_dict(),
+            ok(ref),
+            ok(cand),
+            removal_families,
+        )
+
+    assert classify(reference, candidate)
+    # The removal must cover exactly every output live before the flip.
+    assert not classify(
+        reference,
+        [initial, mapped([removed("k1")]), None, response],
+    )
+    # Non-removal payloads and a changed eventual response remain defects.
+    assert not classify(
+        reference,
+        [initial, mapped([["k1", 99], removed("k2")]), None, response],
+    )
+    assert not classify(
+        reference,
+        [initial, candidate[1], None, mapped([["k1", 4], ["k2", 6]])],
+    )
+    # The released-hgraph side must be its canonical empty-map delta.
+    assert not classify(
+        [initial, None, None, response],
+        candidate,
+    )
+    # The same removal one cycle before the beta-to-alpha flip is unrelated.
+    delayed_flip = {
+        **recipe,
+        "inputs": {
+            "selector": ["beta", None, "alpha", None],
+            "values": recipe["inputs"]["values"],
+        },
+    }
+    assert not classify(reference, candidate, with_recipe=delayed_flip)
+    # Selecting alpha initially is startup, not a branch flip.
+    initial_alpha = {
+        **recipe,
+        "inputs": {
+            "selector": [None, "alpha", None, None],
+            "values": recipe["inputs"]["values"],
+        },
+    }
+    assert not classify(reference, candidate, with_recipe=initial_alpha)
+
+
 def test_nested_no_change_retick_family_is_elision_only():
     from tools.parity.known import (
         is_known_family_failure,

--- a/python/tests/test_service_timing_semantics.py
+++ b/python/tests/test_service_timing_semantics.py
@@ -10,6 +10,10 @@ list in ``roadmap.rst`` and parity issues #64 / #66.
 Issue #95 is a separate reduce boundary: released hgraph waits when a keyed
 mapped slot is live but not yet valid, whereas hg_cpp reduces the currently
 valid values. The eventual service payloads and aggregates remain identical.
+
+The same valid-output rule applies to an unreduced map: when a mapped child
+becomes transiently invalid, hg_cpp removes its element until the child
+validates again instead of retaining a stale value behind an empty delta.
 """
 
 import hgraph as hg
@@ -99,6 +103,46 @@ def test_request_reply_inside_a_mapped_switch_keeps_late_keys():
         ["alpha", None, "beta", None],
         __end_time__=hg.MIN_ST + 10 * hg.MIN_TD,
     ) == [0, None, 10, 6]
+
+
+def test_request_reply_switch_flip_removes_transiently_invalid_map_output():
+    @hg.request_reply_service
+    def adjust(path: str, request: TS[int]) -> TS[int]: ...
+
+    @hg.service_impl(interfaces=adjust)
+    def adjust_impl(request: TSD[int, TS[int]]) -> TSD[int, TS[int]]:
+        return hg.map_(lambda value: value + 2, request)
+
+    @graph
+    def alpha(value: TS[int]) -> TS[int]:
+        return adjust("mapped-request-reply-removal", value)
+
+    @graph
+    def beta(value: TS[int]) -> TS[int]:
+        return value * 2 - 2
+
+    @graph
+    def per_key(key: TS[str], value: TS[int], selector: TS[str]) -> TS[int]:
+        del key
+        return hg.switch_(selector, {"alpha": alpha, "beta": beta}, value)
+
+    @graph
+    def app(
+        values: TSD[str, TS[int]], selector: TS[str]
+    ) -> TSD[str, TS[int]]:
+        hg.register_service("mapped-request-reply-removal", adjust_impl)
+        return hg.map_(per_key, values, selector)
+
+    # Issues #105/#117/#119/#133/#145: changing branches invalidates the
+    # switch output while the request/reply response is in flight. A TSD
+    # contains only valid child outputs, so the old beta value is explicitly
+    # removed and the alpha response later adds the key again.
+    assert eval_node(
+        app,
+        [{"k1": 3}, None],
+        ["beta", "alpha"],
+        __end_time__=hg.MIN_ST + 6 * hg.MIN_TD,
+    ) == [{"k1": 4}, {"k1": hg.REMOVE}, None, {"k1": 5}]
 
 
 def test_subscription_inside_a_mapped_switch_keeps_late_keys():

--- a/tests/cpp/test_service_wiring.cpp
+++ b/tests/cpp/test_service_wiring.cpp
@@ -1217,6 +1217,24 @@ namespace
         }
     };
 
+    struct MappedRequestReplySwitchMapGraph
+    {
+        [[maybe_unused]] static constexpr auto name =
+            "mapped_request_reply_switch_map_graph";
+
+        static Port<TSD<Int, TS<Int>>> compose(
+            Wiring &w, Port<TSD<Int, TS<Int>>> values,
+            Port<TS<Str>> selector)
+        {
+            service::register_request_reply_service<AddOneService, AddOneImplNode>(
+                w, service::path("mapped_switch_request_reply"));
+            return wire<stdlib::map_>(
+                       w, fn<MappedRequestReplySwitchFunction>(),
+                       values, selector)
+                .as<TSD<Int, TS<Int>>>();
+        }
+    };
+
     struct MappedSubscriptionSwitchFunction
     {
         [[maybe_unused]] static constexpr auto name =
@@ -1795,6 +1813,24 @@ TEST_CASE("service wiring: request/reply under map switch retains late keys")
                 dict_delta<Int, TS<Int>>({}, {1})),
             values<Str>(Str{"alpha"}, none, Str{"beta"}, none)),
         values<Int>(0, none, 10, 6));
+}
+
+TEST_CASE("service wiring: request/reply switch flip removes an invalid map output")
+{
+    hgraph::stdlib::register_standard_operators();
+
+    // Issues #105/#117/#119/#133/#145: the request/reply-backed branch is
+    // transiently invalid after the flip. The mapped TSD removes the old
+    // beta output, then adds the alpha response when it arrives.
+    CHECK_OUTPUT(
+        eval_node<MappedRequestReplySwitchMapGraph>(
+            values<Value>(dict_delta<Int, TS<Int>>({{1, 4}}), none),
+            values<Str>(Str{"beta"}, Str{"alpha"})),
+        values<Value>(
+            dict_delta<Int, TS<Int>>({{1, 6}}),
+            dict_delta<Int, TS<Int>>({}, {1}),
+            none,
+            dict_delta<Int, TS<Int>>({{1, 5}})));
 }
 
 TEST_CASE("service wiring: subscription under map switch retains late keys")

--- a/tools/parity/corpus/issue-105-request-reply-map-removal.json
+++ b/tools/parity/corpus/issue-105-request-reply-map-removal.json
@@ -1,0 +1,36 @@
+{
+  "schema_version": 1,
+  "id": "generated-nested-higher-order-61a50c4602c3",
+  "description": "Deterministically generated parity exploration case.",
+  "template": "nested_higher_order",
+  "inputs": {
+    "selector": [
+      "beta",
+      "alpha"
+    ],
+    "values": [
+      {
+        "k2": 1
+      },
+      null
+    ]
+  },
+  "parameters": {
+    "increment": 1,
+    "inner": "request_reply",
+    "outer": "map",
+    "reduce_output": false,
+    "wrap_switch": false
+  },
+  "features": [
+    "binding:non-peered",
+    "lifecycle:multi-cycle",
+    "nested-leaf:request_reply",
+    "nested:map",
+    "reference:REF",
+    "shape:TSD",
+    "topology:nested-higher-order",
+    "type:int"
+  ],
+  "seed": 7
+}

--- a/tools/parity/corpus/issue-117-request-reply-map-removal.json
+++ b/tools/parity/corpus/issue-117-request-reply-map-removal.json
@@ -1,0 +1,38 @@
+{
+  "schema_version": 1,
+  "id": "generated-nested-higher-order-4159a7977413",
+  "description": "Deterministically generated parity exploration case.",
+  "template": "nested_higher_order",
+  "inputs": {
+    "selector": [
+      null,
+      "beta",
+      "alpha"
+    ],
+    "values": [
+      null,
+      {
+        "k1": 0
+      },
+      null
+    ]
+  },
+  "parameters": {
+    "increment": 3,
+    "inner": "request_reply",
+    "outer": "map",
+    "reduce_output": false,
+    "wrap_switch": false
+  },
+  "features": [
+    "binding:non-peered",
+    "lifecycle:multi-cycle",
+    "nested-leaf:request_reply",
+    "nested:map",
+    "reference:REF",
+    "shape:TSD",
+    "topology:nested-higher-order",
+    "type:int"
+  ],
+  "seed": 7
+}

--- a/tools/parity/corpus/issue-119-request-reply-map-removal.json
+++ b/tools/parity/corpus/issue-119-request-reply-map-removal.json
@@ -1,0 +1,38 @@
+{
+  "schema_version": 1,
+  "id": "generated-nested-higher-order-e9b27aed4ff0",
+  "description": "Deterministically generated parity exploration case.",
+  "template": "nested_higher_order",
+  "inputs": {
+    "selector": [
+      "beta",
+      null,
+      "alpha"
+    ],
+    "values": [
+      null,
+      {
+        "k2": -2
+      },
+      null
+    ]
+  },
+  "parameters": {
+    "increment": -5,
+    "inner": "request_reply",
+    "outer": "map",
+    "reduce_output": false,
+    "wrap_switch": false
+  },
+  "features": [
+    "binding:non-peered",
+    "lifecycle:multi-cycle",
+    "nested-leaf:request_reply",
+    "nested:map",
+    "reference:REF",
+    "shape:TSD",
+    "topology:nested-higher-order",
+    "type:int"
+  ],
+  "seed": 7
+}

--- a/tools/parity/corpus/issue-133-request-reply-map-removal.json
+++ b/tools/parity/corpus/issue-133-request-reply-map-removal.json
@@ -1,0 +1,40 @@
+{
+  "schema_version": 1,
+  "id": "generated-nested-higher-order-17d13f28c65d",
+  "description": "Deterministically generated parity exploration case.",
+  "template": "nested_higher_order",
+  "inputs": {
+    "selector": [
+      null,
+      null,
+      "beta",
+      "alpha"
+    ],
+    "values": [
+      null,
+      {
+        "k2": 8
+      },
+      null,
+      null
+    ]
+  },
+  "parameters": {
+    "increment": 0,
+    "inner": "request_reply",
+    "outer": "map",
+    "reduce_output": false,
+    "wrap_switch": false
+  },
+  "features": [
+    "binding:non-peered",
+    "lifecycle:multi-cycle",
+    "nested-leaf:request_reply",
+    "nested:map",
+    "reference:REF",
+    "shape:TSD",
+    "topology:nested-higher-order",
+    "type:int"
+  ],
+  "seed": 7
+}

--- a/tools/parity/corpus/issue-145-request-reply-map-removal.json
+++ b/tools/parity/corpus/issue-145-request-reply-map-removal.json
@@ -1,0 +1,38 @@
+{
+  "schema_version": 1,
+  "id": "generated-nested-higher-order-256ae4a231f4",
+  "description": "Deterministically generated parity exploration case.",
+  "template": "nested_higher_order",
+  "inputs": {
+    "selector": [
+      null,
+      "beta",
+      "alpha"
+    ],
+    "values": [
+      {
+        "k2": -5
+      },
+      null,
+      null
+    ]
+  },
+  "parameters": {
+    "increment": -4,
+    "inner": "request_reply",
+    "outer": "map",
+    "reduce_output": false,
+    "wrap_switch": false
+  },
+  "features": [
+    "binding:non-peered",
+    "lifecycle:multi-cycle",
+    "nested-leaf:request_reply",
+    "nested:map",
+    "reference:REF",
+    "shape:TSD",
+    "topology:nested-higher-order",
+    "type:int"
+  ],
+  "seed": 8
+}

--- a/tools/parity/known.py
+++ b/tools/parity/known.py
@@ -31,6 +31,7 @@ KEY_SET_SIZE_NO_RETICK = "key-set-size-no-retick"
 SUBSCRIPTION_RESAMPLE_ONE_CYCLE = "subscription-resample-one-cycle"
 NO_CHANGE_ELISION = "no-change-elision"
 VALID_SUBSET_REDUCE = "valid-subset-reduce"
+SWITCH_FLIP_MAP_REMOVAL = "switch-flip-map-removal"
 
 
 def load_known_divergences(
@@ -361,6 +362,100 @@ def _switch_flip_valid_subset_relation(
     return extra >= 1
 
 
+def _canonical_map_entries(tick: Any) -> list[Any] | None:
+    if (
+        isinstance(tick, dict)
+        and set(tick) == {"$map"}
+        and isinstance(tick["$map"], list)
+    ):
+        return tick["$map"]
+    return None
+
+
+def _switch_flip_map_removal_relation(
+    recipe: dict[str, Any],
+    difference: dict[str, Any],
+    reference: dict[str, Any],
+    candidate: dict[str, Any],
+    _family: dict[str, Any],
+) -> bool:
+    """Issues #105/#117/#119/#133/#145: a ``beta`` -> request-reply
+    ``alpha`` flip makes the mapped child transiently invalid. Released
+    hgraph publishes an empty TSD delta while retaining its previous element;
+    hg_cpp publishes removals so the TSD contains exactly the currently-valid
+    child outputs.
+
+    Admit only removal-only candidate deltas for every currently-live output,
+    exactly on those flips, opposite a canonical empty reference delta.
+    Everything else must match, including later response payloads.
+    """
+    if difference.get("classification") not in ("value", "length"):
+        return False
+    reference_trace = reference.get("trace")
+    candidate_trace = candidate.get("trace")
+    if (
+        not isinstance(reference_trace, list)
+        or not isinstance(candidate_trace, list)
+        or len(reference_trace) != len(candidate_trace)
+    ):
+        return False
+
+    flip_to_alpha = set()
+    active_selector = None
+    for index, selector in enumerate(
+        (recipe.get("inputs") or {}).get("selector") or ()
+    ):
+        if selector is None:
+            continue
+        if selector == "alpha" and active_selector == "beta":
+            flip_to_alpha.add(index)
+        active_selector = selector
+
+    live_keys: set[str] = set()
+    admitted = 0
+    for index, (ref, cand) in enumerate(
+        zip(reference_trace, candidate_trace)
+    ):
+        candidate_entries = _canonical_map_entries(cand)
+        if ref != cand:
+            reference_entries = _canonical_map_entries(ref)
+            if (
+                index not in flip_to_alpha
+                or reference_entries != []
+                or not candidate_entries
+            ):
+                return False
+            removed_keys: set[str] = set()
+            for entry in candidate_entries:
+                if (
+                    not isinstance(entry, list)
+                    or len(entry) != 2
+                    or not isinstance(entry[0], str)
+                    or entry[1] != {"$remove": True}
+                    or entry[0] in removed_keys
+                ):
+                    return False
+                removed_keys.add(entry[0])
+            if removed_keys != live_keys:
+                return False
+            admitted += 1
+
+        if candidate_entries is None:
+            continue
+        for entry in candidate_entries:
+            if (
+                not isinstance(entry, list)
+                or len(entry) != 2
+                or not isinstance(entry[0], str)
+            ):
+                return False
+            if entry[1] == {"$remove": True}:
+                live_keys.discard(entry[0])
+            else:
+                live_keys.add(entry[0])
+    return admitted >= 1
+
+
 SWITCH_FLIP_VALID_SUBSET = "switch-flip-valid-subset-reduce"
 
 RELATIONS = {
@@ -368,6 +463,7 @@ RELATIONS = {
     NO_CHANGE_ELISION: _no_change_elision_relation,
     VALID_SUBSET_REDUCE: _valid_subset_reduce_relation,
     SWITCH_FLIP_VALID_SUBSET: _switch_flip_valid_subset_relation,
+    SWITCH_FLIP_MAP_REMOVAL: _switch_flip_map_removal_relation,
     SERVICE_ADAPTOR_ONE_CYCLE: _service_adaptor_one_cycle_relation,
     KEY_SET_SIZE_NO_RETICK: _key_set_size_no_retick_relation,
     SUBSCRIPTION_RESAMPLE_ONE_CYCLE: (

--- a/tools/parity/known_divergences.json
+++ b/tools/parity/known_divergences.json
@@ -119,6 +119,21 @@
       "issue": "https://github.com/hhenson/hg_cpp/issues/95",
       "reason": "The same issue #95 semantics reached through a per-key switch_ flip: flipping to the request-reply-backed branch invalidates the switch output on both runtimes (upstream's own value=None reset) while the round trip is in flight; upstream's reduce tree stalls on the invalid input, hg_cpp recomputes the remaining valid subset down to the identity (issues #99/#101/#104/#108/#115/#130/#131/#147/#152/#154/#155). Scoped to the request_reply inner \u2014 only a service round trip opens the in-flight invalid window; a pure-arithmetic branch evaluates same-cycle under sampled semantics, so its extra ticks stay reportable. Suppress only extra candidate emissions inside a disturbance window (from a selector/values input tick until the next agreeing reference emission \u2014 the span a flip or in-flight round trip can cover) while every released-hgraph emission remains exactly equal.",
       "review_after": "2027-07-28"
+    },
+    {
+      "family": "request-reply-switch-map-removal",
+      "template": "nested_higher_order",
+      "parameters_equal": {
+        "inner": "request_reply",
+        "outer": "map",
+        "wrap_switch": false,
+        "reduce_output": false
+      },
+      "parameters_not_equal": {},
+      "relation": "switch-flip-map-removal",
+      "issue": "https://github.com/hhenson/hg_cpp/issues/105",
+      "reason": "Accepted map-validity deviation (issues #105/#117/#119/#133/#145, nested_graphs.rst): a beta-to-request-reply-alpha switch flip transiently invalidates the mapped child while the response is in flight. Released hgraph publishes an empty TSD delta and retains the stale element; hg_cpp removes every currently-live invalid child output so the map contains exactly its valid outputs, then republishes the response normally. Suppress only an all-live-key, removal-only candidate delta opposite the reference's canonical empty-map delta on the exact beta-to-alpha flip; all other ticks and payloads must match.",
+      "review_after": "2027-07-28"
     }
   ]
 }


### PR DESCRIPTION
## Summary

- record the unreduced `map_` behavior as an accepted compatibility deviation: a mapped child that becomes invalid during a request/reply switch flip is removed until its response validates
- add the narrowly bounded `switch-flip-map-removal` parity relation; it accepts only removal-only deltas for exactly the previously live outputs on a `beta` → `alpha` flip
- retain the five minimized issue recipes and add equivalent public Python and native C++ `eval_node` regressions
- document the ruling in the nested-graph contract, parity matrix, parity testing guide, and roadmap

This intentionally makes no runtime change. Retaining the old mapped value behind an empty delta would leave stale data in a TSD whose elements represent valid child outputs. This scope is separate from PR #170.

## Validation

- macOS fresh native acceptance build: 1,288/1,288 C++ tests passed
- macOS Python 3.14 suite from a Python 3.12-built ABI wheel: 1,719 passed, 10 skipped
- OrbStack Ubuntu x86_64 fresh native acceptance build: 1,288/1,288 C++ tests passed
- OrbStack Ubuntu Python 3.14 suite with `polars[rtcompat]`: 1,719 passed, 10 skipped
- all five issue recipes replayed against hgraph 0.5.31 and hg_cpp and classified only at their reported map delta
- 53 parity recipes validated; coverage reports all inventoried operators catalogued
- Sphinx dummy build passed with warnings as errors

One initial macOS Python run hit the existing real-time catalogue no-response flake; that test passed immediately in isolation and the full suite then passed cleanly.

Closes #105
Closes #117
Closes #119
Closes #133
Closes #145