### PR TITLE
Map and mesh scheduling must preserve due children without full scans

### DIFF
--- a/benchmarks/repro_map_schedule_queue.py
+++ b/benchmarks/repro_map_schedule_queue.py
@@ -1,0 +1,55 @@
+"""Exercise map_'s child-schedule queue under repeated broadcast ticks.
+
+Each mapped child owns one deadline beyond the run horizon while a broadcast
+input visits every child on every cycle. The queue should retain one current
+deadline per child rather than one duplicate per ``(child, cycle)``.
+
+Run: ``python benchmarks/repro_map_schedule_queue.py [keys] [cycles] [repeats]``.
+"""
+
+from datetime import timedelta
+import sys
+import time
+
+import hgraph as hg
+from hgraph import TS, TSD, generator, graph
+
+
+KEYS = int(sys.argv[1]) if len(sys.argv) > 1 else 1_000
+CYCLES = int(sys.argv[2]) if len(sys.argv) > 2 else 1_000
+REPEATS = int(sys.argv[3]) if len(sys.argv) > 3 else 5
+
+
+@generator
+def values() -> TSD[int, TS[int]]:
+    yield hg.MIN_TD, {key: key for key in range(KEYS)}
+
+
+@generator
+def pulse() -> TS[int]:
+    for value in range(CYCLES):
+        yield hg.MIN_TD, value
+
+
+@graph
+def scheduled_child(value: TS[int], broadcast: TS[int]) -> TS[int]:
+    delayed = hg.lag(value, timedelta(seconds=1))
+    return hg.default(delayed, 0) + broadcast
+
+
+@graph
+def app():
+    hg.null_sink(hg.map_(scheduled_child, values(), pulse()))
+
+
+for run in range(REPEATS):
+    started = time.perf_counter()
+    hg.run_graph(
+        app,
+        start_time=hg.MIN_ST,
+        end_time=hg.MIN_ST + hg.MIN_TD * (CYCLES + 2),
+    )
+    print(
+        f"run={run} keys={KEYS} cycles={CYCLES} "
+        f"elapsed={time.perf_counter() - started:.6f}s"
+    )

--- a/benchmarks/repro_mesh_schedule_queue.py
+++ b/benchmarks/repro_mesh_schedule_queue.py
@@ -1,0 +1,52 @@
+"""Exercise mesh_'s sparse child worklist and schedule queue.
+
+The first tick creates every mesh child. Later ticks modify one existing key
+at a time while each visited child retains a deadline beyond the run horizon.
+The mesh should evaluate and re-rank only the notified child instead of
+rebuilding the full live-slot order on every sparse tick.
+
+Run: ``python benchmarks/repro_mesh_schedule_queue.py [keys] [cycles] [repeats]``.
+"""
+
+from datetime import timedelta
+import sys
+import time
+
+import hgraph as hg
+from hgraph import TS, TSD, generator, graph
+
+
+KEYS = int(sys.argv[1]) if len(sys.argv) > 1 else 1_000
+CYCLES = int(sys.argv[2]) if len(sys.argv) > 2 else 1_000
+REPEATS = int(sys.argv[3]) if len(sys.argv) > 3 else 5
+
+
+@generator
+def values() -> TSD[int, TS[int]]:
+    yield hg.MIN_TD, {key: key for key in range(KEYS)}
+    for cycle in range(CYCLES):
+        key = cycle % KEYS
+        yield hg.MIN_TD, {key: KEYS + cycle}
+
+
+@graph
+def scheduled_child(value: TS[int]) -> TS[int]:
+    return hg.default(hg.lag(value, timedelta(seconds=1)), 0)
+
+
+@graph
+def app():
+    hg.null_sink(hg.mesh_(scheduled_child, values()))
+
+
+for run in range(REPEATS):
+    started = time.perf_counter()
+    hg.run_graph(
+        app,
+        start_time=hg.MIN_ST,
+        end_time=hg.MIN_ST + hg.MIN_TD * (CYCLES + 2),
+    )
+    print(
+        f"run={run} keys={KEYS} cycles={CYCLES} "
+        f"elapsed={time.perf_counter() - started:.6f}s"
+    )

--- a/docs/source/developer_guide/mesh.rst
+++ b/docs/source/developer_guide/mesh.rst
@@ -281,9 +281,14 @@ Under the type-erased design this is a mesh-specific graph-evaluation op, not a
 change to the standard executor.
 
 **Stable state.** Once edges are known they give a stable dependency order, so in
-a settled mesh no pauses occur: instances are evaluated dependency-first from the
-cached edges and each ``mesh_subscribe`` finds its result already present. Pauses
-arise only when a **new** dependency (or a changed dependency key) is discovered.
+a settled mesh no pauses occur: instances selected by input notification,
+creation, or internal schedule are evaluated dependency-first and each
+``mesh_subscribe`` finds its result already present. The mesh does not rebuild
+and sort the complete live-instance order for a sparse tick. Its child schedule
+observer and coalesced pull queue identify independently due instances; newly
+created dependencies and sibling notifications join the same-cycle candidate
+worklist. Source repoints retain a conservative all-instance rebind. Pauses arise
+only when a **new** dependency (or a changed dependency key) is discovered.
 
 **The ``mesh_subscribe`` node.** Wired inside an instance for ``mesh_(func)[k]``.
 Inputs: ``item`` (``TS<K>``, active — the dependency key) and a dynamic ``value``
@@ -321,10 +326,13 @@ multi-cycle-settle ordering:
   forwarding output bound to ``self[item]``. The ``value`` rebind keeps the node
   reactive: a later tick of the sibling reschedules it (cross-cycle
   re-propagation).
-- **Resolver** (``mesh_evaluate``): a rank-ordered **settle loop** — evaluate due /
-  paused instances by ascending rank, re-scanning until none pauses. ``add_dependency``
-  creates the target on demand (same cycle, ranked below the requester) and ``re_rank``
-  keeps the requester above it; a cycle is a runtime error.
+- **Resolver** (``mesh_evaluate``): a rank-ordered **sparse settle loop** —
+  materialize only input-notified, newly created, paused, or internally due
+  instances by ascending rank, then repeat while same-cycle dependency work is
+  added. ``add_dependency`` creates the target on demand (same cycle, ranked
+  below the requester) and ``re_rank`` keeps the requester above it; a cycle is
+  a runtime error. The schedule queue's future minimum re-arms the mesh parent
+  once after the settle loop.
 - **Wiring**: the ``mesh_`` operator (``wire_mesh``, peer instantiation = ``map_``),
   the wiring-time **mesh-context stack** (pushed around the child compile), and
   ``mesh_(func)[k]`` access via ``mesh_ref<OUT>(w, key)`` (resolves the scope, wires a

--- a/docs/source/developer_guide/nested_graphs.rst
+++ b/docs/source/developer_guide/nested_graphs.rst
@@ -483,10 +483,17 @@ feeds a per-map **schedule queue** — a min-heap of ``(when, slot)`` in the
 map's node storage. Every map evaluation pops the due slots into the
 evaluation candidates before deciding between the sparse and full paths;
 the evaluation loop's own future child schedules push into the same queue
-(the pull half). Queue entries are lazy: a rescheduled, stopped, or
-removed slot pops harmlessly because the evaluation loop re-checks each
-child's due-ness. ``tsl_map`` and ``mesh`` run per-child due checks over
-all entries every cycle and need neither observer nor queue.
+(the pull half). At the end of each map evaluation the queue's minimum
+re-arms the parent, including deadlines belonging to children outside
+that cycle's sparse candidate set. Repeated pull-side observations of the
+same child deadline are coalesced; push-side observations remain distinct
+because different internal nodes may schedule different times. Queue
+entries are otherwise lazy: a rescheduled, stopped, or removed slot pops
+harmlessly because both the current per-child deadline and the child's
+due-ness are re-checked. Current-cycle entries observed after the initial
+queue drain are discarded before the parent is re-armed, so they cannot
+hide a later deadline. ``tsl_map`` and ``mesh`` run per-child due checks
+over all entries every cycle and need neither observer nor queue.
 
 Multi-level nesting recurses up to the root naturally. The boundary *binding*
 helpers shared by all nested node implementations

--- a/docs/source/developer_guide/nested_graphs.rst
+++ b/docs/source/developer_guide/nested_graphs.rst
@@ -484,7 +484,7 @@ map's node storage. Every map evaluation pops the due slots into the
 evaluation candidates before deciding between the sparse and full paths;
 the evaluation loop's own future child schedules push into the same queue
 (the pull half). At the end of each map evaluation the queue's minimum
-re-arms the parent, including deadlines belonging to children outside
+re-arms the parent once, including deadlines belonging to children outside
 that cycle's sparse candidate set. Repeated pull-side observations of the
 same child deadline are coalesced; push-side observations remain distinct
 because different internal nodes may schedule different times. Queue

--- a/docs/source/developer_guide/nested_graphs.rst
+++ b/docs/source/developer_guide/nested_graphs.rst
@@ -470,6 +470,24 @@ graph ops (no separate engine/clock object; see the recorded decision):
   pushing mid-evaluate would schedule a spurious extra parent cycle) and
   while the child is stopped.
 
