### PR TITLE
Hot-loop invocation: single-projection lifted kernels + inline TypeRef accessors

### DIFF
--- a/include/hgraph/runtime/clock_type_ref.h
+++ b/include/hgraph/runtime/clock_type_ref.h
@@ -6,6 +6,7 @@
 
 #include <cstddef>
 #include <functional>
+#include <stdexcept>
 #include <string_view>
 #include <type_traits>
 
@@ -34,8 +35,19 @@ namespace hgraph
             return record_ != nullptr ? record_->plan : nullptr;
         }
         [[nodiscard]] const MemoryUtils::StoragePlan &checked_plan() const;
-        [[nodiscard]] const EvaluationClockOps *ops() const noexcept;
-        [[nodiscard]] const EvaluationClockOps &ops_ref() const;
+        // Header-inline like the other trivial record accessors: these run
+        // on hot evaluation paths and the out-of-line definitions were not
+        // inlined even under LTO (profiled as bare call overhead).
+        [[nodiscard]] const EvaluationClockOps *ops() const noexcept
+        {
+            return record_ != nullptr ? static_cast<const EvaluationClockOps *>(record_->ops) : nullptr;
+        }
+        [[nodiscard]] const EvaluationClockOps &ops_ref() const
+        {
+            const auto *table = ops();
+            if (table == nullptr) { throw std::logic_error("ClockTypeRef is unbound"); }
+            return *table;
+        }
         [[nodiscard]] constexpr TypeCapabilities capabilities() const noexcept
         {
             return record_ != nullptr ? record_->capabilities : TypeCapabilities::None;

--- a/include/hgraph/runtime/executor_type_ref.h
+++ b/include/hgraph/runtime/executor_type_ref.h
@@ -6,6 +6,7 @@
 
 #include <cstddef>
 #include <functional>
+#include <stdexcept>
 #include <string_view>
 #include <type_traits>
 
@@ -34,8 +35,19 @@ namespace hgraph
             return record_ != nullptr ? record_->plan : nullptr;
         }
         [[nodiscard]] const MemoryUtils::StoragePlan &checked_plan() const;
