### PR TITLE
Focus parity discovery on supported semantics

### DIFF
--- a/docs/source/developer_guide/parity_testing.rst
+++ b/docs/source/developer_guide/parity_testing.rst
@@ -111,10 +111,23 @@ independent baseline.
 The pull-request profile generates 48 cases of 8--32 ticks in addition to the
 curated corpus.  The nightly profile generates 5,000 cases of 8--64 ticks and
 may shrink a failure below that range.  Nightly-only parameter variants retain
-known high-value stress points, such as direct formatting of a selected REF
-and service-adaptor transport timing, without turning the merge smoke profile
-into a permanent failure.  Ruled parameter spaces which carry no differential
-signal, such as undeduplicated key-set cardinality, remain corpus-only.
+high-value stress points, such as direct formatting of a selected REF, without
+turning the merge smoke profile into a permanent failure.  Ruled parameter
+spaces which carry no differential signal, such as undeduplicated key-set
+cardinality, remain corpus-only.
+
+Generated discovery targets the agreed compatibility contract, not accepted
+deviations.  The fixed corpus permanently retains the latter, but unrestricted
+generation works around them: every reduction supplies its explicit identity
+zero; collection and nested scalar outputs use ``dedup`` to normalize equal
+re-ticks; subscription keys are not repeated and use a non-zero multiplier;
+nested service-backed invalid windows remain fixed-corpus cases while
+standalone service generators cover their agreed behavior; and the designed
+one-cycle service-adaptor round trip is available only by explicit template
+selection; reference-unsupported temporal method-call spellings and cyclic
+adaptor/outer-switch composition remain ordinary compatibility or fixed
+coverage.  This keeps churn, branch lifecycle, service, and reduction coverage
+while reserving random examples for previously unruled behavior.
 
 Coverage is semantic rather than only line-based.  Reports count templates,
 time-series shapes, scalar types, operator families, topology, lifecycle

--- a/python/tests/test_parity_harness.py
+++ b/python/tests/test_parity_harness.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import sys
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -12,10 +13,10 @@ from tools.artifact_fingerprint import hg_cpp_source_fingerprint
 from tools.parity.campaign import run_campaign
 from tools.parity.canonical import canonicalize
 from tools.parity.catalog import validate_recipe
-from tools.parity.cli import CAMPAIGN_PROFILES
+from tools.parity.cli import CAMPAIGN_PROFILES, _path
 from tools.parity.compare import compare_outcomes
 from tools.parity.coverage import coverage_report, recipe_features
-from tools.parity.environments import ParityEnvironments
+from tools.parity.environments import ParityEnvironments, prepare_environments
 from tools.parity.issues import failure_fingerprint, issue_body, publish_failures
 from tools.parity.model import Recipe, RecipeError, load_corpus
 from tools.parity.reduce import reduce_recipe
@@ -176,12 +177,18 @@ def test_generated_framework_recipes_prioritize_ref_and_non_peered_paths():
         "service_request_reply",
         "service_subscription",
         "adaptor_loopback",
-        "service_adaptor_roundtrip",
         "context_switch",
         "operator_pipeline",
         "tsd_key_set_pipeline",
         "mesh_key_set",
     } <= templates