+The push tells a keyed parent *when* but not *which child*. For ``map_``
+that identity matters: its input-event fast path evaluates only
+input-driven slots, and a child due purely by its own internal schedule
+(a service response delivery, a scheduler alarm) coinciding with an outer
+tick would be starved — the wake-up is for the already-current time, so
+nothing re-schedules it (issue #175). The push half therefore also
+invokes an optional per-child **schedule observer**
+(``GraphView::set_child_schedule_observer``, installed by ``map_`` at
+entry creation with a stable per-entry ``(storage, slot)`` context), which
+feeds a per-map **schedule queue** — a min-heap of ``(when, slot)`` in the
+map's node storage. Every map evaluation pops the due slots into the
+evaluation candidates before deciding between the sparse and full paths;
+the evaluation loop's own future child schedules push into the same queue
+(the pull half). Queue entries are lazy: a rescheduled, stopped, or
+removed slot pops harmlessly because the evaluation loop re-checks each
+child's due-ness. ``tsl_map`` and ``mesh`` run per-child due checks over
+all entries every cycle and need neither observer nor queue.
+
 Multi-level nesting recurses up to the root naturally. The boundary *binding*
 helpers shared by all nested node implementations
 (``walk_ts_path`` / ``bind_input_to_source`` /

--- a/docs/source/developer_guide/nested_graphs.rst
+++ b/docs/source/developer_guide/nested_graphs.rst
@@ -470,30 +470,35 @@ graph ops (no separate engine/clock object; see the recorded decision):
   pushing mid-evaluate would schedule a spurious extra parent cycle) and
   while the child is stopped.
 
-The push tells a keyed parent *when* but not *which child*. For ``map_``
-that identity matters: its input-event fast path evaluates only
-input-driven slots, and a child due purely by its own internal schedule
-(a service response delivery, a scheduler alarm) coinciding with an outer
-tick would be starved — the wake-up is for the already-current time, so
-nothing re-schedules it (issue #175). The push half therefore also
-invokes an optional per-child **schedule observer**
-(``GraphView::set_child_schedule_observer``, installed by ``map_`` at
-entry creation with a stable per-entry ``(storage, slot)`` context), which
-feeds a per-map **schedule queue** — a min-heap of ``(when, slot)`` in the
-map's node storage. Every map evaluation pops the due slots into the
-evaluation candidates before deciding between the sparse and full paths;
-the evaluation loop's own future child schedules push into the same queue
-(the pull half). At the end of each map evaluation the queue's minimum
-re-arms the parent once, including deadlines belonging to children outside
-that cycle's sparse candidate set. Repeated pull-side observations of the
-same child deadline are coalesced; push-side observations remain distinct
-because different internal nodes may schedule different times. Queue
-entries are otherwise lazy: a rescheduled, stopped, or removed slot pops
-harmlessly because both the current per-child deadline and the child's
-due-ness are re-checked. Current-cycle entries observed after the initial
-queue drain are discarded before the parent is re-armed, so they cannot
-hide a later deadline. ``tsl_map`` and ``mesh`` run per-child due checks
-over all entries every cycle and need neither observer nor queue.
+The push tells a keyed parent *when* but not *which child*. For ``map_`` and
+``mesh_`` that identity matters: both operators keep sparse child worklists,
+and a child due purely by its own internal schedule (a service response
+delivery, a scheduler alarm) must be merged with slots selected by an outer
+tick. The push half therefore also invokes an optional per-child **schedule
+observer** (``GraphView::set_child_schedule_observer``, installed at entry
+creation with a stable per-entry ``(storage, slot)`` context), which feeds a
+per-parent **schedule queue** — a min-heap of ``(when, slot)`` in the keyed
+node's storage.
+
+Every evaluation pops due slots into the candidate set; the evaluation loop's
+own future child schedules push into the same queue (the pull half). At the end
+of the evaluation the queue's minimum re-arms the parent once, including
+deadlines belonging to children outside that cycle's sparse candidate set.
+Repeated pull-side observations of the same child deadline are coalesced;
+push-side observations remain distinct because different internal nodes may
+schedule different times. Queue entries are otherwise lazy: a rescheduled,
+stopped, or removed slot pops harmlessly because both the current per-child
+deadline and the child's due-ness are re-checked. Current-cycle entries
+observed after the initial queue drain are discarded before the parent is
+re-armed, so they cannot hide a later deadline.
+
+``map_`` orders its sparse candidates by stable slot. ``mesh_`` rematerializes
+and sorts only its candidate slots by dependency rank on each settle pass;
+newly created dependencies and same-cycle sibling notifications join that
+worklist before the next pass. A source repoint or structured boundary
+retarget retains the conservative all-child rebind path. ``tsl_map`` continues
+to run per-child due checks over all fixed entries and needs neither observer
+nor queue.
 
 Multi-level nesting recurses up to the root naturally. The boundary *binding*
 helpers shared by all nested node implementations

--- a/include/hgraph/runtime/graph.h
+++ b/include/hgraph/runtime/graph.h
@@ -155,6 +155,13 @@ struct HGRAPH_EXPORT GraphEdge
         RootGraphView (*root_impl)(const void *context, const GraphView &graph) = nullptr;
         GraphExecutorView (*graph_executor_impl)(const void *context, void *memory) = nullptr;
         NodeView (*parent_node_impl)(const void *context, void *memory) = nullptr;
+        /** Keyed-parent hook (nested graphs only): observe OUT-OF-BAND child
+            schedules — a notification or scheduler firing while the child is
+            idle — so the parent can track WHICH child is due without
+            scanning its slots. */
+        void (*set_child_schedule_observer_impl)(const void *context, void *memory,
+                                                 void (*observer)(void *, DateTime),
+                                                 void *observer_context) = nullptr;
         /** Cached pointer to the shared (executor-owned) lifecycle observer list; never null once constructed. */
         LifecycleObserverList *(*lifecycle_observers_impl)(const void *context, const void *memory) noexcept = nullptr;
         const TypeRealizationSnapshot *(*type_realization_impl)(const void *context,
@@ -239,6 +246,11 @@ struct HGRAPH_EXPORT GraphEdge
         /// calling evaluate again at the same time; the cursor is held in graph state).
         bool evaluate(DateTime evaluation_time) const;
         void schedule_node(std::size_t node_index, DateTime when) const;
+        /** Install the keyed-parent OUT-OF-BAND schedule observer on this
+            NESTED child graph (see GraphOps). Pass nullptrs to clear.
+            Throws for root graphs, which have no parent to notify. */
+        void set_child_schedule_observer(void (*observer)(void *, DateTime),
+                                         void *observer_context) const;
 
         /** The graph-schedule entry for one node (``MIN_DT`` = not scheduled). */
         [[nodiscard]] DateTime node_scheduled_time(std::size_t node_index) const noexcept;

--- a/include/hgraph/runtime/mesh_node.h
+++ b/include/hgraph/runtime/mesh_node.h
@@ -14,8 +14,8 @@ namespace hgraph
     /**
      * ``mesh_`` runtime node — ``map_`` over a ``TSD`` whose per-key instances
      * may read each other's outputs by key (``mesh_(func)[k]``), create instances
-     * on demand when an absent key is referenced, and are evaluated in
-     * dependency-rank order each cycle (a cyclic dependency is a runtime error).
+     * on demand when an absent key is referenced, and are evaluated from a
+     * sparse, dependency-ranked worklist (a cyclic dependency is a runtime error).
      *
      * It reuses the ``map_`` per-key entry model (``MapArgSource`` for the child
      * boundary args, the child terminal forwarding into the owned ``TSD``

--- a/python/tests/test_parity_fixes.py
+++ b/python/tests/test_parity_fixes.py
@@ -202,3 +202,38 @@ def test_mesh_with_never_valid_keys_never_ticks():
         return hg.mesh_(keyed, __keys__=keys, __key_arg__="key")
 
     assert eval_node(g, [None, None]) is None
+
+
+def test_map_child_response_survives_new_key_in_delivery_cycle():
+    # Issue #175: a map_ child scheduled by its own INTERNAL nodes (here a
+    # request-reply response due for delivery) must evaluate even when an
+    # outer input ticks in the same cycle — the input-event fast path used
+    # to skip it and the wake-up was lost permanently.
+    @hg.request_reply_service
+    def adjust(path: str, request: TS[int]) -> TS[int]: ...
+
+    @hg.service_impl(interfaces=adjust)
+    def adjust_impl(request: hg.TSD[int, TS[int]]) -> hg.TSD[int, TS[int]]:
+        return hg.map_(lambda value: value + 0, request)
+
+    @graph
+    def alpha_branch(value: TS[int]) -> TS[int]:
+        return adjust("issue-175-svc", value)
+
+    @graph
+    def beta_branch(value: TS[int]) -> TS[int]:
+        return value * 2
+
+    @graph
+    def per_key(key: TS[str], value: TS[int], selector: TS[str]) -> TS[int]:
+        del key
+        return hg.switch_(selector, {"alpha": alpha_branch, "beta": beta_branch}, value)
+
+    @graph
+    def g(values: hg.TSD[str, TS[int]], selector: TS[str]) -> hg.TSD[str, TS[int]]:
+        hg.register_service("issue-175-svc", adjust_impl)
+        return hg.map_(per_key, values, selector)
+
+    # k2 arrives EXACTLY in k1's response-delivery cycle (t2).
+    assert eval_node(g, [{"k1": 8}, None, {"k2": -2}], ["alpha", None, None]) == [
+        {}, None, {"k1": 8}, None, {"k2": -2}]

--- a/python/tests/test_parity_fixes.py
+++ b/python/tests/test_parity_fixes.py
@@ -204,11 +204,12 @@ def test_mesh_with_never_valid_keys_never_ticks():
     assert eval_node(g, [None, None]) is None
 
 
-def test_map_child_response_survives_new_key_in_delivery_cycle():
-    # Issue #175: a map_ child scheduled by its own INTERNAL nodes (here a
+@pytest.mark.parametrize("use_mesh", [False, True], ids=["map", "mesh"])
+def test_keyed_child_response_survives_new_key_in_delivery_cycle(use_mesh):
+    # Issue #175: a keyed child scheduled by its own INTERNAL nodes (here a
     # request-reply response due for delivery) must evaluate even when an
-    # outer input ticks in the same cycle — the input-event fast path used
-    # to skip it and the wake-up was lost permanently.
+    # outer input ticks in the same cycle. Map originally lost that wake-up;
+    # mesh uses the same sparse child-schedule worklist.
     @hg.request_reply_service
     def adjust(path: str, request: TS[int]) -> TS[int]: ...
 
@@ -232,7 +233,8 @@ def test_map_child_response_survives_new_key_in_delivery_cycle():
     @graph
     def g(values: hg.TSD[str, TS[int]], selector: TS[str]) -> hg.TSD[str, TS[int]]:
         hg.register_service("issue-175-svc", adjust_impl)
-        return hg.map_(per_key, values, selector)
+        keyed_operator = hg.mesh_ if use_mesh else hg.map_
+        return keyed_operator(per_key, values, selector)
 
     # k2 arrives EXACTLY in k1's response-delivery cycle (t2).
     assert eval_node(g, [{"k1": 8}, None, {"k2": -2}], ["alpha", None, None]) == [

--- a/src/hgraph/runtime/graph.cpp
+++ b/src/hgraph/runtime/graph.cpp
@@ -192,6 +192,10 @@ struct NestedGraphRuntimeStorage : GraphRuntimeBaseStorage {
   [[nodiscard]] NodeView parent_node() { return NodeView{parent_node_ptr}; }
 
   NodePtr parent_node_ptr{};
+  /** Keyed-parent hook: out-of-band child schedules report (context, when)
+      so the parent can track WHICH child is due without scanning slots. */
+  void (*child_schedule_observer)(void *, DateTime) = nullptr;
+  void *child_schedule_observer_context = nullptr;
 };
 
 inline constexpr std::string_view graph_header_field_name{"header"};
@@ -720,7 +724,20 @@ void nested_schedule_node_impl(const void *context, const GraphView &graph,
   if (!state.started || state.evaluating) {
     return;
   }
+  if (state.child_schedule_observer != nullptr) {
+    state.child_schedule_observer(state.child_schedule_observer_context, when);
+  }
   parent.graph().schedule_node(parent.node_index(), when);
+}
+
+void nested_set_child_schedule_observer_impl(const void *context, void *memory,
+                                             void (*observer)(void *,
+                                                              DateTime),
+                                             void *observer_context) {
+  auto &state = graph_header<NestedGraphRuntimeStorage>(graph_context(context),
+                                                        memory);
+  state.child_schedule_observer = observer;
+  state.child_schedule_observer_context = observer_context;
 }
 
 template <typename Storage>
@@ -1165,6 +1182,8 @@ struct GraphRuntimeRegistry {
         .root_impl = &nested_graph_root_impl,
         .graph_executor_impl = &nested_graph_executor_impl,
         .parent_node_impl = &nested_parent_node_impl,
+        .set_child_schedule_observer_impl =
+            &nested_set_child_schedule_observer_impl,
         .lifecycle_observers_impl =
             &lifecycle_observers_impl<NestedGraphRuntimeStorage>,
         .type_realization_impl =
@@ -1513,6 +1532,16 @@ bool GraphView::evaluate(DateTime evaluation_time) const {
 }
 void GraphView::schedule_node(std::size_t node_index, DateTime when) const {
   ops().schedule_node_impl(ops().context, *this, node_index, when);
+}
+
+void GraphView::set_child_schedule_observer(void (*observer)(void *, DateTime),
+                                            void *observer_context) const {
+  if (ops().set_child_schedule_observer_impl == nullptr) {
+    throw std::logic_error(
+        "set_child_schedule_observer requires a nested child graph");
+  }
+  ops().set_child_schedule_observer_impl(ops().context, data(), observer,
+                                         observer_context);
 }
 
 const GraphOps &GraphView::ops() const { return type().ops_ref(); }

--- a/src/hgraph/runtime/map_node.cpp
+++ b/src/hgraph/runtime/map_node.cpp
@@ -36,6 +36,26 @@ namespace hgraph
         {
             MapNodeStorage *storage{nullptr};
             std::size_t     slot{0};
+            // The current PULL-side heap entry for this child. Repeated outer
+            // input visits often observe the same future child deadline;
+            // coalesce those observations instead of growing the lazy heap
+            // per tick. Push-side observations remain distinct because one
+            // child graph may schedule multiple internal nodes.
+            DateTime pulled_when{MAX_DT};
+        };
+
+        struct MapChildSchedule
+        {
+            DateTime    when{MAX_DT};
+            std::size_t slot{0};
+            bool        pulled{false};
+
+            [[nodiscard]] bool operator>(const MapChildSchedule &other) const noexcept
+            {
+                if (when != other.when) { return when > other.when; }
+                if (slot != other.slot) { return slot > other.slot; }
+                return pulled > other.pulled;
+            }
         };
 
         struct MapKeyEntry
@@ -108,13 +128,34 @@ namespace hgraph
             // out-of-band hook and the evaluation loop's future schedules.
             // Entries are LAZY: a stale (rescheduled, stopped, or removed)
             // slot pops harmlessly — the evaluation loop re-checks due-ness.
-            std::vector<std::pair<DateTime, std::size_t>> child_schedule_queue{};
+            std::vector<MapChildSchedule> child_schedule_queue{};
 
-            void push_child_schedule(DateTime when, std::size_t slot)
+            void push_child_schedule(MapChildSchedule schedule)
             {
-                child_schedule_queue.emplace_back(when, slot);
+                child_schedule_queue.push_back(schedule);
                 std::push_heap(child_schedule_queue.begin(), child_schedule_queue.end(),
                                std::greater<>{});
+            }
+
+            void push_observed_child_schedule(DateTime when,
+                                              const MapChildScheduleContext &schedule)
+            {
+                if (schedule.storage != this)
+                {
+                    return;
+                }
+                push_child_schedule(MapChildSchedule{when, schedule.slot, false});
+            }
+
+            void push_pulled_child_schedule(DateTime when,
+                                            MapChildScheduleContext &schedule)
+            {
+                if (schedule.storage != this || schedule.pulled_when == when)
+                {
+                    return;
+                }
+                schedule.pulled_when = when;
+                push_child_schedule(MapChildSchedule{when, schedule.slot, true});
             }
 
             [[nodiscard]] std::size_t active_count() const noexcept
@@ -398,6 +439,7 @@ namespace hgraph
             if (entry->graph.has_value() && entry->graph.view().started()) {
                 entry->graph.view().stop(evaluation_time);
             }
+            entry->schedule_context.pulled_when = MAX_DT;
             if (output_mutation != nullptr) { (void)output_mutation->erase(entry->key.view()); }
             if (error_mutation != nullptr && error_mutation->contains(entry->key.view()))
             {
@@ -473,7 +515,7 @@ namespace hgraph
             entry.graph.view().set_child_schedule_observer(
                 [](void *context, DateTime when) {
                     auto *schedule = static_cast<MapChildScheduleContext *>(context);
-                    schedule->storage->push_child_schedule(when, schedule->slot);
+                    schedule->storage->push_observed_child_schedule(when, *schedule);
                 },
                 &entry.schedule_context);
             schedule_sampled_input_consumers(
@@ -841,12 +883,27 @@ namespace hgraph
             // cycle). Stale entries pop harmlessly: the evaluation loop
             // re-checks each child's due-ness.
             while (!storage.child_schedule_queue.empty() &&
-                   storage.child_schedule_queue.front().first <= evaluation_time)
+                   storage.child_schedule_queue.front().when <= evaluation_time)
             {
                 std::pop_heap(storage.child_schedule_queue.begin(),
                               storage.child_schedule_queue.end(), std::greater<>{});
-                add_map_evaluation_slot(storage, storage.child_schedule_queue.back().second);
+                const MapChildSchedule schedule =
+                    storage.child_schedule_queue.back();
                 storage.child_schedule_queue.pop_back();
+                auto *entry = storage.entry_at(schedule.slot);
+                if (entry == nullptr)
+                {
+                    continue;
+                }
+                if (schedule.pulled)
+                {
+                    if (entry->schedule_context.pulled_when != schedule.when)
+                    {
+                        continue;
+                    }
+                    entry->schedule_context.pulled_when = MAX_DT;
+                }
+                add_map_evaluation_slot(storage, schedule.slot);
             }
 
             // With no outer input event the parent was woken by a nested
@@ -967,8 +1024,15 @@ namespace hgraph
                     // the child land in the queue here; the out-of-band
                     // observer covers schedules arriving between map
                     // evaluations.
-                    storage.push_child_schedule(next, slot);
+                    storage.push_pulled_child_schedule(
+                        next, entry->schedule_context);
                     view.graph().schedule_node(view.node_index(), next);
+                }
+                else
+                {
+                    // Invalidate a lazy entry when the child consumed or
+                    // cancelled its previous deadline.
+                    entry->schedule_context.pulled_when = MAX_DT;
                 }
             }
             storage.resume_position_plus_one = 0;
@@ -977,6 +1041,38 @@ namespace hgraph
             storage.selective_repoint_bindings = false;
             storage.membership_changed_keys.clear();
             storage.repoint_modified_keys.clear();
+            // Current-cycle observer callbacks can enqueue a due entry after
+            // the queue was drained at the start of this evaluation (for
+            // example while a newly created child samples a valid config
+            // input). Do not let that stale minimum replace the future
+            // deadline propagated by the child.
+            while (!storage.child_schedule_queue.empty() &&
+                   storage.child_schedule_queue.front().when <= evaluation_time)
+            {
+                std::pop_heap(storage.child_schedule_queue.begin(),
+                              storage.child_schedule_queue.end(), std::greater<>{});
+                const MapChildSchedule schedule =
+                    storage.child_schedule_queue.back();
+                storage.child_schedule_queue.pop_back();
+                if (schedule.pulled)
+                {
+                    auto *entry = storage.entry_at(schedule.slot);
+                    if (entry != nullptr &&
+                        entry->schedule_context.pulled_when == schedule.when)
+                    {
+                        entry->schedule_context.pulled_when = MAX_DT;
+                    }
+                }
+            }
+            if (!storage.child_schedule_queue.empty())
+            {
+                // The heap, rather than the sparse candidate set, owns the
+                // earliest child wake-up. Re-arm from its minimum so a
+                // future child that was not input-driven this cycle cannot be
+                // hidden by another candidate's later deadline.
+                view.graph().schedule_node(
+                    view.node_index(), storage.child_schedule_queue.front().when);
+            }
             return true;
         }
 

--- a/src/hgraph/runtime/map_node.cpp
+++ b/src/hgraph/runtime/map_node.cpp
@@ -13,6 +13,7 @@
 #include <array>
 #include <bit>
 #include <cstddef>
+#include <functional>
 #include <memory>
 #include <optional>
 #include <stdexcept>
@@ -26,6 +27,17 @@ namespace hgraph
     {
         constexpr std::string_view map_storage_field_name{"map"};
 
+        struct MapNodeStorage;
+
+        /** Stable per-entry context for the out-of-band child schedule
+            observer: identifies WHICH slot became due (the nested hook only
+            knows when). */
+        struct MapChildScheduleContext
+        {
+            MapNodeStorage *storage{nullptr};
+            std::size_t     slot{0};
+        };
+
         struct MapKeyEntry
         {
             explicit MapKeyEntry(Value key_)
@@ -36,9 +48,11 @@ namespace hgraph
             // Declaration order is load-bearing: members destroy in reverse, and
             // the child graph's inputs are subscribed to ``key_source`` — the
             // graph (the subscriber) must tear down BEFORE the source it
-            // observes.
+            // observes (and before ``schedule_context``, which the graph's
+            // installed observer points at).
             Value                          key{};
             runtime_detail::MappedKeySource key_source{};
+            MapChildScheduleContext        schedule_context{};
             GraphValue                     graph{};
         };
 
@@ -89,7 +103,19 @@ namespace hgraph
             SlotBitmap              evaluation_candidates{};
             std::vector<std::size_t> evaluation_slots{};
             std::size_t              resume_position_plus_one{0};
-            bool                     has_future_child_schedule{false};
+            // Priority queue of (when, slot) child schedules — a min-heap
+            // popped for due slots each evaluation, fed by the nested
+            // out-of-band hook and the evaluation loop's future schedules.
+            // Entries are LAZY: a stale (rescheduled, stopped, or removed)
+            // slot pops harmlessly — the evaluation loop re-checks due-ness.
+            std::vector<std::pair<DateTime, std::size_t>> child_schedule_queue{};
+
+            void push_child_schedule(DateTime when, std::size_t slot)
+            {
+                child_schedule_queue.emplace_back(when, slot);
+                std::push_heap(child_schedule_queue.begin(), child_schedule_queue.end(),
+                               std::greater<>{});
+            }
 
             [[nodiscard]] std::size_t active_count() const noexcept
             {
@@ -439,6 +465,17 @@ namespace hgraph
                                                      key_source,
                                                      spec.output_binding_mode);
             entry.graph.view().start(evaluation_time);
+            // Out-of-band child schedules (a notification or scheduler firing
+            // while the child is idle between map evaluations) report into
+            // the schedule queue so the input-event fast path knows the slot
+            // is due (issue #175).
+            entry.schedule_context = MapChildScheduleContext{&storage, slot};
+            entry.graph.view().set_child_schedule_observer(
+                [](void *context, DateTime when) {
+                    auto *schedule = static_cast<MapChildScheduleContext *>(context);
+                    schedule->storage->push_child_schedule(when, schedule->slot);
+                },
+                &entry.schedule_context);
             schedule_sampled_input_consumers(
                 entry.graph.view(), evaluation_time, spec.child.input_bindings);
             rollback.release();
@@ -731,8 +768,7 @@ namespace hgraph
             auto root_input = view.input(evaluation_time);
             auto keys_input = root_input.indexed_child_at(*context.spec.keys_input_index);
             bool input_event = keys_input.modified();
-            bool full_scan = storage.refresh_all_bindings || !was_primed ||
-                             storage.has_future_child_schedule;
+            bool full_scan = storage.refresh_all_bindings || !was_primed;
 
             for (const MapArgSource &arg : context.spec.args)
             {
@@ -797,37 +833,33 @@ namespace hgraph
                 }
             }
 
+            // Children DUE by their own internal schedules (a service
+            // response delivery, a scheduler alarm) pop from the schedule
+            // queue — the fast path must not starve them when an outer tick
+            // coincides with the wake-up cycle (issue #175: a request-reply
+            // response dropped when a new key arrived in the delivery
+            // cycle). Stale entries pop harmlessly: the evaluation loop
+            // re-checks each child's due-ness.
+            while (!storage.child_schedule_queue.empty() &&
+                   storage.child_schedule_queue.front().first <= evaluation_time)
+            {
+                std::pop_heap(storage.child_schedule_queue.begin(),
+                              storage.child_schedule_queue.end(), std::greater<>{});
+                add_map_evaluation_slot(storage, storage.child_schedule_queue.back().second);
+                storage.child_schedule_queue.pop_back();
+            }
+
             // With no outer input event the parent was woken by a nested
-            // child's own scheduler or dependency; its identity is not encoded
-            // in the graph schedule table, so retain the conservative scan.
+            // child's own dependency (e.g. a mesh resume); its identity is
+            // not encoded in the graph schedule table, so retain the
+            // conservative scan.
             if (!input_event) { full_scan = true; }
             if (full_scan)
             {
                 storage.evaluation_slots.clear();
                 collect_all_map_evaluation_slots(storage);
-                materialize_map_evaluation_slots(storage);
             }
-            else
-            {
-                // The input-event fast path must not starve a child that is
-                // DUE by its own internal schedule (a service response
-                // delivery, a scheduler alarm): when an outer tick coincides
-                // with the child's wake-up cycle, missing it here loses the
-                // wake-up permanently (issue #175 — a request-reply response
-                // dropped when a new key arrived in the delivery cycle).
-                for (std::size_t slot = 0; slot < storage.entries.slot_capacity(); ++slot)
-                {
-                    const MapKeyEntry *entry = storage.entry_at(slot);
-                    if (entry == nullptr || !entry->graph.has_value()) { continue; }
-                    const DateTime next = entry->graph.view().next_scheduled_time();
-                    if (next != MAX_DT && next <= evaluation_time)
-                    {
-                        add_map_evaluation_slot(storage, slot);
-                    }
-                }
-                materialize_map_evaluation_slots(storage);
-            }
-            storage.has_future_child_schedule = false;
+            materialize_map_evaluation_slots(storage);
         }
 
         void write_map_error(const NodeView &view, const NodeView &failed_node,
@@ -931,7 +963,11 @@ namespace hgraph
                 }
                 if (const DateTime next = child.next_scheduled_time(); next != MAX_DT && next > evaluation_time)
                 {
-                    storage.has_future_child_schedule = true;
+                    // The PULL half: schedules created while the map drove
+                    // the child land in the queue here; the out-of-band
+                    // observer covers schedules arriving between map
+                    // evaluations.
+                    storage.push_child_schedule(next, slot);
                     view.graph().schedule_node(view.node_index(), next);
                 }
             }
