### PR TITLE
Evaluate string annotations at the remaining signature-resolution sites

### DIFF
--- a/python/hgraph/_signature.py
+++ b/python/hgraph/_signature.py
@@ -64,7 +64,7 @@ def _is_unresolved(annotation):
 
 def extract_signature(fn, node_type) -> WiringNodeSignature:
     """Build the WiringNodeSignature for a wiring function."""
-    sig = inspect.signature(fn)
+    sig = inspect.signature(fn, eval_str=True)
     args, defaults, input_types = [], {}, {}
     time_series, unresolved = set(), set()
     for name, param in sig.parameters.items():

--- a/python/hgraph/_wiring/_core.py
+++ b/python/hgraph/_wiring/_core.py
@@ -125,7 +125,7 @@ class _OperatorFunction:
             import inspect
             from .._types import TS
 
-            result_type = inspect.signature(args[0]).return_annotation
+            result_type = inspect.signature(args[0], eval_str=True).return_annotation
             if result_type is not inspect.Signature.empty:
                 kwargs["output_type"] = TS[result_type]
         # hgraph parity: a trailing ``None`` argument means "use the

--- a/python/hgraph/_wiring/_lower.py
+++ b/python/hgraph/_wiring/_lower.py
@@ -30,7 +30,7 @@ def lower(fn, /, date_col="date", as_of_col="as_of", no_as_of_support=True):
         raise TypeError("lower expects a function decorated with @graph, @compute_node, or @sink_node")
 
     user_fn = fn.fn
