### PR TITLE
Optimize Linux shared-library call binding

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -163,6 +163,29 @@ target_link_libraries(hgraph_stdlib PRIVATE $<BUILD_INTERFACE:Boost::math>)
 target_link_libraries(hgraph_core INTERFACE hgraph_stdlib hgraph::options)
 
 if(HGRAPH_BUILD_SHARED)
+    if(UNIX AND NOT APPLE)
+        include(CheckCXXCompilerFlag)
+        check_cxx_compiler_flag(
+            "-fno-semantic-interposition"
+            HGRAPH_HAS_NO_SEMANTIC_INTERPOSITION
+        )
+        if(HGRAPH_HAS_NO_SEMANTIC_INTERPOSITION)
+            # ELF makes every default-visible C++ method preemptible unless the
+            # compiler is told otherwise. hgraph's public methods are also used
+            # heavily inside these DSOs; preserving interposition there forces
+            # PLT calls and prevents local optimization throughout the runtime
+            # hot path. The public symbols remain exported for SDK consumers,
+            # but hgraph does not support replacing its C++ ABI via LD_PRELOAD.
+            foreach(_hgraph_target IN ITEMS hgraph_runtime hgraph_wiring hgraph_stdlib)
+                target_compile_options(${_hgraph_target} PRIVATE
+                    $<$<CONFIG:Release>:-fno-semantic-interposition>
+                    $<$<CONFIG:RelWithDebInfo>:-fno-semantic-interposition>
+                    $<$<CONFIG:MinSizeRel>:-fno-semantic-interposition>
+                )
+            endforeach()
+        endif()
+    endif()
+
     if(HGRAPH_WINDOWS_UNIFIED_SHARED)
         target_link_libraries(hgraph_stdlib PRIVATE hgraph_private_dependencies)
         target_compile_definitions(hgraph_stdlib PRIVATE hgraph_EXPORTS)


### PR DESCRIPTION
## What changed

Apply `-fno-semantic-interposition` to the Linux `hgraph_runtime`, `hgraph_wiring`, and `hgraph_stdlib` shared libraries in optimized configurations when the compiler supports it. macOS, Windows, debug builds, unsupported compilers, and static builds are unchanged.

## Why

The split Linux wheel exposes the public C++ ABI from three ELF DSOs. GCC must otherwise treat every default-visible method as preemptible, so hot internal calls go through the PLT and cannot be locally optimized. This accounted for most of the Linux regression relative to both macOS and the legacy monolithic extension.

The flag keeps public SDK symbols exported, but allows each DSO to bind and optimize its own internal calls. hgraph does not support replacing C++ ABI methods with `LD_PRELOAD` interposition.

## Performance

On the physical x86_64 `hg-linux` host, interleaved five-sample comparisons on the same P-core showed:

- tick path: about 57% faster
- scheduler fanout/fanin: about 55–56% faster
- dense map: about 51% faster
- nested reduce: about 49% faster
- service adaptor: about 50% faster
- mesh: about 30% faster

The complete 68-scenario candidate pack had all validators pass. Against the previous hg-cpp build, 67 scenarios improved by more than 5%, one was at parity, and none regressed. Against legacy C++ where comparable, the balance moved from 24 faster / 2 parity / 30 slower to 48 faster / 4 parity / 4 slower.

## Validation

macOS:

- fresh native acceptance build: 1,290/1,290 tests passed
- stable-ABI wheel built with Python 3.12 and tested under Python 3.14: 1,725 passed, 10 skipped
- installed-wheel C++/Python extension consumer passed

Linux (`hg-linux`, GCC 15.2):

- complete 68-scenario performance pack: all validators passed
- fresh native acceptance build: 1,290/1,290 tests passed
- stable-ABI wheel built with Python 3.12 and tested under Python 3.14: 1,725 passed, 10 skipped
- installed-wheel C++/Python extension consumer passed and shared the runtime registry correctly