### PR TITLE
Expose ddof for window standard deviation

### DIFF
--- a/include/hgraph/lib/std/operators/collection.h
+++ b/include/hgraph/lib/std/operators/collection.h
@@ -35,8 +35,11 @@ namespace hgraph::stdlib
     {
     };
 
-    /** ``std_`` — running / element-wise standard deviation. */
-    struct std_ : Operator<"std", In<"ts", TsVar<"S">>, Out<TsVar<"O">>>
+    /** ``std_`` — running / element-wise standard deviation.
+        Window overloads accept ``ddof`` to use an ``N - ddof`` divisor. */
+    struct std_
+        : Operator<"std", In<"ts", TsVar<"S">>, Scalar<"ddof", Int>,
+                   Out<TsVar<"O">>>
     {
     };
 

--- a/include/hgraph/lib/std/operators/impl/stream_impl.h
+++ b/include/hgraph/lib/std/operators/impl/stream_impl.h
@@ -306,8 +306,8 @@ namespace hgraph::stdlib
             }
         };
 
-        /** std over a NUMERIC TSW: the POPULATION standard deviation of the
-            window contents (hgraph parity for windowed std). */
+        /** std over a NUMERIC TSW. The no-ddof overload uses the population
+            divisor; the explicit overload uses N - ddof. */
         template <typename T>
         struct tsw_std_impl
         {
@@ -330,7 +330,9 @@ namespace hgraph::stdlib
                             TypeRegistry::instance().ts(scalar_descriptor<Float>::value_meta()));
             }
 
-            static void eval(In<"ts", TsVar<"S">> ts, Out<TsVar<"__out__">> out)
+            static void eval_with_ddof(
+                const In<"ts", TsVar<"S">> &ts, Int ddof,
+                const Out<TsVar<"__out__">> &out)
             {
                 const auto &erased = static_cast<const TSOutputView &>(out);
                 if (!ts.valid()) { return; }
@@ -351,9 +353,35 @@ namespace hgraph::stdlib
                     const Float delta = static_cast<Float>(window.at(index).checked_as<T>()) - mean_value;
                     squares += delta * delta;
                 }
+                const Float divisor =
+                    static_cast<Float>(size) - static_cast<Float>(ddof);
+                const Float variance =
+                    divisor > 0.0
+                        ? squares / divisor
+                        : std::numeric_limits<Float>::quiet_NaN();
                 auto mutation = erased.data_view().begin_mutation(erased.evaluation_time());
                 static_cast<void>(mutation.move_value_from(
-                    Value{std::sqrt(squares / static_cast<Float>(size))}));
+                    Value{std::sqrt(variance)}));
+            }
+
+            static void eval(In<"ts", TsVar<"S">> ts,
+                             Out<TsVar<"__out__">> out)
+            {
+                eval_with_ddof(ts, 0, out);
+            }
+        };
+
+        template <typename T>
+        struct tsw_std_ddof_impl : tsw_std_impl<T>
+        {
+            static constexpr auto name =
+                std::same_as<T, Int> ? "std_tsw_ddof_int" : "std_tsw_ddof_float";
+
+            static void eval(In<"ts", TsVar<"S">> ts,
+                             Scalar<"ddof", Int> ddof,
+                             Out<TsVar<"__out__">> out)
+            {
+                tsw_std_impl<T>::eval_with_ddof(ts, ddof.value(), out);
             }
         };
 

--- a/python/tests/ported/_operators/test_scalar_operators.py
+++ b/python/tests/ported/_operators/test_scalar_operators.py
@@ -479,6 +479,17 @@ def test_std_tsw_number():
     assert eval_node(app, [1, 2, 3, 4, 5]) == [None, None, 0.816496580927726, 1.118033988749895, 1.4142135623730951]
 
 