+    assert "service_adaptor_roundtrip" not in templates
+    assert {
+        recipe.template
+        for recipe in generate_recipes(
+            8, seed=31, templates=("service_adaptor_roundtrip",),
+        )
+    } == {"service_adaptor_roundtrip"}
     assert sum(
         "reference:REF" in recipe.features
         and "binding:non-peered" in recipe.features
@@ -206,6 +213,37 @@ def test_campaign_profiles_scale_nightly_breadth_and_tick_depth():
     assert CAMPAIGN_PROFILES["nightly"]["examples"] == 5000
     assert CAMPAIGN_PROFILES["nightly"]["max_ticks"] == 64
     assert CAMPAIGN_PROFILES["nightly"]["time_budget"] == 3600.0
+
+
+def test_external_environment_paths_preserve_virtualenv_symlinks(
+    monkeypatch, tmp_path
+):
+    reference = tmp_path / "reference" / "bin" / "python"
+    candidate = tmp_path / "candidate" / "bin" / "python"
+    reference.parent.mkdir(parents=True)
+    candidate.parent.mkdir(parents=True)
+    try:
+        reference.symlink_to(sys.executable)
+        candidate.symlink_to(sys.executable)
+    except OSError:
+        pytest.skip("gap: interpreter symlinks are unavailable on this platform")
+    identities = {
+        reference: {"distribution": "hgraph"},
+        candidate: {"distribution": "hg_cpp"},
+    }
+
+    monkeypatch.setattr(
+        "tools.parity.environments.environment_identity",
+        identities.__getitem__,
+    )
+    environments = prepare_environments(
+        reference_python=reference,
+        candidate_python=candidate,
+    )
+
+    assert _path(str(reference)) == reference
+    assert environments.reference_python == reference
+    assert environments.candidate_python == candidate
 
 
 def test_operator_inventory_fallback_excludes_callable_types_and_helpers():
@@ -473,16 +511,61 @@ def test_family_suppression_covers_only_the_documented_difference(
     assert report["summary"]["known_failures"] == 0
 
 
-def test_generated_tsd_map_reduce_recipes_use_identity_zero():
-    # Non-identity zeros are the documented reduce deviation: the generator
-    # must not explore that space (differential results there measure the
-    # deviation, not candidate defects).
+def test_generated_recipes_avoid_accepted_deviation_spaces():
+    # Generated discovery must test the agreed contract rather than consume
+    # examples rediscovering accepted deviations. Fixed corpus recipes retain
+    # each ruled behavior as a permanent regression.
     from tools.parity.generate import generate_recipes
 
-    recipes = generate_recipes(200, seed=7)
-    tsd = [r for r in recipes if r.template == "tsd_map_reduce"]
-    assert tsd, "expected generated tsd_map_reduce recipes"
-    assert all(r.parameters["zero"] == 0 for r in tsd)
+    unrestricted = generate_recipes(400, seed=7)
+    assert all(
+        recipe.template != "service_adaptor_roundtrip"
+        for recipe in unrestricted
+    )
+
+    def generated(template):
+        recipes = generate_recipes(
+            80, seed=11, templates=(template,),
+        )
+        assert recipes, f"expected generated {template} recipes"
+        return recipes
+
+    # Non-identity reduce zeros have capacity-history-dependent reference
+    # behavior. Every generated reduce uses the explicit identity zero.
+    assert all(
+        recipe.parameters["zero"] == 0
+        for recipe in generated("tsd_map_reduce")
+    )
+
+    # Equal derived values are normalized at the graph boundary so an
+    # operator's value semantics are tested without the ruled re-tick policy.
+    assert all(
+        recipe.parameters["normalize_output"] is True
+        for recipe in generated("collection_size")
+    )
+
+    subscriptions = generated("service_subscription")
+    for recipe in subscriptions:
+        symbols = [tick for tick in recipe.inputs["symbol"] if tick is not None]
+        assert len(symbols) == len(set(symbols))
+        assert recipe.parameters["multiplier"] != 0
+
+    nested = generated("nested_higher_order")
+    for recipe in nested:
+        parameters = recipe.parameters
+        assert parameters["reduce_output"] is True
+        assert parameters["normalize_output"] is True
+        assert parameters["inner"] in ("arithmetic", "adaptor")
+        if parameters["inner"] == "adaptor":
+            assert parameters["wrap_switch"] is False
+
+    assert all(
+        recipe.parameters["accessor"] in {
+            "year", "month", "day", "hour", "minute", "second",
+            "microsecond", "days", "seconds", "microseconds",
+        }
+        for recipe in generated("temporal_expression")
+    )
 
 
 def test_reference_failure_is_quarantined_not_promoted(monkeypatch, tmp_path):
@@ -1613,6 +1696,18 @@ def test_new_template_validators_reject_malformed_recipes():
     )
     rejects(
         {
+            "template": "collection_size",
+            "inputs": {"ts": ["abc"]},
+            "parameters": {
+                "shape": "str",
+                "operation": "len",
+                "normalize_output": "yes",
+            },
+        },
+        "normalize_output must be a boolean",
+    )
+    rejects(
+        {
             "template": "lifecycle_state",
             "inputs": {"value": [1]},
             "parameters": {"start_spelling": "banana"},
@@ -1635,6 +1730,20 @@ def test_new_template_validators_reject_malformed_recipes():
                            "wrap_switch": False, "reduce_output": False},
         },
         "adaptor inner requires reduce_output",
+    )
+    rejects(
+        {
+            "template": "nested_higher_order",
+            "inputs": {"values": [{"k1": 1}], "selector": ["alpha"]},
+            "parameters": {
+                "inner": "arithmetic",
+                "outer": "map",
+                "wrap_switch": False,
+                "reduce_output": False,
+                "normalize_output": True,
+            },
+        },
+        "normalize_output requires reduce_output",
     )
     rejects(
         {

--- a/tools/parity/catalog.py
+++ b/tools/parity/catalog.py
@@ -391,6 +391,8 @@ def _validate_collection_size(recipe):
             raise RecipeError("collection_size contains needs a matching probe scalar")
     elif probe is not None:
         raise RecipeError("collection_size probe applies to contains only")
+    if not isinstance(parameters.get("normalize_output", False), bool):
+        raise RecipeError("collection_size normalize_output must be a boolean")
 
 
 def _collection_size(hg, recipe):
@@ -400,11 +402,13 @@ def _collection_size(hg, recipe):
     shape = parameters["shape"]
     operation = parameters["operation"]
     probe = parameters.get("probe")
+    normalize_output = parameters.get("normalize_output", False)
     inputs = decoded_inputs(hg, recipe)
     if shape == "tsl":
         @hg.graph
         def parity_graph(a: hg.TS[int], b: hg.TS[int]) -> hg.TS[int]:
-            return hg.len_(hg.TSL.from_ts(_via_non_peered_ref(hg, a), b))
+            result = hg.len_(hg.TSL.from_ts(_via_non_peered_ref(hg, a), b))
+            return hg.dedup(result) if normalize_output else result
 
         return eval_node(parity_graph, inputs["a"], inputs["b"])
 
@@ -417,15 +421,18 @@ def _collection_size(hg, recipe):
     if operation == "len":
         @hg.graph
         def parity_graph(ts: annotation) -> hg.TS[int]:
-            return hg.len_(_via_non_peered_ref(hg, ts))
+            result = hg.len_(_via_non_peered_ref(hg, ts))
+            return hg.dedup(result) if normalize_output else result
     elif operation == "is_empty":
         @hg.graph
         def parity_graph(ts: annotation) -> hg.TS[bool]:
-            return hg.is_empty(_via_non_peered_ref(hg, ts))
+            result = hg.is_empty(_via_non_peered_ref(hg, ts))
+            return hg.dedup(result) if normalize_output else result
     else:
         @hg.graph
         def parity_graph(ts: annotation) -> hg.TS[bool]:
-            return hg.contains_(_via_non_peered_ref(hg, ts), probe)
+            result = hg.contains_(_via_non_peered_ref(hg, ts), probe)
+            return hg.dedup(result) if normalize_output else result
 
     return eval_node(parity_graph, inputs["ts"])
 
@@ -525,11 +532,19 @@ def _validate_nested_higher_order(recipe):
         raise RecipeError(f"nested_higher_order outer must be one of {_NESTED_OUTER}")
     wrap_switch = parameters.get("wrap_switch", False)
     reduce_output = parameters.get("reduce_output", True)
-    if not isinstance(wrap_switch, bool) or not isinstance(reduce_output, bool):
-        raise RecipeError("nested_higher_order wrap_switch/reduce_output must be booleans")
+    normalize_output = parameters.get("normalize_output", False)
+    if (not isinstance(wrap_switch, bool)
+            or not isinstance(reduce_output, bool)
+            or not isinstance(normalize_output, bool)):
+        raise RecipeError(
+            "nested_higher_order wrap_switch/reduce_output/normalize_output "
+            "must be booleans")
     if wrap_switch and not reduce_output:
         raise RecipeError(
             "nested_higher_order wrap_switch requires reduce_output (one output shape)")
+    if normalize_output and not reduce_output:
+        raise RecipeError(
+            "nested_higher_order normalize_output requires reduce_output")
     increment = parameters.get("increment", 1)
     if (not isinstance(increment, int) or isinstance(increment, bool)
             or not -20 <= increment <= 20):
@@ -569,6 +584,7 @@ def _nested_higher_order(hg, recipe):
     outer = parameters["outer"]
     wrap_switch = parameters.get("wrap_switch", False)
     reduce_output = parameters.get("reduce_output", True)
+    normalize_output = parameters.get("normalize_output", False)
     increment = parameters.get("increment", 1)
     path = f"nested_{inner}"
 
@@ -688,7 +704,7 @@ def _nested_higher_order(hg, recipe):
                          outer_selector: hg.TS[str]) -> hg.TS[int]:
             register()
             values = _via_non_peered_ref(hg, values)
-            return hg.switch_(
+            result = hg.switch_(
                 outer_selector,
                 {
                     "on": lambda values, selector: pipeline(values, selector),
@@ -697,13 +713,15 @@ def _nested_higher_order(hg, recipe):
                 values,
                 selector,
             )
+            return hg.dedup(result) if normalize_output else result
     elif reduce_output:
         @hg.graph
         def parity_graph(values: hg.TSD[str, hg.TS[int]],
                          selector: hg.TS[str]) -> hg.TS[int]:
             register()
             values = _via_non_peered_ref(hg, values)
-            return pipeline(values, selector)
+            result = pipeline(values, selector)
+            return hg.dedup(result) if normalize_output else result
     else:
         @hg.graph
         def parity_graph(values: hg.TSD[str, hg.TS[int]],
@@ -1653,7 +1671,7 @@ CATALOG = {
             "reference:REF",
             "binding:non-peered",
         ),
-        operators=("len_", "is_empty", "contains_"),
+        operators=("len_", "is_empty", "contains_", "dedup"),
         execute=_collection_size,
     ),
     "lifecycle_state": TemplateSpec(
@@ -1681,7 +1699,9 @@ CATALOG = {
             "binding:non-peered",
             "lifecycle:multi-cycle",
         ),
-        operators=("map_", "mesh_", "switch_", "reduce", "len_", "keys_"),
+        operators=(
+            "map_", "mesh_", "switch_", "reduce", "len_", "keys_", "dedup",
+        ),
         execute=_nested_higher_order,
     ),
     "data_frame_recording": TemplateSpec(

--- a/tools/parity/cli.py
+++ b/tools/parity/cli.py
@@ -47,7 +47,10 @@ CAMPAIGN_PROFILES = {
 
 
 def _path(value: str | None) -> Path | None:
-    return Path(value).resolve() if value else None
+    # Preserve a virtual environment's bin/python symlink. Resolving it can
+    # select the base interpreter on platforms where uv uses symlinked
+    # launchers, causing isolated parity subprocesses to lose the environment.
+    return Path(value).absolute() if value else None
 
 
 def _load_selected_recipes(paths: list[str] | None) -> list[Recipe]:

--- a/tools/parity/corpus/coverage-collection-size-normalized-discovery.json
+++ b/tools/parity/corpus/coverage-collection-size-normalized-discovery.json
@@ -1,0 +1,27 @@
+{
+  "schema_version": 1,
+  "id": "coverage-collection-size-normalized-discovery",
+  "description": "Generated discovery normalizes equal len_ re-ticks with dedup while retaining collection churn.",
+  "template": "collection_size",
+  "inputs": {
+    "ts": [
+      {"$set_delta": {"added": [1, 2], "removed": []}},
+      {"$set_delta": {"added": [2], "removed": []}},
+      {"$set_delta": {"added": [3], "removed": [1]}},
+      {"$set_delta": {"added": [], "removed": [2, 3]}}
+    ]
+  },
+  "parameters": {
+    "shape": "tss",
+    "operation": "len",
+    "normalize_output": true
+  },
+  "features": [
+    "domain:collection-size",
+    "normalization:dedup",
+    "operator:dedup",
+    "operator:len",
+    "shape:TSS",
+    "topology:expression"
+  ]
+}

--- a/tools/parity/corpus/coverage-nested-explicit-zero-normalized-discovery.json
+++ b/tools/parity/corpus/coverage-nested-explicit-zero-normalized-discovery.json
@@ -1,0 +1,47 @@
+{
+  "schema_version": 1,
+  "id": "coverage-nested-explicit-zero-normalized-discovery",
+  "description": "Generated nested discovery uses an explicit identity zero and dedup normalization around arithmetic branch and key churn.",
+  "template": "nested_higher_order",
+  "inputs": {
+    "values": [
+      {"k1": 3},
+      {"k2": 4},
+      null,
+      {"k1": 5},
+      {"k2": {"$remove": true}},
+      null
+    ],
+    "selector": [
+      "alpha",
+      null,
+      null,
+      "beta",
+      null,
+      null
+    ]
+  },
+  "parameters": {
+    "inner": "arithmetic",
+    "outer": "map",
+    "wrap_switch": false,
+    "reduce_output": true,
+    "normalize_output": true,
+    "increment": 2
+  },
+  "features": [
+    "binding:non-peered",
+    "lifecycle:branch-rebind",
+    "lifecycle:multi-cycle",
+    "nested-leaf:arithmetic",
+    "nested:map",
+    "normalization:dedup",
+    "operator:dedup",
+    "reduction:explicit-identity-zero",
+    "reference:REF",
+    "shape:TSD",
+    "topology:nested-higher-order",
+    "topology:reduce",
+    "type:int"
+  ]
+}

--- a/tools/parity/environments.py
+++ b/tools/parity/environments.py
@@ -170,7 +170,7 @@ def prepare_environments(
             interpreter=interpreter
         )
     else:
-        reference_python = reference_python.resolve()
+        reference_python = reference_python.absolute()
         reference_identity = environment_identity(reference_python)
     if candidate_python is None:
         candidate_python, candidate_identity, fingerprint = (
@@ -184,7 +184,7 @@ def prepare_environments(
             raise ValueError(
                 "candidate_wheel cannot be combined with candidate_python"
             )
-        candidate_python = candidate_python.resolve()
+        candidate_python = candidate_python.absolute()
         candidate_identity = environment_identity(candidate_python)
         fingerprint = "external-" + hashlib.sha256(
             str(candidate_python).encode()

--- a/tools/parity/generate.py
+++ b/tools/parity/generate.py
@@ -263,7 +263,13 @@ def recipe_payload_strategy(*, min_ticks: int = 8, max_ticks: int = 32,
             "template": "service_subscription",
             "inputs": {"symbol": ticks},
             "parameters": {
-                "multiplier": draw(st.integers(min_value=-3, max_value=10)),
+                # A zero multiplier turns distinct subscriptions into equal
+                # outputs, measuring the ruled no-change re-tick behavior
+                # instead of service correctness.
+                "multiplier": draw(st.one_of(
+                    st.integers(min_value=-3, max_value=-1),
+                    st.integers(min_value=1, max_value=10),
+                )),
                 "path": draw(st.sampled_from(("quotes", "prices", "live"))),
             },
             "features": [*CATALOG["service_subscription"].features],
@@ -428,13 +434,6 @@ def recipe_payload_strategy(*, min_ticks: int = 8, max_ticks: int = 32,
                      "microsecond"),
         "timedelta": ("days", "seconds", "microseconds"),
     }
-    _TEMPORAL_METHODS = {
-        "date": ("weekday", "isoweekday"),
-        "datetime": ("weekday", "isoweekday"),
-        "timedelta": ("total_seconds",),
-    }
-    _TEMPORAL_OUTPUT = {"total_seconds": "float"}
-
     @st.composite
     def temporal_expression(draw):
         import datetime as dt
@@ -442,8 +441,11 @@ def recipe_payload_strategy(*, min_ticks: int = 8, max_ticks: int = 32,
         input_type = draw(st.sampled_from(("date", "datetime")))
         target = draw(st.sampled_from(("difference", "shifted", "input")))
         kind = "timedelta" if target == "difference" else input_type
-        accessor = draw(st.sampled_from(
-            _TEMPORAL_PROPERTIES[kind] + _TEMPORAL_METHODS[kind]))
+        # Released hgraph exposes method-call spellings as WiringPort values
+        # rather than callable ports in this generated form. Keep those
+        # candidate-only extensions in ordinary compatibility tests; the
+        # differential generator uses the common property surface.
+        accessor = draw(st.sampled_from(_TEMPORAL_PROPERTIES[kind]))
         count = draw(st.integers(min_value=min_ticks, max_value=max_ticks))
         day = st.integers(min_value=0, max_value=36_500)
         micro = st.integers(min_value=0, max_value=86_399_999_999)
@@ -466,7 +468,7 @@ def recipe_payload_strategy(*, min_ticks: int = 8, max_ticks: int = 32,
             "input_type": input_type,
             "target": target,
             "accessor": accessor,
-            "output_type": _TEMPORAL_OUTPUT.get(accessor, "int"),
+            "output_type": "int",
             "postponed_annotations": draw(
                 st.sampled_from((False, False, False, True))),
         }
@@ -500,7 +502,14 @@ def recipe_payload_strategy(*, min_ticks: int = 8, max_ticks: int = 32,
         operation = ("len" if shape == "tsl"
                      else draw(st.sampled_from(("len", "is_empty", "contains"))))
         count = draw(st.integers(min_value=min_ticks, max_value=max_ticks))
-        parameters = {"shape": shape, "operation": operation}
+        parameters = {
+            "shape": shape,
+            "operation": operation,
+            # Normalize released hgraph's equal-value re-ticks at the graph
+            # boundary. Fixed corpus cases retain the unnormalized output to
+            # pin the accepted no-change deviation.
+            "normalize_output": True,
+        }
         keys = st.sampled_from(("a", "b", "c", "d"))
         small = st.integers(min_value=-5, max_value=5)
         if shape == "str":
@@ -588,20 +597,25 @@ def recipe_payload_strategy(*, min_ticks: int = 8, max_ticks: int = 32,
     def nested_higher_order(draw):
         # The composition breeding ground: churning key sets under map_/mesh_,
         # per-key switch_ branches flipping (nested graphs start/stop),
-        # services/adaptors INSIDE the branches, optionally the whole
+        # an adaptor around the reduced pipeline, and optionally the whole
         # pipeline under an outer switch_ tearing it down and rebuilding it.
-        inner = draw(st.sampled_from(
-            ("arithmetic", "request_reply", "request_reply",
-             "subscription", "adaptor")))
+        # Service-backed children have intentional invalid startup/round-trip
+        # windows under nested map/reduce. Standalone service generators cover
+        # their agreed behavior; fixed nested corpus cases pin the deviations.
+        inner = draw(st.sampled_from(("arithmetic", "arithmetic", "adaptor")))
         outer = draw(st.sampled_from(("map", "map", "mesh")))
-        subscription = inner == "subscription"
-        wrap = False if subscription else draw(st.booleans())
-        reduce_output = (True if wrap or inner == "adaptor"
-                         else draw(st.sampled_from((True, True, False))))
+        # Feeding an adaptor-wrapped result through the outer switch creates
+        # a reference-side wiring cycle. The inner switch and keyed churn
+        # remain covered without that unsupported composition.
+        wrap = False if inner == "adaptor" else draw(st.booleans())
+        # Generated reductions always provide the identity zero in the
+        # catalogue. Keeping one scalar output also lets dedup normalize the
+        # separately ruled no-change re-tick behavior. Map-valued and
+        # non-identity-zero deviations remain fixed corpus cases.
+        reduce_output = True
         count = draw(st.integers(min_value=min_ticks, max_value=max_ticks))
         keys = ("k1", "k2", "k3")
         active: set = set()
-        retired: set = set()
         first_key = draw(st.sampled_from(keys))
         active.add(first_key)
         values: list = [{first_key: draw(st.integers(-10, 10))}]
@@ -614,13 +628,9 @@ def recipe_payload_strategy(*, min_ticks: int = 8, max_ticks: int = 32,
                 key = draw(st.sampled_from(sorted(active)))
                 values.append({key: {"$remove": True}})
                 active.remove(key)
-                retired.add(key)
                 continue
             if action == "add":
-                # The re-subscription timing deviation is ruled: with a
-                # subscription leaf a removed key is never re-added.
-                pool = [key for key in keys if key not in active
-                        and not (subscription and key in retired)]
+                pool = [key for key in keys if key not in active]
                 if not pool:
                     values.append(None)
                     continue
@@ -631,13 +641,15 @@ def recipe_payload_strategy(*, min_ticks: int = 8, max_ticks: int = 32,
             values.append({key: draw(st.integers(-10, 10))})
         selector = ["alpha"] + [
             draw(st.sampled_from((None, "alpha", "beta", "beta")))
-            for _ in range(count - 1)]
+            for _ in range(count - 1)
+        ]
         inputs = {"values": values, "selector": selector}
         parameters = {
             "inner": inner,
             "outer": outer,
             "wrap_switch": wrap,
             "reduce_output": reduce_output,
+            "normalize_output": True,
             "increment": draw(st.integers(min_value=-5, max_value=5)),
         }
         if wrap:
@@ -653,7 +665,9 @@ def recipe_payload_strategy(*, min_ticks: int = 8, max_ticks: int = 32,
                 f"nested:{outer}",
                 f"nested-leaf:{inner}",
                 *(("nested:outer-switch",) if wrap else ()),
-                *(("topology:reduce",) if reduce_output else ()),
+                "topology:reduce",
+                "reduction:explicit-identity-zero",
+                "normalization:dedup",
             ],
         }
 
@@ -672,10 +686,10 @@ def recipe_payload_strategy(*, min_ticks: int = 8, max_ticks: int = 32,
             "features": [*CATALOG["data_frame_recording"].features],
         }
 
-    # (name, factory) pairs; a repeated name WEIGHTS that template in the
-    # unrestricted draw (nested_higher_order is the composition breeding
-    # ground and draws double).
-    weighted = (
+    # (name, factory) pairs for discovery. Families whose every differential
+    # is already an accepted deviation stay in the fixed corpus rather than
+    # consuming random examples here.
+    discovery_weighted = (
         ("scalar_expression", scalar_expression),
         ("feedback_accumulate", feedback_accumulate),
         ("switch_arithmetic", switch_arithmetic),
@@ -684,7 +698,6 @@ def recipe_payload_strategy(*, min_ticks: int = 8, max_ticks: int = 32,
         ("service_request_reply", service_request_reply),
         ("service_subscription", service_subscription),
         ("adaptor_loopback", adaptor_loopback),
-        ("service_adaptor_roundtrip", service_adaptor_roundtrip),
         ("context_switch", context_switch),
         ("operator_pipeline", operator_pipeline),
         ("tsd_key_set_pipeline", tsd_key_set_pipeline),
@@ -696,17 +709,24 @@ def recipe_payload_strategy(*, min_ticks: int = 8, max_ticks: int = 32,
         ("nested_higher_order", nested_higher_order),
         ("nested_higher_order", nested_higher_order),
     )
+    selectable = (
+        *discovery_weighted,
+        # Explicit selection remains available for controller tests and
+        # reproductions; unrestricted discovery excludes its designed
+        # one-cycle transport difference.
+        ("service_adaptor_roundtrip", service_adaptor_roundtrip),
+    )
     if templates is None:
-        return st.one_of(*(factory() for _, factory in weighted))
+        return st.one_of(*(factory() for _, factory in discovery_weighted))
     # A restricted profile draws ONLY the allowed strategies — selecting at
     # the source, never filtering the union (a post-hoc filter discards most
     # draws and trips hypothesis's filter_too_much health check).
     allowed = frozenset(templates)
-    unknown = allowed - {name for name, _ in weighted}
+    unknown = allowed - {name for name, _ in selectable}
     if unknown:
         raise ValueError(
             f"unknown generated template(s): {', '.join(sorted(unknown))}")
-    return st.one_of(*(factory() for name, factory in weighted
+    return st.one_of(*(factory() for name, factory in selectable
                        if name in allowed))
 
 


### PR DESCRIPTION
Stacked on #179 so cold fresh-wheel validation includes the catalogue timing fix. Once #179 merges, this PR can be retargeted to `main` without changing its single parity commit.

## What changed

- Make generated reductions use an explicit identity zero.
- Normalize generated collection-size and nested scalar outputs with `dedup`, while retaining the unnormalized accepted deviations in the fixed corpus.
- Keep service subscription generations distinct and non-zero, and move designed nested/service-adaptor deviation spaces out of unrestricted random discovery.
- Restrict generated temporal accessors to the property surface supported by released hgraph.
- Add fixed normalized collection and nested-reduction recipes plus generator/validator regression coverage.
- Preserve supplied virtual-environment interpreter symlinks instead of resolving them to the Linux base interpreter.
- Document the discovery-versus-fixed-corpus policy.

## Why

The expanded campaign was spending many examples rediscovering already-accepted behavioral differences. Random discovery should work around those spaces and search for previously unknown mismatches; the fixed corpus remains responsible for pinning accepted deviations.

Linux validation also exposed that resolving `uv`'s symlinked `bin/python` paths selected `/usr/bin/python3.14`, so isolated parity subprocesses lost their installed environment. Keeping paths absolute without resolving symlinks makes explicit reference/candidate environments portable.

## Validation

- Parity harness plus release-readiness checks: 39 passed
- Corpus validation: 55 recipes
- Sphinx dummy build with warnings as errors: 65 sources passed
- Targeted normalized collection and nested-reduction replays: matched released hgraph
- Local PR campaign: 103/103 attempted; 88 matched; 15 known; 0 new; 0 quarantined
- Local 300-example audit: 327 attempted; 312 matched; 15 known; 0 new; 0 quarantined
- Linux PR campaign: 103/103 attempted; 88 matched; 15 known; 0 new; 0 quarantined
- macOS native suite: 1,288 passed
- Linux native suite: 1,288 passed
- Final stacked macOS Python 3.14 non-WIP suite from a Python 3.12 stable-ABI wheel: 1,723 passed, 10 skipped
- Final stacked Linux Python 3.14 non-WIP suite from a Python 3.12 stable-ABI wheel with Polars rtcompat: 1,723 passed, 10 skipped