### PR TITLE
Use an untagged package version sentinel

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -3,7 +3,7 @@ from datetime import datetime
 project = "hgraph"
 author = "Howard Henson"
 copyright = f"{datetime.now().year}, {author}"
-release = "0.4.0rc1"
+release = "0.4.0"
 
 extensions = [
     "myst_parser",

--- a/docs/source/developer_guide/build_system.rst
+++ b/docs/source/developer_guide/build_system.rst
@@ -64,14 +64,14 @@ Windows x86_64, and Apple Silicon macOS, then installs each platform wheel under
 CPython 3.12, 3.13, and 3.14.  A tag matching ``v_x.x.x`` publishes the tested
 wheels and source distribution through PyPI trusted publishing.  The tag is the
 release version authority: the publish job restamps the metadata of artifacts
-already tested for that exact commit, rather than rebuilding them.  The version
-in ``pyproject.toml`` and ``docs/source/conf.py`` is the untagged artifact
-baseline.  CMake's ``project(VERSION)`` field is numeric and matches that
-baseline's base version (for example ``0.4.0rc1`` maps to ``0.4.0``).  Packaging
-tests enforce the baseline relationships and the release workflow validates
-the tag syntax and rejects versions already present on PyPI.  The PyPI trusted
-publisher is bound to the ``build.yml`` workflow and the GitHub ``release``
-environment.
+already tested for that exact commit, rather than rebuilding them.
+``pyproject.toml`` therefore uses ``0.0.0`` as an explicit untagged-artifact
+sentinel; it is never the version published to PyPI.  CMake's numeric
+``project(VERSION)`` and ``docs/source/conf.py`` track the current C++ API line
+independently.  Packaging tests enforce these relationships and the release
+workflow validates the tag syntax and rejects versions already present on
+PyPI.  The PyPI trusted publisher is bound to the ``build.yml`` workflow and
+the GitHub ``release`` environment.
 
 The macOS build uses the current system Clang from the latest Apple Silicon
 runner image while retaining a macOS 15 deployment target.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,8 +8,9 @@ build-backend = "scikit_build_core.build"
 
 [project]
 name = "hg_cpp"
-version = "0.4.0rc1"
-description = "Release candidate for the C++ first hgraph runtime and Python compatibility bridge"
+# Release artifacts are restamped from the v_x.x.x tag by build.yml.
+version = "0.0.0"
+description = "C++-first hgraph runtime and Python compatibility bridge"
 readme = "README.md"
 requires-python = ">=3.12"
 license = {text = "MIT"}

--- a/python/tests/test_packaging.py
+++ b/python/tests/test_packaging.py
@@ -16,7 +16,7 @@ NANOBIND_REQUIREMENT = "nanobind==2.13.0"
 SUPPORTED_PYTHON_MINIMUM = ">=3.12"
 STABLE_ABI_TAG = "cp312"
 DISTRIBUTION_NAME = "hg_cpp"
-RELEASE_CANDIDATE = Version("0.4.0rc1")
+UNTAGGED_VERSION = Version("0.0.0")
 
 
 def load_project():
@@ -68,23 +68,25 @@ def test_pypi_classifiers_are_valid():
     assert not invalid_classifiers, f"invalid PyPI classifiers: {sorted(invalid_classifiers)}"
 
 
-def test_release_metadata_is_consistent():
+def test_release_metadata_uses_untagged_sentinel():
     project = load_project()["project"]
     version = Version(project["version"])
 
     assert project["name"] == DISTRIBUTION_NAME
-    assert version == RELEASE_CANDIDATE
-    assert version.is_prerelease
+    assert version == UNTAGGED_VERSION
 
     cmake = (ROOT / "CMakeLists.txt").read_text()
     cmake_version = re.search(r"project\(\s*hgraph\s+VERSION\s+(\d+\.\d+\.\d+)", cmake)
     assert cmake_version is not None
-    assert Version(cmake_version.group(1)) == Version(version.base_version)
 
     sphinx = (ROOT / "docs/source/conf.py").read_text()
     sphinx_version = re.search(r'^release = "([^"]+)"$', sphinx, re.MULTILINE)
     assert sphinx_version is not None
-    assert Version(sphinx_version.group(1)) == version
+    assert Version(sphinx_version.group(1)) == Version(cmake_version.group(1))
+
+    workflow = (ROOT / ".github/workflows/build.yml").read_text()
+    assert "Restamp distributions to the tag version" in workflow
+    assert 'version = os.environ["RELEASE_TAG"].removeprefix("v_")' in workflow
 
 
 def test_wheel_targets_the_python_312_stable_abi():
@@ -203,7 +205,7 @@ def main():
     test_windows_wheel_installs_all_linked_pyarrow_runtimes()
     test_supported_python_versions_are_declared()
     test_pypi_classifiers_are_valid()
-    test_release_metadata_is_consistent()
+    test_release_metadata_uses_untagged_sentinel()
     test_wheel_targets_the_python_312_stable_abi()
     test_wheel_uses_shared_runtime_for_downstream_native_extensions()
     test_source_distribution_excludes_private_release_evidence()
@@ -217,7 +219,7 @@ def main():
     print("PASS test_windows_wheel_installs_all_linked_pyarrow_runtimes")
     print("PASS test_supported_python_versions_are_declared")
     print("PASS test_pypi_classifiers_are_valid")
-    print("PASS test_release_metadata_is_consistent")
+    print("PASS test_release_metadata_uses_untagged_sentinel")
     print("PASS test_wheel_targets_the_python_312_stable_abi")
     print("PASS test_wheel_uses_shared_runtime_for_downstream_native_extensions")
     print("PASS test_source_distribution_excludes_private_release_evidence")

--- a/uv.lock
+++ b/uv.lock
@@ -430,7 +430,7 @@ wheels = [
 
 [[package]]
 name = "hg-cpp"
-version = "0.4.0rc1"
+version = "0.0.0"
 source = { editable = "." }
 dependencies = [
     { name = "frozendict" },


### PR DESCRIPTION
## Summary

- replace the stale checked-in `0.4.0rc1` Python package version with an explicit `0.0.0` untagged-artifact sentinel
- document that `build.yml` restamps wheels and source distributions from the authoritative `v_x.x.x` release tag
- synchronize `uv.lock` and remove the obsolete release-candidate wording from the package description
- keep CMake and Sphinx aligned on the current `0.4.0` C++ API line, independently of the Python artifact sentinel
- update the packaging contract to enforce the sentinel and the tag-restamping path

## Why

The repository has released well beyond `0.4.0rc1`, but the checked-in Python version was never advanced after publishing. That made ordinary local artifacts appear to be an old release candidate. The release workflow already treats the Git tag as the version authority and rewrites tested artifact metadata before publication, so a neutral sentinel makes the checked-in state unambiguous and removes the need for post-release version commits.

## Validation

- packaging contract script: passed
- source distribution: built as `hg_cpp-0.0.0.tar.gz`; `PKG-INFO` verified as `Version: 0.0.0`
- Sphinx documentation build with warnings as errors: passed
- clean native configure/build: passed
- complete native suite: 1,291 passed
- Python 3.12 stable-ABI wheel: built as `hg_cpp-0.0.0-cp312-abi3-macosx_26_0_arm64.whl`
- wheel installed into a fresh Python 3.14 environment; installed metadata verified as `0.0.0`
- complete non-WIP Python suite: 1,728 passed, 10 skipped
- installed-wheel C++/nanobind extension consumer under Python 3.12: passed
- `uv lock --check`: passed