@@ -963,7 +999,7 @@ namespace hgraph
             storage.repoint_modified_keys.clear();
             storage.evaluation_slots.clear();
             storage.resume_position_plus_one = 0;
-            storage.has_future_child_schedule = false;
+            storage.child_schedule_queue.clear();
         }
 
         void validate_map_node_spec(const NodeTypeMetaData &meta, const MapNodeSpec &spec)

--- a/src/hgraph/runtime/map_node.cpp
+++ b/src/hgraph/runtime/map_node.cpp
@@ -1026,7 +1026,6 @@ namespace hgraph
                     // evaluations.
                     storage.push_pulled_child_schedule(
                         next, entry->schedule_context);
-                    view.graph().schedule_node(view.node_index(), next);
                 }
                 else
                 {

--- a/src/hgraph/runtime/map_node.cpp
+++ b/src/hgraph/runtime/map_node.cpp
@@ -809,6 +809,22 @@ namespace hgraph
             }
             else
             {
+                // The input-event fast path must not starve a child that is
+                // DUE by its own internal schedule (a service response
+                // delivery, a scheduler alarm): when an outer tick coincides
+                // with the child's wake-up cycle, missing it here loses the
+                // wake-up permanently (issue #175 — a request-reply response
+                // dropped when a new key arrived in the delivery cycle).
+                for (std::size_t slot = 0; slot < storage.entries.slot_capacity(); ++slot)
+                {
+                    const MapKeyEntry *entry = storage.entry_at(slot);
+                    if (entry == nullptr || !entry->graph.has_value()) { continue; }
+                    const DateTime next = entry->graph.view().next_scheduled_time();
+                    if (next != MAX_DT && next <= evaluation_time)
+                    {
+                        add_map_evaluation_slot(storage, slot);
+                    }
+                }
                 materialize_map_evaluation_slots(storage);
             }
             storage.has_future_child_schedule = false;