-    signature = inspect.signature(getattr(user_fn, "fn", user_fn))
+    signature = inspect.signature(getattr(user_fn, "fn", user_fn), eval_str=True)
     parameters = tuple(signature.parameters.values())
     if any(parameter.kind in (
             inspect.Parameter.VAR_POSITIONAL,

--- a/python/hgraph/_wiring/_operator.py
+++ b/python/hgraph/_wiring/_operator.py
@@ -163,7 +163,7 @@ def _overload_wire_trampoline(impl):
 
     signature = (
         getattr(impl, "_wiring_signature", None)
-        or inspect.signature(impl.fn)
+        or inspect.signature(impl.fn, eval_str=True)
     )
     call_parameters = [
         parameter
@@ -254,12 +254,12 @@ def _register_overload(target, impl, requires=None):
     name = _overload_registry_name(target)
     if isinstance(target, _Operator):
         target._overloads.append(
-            (impl, getattr(impl, "_wiring_signature", None) or inspect.signature(impl.fn)))
+            (impl, getattr(impl, "_wiring_signature", None) or inspect.signature(impl.fn, eval_str=True)))
     fn = impl.fn
     # the ORIGINAL wiring signature: star-group nodes rewrite fn's code
     # object to keyword-only params (upstream parity), so fn's live
     # signature no longer shows *args/**kwargs.
-    sig = getattr(impl, "_wiring_signature", None) or inspect.signature(fn)
+    sig = getattr(impl, "_wiring_signature", None) or inspect.signature(fn, eval_str=True)
     param_options, variadic, has_kwargs = [], False, False
     positional = None
     for parameter in sig.parameters.values():
@@ -513,7 +513,7 @@ def dispatch_(overloaded, *args, __on__=None, __output_type=None, **kwargs):
         raise WiringError(f"dispatch_ needs an @operator/@dispatch target, got {op!r}")
     if not op._overloads:
         raise WiringError(f"{op.__name__} has no overloads to dispatch to")
-    sig = inspect.signature(op.fn)
+    sig = inspect.signature(op.fn, eval_str=True)
     if __output_type is None and isinstance(sig.return_annotation, _TsExpr):
         __output_type = sig.return_annotation
     bound = sig.bind(*args, **kwargs)
@@ -653,7 +653,7 @@ class _Dispatch(_Operator):
         if not isinstance(item, _TsExpr):
             return super().__getitem__(item)
 
-        signature = inspect.signature(self.fn)
+        signature = inspect.signature(self.fn, eval_str=True)
         ts_parameters = [
             parameter for parameter in signature.parameters.values()
             if _is_time_series_annotation(parameter.annotation)

--- a/python/hgraph/_wiring/_runner.py
+++ b/python/hgraph/_wiring/_runner.py
@@ -405,7 +405,8 @@ def eval_node(fn, *inputs, output_type=None, resolution_dict=None,
     until per-edge passive support lands) must set it and say why."""
     try:
         fn_sig = inspect.signature(
-            fn.fn if isinstance(fn, _GraphFn) or hasattr(fn, "_delegate") else fn)
+            fn.fn if isinstance(fn, _GraphFn) or hasattr(fn, "_delegate") else fn,
+            eval_str=True)
         params = list(fn_sig.parameters.values())
     except (TypeError, ValueError):
         params = []

--- a/python/hgraph/adaptors/data_catalogue/publish.py
+++ b/python/hgraph/adaptors/data_catalogue/publish.py
@@ -220,7 +220,7 @@ publish = _Publish()
 
 def _publisher_function(fn):
     fn = fn if hasattr(fn, "signature") else graph(fn)
-    signature = inspect.signature(fn)
+    signature = inspect.signature(fn, eval_str=True)
     for name in ("dce", "data_sink", "options", "request_id", "data"):
         if name not in signature.parameters:
             raise TypeError(f"{fn.__name__} requires a '{name}' parameter")

--- a/python/hgraph/adaptors/data_catalogue/subscribe.py
+++ b/python/hgraph/adaptors/data_catalogue/subscribe.py
@@ -191,7 +191,7 @@ subscribe = _Subscribe()
 
 def _subscriber_function(fn):
     fn = fn if hasattr(fn, "signature") else graph(fn)
-    signature = inspect.signature(fn)
+    signature = inspect.signature(fn, eval_str=True)
     for name in ("dce", "ds", "options", "request_id"):
         if name not in signature.parameters:
             raise TypeError(f"{fn.__name__} requires a '{name}' parameter")

--- a/python/hgraph/adaptors/dataclass/_dataclass_to_compound_scalar.py
+++ b/python/hgraph/adaptors/dataclass/_dataclass_to_compound_scalar.py
@@ -87,7 +87,7 @@ def _model_fields(model: type) -> tuple[dict[str, Any], dict[str, Any]]:
     init = getattr(model, "__init__", None)
     if init is not None:
         try:
-            signature = inspect.signature(init)
+            signature = inspect.signature(init, eval_str=True)
         except (TypeError, ValueError):
             signature = None
         if signature is not None:

--- a/python/hgraph/adaptors/dataclass/_dataclass_to_compound_scalar.py
+++ b/python/hgraph/adaptors/dataclass/_dataclass_to_compound_scalar.py
@@ -87,15 +87,27 @@ def _model_fields(model: type) -> tuple[dict[str, Any], dict[str, Any]]:
     init = getattr(model, "__init__", None)
     if init is not None:
         try:
-            signature = inspect.signature(init, eval_str=True)
+            signature = inspect.signature(init)
         except (TypeError, ValueError):
             signature = None
         if signature is not None:
+            # Resolve postponed (string) annotations PER PARAMETER: only the
+            # parameter annotations are read here, and a whole-signature
+            # eval_str would also evaluate the unread RETURN annotation — a
+            # locally declared model's self-referential ``-> Model`` exists
+            # only in the enclosing local scope and would raise NameError.
+            globalns = getattr(init, "__globals__", {})
             for name, parameter in signature.parameters.items():
                 if name == "self":
                     continue
-                if parameter.annotation is not inspect.Parameter.empty:
-                    annotations.setdefault(name, parameter.annotation)
+                annotation = parameter.annotation
+                if isinstance(annotation, str):
+                    try:
+                        annotation = eval(annotation, globalns)  # noqa: S307
+                    except (NameError, SyntaxError):
+                        annotation = parameter.annotation
+                if annotation is not inspect.Parameter.empty:
+                    annotations.setdefault(name, annotation)
                 if parameter.default is not inspect.Parameter.empty:
                     defaults.setdefault(name, parameter.default)
     return annotations, defaults

--- a/python/hgraph/adaptors/kafka/_api.py
+++ b/python/hgraph/adaptors/kafka/_api.py
@@ -94,7 +94,7 @@ def message_publisher_operator(msg, topic: str):
 
 def _decorator_signature(fn, excluded, topic):
     target = getattr(fn, "fn", fn)
-    signature = inspect.signature(target)
+    signature = inspect.signature(target, eval_str=True)
     parameters = [
         parameter
         for parameter in signature.parameters.values()

--- a/python/hgraph/adaptors/run_graph_on_thread/run_graph_on_thread.py
+++ b/python/hgraph/adaptors/run_graph_on_thread/run_graph_on_thread.py
@@ -220,7 +220,7 @@ class _ResponseState:
 
 def _graph_parameters(fn, params):
     target = getattr(fn, "fn", fn)
-    signature = inspect.signature(target)
+    signature = inspect.signature(target, eval_str=True)
     return {
         name: value
         for name, value in params.items()
@@ -232,7 +232,7 @@ def _wire_graph_parameters(fn, params):
     from hgraph._types import _TsExpr
 
     target = getattr(fn, "fn", fn)
-    signature = inspect.signature(target)
+    signature = inspect.signature(target, eval_str=True)
     return {
         name: const(value, tp=signature.parameters[name].annotation)
         if isinstance(signature.parameters[name].annotation, _TsExpr)

--- a/python/hgraph/adaptors/tornado/_rest_handler.py
+++ b/python/hgraph/adaptors/tornado/_rest_handler.py
@@ -160,7 +160,7 @@ def rest_handler(fn=None, *, url: str, data_type: type[CompoundScalar]):
     if target is fn:
         fn = graph(fn)
         target = fn.fn
-    signature = inspect.signature(target)
+    signature = inspect.signature(target, eval_str=True)
     request = signature.parameters.get("request")
     if request is None:
         raise TypeError("REST handler requires a 'request' time-series input")

--- a/python/hgraph/adaptors/tornado/http_server_adaptor.py
+++ b/python/hgraph/adaptors/tornado/http_server_adaptor.py
@@ -330,7 +330,7 @@ class _HttpServerHandler:
         self.__name__ = getattr(fn, "__name__", "http_server_handler")
 
         target = getattr(fn, "fn", fn)
-        signature = inspect.signature(target)
+        signature = inspect.signature(target, eval_str=True)
         request = signature.parameters.get("request")
         if request is None:
             raise TypeError("HTTP handler requires a 'request' time-series input")

--- a/python/hgraph/adaptors/tornado/websocket_server_adaptor.py
+++ b/python/hgraph/adaptors/tornado/websocket_server_adaptor.py
@@ -282,7 +282,7 @@ class _WebSocketServerHandler:
         self.__name__ = getattr(fn, "__name__", "websocket_server_handler")
 
         target = getattr(fn, "fn", fn)
-        signature = inspect.signature(target)
+        signature = inspect.signature(target, eval_str=True)
         request = signature.parameters.get("request")
         if request is None:
             raise TypeError("WebSocket handler requires a 'request' time-series input")

--- a/python/tests/test_postponed_annotations.py
+++ b/python/tests/test_postponed_annotations.py
@@ -100,3 +100,26 @@ def test_postponed_generator_and_lifecycle():
 
     assert eval_node(app) == [5]
     assert seen == [5]
+
+
+def test_postponed_local_model_with_self_referential_init_converts():
+    # PR #172 review: a non-dataclass model declared INSIDE a function whose
+    # __init__ carries a postponed self-referential return annotation
+    # ("-> Model", resolvable only in the enclosing local scope). Only the
+    # parameter annotations are read for conversion, so the unread return
+    # annotation must not break it.
+    from hgraph.adaptors.dataclass import CS
+    from hgraph import CompoundScalar
+
+    class Model:
+        x: int
+
+        def __init__(self, x: int = 0, y: str = "") -> Model:
+            self.x = x
+            self.y = y
+
+    model_type = CS[Model]
+    assert issubclass(model_type, CompoundScalar)
+    assert model_type.__annotations__["x"] is int
+    # The __init__-supplied parameter annotation still resolves and lands.
+    assert model_type.__annotations__["y"] is str

--- a/python/tests/test_postponed_annotations.py
+++ b/python/tests/test_postponed_annotations.py
@@ -36,6 +36,31 @@ def test_postponed_compute_node_and_graph():
     assert eval_node(app, [1, 2]) == [2, 3]
 
 
+def test_postponed_annotation_types_inputs_without_samples():
+    # The annotation itself must type the replay source: an all-None input
+    # vector offers nothing to infer from, so this only wires if the string
+    # 'TS[int]' was evaluated (review finding on issue #83).
+    @hg.compute_node
+    def add_one(value: TS[int]) -> TS[int]:
+        return value.value + 1
+
+    @hg.graph
+    def app(value: TS[int]) -> TS[int]:
+        return add_one(value)
+
+    assert eval_node(app, [None, None]) is None
+
+
+def test_postponed_lower():
+    # Public lower() reads the raw signature too (review finding).
+    @hg.graph
+    def add_graph(lhs: TS[int], rhs: TS[int]) -> TS[int]:
+        return lhs + rhs
+
+    lowered = hg.lower(add_graph)
+    assert lowered is not None
+
+
 def test_postponed_tsb_schema():
     @hg.graph
     def bundle(a: TS[int], b: TS[int]) -> TSB[Pair]:


### PR DESCRIPTION
## Summary

Recovers the stranded review follow-up to issue #83: the first sweep (merged) covered only the files the issue named, and this commit — which was pushed to `agent/issue-79-83-python-signatures` but never merged — extends `eval_str=True` to every remaining site that READS annotations: `extract_signature` (`_signature.py`), public `lower()` (`_lower.py`), apply return-annotation inference (`_core.py`), the operator overload pattern/wire-reentry signatures (`_operator.py`), the `eval_node` passive-scan signature (`_runner.py`), and the adaptor signature extractors (data_catalogue, dataclass, kafka, run_graph_on_thread, tornado). Sites that read only parameter names/kinds/defaults are deliberately untouched.

Verified still relevant before recovery: current main has zero `eval_str=True` at these sites, so modules using `from __future__ import annotations` still fail resolution through them. Cherry-picked cleanly onto main (original commit authorship preserved).

## Verification

- `test_postponed_annotations.py` (extended by this commit): 6 passed.
- Full python tree: 1607 passed / 10 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)