### PR TITLE
Complete the Linux shared-library call optimization: LTO + Bsymbolic

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -184,6 +184,48 @@ if(HGRAPH_BUILD_SHARED)
                 )
             endforeach()
         endif()
+
+        # The compile flag above lets the compiler bind calls locally, but the
+        # linker still routes cross-TU calls to exported functions through the
+        # PLT. Binding the DSO's own non-weak definitions removes that hop;
+        # weak (vague-linkage) symbols — template instantiations, inline
+        # functions, typeinfo — stay interposable so cross-DSO exception
+        # identity and dynamic_cast against SDK extensions keep working.
+        if(HGRAPH_BUILD_SHARED)
+            include(CheckLinkerFlag)
+            check_linker_flag(CXX "-Wl,-Bsymbolic-non-weak-functions"
+                              HGRAPH_HAS_BSYMBOLIC_NON_WEAK_FUNCTIONS)
+            if(HGRAPH_HAS_BSYMBOLIC_NON_WEAK_FUNCTIONS)
+                foreach(_hgraph_target IN ITEMS hgraph_runtime hgraph_wiring hgraph_stdlib)
+                    target_link_options(${_hgraph_target} PRIVATE
+                        $<$<CONFIG:Release>:-Wl,-Bsymbolic-non-weak-functions>
+                        $<$<CONFIG:RelWithDebInfo>:-Wl,-Bsymbolic-non-weak-functions>
+                        $<$<CONFIG:MinSizeRel>:-Wl,-Bsymbolic-non-weak-functions>
+                    )
+                endforeach()
+            endif()
+        endif()
+    endif()
+
+    if(UNIX)
+        # Cross-TU inlining for the ops-table/fn-pointer hot paths: the
+        # interposition flag only helps where the definition is visible in
+        # the same TU; IPO (thin LTO under Clang) extends it library-wide.
+        # Optimized configurations only — debug/sanitizer builds keep fast
+        # incremental links.
+        include(CheckIPOSupported)
+        check_ipo_supported(RESULT HGRAPH_HAS_IPO OUTPUT _hgraph_ipo_reason LANGUAGES CXX)
+        if(HGRAPH_HAS_IPO)
+            foreach(_hgraph_target IN ITEMS hgraph_runtime hgraph_wiring hgraph_stdlib)
+                set_target_properties(${_hgraph_target} PROPERTIES
+                    INTERPROCEDURAL_OPTIMIZATION_RELEASE TRUE
+                    INTERPROCEDURAL_OPTIMIZATION_RELWITHDEBINFO TRUE
+                    INTERPROCEDURAL_OPTIMIZATION_MINSIZEREL TRUE
+                )
+            endforeach()
+        else()
+            message(STATUS "hgraph: IPO unavailable (${_hgraph_ipo_reason})")
+        endif()
     endif()
 
     if(HGRAPH_WINDOWS_UNIFIED_SHARED)


### PR DESCRIPTION
## Summary

Answers "did we enable LTO?" — we hadn't. PR #181's `-fno-semantic-interposition` is one of three legs of the same mechanism; this adds the other two on the same targets, inside the same `HGRAPH_BUILD_SHARED` scope (dev static builds keep fast incremental links):

- **IPO / thin LTO** (`check_ipo_supported`-guarded, optimized configs, UNIX): the interposition flag only lets the compiler bind calls where the definition is visible within the TU — LTO extends that library-wide, which is where the ops-table/fn-pointer hot paths actually live. Verified `-flto=thin` lands in the shared Release configuration (the wheel's exact shape).
- **`-Wl,-Bsymbolic-non-weak-functions`** (Linux/ELF only): removes the remaining PLT hop by binding the DSO's own non-weak definitions at link time. "Non-weak" is the SDK-safety detail — template instantiations, inline functions, and typeinfo stay interposable, so cross-DSO exception identity and `dynamic_cast` against downstream extensions are preserved (same contract as #181: exported symbols remain exported; replacing hgraph's C++ ABI via LD_PRELOAD is not supported).

## Verification

- macOS Release C++ suite: 253,422 assertions / 1,286 cases green.
- LTO'd shared wheel passes the full python tree: 1,611 passed / 10 skipped.
- Linux CI validates the ELF/`-Bsymbolic` half (flag is `check_linker_flag`-guarded either way).

Benchmark note: this completes the top-ranked untested lever for the Linux-vs-mac gap (`-march` and module-LTO both measured marginal). If the trio still measures flat on hg-linux, the remaining suspects are the allocator (LD_PRELOAD mimalloc test) and the CPU frequency governor, and a `perf` profile is the next step rather than more flags.

🤖 Generated with [Claude Code](https://claude.com/claude-code)