-        [[nodiscard]] const GraphExecutorOps *ops() const noexcept;
-        [[nodiscard]] const GraphExecutorOps &ops_ref() const;
+        // Header-inline like the other trivial record accessors: these run
+        // on hot evaluation paths and the out-of-line definitions were not
+        // inlined even under LTO (profiled as bare call overhead).
+        [[nodiscard]] const GraphExecutorOps *ops() const noexcept
+        {
+            return record_ != nullptr ? static_cast<const GraphExecutorOps *>(record_->ops) : nullptr;
+        }
+        [[nodiscard]] const GraphExecutorOps &ops_ref() const
+        {
+            const auto *table = ops();
+            if (table == nullptr) { throw std::logic_error("ExecutorTypeRef is unbound"); }
+            return *table;
+        }
         [[nodiscard]] constexpr TypeCapabilities capabilities() const noexcept
         {
             return record_ != nullptr ? record_->capabilities : TypeCapabilities::None;

--- a/include/hgraph/runtime/graph_type_ref.h
+++ b/include/hgraph/runtime/graph_type_ref.h
@@ -6,6 +6,7 @@
 
 #include <cstddef>
 #include <functional>
+#include <stdexcept>
 #include <string_view>
 #include <type_traits>
 
@@ -38,8 +39,19 @@ namespace hgraph
         {
             if (plan() != nullptr) plan()->destroy(memory);
         }
-        [[nodiscard]] const GraphOps *ops() const noexcept;
-        [[nodiscard]] const GraphOps &ops_ref() const;
+        // Header-inline like the other trivial record accessors: these run
+        // on hot evaluation paths and the out-of-line definitions were not
+        // inlined even under LTO (profiled as bare call overhead).
+        [[nodiscard]] const GraphOps *ops() const noexcept
+        {
+            return record_ != nullptr ? static_cast<const GraphOps *>(record_->ops) : nullptr;
+        }
+        [[nodiscard]] const GraphOps &ops_ref() const
+        {
+            const auto *table = ops();
+            if (table == nullptr) { throw std::logic_error("GraphTypeRef is unbound"); }
+            return *table;
+        }
         [[nodiscard]] constexpr TypeCapabilities capabilities() const noexcept
         {
             return record_ != nullptr ? record_->capabilities : TypeCapabilities::None;

--- a/include/hgraph/runtime/node_type_ref.h
+++ b/include/hgraph/runtime/node_type_ref.h
@@ -42,8 +42,20 @@ namespace hgraph
         {
             if (plan() != nullptr) plan()->destroy(memory);
         }
-        [[nodiscard]] const NodeOps *ops() const noexcept;
-        [[nodiscard]] const NodeOps &ops_ref() const;
+        // ops()/ops_ref() are header-inline like plan()/capabilities():
+        // they run on every node evaluation and profiling showed the
+        // out-of-line definitions were not inlined even under LTO
+        // (~2-3% self time as bare call overhead).
+        [[nodiscard]] const NodeOps *ops() const noexcept
+        {
+            return record_ != nullptr ? static_cast<const NodeOps *>(record_->ops) : nullptr;
+        }
+        [[nodiscard]] const NodeOps &ops_ref() const
+        {
+            const auto *table = ops();
+            if (table == nullptr) { throw std::logic_error("NodeTypeRef is unbound"); }
+            return *table;
+        }
         [[nodiscard]] constexpr TypeCapabilities capabilities() const noexcept
         {
             return record_ != nullptr ? record_->capabilities : TypeCapabilities::None;

--- a/include/hgraph/types/lift.h
+++ b/include/hgraph/types/lift.h
@@ -229,13 +229,6 @@ namespace hgraph
         }
 
         template <typename F, std::size_t... I>
-        [[nodiscard]] result_t<F> eval_input_values(TSBInputView &input, std::index_sequence<I...>)
-        {
-            using tuple = arg_tuple_t<F>;
-            return invoke<F>(input.at(I).value().template checked_as<tuple_arg_t<tuple, I>>()...);
-        }
-
-        template <typename F, std::size_t... I>
         [[nodiscard]] const TSValueTypeMetaData *input_schema_impl(std::size_t index, std::index_sequence<I...>)
         {
             using tuple = arg_tuple_t<F>;
@@ -393,9 +386,25 @@ namespace hgraph
         }
 
         template <typename F, std::size_t... I>
-        [[nodiscard]] bool lifted_inputs_valid(TSBInputView &input, std::index_sequence<I...>)
+        bool evaluate_lifted_children(const NodeView &view, TSBInputView &input,
+                                      DateTime evaluation_time, std::index_sequence<I...>)
         {
-            return (input.at(I).valid() && ...);
+            // Project each argument child ONCE per evaluation: at(I) walks
+            // the input child projection, and the validity pass plus the
+            // value pass previously each paid it — the lifted twin of the
+            // static-node invocation frame (RFC 0008 profile).
+            std::array<TSInputView, sizeof...(I)> children{input.at(I)...};
+            if (!(children[I].valid() && ...)) { return true; }
+            auto output = view.output(evaluation_time);
+
+            using tuple = arg_tuple_t<F>;
+            result_t<F> result =
+                invoke<F>(children[I].value().template checked_as<tuple_arg_t<tuple, I>>()...);
+            auto mutation = output.begin_mutation(evaluation_time);
+            auto destination = mutation.value();
+            const ValueView source{destination.binding(), static_cast<const void *>(&result)};
+            static_cast<void>(mutation.copy_value_from(source));
+            return true;
         }
 
         template <typename F, auto Identity>
@@ -405,15 +414,8 @@ namespace hgraph
 
             auto root_input = view.input(evaluation_time);
             auto input      = root_input.as_bundle();
-            if (!lifted_inputs_valid<F>(input, std::make_index_sequence<arity_v<F>>{})) { return true; }
-            auto output     = view.output(evaluation_time);
-
-            result_t<F> result = eval_input_values<F>(input, std::make_index_sequence<arity_v<F>>{});
-            auto mutation = output.begin_mutation(evaluation_time);
-            auto destination = mutation.value();
-            const ValueView source{destination.binding(), static_cast<const void *>(&result)};
-            static_cast<void>(mutation.copy_value_from(source));
-            return true;
+            return evaluate_lifted_children<F>(view, input, evaluation_time,
+                                               std::make_index_sequence<arity_v<F>>{});
         }
 
         template <typename F, auto Identity>

--- a/include/hgraph/types/value/value_type_ref.h
+++ b/include/hgraph/types/value/value_type_ref.h
@@ -37,8 +37,19 @@ namespace hgraph
             return record_ != nullptr ? record_->plan : nullptr;
         }
         [[nodiscard]] const MemoryUtils::StoragePlan &checked_plan() const;
