### PR TITLE
Cover the subset-family edges: mesh subscriptions and never-emitting runs

### DIFF
--- a/python/tests/test_parity_harness.py
+++ b/python/tests/test_parity_harness.py
@@ -1216,6 +1216,11 @@ def test_valid_subset_reduce_relation_is_narrowly_bounded():
     assert classify([None, 0], [0, None])
     assert not classify([None, 7], [0, None])
     assert not classify([None, 0], [None, None])
+    # The limiting case (issues #174/#176): released hgraph emitted NOTHING
+    # for the whole run (a null trace) — the candidate's early emission is
+    # still the ruled extra. A null CANDIDATE trace stays reportable.
+    assert classify(None, [0])
+    assert not classify([0], None)
 
 
 def test_switch_flip_valid_subset_relation_is_windowed():

--- a/tools/parity/known.py
+++ b/tools/parity/known.py
@@ -295,6 +295,11 @@ def _valid_subset_reduce_relation(
         return False
     reference_trace = reference.get("trace")
     candidate_trace = candidate.get("trace")
+    if reference_trace is None and isinstance(candidate_trace, list):
+        # Released hgraph emitted NOTHING for the whole run — the limiting
+        # case of catching up later (issues #174/#176): every candidate
+        # position must then qualify as an admissible extra emission.
+        reference_trace = [None] * len(candidate_trace)
     if (
         not isinstance(reference_trace, list)
         or not isinstance(candidate_trace, list)
@@ -339,6 +344,11 @@ def _switch_flip_valid_subset_relation(
         return False
     reference_trace = reference.get("trace")
     candidate_trace = candidate.get("trace")
+    if reference_trace is None and isinstance(candidate_trace, list):
+        # Released hgraph emitted NOTHING for the whole run — the limiting
+        # case of catching up later (issues #174/#176): every candidate
+        # position must then qualify as an admissible extra emission.
+        reference_trace = [None] * len(candidate_trace)
     if (
         not isinstance(reference_trace, list)
         or not isinstance(candidate_trace, list)

--- a/tools/parity/known_divergences.json
+++ b/tools/parity/known_divergences.json
@@ -97,14 +97,12 @@
       "template": "nested_higher_order",
       "parameters_equal": {
         "inner": "subscription",
-        "outer": "map",
-        "wrap_switch": false,
         "reduce_output": true
       },
       "parameters_not_equal": {},
       "relation": "valid-subset-reduce",
       "issue": "https://github.com/hhenson/hg_cpp/issues/95",
-      "reason": "Accepted reduce deviation (issue #95, roadmap.rst): reduction is over currently-valid values \u2014 a mapped subscription child can exist before its output first validates, and hg_cpp may publish the valid-subset aggregate while released hgraph waits for every live keyed slot. Suppress only extra candidate emissions while every released-hgraph emission remains exactly equal. When released hgraph later emits exactly the value the candidate published early, the candidate's silent position is the composed no-change elision of the equal re-tick (issues #98/#102/#110/#150); any other released-hgraph emission must match exactly.",
+      "reason": "Accepted reduce deviation (issue #95, roadmap.rst): reduction is over currently-valid values \u2014 a mapped/meshed subscription child can exist before its output first validates, and hg_cpp may publish the valid-subset aggregate while released hgraph waits for every live keyed slot. Suppress only extra candidate emissions while every released-hgraph emission remains exactly equal. When released hgraph later emits exactly the value the candidate published early, the candidate's silent position is the composed no-change elision of the equal re-tick (issues #98/#102/#110/#150); any other released-hgraph emission must match exactly. The mesh_ outer reaches the same startup window (issue #173).",
       "review_after": "2027-07-28"
     },
     {


### PR DESCRIPTION
## Summary

Two edges of the ruled valid-subset deviation, from the 2026-07-28 afternoon nightly batch:

- **#173** — the subscription-startup family was scoped `outer=map`; the identical phantom window through `mesh_` refiled (`[None, 17]` vs `[0, 17]`). The entry now constrains only `inner=subscription` + `reduce_output`.
- **#174/#176** — when the run ends before released hgraph ever emits, its trace is `null` (not a list), which the relations rejected outright. This is the limiting case of the catch-up composition: both subset relations now normalize a null *reference* trace to all-None of the candidate's length, so every candidate position must qualify as an admissible in-window extra; a null *candidate* trace stays reportable (bounds pinned in the harness tests).

**#175 stays open as a real bug**: upstream delivers k1's request-reply response at t2 (`{"k1": 8}` in the mapped trace) while hg_cpp ticks an empty map and k1's value never lands — the in-flight response is dropped when a new key arrives in the same cycle. Root-causing next.

## Verification

- Harness selection: 36 passed.
- Differential sweeps: #173, #174, #176 all family-covered on current main.

Closes #173. Closes #174. Closes #176.

🤖 Generated with [Claude Code](https://claude.com/claude-code)