### PR TITLE
Fast-path the hot TimeSeries reads at the python-node boundary

### DIFF
--- a/python/module_internal.h
+++ b/python/module_internal.h
@@ -27,6 +27,40 @@ namespace hgraph::python_bridge
     namespace nb = nanobind;
 
     struct PyObj;
+
+    /**
+     * Raw-CPython-entry-point boundary (the ``tp_getset`` / ``tp_*`` slot
+     * family): run ``f`` and return its result. If ``f`` throws, SET the
+     * corresponding Python error — an in-flight ``nb::python_error``
+     * restores itself, anything else becomes ``RuntimeError`` — and return
+     * ``error_result``, the slot's CPython error sentinel (``nullptr`` for
+     * getters, ``-1`` for setters). The python-boundary member of the
+     * ``scope.h`` ``fallback_on_exception`` / ``annotate_on_exception``
+     * control family: call sites stay expression-shaped instead of
+     * hand-rolled try/catch blocks.
+     */
+    template <typename Result, typename F>
+    [[nodiscard]] Result py_error_on_exception(Result error_result, F &&f) noexcept
+    {
+        try
+        {
+            return std::forward<F>(f)();
+        }
+        catch (nb::python_error &error)
+        {
+            error.restore();
+        }
+        catch (const std::exception &error)
+        {
+            PyErr_SetString(PyExc_RuntimeError, error.what());
+        }
+        catch (...)
+        {
+            PyErr_SetString(PyExc_RuntimeError,
+                            "unhandled C++ exception at the Python boundary");
+        }
+        return error_result;
+    }
 }
 
 namespace hgraph::python_bridge

--- a/python/py_runtime.h
+++ b/python/py_runtime.h
@@ -656,6 +656,26 @@ namespace hgraph::python_bridge
         [[nodiscard]] nb::object value() const
         {
             const auto &v = checked();
+            const auto *schema = v.schema();
+            if (schema != nullptr && schema->kind == TSTypeKind::TS)
+            {
+                // HOT PATH: atomic scalars dominate python-node reads.
+                // value_to_python() folds the has_current_value check into
+                // one ops dispatch; the invalid/None read falls out of it.
+                TSDataView data = evaluation_data.has_value()
+                                      ? TSDataView{evaluation_data}
+                                      : v.data_view().borrowed_ref();
+                if (!data.valid()) { return nb::none(); }
+                nb::object result = data.value_to_python();
+                if (PySet_CheckExact(result.ptr()))
+                {
+                    // hgraph parity: a scalar set is a FROZENSET (TSS values
+                    // stay mutable sets) - returning it to a TSS output means
+                    // replace.
+                    return nb::steal(PyFrozenSet_New(result.ptr()));
+                }
+                return result;
+            }
             TSDataView data = evaluation_data.has_value()
                                   ? TSDataView{evaluation_data}
                                   : v.data_view().borrowed_ref();
@@ -663,7 +683,6 @@ namespace hgraph::python_bridge
             {
                 return nb::none();   // hgraph: invalid reads as None
             }
-            const auto *schema = v.schema();
             if (schema != nullptr && schema->kind == TSTypeKind::TSL)
             {
                 // hgraph parity: a TSL's value is a tuple of child values
@@ -697,14 +716,7 @@ namespace hgraph::python_bridge
                 }
                 return materialize_tsb_value(schema, std::move(result));
             }
-            nb::object result = data.value_to_python();
-            if (schema != nullptr && schema->kind == TSTypeKind::TS && PySet_CheckExact(result.ptr()))
-            {
-                // hgraph parity: a scalar set is a FROZENSET (TSS values stay
-                // mutable sets) - returning it to a TSS output means replace.
-                return nb::steal(PyFrozenSet_New(result.ptr()));
-            }
-            return result;
+            return data.value_to_python();   // TS handled on the hot path above
         }
 
         [[nodiscard]] nb::object delta_value() const