-        [[nodiscard]] const ValueOps *ops() const noexcept;
-        [[nodiscard]] const ValueOps &ops_ref() const;
+        // Header-inline like the other trivial record accessors: these run
+        // on hot evaluation paths and the out-of-line definitions were not
+        // inlined even under LTO (profiled as bare call overhead).
+        [[nodiscard]] const ValueOps *ops() const noexcept
+        {
+            return record_ != nullptr ? static_cast<const ValueOps *>(record_->ops) : nullptr;
+        }
+        [[nodiscard]] const ValueOps &ops_ref() const
+        {
+            const auto *table = ops();
+            if (table == nullptr) { throw std::logic_error("ValueTypeRef is unbound"); }
+            return *table;
+        }
         [[nodiscard]] const MemoryUtils::LifecycleOps *lifecycle() const noexcept
         {
             return plan() != nullptr ? &plan()->lifecycle : nullptr;

--- a/src/hgraph/runtime/evaluation_clock.cpp
+++ b/src/hgraph/runtime/evaluation_clock.cpp
@@ -84,17 +84,6 @@ namespace hgraph
         return *plan();
     }
 
-    const EvaluationClockOps *ClockTypeRef::ops() const noexcept
-    {
-        return record_ != nullptr ? static_cast<const EvaluationClockOps *>(record_->ops) : nullptr;
-    }
-
-    const EvaluationClockOps &ClockTypeRef::ops_ref() const
-    {
-        if (ops() == nullptr) throw std::logic_error("ClockTypeRef is unbound");
-        return *ops();
-    }
-
     ClockPtr ClockTypeRef::typed_null() const noexcept
     {
         return ClockPtr{AnyPtr{record_, nullptr, AccessMode::ReadOnly}, ClockPtr::UncheckedTag{}};

--- a/src/hgraph/runtime/executor.cpp
+++ b/src/hgraph/runtime/executor.cpp
@@ -806,17 +806,6 @@ namespace hgraph
         return *plan();
     }
 