--- a/src/hgraph/runtime/mesh_node.cpp
+++ b/src/hgraph/runtime/mesh_node.cpp
@@ -5,6 +5,7 @@
 #include <hgraph/types/metadata/type_registry.h>
 #include <hgraph/types/metadata/value_plan_factory.h>
 #include <hgraph/types/utils/key_slot_store.h>
+#include <hgraph/types/utils/slot_bitmap.h>
 #include <hgraph/util/date_time.h>
 #include <hgraph/util/scope.h>
 
@@ -15,7 +16,9 @@
 
 #include <algorithm>
 #include <array>
+#include <bit>
 #include <cstddef>
+#include <functional>
 #include <memory>
 #include <optional>
 #include <stdexcept>
@@ -58,14 +61,45 @@ struct ValueKeyEqual {
 using ValueSet =
     ankerl::unordered_dense::set<Value, ValueKeyHash, ValueKeyEqual>;
 
+struct MeshNodeStorage;
+
+/** Stable per-instance context for the out-of-band child schedule observer. */
+struct MeshChildScheduleContext {
+  MeshNodeStorage *storage{nullptr};
+  std::size_t slot{0};
+  NodePtr parent_node{};
+  // Coalesce repeated pull observations of the same retained child deadline.
+  // Push observations remain distinct because one child graph may schedule
+  // multiple internal nodes.
+  DateTime pulled_when{MAX_DT};
+};
+
+struct MeshChildSchedule {
+  DateTime when{MAX_DT};
+  std::size_t slot{0};
+  bool pulled{false};
+
+  [[nodiscard]] bool operator>(const MeshChildSchedule &other) const noexcept {
+    if (when != other.when) {
+      return when > other.when;
+    }
+    if (slot != other.slot) {
+      return slot > other.slot;
+    }
+    return pulled > other.pulled;
+  }
+};
+
 // One mesh instance. Declaration order is load-bearing (reverse
 // destruction): the child graph (a subscriber to key_source) tears down
-// before the key source it observes.
+// before the key source it observes and the schedule-observer context it
+// references.
 struct MeshEntry {
   explicit MeshEntry(Value key_) : key(std::move(key_)) {}
 
   Value key{};
   runtime_detail::MappedKeySource key_source{};
+  MeshChildScheduleContext schedule_context{};
   GraphValue graph{};
   int rank{0};
   // Pause/resume settle state, per cycle:
@@ -114,19 +148,60 @@ struct MeshNodeStorage final : SlotObserver {
   TSOutputHandle observed_requested_keys_source{};
   bool observing_requested_keys{false};
   bool requested_keys_source_cleared{false};
+  // Cached effective outer sources detect forwarding/repoint changes that
+  // require every surviving child boundary to be rebound.
+  std::vector<TSOutputHandle> outer_sources{};
+  bool refresh_all_bindings{false};
   // depends_on -> set of keys that depend on it (reverse edges).
   ankerl::unordered_dense::map<Value, ValueSet, ValueKeyHash, ValueKeyEqual>
       dependents{};
 
   std::vector<Value>
       graphs_to_remove{}; // lost a dependent; remove if unreferenced
+  // Ordinary input notifications and internal child schedules identify a
+  // sparse worklist. Only those slots need dependency-rank ordering.
+  SlotBitmap evaluation_candidates{};
   std::vector<std::pair<int, std::size_t>> evaluation_order{};
+  // Min-heap of child wake-ups, fed by the nested out-of-band observer and by
+  // the pull after mesh-driven child evaluation.
+  std::vector<MeshChildSchedule> child_schedule_queue{};
   int max_rank{0};
   bool primed{false};
   // The instance whose child graph is currently being evaluated; a
   // mesh_subscribe inside it reads this as its "my_key" (the requester).
   ValuePtr current_eval_key{};
   DateTime retirement_time{MIN_DT};
+
+  void push_child_schedule(MeshChildSchedule schedule) {
+    child_schedule_queue.push_back(schedule);
+    std::push_heap(child_schedule_queue.begin(), child_schedule_queue.end(),
+                   std::greater<>{});
+  }
+
+  void push_observed_child_schedule(DateTime when,
+                                    const MeshChildScheduleContext &schedule) {
+    if (schedule.storage != this) {
+      return;
+    }
+    const NodeView parent{schedule.parent_node};
+    if (parent.valid() && when <= parent.graph().evaluation_time()) {
+      // Current-cycle notifications already identify their slot. Recording
+      // them directly avoids two heap operations per child on broadcast
+      // ticks while future deadlines still use the priority queue.
+      evaluation_candidates.set(schedule.slot);
+      return;
+    }
+    push_child_schedule(MeshChildSchedule{when, schedule.slot, false});
+  }
+
+  void push_pulled_child_schedule(DateTime when,
+                                  MeshChildScheduleContext &schedule) {
+    if (schedule.storage != this || schedule.pulled_when == when) {
+      return;
+    }
+    schedule.pulled_when = when;
+    push_child_schedule(MeshChildSchedule{when, schedule.slot, true});
+  }
 
   void initialise(const ValueTypeRef &key_binding,
                   MemoryUtils::StorageLayout graph_layout) {
@@ -186,6 +261,11 @@ struct MeshNodeStorage final : SlotObserver {
     entries.destroy_all();
     dependents.clear();
     graphs_to_remove.clear();
+    outer_sources.clear();
+    refresh_all_bindings = false;
+    evaluation_candidates.reset();
+    evaluation_order.clear();
+    child_schedule_queue.clear();
     max_rank = 0;
     primed = false;
     current_eval_key = {};
@@ -213,6 +293,10 @@ struct MeshNodeStorage final : SlotObserver {
     if (!instance_keys.has_value() || !instance_keys->slot_live(slot)) {
       return;
     }
+    if (MeshEntry *entry = entries.entry_at(slot); entry != nullptr) {
+      entry->schedule_context.pulled_when = MAX_DT;
+    }
+    evaluation_candidates.reset(slot);
     retirement_time = evaluation_time;
     static_cast<void>(instance_keys->remove_slot(slot));
   }
@@ -228,12 +312,17 @@ struct MeshNodeStorage final : SlotObserver {
 
   void on_capacity(std::size_t, std::size_t new_capacity) override {
     entries.reserve_to(new_capacity);
+    evaluation_candidates.resize(new_capacity);
   }
 
   void on_insert(std::size_t) override {}
 
   void on_remove(std::size_t slot) override {
     MeshEntry *entry = entries.entry_at(slot);
+    evaluation_candidates.reset(slot);
+    if (entry != nullptr) {
+      entry->schedule_context.pulled_when = MAX_DT;
+    }
     if (entry != nullptr && entry->graph.has_value() &&
         entry->graph.view().started()) {
       static_cast<void>(fallback_on_exception(false, [&] {
@@ -244,7 +333,10 @@ struct MeshNodeStorage final : SlotObserver {
   }
 
   void on_erase(std::size_t slot) override { entries.destroy_at(slot); }
-  void on_clear() override { entries.destroy_all(); }
+  void on_clear() override {
+    evaluation_candidates.reset();
+    entries.destroy_all();
+  }
 };
 
 struct MeshNodeContext {
@@ -373,6 +465,177 @@ MeshNodeStorage &storage_of(const NodeView &view,
   return current;
 }
 
+[[nodiscard]] bool update_mesh_source_handles(const TSInputView &root_input,
+                                              MeshNodeStorage &storage,
+                                              std::size_t keys_input_index) {
+  const std::size_t outer_count = root_input.as_bundle().size();
+  const bool initialized = storage.outer_sources.size() == outer_count;
+  storage.outer_sources.resize(outer_count);
+
+  bool changed = false;
+  for (std::size_t index = 0; index < outer_count; ++index) {
+    TSOutputHandle current = effective_output_handle(
+        root_input.indexed_child_at(index).bound_output());
+    if (!current.same_as(storage.outer_sources[index])) {
+      storage.outer_sources[index] = current;
+      if (initialized && index != keys_input_index) {
+        changed = true;
+      }
+    }
+  }
+  return changed;
+}
+
+void add_mesh_evaluation_slot(MeshNodeStorage &storage, std::size_t slot) {
+  if (!storage.instance_keys.has_value() || slot == KeySlotStore::npos ||
+      !storage.instance_keys->slot_live(slot) ||
+      storage.entries.entry_at(slot) == nullptr) {
+    return;
+  }
+  storage.evaluation_candidates.set(slot);
+}
+
+void collect_all_mesh_evaluation_slots(MeshNodeStorage &storage) {
+  if (!storage.instance_keys.has_value()) {
+    return;
+  }
+  for (std::size_t slot = 0; slot < storage.instance_keys->slot_capacity();
+       ++slot) {
+    add_mesh_evaluation_slot(storage, slot);
+  }
+}
+
+[[nodiscard]] bool drain_due_mesh_schedules(MeshNodeStorage &storage,
+                                            DateTime evaluation_time) {
+  bool added = false;
+  while (!storage.child_schedule_queue.empty() &&
+         storage.child_schedule_queue.front().when <= evaluation_time) {
+    std::pop_heap(storage.child_schedule_queue.begin(),
+                  storage.child_schedule_queue.end(), std::greater<>{});
+    const MeshChildSchedule schedule = storage.child_schedule_queue.back();
+    storage.child_schedule_queue.pop_back();
+
+    MeshEntry *entry = storage.entries.entry_at(schedule.slot);
+    if (entry == nullptr || !storage.instance_keys.has_value() ||
+        !storage.instance_keys->slot_live(schedule.slot)) {
+      continue;
+    }
+    if (schedule.pulled) {
+      if (entry->schedule_context.pulled_when != schedule.when) {
+        continue;
+      }
+      entry->schedule_context.pulled_when = MAX_DT;
+    }
+    add_mesh_evaluation_slot(storage, schedule.slot);
+    added = true;
+  }
+  return added;
+}
+
+void materialize_mesh_evaluation_order(MeshNodeStorage &storage) {
+  auto &order = storage.evaluation_order;
+  order.clear();
+  order.reserve(storage.evaluation_candidates.count());
+  for (std::size_t word_index = 0;
+       word_index < storage.evaluation_candidates.word_count(); ++word_index) {
+    std::uint64_t word = storage.evaluation_candidates.words[word_index];
+    while (word != 0) {
+      const auto bit = static_cast<std::size_t>(std::countr_zero(word));
+      const std::size_t slot = word_index * SlotBitmap::bits_per_word + bit;
+      if (storage.instance_keys.has_value() &&
+          storage.instance_keys->slot_live(slot)) {
+        if (MeshEntry *entry = storage.entries.entry_at(slot);
+            entry != nullptr) {
+          order.emplace_back(entry->rank, slot);
+        }
+      }
+      word &= word - 1;
+    }
+  }
+  std::sort(order.begin(), order.end(), [](const auto &a, const auto &b) {
+    if (a.first != b.first) {
+      return a.first < b.first;
+    }
+    return a.second < b.second;
+  });
+}
+
+void prepare_mesh_evaluation_candidates(const NodeView &view,
+                                        const MeshNodeContext &context,
+                                        MeshNodeStorage &storage,
+                                        DateTime evaluation_time) {
+  auto root_input = view.input(evaluation_time);
+  bool input_event = false;
+  storage.refresh_all_bindings = update_mesh_source_handles(
+      root_input.borrowed_ref(), storage, context.spec.keys_input_index);
+
+  const auto root_bundle = root_input.as_bundle();
+  for (std::size_t index = 0; index < root_bundle.size(); ++index) {
+    auto input = root_input.indexed_child_at(index);
+    if (!input.modified()) {
+      continue;
+    }
+    input_event = true;
+  }
+
+  for (const MapArgSource &arg : context.spec.args) {
+    if (arg.kind != MapArgSourceKind::OuterInput) {
+      continue;
+    }
+    auto input = root_input.indexed_child_at(arg.outer_index);
+    if (!input.modified()) {
+      continue;
+    }
+    const auto *schema = input.schema();
+    if (schema != nullptr &&
+        (schema->kind == TSTypeKind::TSB || schema->kind == TSTypeKind::TSL)) {
+      // A structured forwarding boundary may preserve its root handle while
+      // projected leaf endpoints move.
+      storage.refresh_all_bindings = true;
+    }
+  }
+
+  // Multiplexed membership changes can replace or remove an element endpoint.
+  // Explicitly select those keys so their child boundaries are rebound even
+  // if the old element produced no notification.
+  for (const std::size_t mux_index : context.spec.multiplexed_inputs) {
+    if (mux_index >= storage.outer_sources.size()) {
+      continue;
+    }
+    const TSOutputHandle &source = storage.outer_sources[mux_index];
+    if (!source.bound()) {
+      continue;
+    }
+    auto source_data = source.data_view();
+    if (!source_data.valid()) {
+      if (root_input.indexed_child_at(mux_index).modified()) {
+        storage.refresh_all_bindings = true;
+      }
+      continue;
+    }
+    auto dict = source_data.as_dict();
+    if (!dict.modified(evaluation_time)) {
+      continue;
+    }
+    for (const ValueView &key : dict.modified_keys(evaluation_time)) {
+      add_mesh_evaluation_slot(storage, storage.find_slot(key));
+    }
+    for (const ValueView &key : dict.added_keys()) {
+      add_mesh_evaluation_slot(storage, storage.find_slot(key));
+    }
+    for (const ValueView &key : dict.removed_keys()) {
+      add_mesh_evaluation_slot(storage, storage.find_slot(key));
+    }
+  }
+
+  static_cast<void>(drain_due_mesh_schedules(storage, evaluation_time));
+
+  if (storage.refresh_all_bindings ||
+      (!input_event && !storage.evaluation_candidates.any())) {
+    collect_all_mesh_evaluation_slots(storage);
+  }
+}
+
 const MeshSubscribeContext &mesh_subscribe_context_of(const NodeView &view) {
   const NodeTypeRef type = view.type();
   if (!type) {
@@ -485,6 +748,10 @@ void stop_and_clear_all_instances(const NodeView &view,
   }
   storage.dependents.clear();
   storage.graphs_to_remove.clear();
+  storage.evaluation_candidates.reset();
+  storage.evaluation_order.clear();
+  storage.child_schedule_queue.clear();
+  storage.refresh_all_bindings = false;
   storage.max_rank = 0;
   storage.primed = false;
   storage.current_eval_key = {};
@@ -544,9 +811,20 @@ MeshEntry &create_instance(const NodeView &view, const MeshNodeContext &context,
 
   bind_instance_inputs(view, context, entry, evaluation_time, true);
   bind_instance_output(view, context, entry, evaluation_time);
+  entry.schedule_context =
+      MeshChildScheduleContext{&storage, slot, view.pointer()};
+  entry.graph.view().set_child_schedule_observer(
+      [](void *raw_context, DateTime when) {
+        auto *schedule = static_cast<MeshChildScheduleContext *>(raw_context);
+        if (schedule->storage != nullptr) {
+          schedule->storage->push_observed_child_schedule(when, *schedule);
+        }
+      },
+      &entry.schedule_context);
   entry.graph.view().start(evaluation_time);
   schedule_sampled_input_consumers(entry.graph.view(), evaluation_time,
                                    spec.child.input_bindings);
+  add_mesh_evaluation_slot(storage, slot);
   rollback.release();
 
   storage.max_rank = std::max(storage.max_rank, rank);
@@ -755,36 +1033,21 @@ bool mesh_evaluate_impl(const void *, const NodeView &view,
   // 2. Removals queued because a dependent went away (remove_dependency).
   process_graphs_to_remove(view, context, storage, evaluation_time);
 
-  // 3. Settle loop (pause/resume). Evaluate instances in dependency-rank order,
-  //    re-scanning until none pauses. A pause has, via add_dependency, created
-  //    and/or ranked the missing dependency below the requester; a later pass
-  //    evaluates that dependency first and then resumes the paused instance —
-  //    so the whole transitive closure settles within this cycle.
-  DateTime next_time = MAX_DT;
-  bool progress = true;
+  // 3. Settle loop (pause/resume). Only children selected by an input
+  //    notification, creation, pause, or internal schedule enter the worklist.
+  //    Those candidates still evaluate in dependency-rank order, and a pause
+  //    can add/rank a missing dependency for the next pass.
+  prepare_mesh_evaluation_candidates(view, context, storage, evaluation_time);
+
   std::size_t guard = 0;
-  while (progress) {
-    progress = false;
+  while (true) {
+    static_cast<void>(drain_due_mesh_schedules(storage, evaluation_time));
+    // Snapshot candidate slots by rank. add_dependency can create or re-rank
+    // instances mid-pass, so the next pass rematerializes this order.
+    materialize_mesh_evaluation_order(storage);
+    bool evaluated = false;
 
-    // Snapshot stable slots by rank: add_dependency can create
-    // instances mid-pass, but existing slot addresses never move.
-    auto &order = storage.evaluation_order;
-    order.clear();
-    order.reserve(storage.active_count());
-    for (std::size_t slot = 0; slot < storage.instance_keys->slot_capacity();
-         ++slot) {
-      if (!storage.instance_keys->slot_live(slot)) {
-        continue;
-      }
-      MeshEntry *entry = storage.entries.entry_at(slot);
-      if (entry != nullptr) {
-        order.emplace_back(entry->rank, slot);
-      }
-    }
-    std::sort(order.begin(), order.end(),
-              [](const auto &a, const auto &b) { return a.first < b.first; });
-
-    for (const auto &ranked : order) {
+    for (const auto &ranked : storage.evaluation_order) {
       MeshEntry *entry = storage.entries.entry_at(ranked.second);
       if (!storage.instance_keys->slot_live(ranked.second)) {
         continue;
@@ -801,11 +1064,14 @@ bool mesh_evaluate_impl(const void *, const NodeView &view,
 
       auto child = entry->graph.view();
       const DateTime child_next = child.next_scheduled_time();
-      if (child_next != MAX_DT && child_next > evaluation_time) {
-        next_time = std::min(next_time, child_next);
-      }
       const bool due = child_next <= evaluation_time;
       if (!due && !entry->paused) {
+        if (child_next != MAX_DT) {
+          storage.push_pulled_child_schedule(child_next,
+                                             entry->schedule_context);
+        } else {
+          entry->schedule_context.pulled_when = MAX_DT;
+        }
         continue;
       }
 
@@ -822,11 +1088,13 @@ bool mesh_evaluate_impl(const void *, const NodeView &view,
       } else {
         entry->paused = true;
       } // a dependency was created / ranked; re-scan
-      progress = true;
+      evaluated = true;
 
       if (const DateTime next = child.next_scheduled_time();
           next != MAX_DT && next > evaluation_time) {
-        next_time = std::min(next_time, next);
+        storage.push_pulled_child_schedule(next, entry->schedule_context);
+      } else {
+        entry->schedule_context.pulled_when = MAX_DT;
       }
     }
 
@@ -860,12 +1128,30 @@ bool mesh_evaluate_impl(const void *, const NodeView &view,
       throw std::runtime_error(
           fmt::format("mesh_ failed to settle within the cycle: {}", detail));
     }
+
+    // Output propagation or an input rebind may have scheduled another child
+    // while this rank snapshot was being processed. Pull those callbacks into
+    // the next pass even when no prior candidate evaluated.
+    const bool added_during_pass =
+        drain_due_mesh_schedules(storage, evaluation_time);
+    if (!evaluated && !added_during_pass) {
+      break;
+    }
   }
   storage.current_eval_key = {};
   process_graphs_to_remove(view, context, storage, evaluation_time);
+  storage.evaluation_candidates.reset();
+  storage.evaluation_order.clear();
+  storage.refresh_all_bindings = false;
 
-  if (next_time < MAX_DT) {
-    view.graph().schedule_node(view.node_index(), next_time);
+  // Current-cycle observer callbacks can arrive after the queue was drained at
+  // the start of a pass (for example while a new child samples valid config).
+  // Purge them before the minimum future deadline re-arms the mesh parent.
+  static_cast<void>(drain_due_mesh_schedules(storage, evaluation_time));
+  storage.evaluation_candidates.reset();
+  if (!storage.child_schedule_queue.empty()) {
+    view.graph().schedule_node(view.node_index(),
+                               storage.child_schedule_queue.front().when);
   }
   return true;
 }

--- a/tests/cpp/test_service_wiring.cpp
+++ b/tests/cpp/test_service_wiring.cpp
@@ -1833,6 +1833,30 @@ TEST_CASE("service wiring: request/reply switch flip removes an invalid map outp
             dict_delta<Int, TS<Int>>({{1, 5}})));
 }
 
+TEST_CASE("service wiring: a mapped response survives a new key in its delivery cycle")
+{
+    hgraph::stdlib::register_standard_operators();
+
+    // Issue #175: key 2 arrives EXACTLY in key 1's response-delivery cycle.
+    // The map's input-event fast path must still evaluate the child that is
+    // due by its own internal schedule — the wake-up was previously lost and
+    // key 1's response never arrived at all. (Key 2 one cycle later is the
+    // neighbouring test's shape and always worked.)
+    CHECK_OUTPUT(
+        eval_node<MappedRequestReplySwitchMapGraph>(
+            values<Value>(dict_delta<Int, TS<Int>>({{1, 4}}),
+                          none,
+                          dict_delta<Int, TS<Int>>({{2, 10}}),
+                          none,
+                          none),
+            values<Str>(Str{"alpha"}, none, none, none, none)),
+        values<Value>(dict_delta<Int, TS<Int>>({}),
+                      none,
+                      dict_delta<Int, TS<Int>>({{1, 5}}),
+                      none,
+                      dict_delta<Int, TS<Int>>({{2, 11}})));
+}
+
 TEST_CASE("service wiring: subscription under map switch retains late keys")
 {
     hgraph::stdlib::register_standard_operators();

--- a/tests/cpp/test_service_wiring.cpp
+++ b/tests/cpp/test_service_wiring.cpp
@@ -1235,6 +1235,24 @@ namespace
         }
     };
 
+    struct MeshedRequestReplySwitchGraph
+    {
+        [[maybe_unused]] static constexpr auto name =
+            "meshed_request_reply_switch_graph";
+
+        static Port<TSD<Int, TS<Int>>> compose(
+            Wiring &w, Port<TSD<Int, TS<Int>>> values,
+            Port<TS<Str>> selector)
+        {
+            service::register_request_reply_service<AddOneService, AddOneImplNode>(
+                w, service::path("mapped_switch_request_reply"));
+            return wire<stdlib::mesh_>(
+                       w, fn<MappedRequestReplySwitchFunction>(),
+                       values, selector)
+                .as<TSD<Int, TS<Int>>>();
+        }
+    };
+
     struct MappedSubscriptionSwitchFunction
     {
         [[maybe_unused]] static constexpr auto name =
@@ -1844,6 +1862,27 @@ TEST_CASE("service wiring: a mapped response survives a new key in its delivery 
     // neighbouring test's shape and always worked.)
     CHECK_OUTPUT(
         eval_node<MappedRequestReplySwitchMapGraph>(
+            values<Value>(dict_delta<Int, TS<Int>>({{1, 4}}),
+                          none,
+                          dict_delta<Int, TS<Int>>({{2, 10}}),
+                          none,
+                          none),
+            values<Str>(Str{"alpha"}, none, none, none, none)),
+        values<Value>(dict_delta<Int, TS<Int>>({}),
+                      none,
+                      dict_delta<Int, TS<Int>>({{1, 5}}),
+                      none,
+                      dict_delta<Int, TS<Int>>({{2, 11}})));
+}
+
+TEST_CASE("service wiring: a meshed response survives a new key in its delivery cycle")
+{
+    hgraph::stdlib::register_standard_operators();
+
+    // The mesh worklist must merge a child due by its own internal schedule
+    // with a different child created by the outer key tick in the same cycle.
+    CHECK_OUTPUT(
+        eval_node<MeshedRequestReplySwitchGraph>(
             values<Value>(dict_delta<Int, TS<Int>>({{1, 4}}),
                           none,
                           dict_delta<Int, TS<Int>>({{2, 10}}),

--- a/tools/parity/corpus/issue-175-map-response-delivery-vs-new-key.json
+++ b/tools/parity/corpus/issue-175-map-response-delivery-vs-new-key.json
@@ -1,0 +1,41 @@
+{
+  "description": "Issue #175: a map_ child due by its own internal schedule (request-reply response delivery) must evaluate even when an outer input ticks the same cycle \u2014 the input-event fast path starved it and the response was lost.",
+  "features": [
+    "binding:non-peered",
+    "lifecycle:multi-cycle",
+    "nested-leaf:request_reply",
+    "nested:map",
+    "reference:REF",
+    "shape:TSD",
+    "topology:nested-higher-order",
+    "type:int"
+  ],
+  "id": "issue-175-map-response-delivery-vs-new-key",
+  "inputs": {
+    "selector": [
+      "alpha",
+      null,
+      null
+    ],
+    "values": [
+      {
+        "k1": 8
+      },
+      null,
+      {
+        "k2": -2
+      }
+    ]
+  },
+  "parameters": {
+    "increment": 0,
+    "inner": "request_reply",
+    "outer": "map",
+    "reduce_output": false,
+    "wrap_switch": false
+  },
+  "schema_version": 1,
+  "seed": 9,
+  "source_issue": "https://github.com/hhenson/hg_cpp/issues/175",
+  "template": "nested_higher_order"
+}


### PR DESCRIPTION
## Summary

Fixes #175: a keyed child response due for delivery could be starved when a new outer key arrived in the same evaluation cycle.

Map and mesh now observe child schedule changes and maintain sparse scheduling worklists:

- future child deadlines are retained in a min-heap and re-arm the parent once;
- current-cycle child notifications join the candidate bitmap directly;
- input-driven, on-demand dependency, and sibling-notification candidates settle in dependency-rank order;
- stale, stopped, or removed entries are discarded lazily;
- source repoints and structured outer-input retargets retain a conservative full-rebind path.

This also removes the mesh hot-path behavior that rebuilt and sorted every live instance on each parent evaluation. Sparse work is proportional to the children that are actually due while preserving full broadcast behavior.

## Performance

With 1,000 live mesh instances over 1,000 ticks:

- sparse one-key ticks: about 0.45 s before and 0.012 s after, roughly 35-40x faster;
- broadcast ticks: about 0.609 s before and 0.620 s after, roughly 2% slower while all children necessarily evaluate.

The benchmark is checked in as `benchmarks/repro_mesh_schedule_queue.py`.

## Verification

- Fresh macOS native suite: 1,290 / 1,290 tests passed.
- Python 3.12 stable-ABI wheel installed into Python 3.14: 1,725 passed, 10 skipped.
- Fresh x86_64 Linux native suite: 1,290 / 1,290 tests passed.
- Linux Python 3.14 compatibility suite with `polars[rtcompat]`: 1,725 passed, 10 skipped.
- Linux ASan extension plus full Python suite: 1,725 passed, 10 skipped; no sanitizer findings.
- Sphinx documentation build with warnings as errors passed.

The initial macOS Python pass hit the known real-time catalogue timing flake once; that test then passed 10/10 isolated retries and the complete suite passed on rerun.

Closes #175.