### PR TITLE
Accept Arrow string-view columns in the table codec

### DIFF
--- a/src/hgraph/types/value/table_codec.cpp
+++ b/src/hgraph/types/value/table_codec.cpp
@@ -340,7 +340,12 @@ namespace hgraph
         Value read_str(const Column &, const arrow::Array &array, std::int64_t row)
         {
             // polars-built tables carry large_utf8 (64-bit offsets); reading
-            // one through StringArray misreads the offset buffer.
+            // one through StringArray misreads the offset buffer. Arrow's
+            // utf8_view representation likewise uses a distinct array layout.
+            if (array.type_id() == arrow::Type::STRING_VIEW)
+            {
+                return Value{Str{static_cast<const arrow::StringViewArray &>(array).GetView(row)}};
+            }
             if (array.type_id() == arrow::Type::LARGE_STRING)
             {
                 return Value{Str{static_cast<const arrow::LargeStringArray &>(array).GetView(row)}};
@@ -672,7 +677,8 @@ namespace hgraph
                                      actual->Equals(arrow::timestamp(
                                          arrow::TimeUnit::MICRO))) ||
                                     (ops.type->id() == arrow::Type::STRING &&
-                                     actual->id() == arrow::Type::LARGE_STRING) ||
+                                     (actual->id() == arrow::Type::LARGE_STRING ||
+                                      actual->id() == arrow::Type::STRING_VIEW)) ||
                                     (ops.type->id() == arrow::Type::BINARY &&
                                      actual->id() == arrow::Type::LARGE_BINARY);
             if (!compatible)

--- a/tests/cpp/test_table.cpp
+++ b/tests/cpp/test_table.cpp
@@ -169,6 +169,21 @@ TEST_CASE("table codec: schema-declared legacy Instant reads but version 2 rejec
         std::invalid_argument);
 }
 
+TEST_CASE("table codec: Arrow utf8_view arrays decode as native strings")
+{
+    arrow::StringViewBuilder builder;
+    const Str expected{"a string-view value stored outside the inline view"};
+    REQUIRE(builder.Append(expected).ok());
+
+    std::shared_ptr<arrow::Array> values;
+    REQUIRE(builder.Finish(&values).ok());
+    REQUIRE(values->type_id() == arrow::Type::STRING_VIEW);
+
+    const Value decoded =
+        array_cell(*values, scalar_descriptor<Str>::value_meta(), 0);
+    CHECK(decoded.view().checked_as<Str>() == expected);
+}
+
 TEST_CASE("table codec: bytes and variadic tuples are Arrow leaf values")
 {
     auto &registry = TypeRegistry::instance();


### PR DESCRIPTION
## What changed

- treat Arrow `utf8_view` / `StringViewArray` as a compatible source for native `Str` values
- decode the view with its correct physical array representation instead of casting it as a normal `StringArray`
- add native coverage using an out-of-line string-view payload

## Why

The table codec accepted Arrow `utf8` and `large_utf8` columns, but rejected `utf8_view`. Merely relaxing schema validation would still have been unsafe because `StringViewArray` has a different physical layout from `StringArray`.

This lets Arrow pipelines using the view-based string type feed native hgraph string fields without conversion.

## Validation

- clean native macOS configure/build and complete suite: 1,291 passed
- stable-ABI wheel built with Python 3.12 and installed into a fresh Python 3.14 environment
- complete non-WIP Python compatibility suite: 1,727 passed, 10 skipped
- the catalogue real-time timing test flaked once on the first pass, then passed 10/10 isolated replays and the complete rerun