-    const GraphExecutorOps *ExecutorTypeRef::ops() const noexcept
-    {
-        return record_ != nullptr ? static_cast<const GraphExecutorOps *>(record_->ops) : nullptr;
-    }
-
-    const GraphExecutorOps &ExecutorTypeRef::ops_ref() const
-    {
-        if (ops() == nullptr) throw std::logic_error("ExecutorTypeRef is unbound");
-        return *ops();
-    }
-
     ExecutorPtr ExecutorTypeRef::typed_null() const noexcept
     {
         return ExecutorPtr{AnyPtr{record_, nullptr, AccessMode::ReadOnly}, ExecutorPtr::UncheckedTag{}};

--- a/src/hgraph/runtime/graph.cpp
+++ b/src/hgraph/runtime/graph.cpp
@@ -1307,17 +1307,6 @@ const MemoryUtils::StoragePlan &GraphTypeRef::checked_plan() const {
   return *plan();
 }
 
-const GraphOps *GraphTypeRef::ops() const noexcept {
-  return record_ != nullptr ? static_cast<const GraphOps *>(record_->ops)
-                            : nullptr;
-}
-
-const GraphOps &GraphTypeRef::ops_ref() const {
-  if (ops() == nullptr)
-    throw std::logic_error("GraphTypeRef is unbound");
-  return *ops();
-}
-
 GraphPtr GraphTypeRef::typed_null() const noexcept {
   return GraphPtr{AnyPtr{record_, nullptr, AccessMode::ReadOnly},
                   GraphPtr::UncheckedTag{}};

--- a/src/hgraph/runtime/node.cpp
+++ b/src/hgraph/runtime/node.cpp
@@ -1089,17 +1089,6 @@ namespace hgraph
         return *plan();
     }
 
-    const NodeOps *NodeTypeRef::ops() const noexcept
-    {
-        return record_ != nullptr ? static_cast<const NodeOps *>(record_->ops) : nullptr;
-    }
-
-    const NodeOps &NodeTypeRef::ops_ref() const
-    {
-        if (ops() == nullptr) throw std::logic_error("NodeTypeRef is unbound");
-        return *ops();
-    }
-
     NodePtr NodeTypeRef::typed_null() const noexcept
     {
         return NodePtr{AnyPtr{record_, nullptr, AccessMode::ReadOnly}, NodePtr::UncheckedTag{}};

--- a/src/hgraph/types/value/value_type_ref.cpp
+++ b/src/hgraph/types/value/value_type_ref.cpp
@@ -110,17 +110,6 @@ namespace hgraph
         return *plan();
     }
 
-    const ValueOps *ValueTypeRef::ops() const noexcept
-    {
-        return record_ != nullptr ? static_cast<const ValueOps *>(record_->ops) : nullptr;
-    }
-
-    const ValueOps &ValueTypeRef::ops_ref() const
-    {
-        if (ops() == nullptr) throw std::logic_error("ValueTypeRef is unbound");
-        return *ops();
-    }
-
     ValuePtr ValueTypeRef::typed_null() const noexcept
     {
         return ValuePtr{AnyPtr{record_, nullptr, AccessMode::ReadOnly}, ValuePtr::UncheckedTag{}};


### PR DESCRIPTION
## Summary

Items #1 and #2 from the continued performance review (post-#187 re-profiling on hg-linux):

- **Lifted kernels project each argument once per evaluation** (`lift.h`). The lifted scalar kernels — every native arithmetic/comparison node — kept the pre-RFC-0008 pattern: root+bundle per evaluation, then `at(I)` per argument *twice* (validity pass + value pass), each walking the input child projection that profiling showed still at ~14% self time on the lifted-add hot loop after #187 covered static nodes. Arguments now project once into a stack array; validity and value reads run from the cached views — the lifted twin of #187's invocation frame.
- **The trivial `TypeRef` `ops()`/`ops_ref()` accessors move header-inline** (Node/Graph/Executor/Clock/Value families). Two-instruction record reads defined out-of-line, which profiling showed were *not* inlined even under thin LTO — 1–3% self time as bare call overhead in every workload shape. Their siblings (`plan()`, `capabilities()`) were already constexpr-inline; this aligns the family, unbound checks preserved.

## Measurements

macOS, quiet machine, like-for-like vs current main (which includes #187/#182):

| per node-tick | main | this PR |
|---|---|---|
| native `+1` chain | 111.5 ns | **80.6 ns (−28%)** |
| `py_const` (control) | 122.1 ns | 113.8 ns (−7%, accessor share) |

hg-linux paired worktree runs agree directionally (~9% on `tick_std` medians) but were taken under load-avg 18 contention and are indicative only.

## Verification

- C++ suite green; full python tree 1614 passed / 10 skipped; ported suites 1145 passed.

Review-note: #4 from the review (dense-map `ValueView::equals`) traced to keyed target links re-resolving dict children by key per tick — that folds into RFC 0008's stable-handle scope rather than a standalone fix; a plan for #3 (observer notify) follows separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)