### PR TITLE
Enable IPO for Linux shared libraries

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -169,6 +169,14 @@ if(HGRAPH_BUILD_SHARED)
             "-fno-semantic-interposition"
             HGRAPH_HAS_NO_SEMANTIC_INTERPOSITION
         )
+
+        include(CheckIPOSupported)
+        check_ipo_supported(
+            RESULT HGRAPH_HAS_INTERPROCEDURAL_OPTIMIZATION
+            OUTPUT HGRAPH_INTERPROCEDURAL_OPTIMIZATION_ERROR
+            LANGUAGES CXX
+        )
+
         if(HGRAPH_HAS_NO_SEMANTIC_INTERPOSITION)
             # ELF makes every default-visible C++ method preemptible unless the
             # compiler is told otherwise. hgraph's public methods are also used
@@ -183,6 +191,17 @@ if(HGRAPH_BUILD_SHARED)
                     $<$<CONFIG:MinSizeRel>:-fno-semantic-interposition>
                 )
             endforeach()
+        endif()
+
+        if(HGRAPH_HAS_INTERPROCEDURAL_OPTIMIZATION)
+            # The runtime's hot paths span many translation units. Preserve the
+            # public DSO boundaries while allowing the compiler and linker to
+            # optimize calls within each component as a whole.
+            set_target_properties(hgraph_runtime hgraph_wiring hgraph_stdlib PROPERTIES
+                INTERPROCEDURAL_OPTIMIZATION_RELEASE ON
+                INTERPROCEDURAL_OPTIMIZATION_RELWITHDEBINFO ON
+                INTERPROCEDURAL_OPTIMIZATION_MINSIZEREL ON
+            )
         endif()
     endif()
 


### PR DESCRIPTION
## What changed

Enable capability-checked interprocedural optimization for `hgraph_runtime`, `hgraph_wiring`, and `hgraph_stdlib` in optimized Linux shared-library builds.

This is deliberately target-scoped: the Python bridge, nanobind runtime, third-party dependencies, static builds, debug builds, macOS, and Windows are unchanged. Public symbols and the installed SDK ABI remain unchanged.

This follows the semantic-interposition fix merged in #181. CMake's `CheckIPOSupported` makes unsupported toolchains fall back to the existing build.

## Performance

On the physical x86_64 `hg-linux` host (GCC 15.2, pinned P-core), the complete 68-scenario, five-sample candidate pack compared with the #181 build showed:

- geometric-mean throughput: **+8.9%**
- more than 5% faster / within 5% / more than 5% slower: **42 / 26 / 0**
- Scheduler: **+17.6%**
- Reduce: **+12.5%**
- Nested graphs: **+12.8%**
- Services: **+12.3%**
- TSD sparse: **+11.5%**

Largest individual gains were scheduler fan-in (+30%), ordered fixed-list reduction (+25%), subscription service (+23%), scheduler fan-out (+23%), and the native feedback loop (+21%).

Against the reusable hgraph 0.5.31 legacy-C++ baseline, Linux's 56-workload geometric mean improves from **1.81x to 1.99x**. The matching macOS result is 1.80x; scheduler and reduce relative performance are now effectively at Mac parity.

The three hgraph DSOs also shrink from 29.8 MB to 23.6 MB in the measured wheel build, while internal dynamic call relocations fall substantially.

## Rejected follow-ups

Two nine-sample focused A/B experiments were not retained:

- `x86-64-v3`: +0.3% geometric mean; insufficient to narrow wheel CPU compatibility.
- nanobind `LTO` on `_hgraph`: +0.2%; insufficient to add another link bottleneck.

The v3 experiment did prove a clean future failure mechanism: GNU `-z x86-64-v3` records the required ISA in the ELF property note, and the AVX2-less OrbStack VM rejected the DSO with `CPU ISA level is lower than required` before executing code rather than raising `SIGILL`.

## Validation

macOS:

- fresh native acceptance build: 1,290/1,290 passed
- stable-ABI wheel built with Python 3.12 and tested under Python 3.14: 1,725 passed, 10 skipped
- installed-wheel C++/Python extension consumer passed

Linux (`hg-linux`, GCC 15.2):

- complete 68-scenario performance pack: all validators passed
- fresh native acceptance build: 1,290/1,290 passed
- stable-ABI wheel built with Python 3.12 and tested under Python 3.14: 1,725 passed, 10 skipped
- installed-wheel C++/Python extension consumer passed