--- a/python/py_state_services.cpp
+++ b/python/py_state_services.cpp
@@ -17,6 +17,44 @@ namespace hgraph::python_bridge
 {
     namespace
     {
+        /** Raw tp_getset getter for the hot per-tick TimeSeries reads
+            (value/delta_value/modified/valid): a direct C call from
+            CPython's attribute lookup, where def_prop_ro routes through an
+            nb_func vectorcall (~15-20ns per read on the python-node
+            boundary). */
+        template <auto Member>
+        PyObject *py_ts_raw_get(PyObject *self, void *) noexcept
+        {
+            try
+            {
+                auto *ts = nb::inst_ptr<PyTimeSeries>(self);
+                if constexpr (std::is_same_v<decltype((ts->*Member)()), bool>)
+                {
+                    return PyBool_FromLong((ts->*Member)() ? 1 : 0);
+                }
+                else
+                {
+                    return (ts->*Member)().release().ptr();
+                }
+            }
+            catch (nb::python_error &error)
+            {
+                error.restore();
+                return nullptr;
+            }
+            catch (const std::exception &error)
+            {
+                PyErr_SetString(PyExc_RuntimeError, error.what());
+                return nullptr;
+            }
+            catch (...)
+            {
+                PyErr_SetString(PyExc_RuntimeError,
+                                "unexpected error reading a TimeSeries attribute");
+                return nullptr;
+            }
+        }
+
         std::vector<WiringPortRef> wiring_ports(nb::list inputs)
         {
             std::vector<WiringPortRef> result;
@@ -569,8 +607,18 @@ namespace hgraph::python_bridge
               return checked_add(
                   value, delta, time_zone_provider(view));
           });
-    nb::class_<PyTimeSeries>(m, "TimeSeries")
-        .def_prop_ro("value", &PyTimeSeries::value)
+    static PyGetSetDef py_ts_getset[] = {
+        {"value", &py_ts_raw_get<&PyTimeSeries::value>, nullptr, nullptr, nullptr},
+        {"delta_value", &py_ts_raw_get<&PyTimeSeries::delta_value>, nullptr, nullptr, nullptr},
+        {"modified", &py_ts_raw_get<&PyTimeSeries::modified>, nullptr, nullptr, nullptr},
+        {"valid", &py_ts_raw_get<&PyTimeSeries::valid>, nullptr, nullptr, nullptr},
+        {nullptr, nullptr, nullptr, nullptr, nullptr},
+    };
+    static PyType_Slot py_ts_slots[] = {
+        {Py_tp_getset, static_cast<void *>(py_ts_getset)},
+        {0, nullptr},
+    };
+    nb::class_<PyTimeSeries>(m, "TimeSeries", nb::type_slots(py_ts_slots))
         .def_prop_ro("_kind", [](const PyTimeSeries &self) { return static_cast<int>(self.kind()); })
         // hgraph's runtime activity control: a node may passivate/reactivate
         // its own input subscription (the C++ In views expose the same).

--- a/python/py_state_services.cpp
+++ b/python/py_state_services.cpp
@@ -615,9 +615,9 @@ namespace hgraph::python_bridge
                  self.require_alive();
                  self.view.make_active();
              })
-        .def_prop_ro("delta_value", &PyTimeSeries::delta_value)
-        .def_prop_ro("modified", &PyTimeSeries::modified)
-        .def_prop_ro("valid", &PyTimeSeries::valid)
+        // value/delta_value/modified/valid are raw tp_getset slots above —
+        // a def_prop_ro here would REPLACE the raw descriptor in the type
+        // dictionary and silently restore the vectorcall path.
         .def_prop_ro("all_valid", &PyTimeSeries::all_valid)
         // TSW eviction surface (hgraph's removed_value pair).
         .def_prop_ro("has_removed_value",

--- a/python/py_state_services.cpp
+++ b/python/py_state_services.cpp
@@ -25,8 +25,7 @@ namespace hgraph::python_bridge
         template <auto Member>
         PyObject *py_ts_raw_get(PyObject *self, void *) noexcept
         {
-            try
-            {
+            return py_error_on_exception<PyObject *>(nullptr, [&] {
                 auto *ts = nb::inst_ptr<PyTimeSeries>(self);
                 if constexpr (std::is_same_v<decltype((ts->*Member)()), bool>)
                 {
@@ -36,23 +35,7 @@ namespace hgraph::python_bridge
                 {
                     return (ts->*Member)().release().ptr();
                 }
-            }
-            catch (nb::python_error &error)
-            {
-                error.restore();
-                return nullptr;
-            }
-            catch (const std::exception &error)
-            {
-                PyErr_SetString(PyExc_RuntimeError, error.what());
-                return nullptr;
-            }
-            catch (...)
-            {
-                PyErr_SetString(PyExc_RuntimeError,
-                                "unexpected error reading a TimeSeries attribute");
-                return nullptr;
-            }
+            });
         }
 
         std::vector<WiringPortRef> wiring_ports(nb::list inputs)


### PR DESCRIPTION
## Summary

From the python-node-boundary investigation. Attribution first (differential micro-bench: const vs ident vs add python chains, source cost subtracted): the call+apply machinery costs only ~4ns over a native node — the existing `direct` fast-compute path is effectively free — while each `ts.value` read cost ~40ns against legacy's ~15ns. This PR attacks the read:

- **Raw `tp_getset` slots** for the four hot per-tick properties (`value`, `delta_value`, `modified`, `valid`) via `nb::type_slots` — a direct C call from CPython's attribute lookup, replacing nanobind's `nb_func` vectorcall property dispatch. C++ exceptions translate to Python at the getter boundary; all other properties/methods stay on `def_prop_ro`.
- **Atomic-scalar hot path in `PyTimeSeries::value()`**: the dominant TS kind short-circuits ahead of the TSL/REF/TSB branches, and the redundant `has_current_value` pre-check is dropped (`value_to_python()` already folds that check into a single ops dispatch).

## Measurements (mac, like-for-like vs main, same build config)

| per node-tick | main | this PR |
|---|---|---|
| `py_ident` (`.value` read) | 160.2 ns | **145.9 ns** |
| `py_add` (benchmark node shape) | 158.7 ns | **147.5 ns** |
| `py_const` (control: call+apply only) | 120.1 ns | 119.6 ns |
| native `+1` (control) | 130.2 ns | 132.4 ns |

The `.value` increment over the const baseline falls ~35% (40 → 26 ns). Bounded, honest impact: moves the `tick_py`-class scenarios toward parity; the larger residual is the shared fixed per-node cost, tracked separately (needs `perf` on hg-linux — `kernel.perf_event_paranoid` currently blocks it).

## Verification

- C++ suite green; full python tree 1613 passed / 10 skipped; ported suites 1144 passed (every existing attribute-access pattern exercises the raw getters).

🤖 Generated with [Claude Code](https://claude.com/claude-code)