+def test_std_tsw_ddof():
+    @graph
+    def app(ts: TS[int]) -> TS[float]:
+        window = to_window(ts, 5, 3)
+        return std(window, ddof=1)
+
+    actual = eval_node(app, [1, 2, 3, 4, 5])
+    assert actual[:2] == [None, None]
+    assert actual[2:] == pytest.approx([1.0, 1.2909944487358056, 1.5811388300841898])
+
+
 @pytest.mark.parametrize(
     ["lhs", "rhs", "expected"],
     [

--- a/src/hgraph/lib/std/operators/stream_impl.cpp
+++ b/src/hgraph/lib/std/operators/stream_impl.cpp
@@ -40,6 +40,8 @@ namespace hgraph::stdlib
         register_overload<mean, stream_impl_detail::tsw_numeric_aggregate_impl<true, Float>>();
         register_overload<std_, stream_impl_detail::tsw_std_impl<Int>>();
         register_overload<std_, stream_impl_detail::tsw_std_impl<Float>>();
+        register_overload<std_, stream_impl_detail::tsw_std_ddof_impl<Int>>();
+        register_overload<std_, stream_impl_detail::tsw_std_ddof_impl<Float>>();
         register_overload<min_, stream_impl_detail::tsw_extremum_impl<true>>();
         register_overload<max_, stream_impl_detail::tsw_extremum_impl<false>>();
         register_overload<min_, stream_impl_detail::tsw_extremum_default_impl<true>>();

--- a/tests/cpp/test_std_operators.cpp
+++ b/tests/cpp/test_std_operators.cpp
@@ -219,6 +219,19 @@ namespace
         }
     };
 
+    struct WindowStdDdofGraph
+    {
+        static constexpr auto name = "window_std_ddof_graph";
+
+        static Port<TS<Float>> compose(Wiring &w, Port<TS<Int>> ts)
+        {
+            auto window = wire<stdlib::to_window>(w, ts, Int{3}, Int{3});
+            return wire<stdlib::std_>(
+                       w, window, arg<"ddof">(Int{1}))
+                .as<TS<Float>>();
+        }
+    };
+
     // Scalar-container TS schemas are runtime metadata today. The wrapper graph
     // pins the output type expectation while eval_runtime_schema_graph supplies
     // the input schema at replay.
@@ -2211,6 +2224,9 @@ TEST_CASE("std operators: stream operators cover sampling filtering slicing and 
                      values<Int>(1, 2, none, 3),
                      values<Bool>(none, none, true, none)),
                  values<Int>(101, 203, 0, 103));
+    CHECK_OUTPUT(eval_node<WindowStdDdofGraph>(
+                     values<Int>(1, 2, 3, 4, 5)),
+                 values<Float>(none, none, 1.0, 1.0, 1.0));
 
     CHECK_OUTPUT(eval_node<stdlib::count>(values<Int>(3, none, 2, 1)), values<Int>(1, none, 2, 3));
     CHECK_OUTPUT(eval_node<stdlib::dedup>(values<Int>(1, 2, 2, 3, 3, 3, 4)),


### PR DESCRIPTION
## Summary

- expose `ddof` on the public `std` operator
- add native integer and floating-point TSW overloads using an `N - ddof` divisor
- preserve the existing population-standard-deviation behavior when `ddof` is omitted
- add matching public-wiring C++ and Python compatibility coverage

## Root cause

The native TSW standard-deviation implementation always divided by the window size and the public operator surface did not declare a `ddof` scalar, so Python's `std(window, ddof=...)` could not select a native implementation. The explicit overload now applies the requested degrees-of-freedom correction. Other `std` shapes and their existing defaults are unchanged.

When `N - ddof <= 0`, the implementation publishes NaN, matching NumPy-style behavior.

## Validation

macOS:

- clean native configure/build: passed
- complete native suite: 1,290 passed
- Python 3.12 stable-ABI wheel installed into fresh Python 3.14 environment: 1,728 passed, 10 skipped

Linux (`hg-linux`, x86_64 Ubuntu):

- clean native configure/build: passed
- complete native suite: 1,290 passed
- Python 3.12 stable-ABI wheel installed into fresh Python 3.14 environment: 1,728 passed, 10 skipped