### PR TITLE
Add type-erased time-series endpoint visitors

### DIFF
--- a/docs/source/developer_guide/data_structures/plans_and_ops/time_series.rst
+++ b/docs/source/developer_guide/data_structures/plans_and_ops/time_series.rst
@@ -578,8 +578,12 @@ to the matching callable. Existing collection views are used for ``TSS``,
 
 A specialised handler takes precedence over the role-level
 ``TSInputView`` / ``TSOutputView`` catch-all. Every reachable branch must
-return ``void`` or the same non-reference type. Reference returns are rejected
-because the selected wrapper is a temporary cursor.
+return ``void`` or the same safe value type. Reference returns and lazy
+``Range`` / ``KeyValueRange`` results are rejected because the selected wrapper
+is a temporary cursor and a range may retain it as projection context. Consume
+ranges inside the handler or return an owned materialisation such as
+``std::vector``. User-defined result types must likewise not retain a pointer or
+reference to the selected wrapper.
 
 Dispatch is intentionally one level. It does not walk collection children or
 follow ``REF`` values. A caller that wants recursion selects children through

--- a/docs/source/developer_guide/data_structures/plans_and_ops/time_series.rst
+++ b/docs/source/developer_guide/data_structures/plans_and_ops/time_series.rst
@@ -556,6 +556,38 @@ it uses ``value().as_set()``, ``value().as_map()``,
 storage, which is distinct from ``valid()``; an output can be
 bound before its time-series value has ever been set.
 
+One-level endpoint visitation
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Generic endpoint algorithms can dispatch a live ``TSInputView`` or
+``TSOutputView`` with ``hgraph::visit`` from
+``<hgraph/types/time_series/visitor.h>``. The visitor performs one switch on
+the endpoint's semantic ``TSTypeKind`` and passes a borrowed specialised view
+to the matching callable. Existing collection views are used for ``TSS``,
+``TSD``, ``TSL``, ``TSW``, and ``TSB``; ``TSValue*View``,
+``TSReference*View``, and ``TSSignal*View`` tag the three leaf kinds.
+
+.. code-block:: cpp
+
+   const std::size_t child_count = hgraph::visit(
+       input,
+       [](hgraph::TSDInputView dict) { return dict.size(); },
+       [](hgraph::TSLInputView list) { return list.size(); },
+       [](hgraph::TSBInputView bundle) { return bundle.size(); },
+       [](hgraph::TSInputView) { return std::size_t{0}; });
+
+A specialised handler takes precedence over the role-level
+``TSInputView`` / ``TSOutputView`` catch-all. Every reachable branch must
+return ``void`` or the same non-reference type. Reference returns are rejected
+because the selected wrapper is a temporary cursor.
+
+Dispatch is intentionally one level. It does not walk collection children or
+follow ``REF`` values. A caller that wants recursion selects children through
+the specialised view and calls ``visit`` again, making key selection,
+validity filtering, and reference-cycle policy explicit. An endpoint with a
+schema remains dispatchable while its current value or peered target is
+invalid; a default view without a schema throws ``std::invalid_argument``.
+
 TSData Memory Layout and Delta Tracking
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/source/rfc/index.rst
+++ b/docs/source/rfc/index.rst
@@ -22,3 +22,4 @@ workflow are defined by :doc:`rfc_0000`.
    rfc_0006_tsw_reset_and_clear
    rfc_0007_scheduled_duration_tsw_eviction
    rfc_0008_prepared_node_inputs
+   rfc_0009_time_series_endpoint_visitors

--- a/docs/source/rfc/rfc_0009_time_series_endpoint_visitors.rst
+++ b/docs/source/rfc/rfc_0009_time_series_endpoint_visitors.rst
@@ -1,0 +1,196 @@
+RFC 0009: Type-Erased Time-Series Endpoint Visitors
+====================================================
+
+:Status: Proposed
+:Author: Howard Henson
+:Created: 2026-07-29
+:Target: Public C++ time-series endpoint views
+
+Summary
+-------
+
+Add one-level, callable-based visitation for ``TSInputView`` and
+``TSOutputView``. The visitor dispatches on the endpoint's semantic
+``TSTypeKind`` and passes a shape-specific borrowed view to the selected
+handler. It uses the runtime's existing type-erased schema and view surfaces;
+it does not add virtual ``accept`` methods, RTTI, heap allocation, or a new
+operations-table entry.
+
+This first RFC deliberately covers endpoints only. ``ValueView``,
+``TSDataView``, nodes, graphs, executors, clocks, and recursive traversal are
+left for separate proposals after endpoint usage has established the right
+callable conventions.
+
+Motivation
+----------
+
+Generic endpoint algorithms currently repeat a switch on ``schema()->kind``
+and manually construct ``TSSInputView``, ``TSDOutputView``, and the other
+shape-specific views. The legacy C++ hgraph implementation supplied visitor
+dispatch for this purpose, but its class hierarchy and double-dispatch
+mechanism do not fit the current type-erased runtime.
+
+The current runtime already carries the complete discriminator and the
+layout-independent view projections required for dispatch. A free function can
+therefore perform one semantic-kind switch and hand the caller the appropriate
+view without introducing another object hierarchy or making the runtime aware
+of caller-defined visitor classes.
+
+Ownership boundary
+------------------
+
+Endpoint visitation is a core C++ SDK facility because generic algorithms and
+independently built extensions both consume the public endpoint views. The
+runtime remains the source of truth for endpoint semantics and projections.
+
+Python receives no new API. Python already performs dynamic dispatch on its
+time-series wrappers, and this C++ callable convenience does not change
+runtime behaviour visible through the bridge.
+
+Public C++ contract
+-------------------
+
+The public header ``<hgraph/types/time_series/visitor.h>`` provides:
+
+.. code-block:: cpp
+
+   template<class... Handlers>
+   decltype(auto) visit(const TSInputView &view, Handlers&&... handlers);
+
+   template<class... Handlers>
+   decltype(auto) visit(const TSOutputView &view, Handlers&&... handlers);
+
+Handlers are combined into one overload set. Dispatch selects the following
+argument type:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 16 42 42
+
+   * - Kind
+     - Input handler argument
+     - Output handler argument
+   * - ``TS``
+     - ``TSValueInputView``
+     - ``TSValueOutputView``
+   * - ``TSS``
+     - ``TSSInputView``
+     - ``TSSOutputView``
+   * - ``TSD``
+     - ``TSDInputView``
+     - ``TSDOutputView``
+   * - ``TSL``
+     - ``TSLInputView``
+     - ``TSLOutputView``
+   * - ``TSW``
+     - ``TSWInputView``
+     - ``TSWOutputView``
+   * - ``TSB``
+     - ``TSBInputView``
+     - ``TSBOutputView``
+   * - ``REF``
+     - ``TSReferenceInputView``
+     - ``TSReferenceOutputView``
+   * - ``SIGNAL``
+     - ``TSSignalInputView``
+     - ``TSSignalOutputView``
+
+The six new leaf views are move-only tagged wrappers over the corresponding
+erased endpoint view. They add only ``kind`` identity and the normal ``base()``
+projection; collection kinds retain their existing specialised views.
+
+A handler for the selected specialised type takes precedence. When that
+handler is absent, a handler accepting the role's erased ``TSInputView`` or
+``TSOutputView`` is the catch-all. A generic callable accepting the specialised
+view is also valid. If neither a specialised nor base handler can accept any
+reachable alternative, the visitor is ill-formed.
+
+Every selected branch returns ``void`` or the same non-reference result type.
+Reference results are rejected because the shape-specific wrapper is a
+temporary borrowed cursor. The visitor forwards the returned value without
+materialising an optional or allocating storage.
+
+Endpoint and reference semantics
+--------------------------------
+
+Dispatch depends on ``view.schema()->kind``. It does not inspect the current
+value schema, concrete storage implementation, or source endpoint:
+
+* an input cursor with a schema is dispatchable even when its current value or
+  peered target is invalid;
+* an untyped/default endpoint throws ``std::invalid_argument``;
+* a ``REF`` endpoint dispatches as ``TSReference*View`` and is not followed;
+* a target link exposing a non-``REF`` schema dispatches as that exposed
+  semantic kind, irrespective of the route used to reach its source; and
+* collection elements and structural children are not visited automatically.
+
+The handler receives a borrowed cursor over the same endpoint position and
+evaluation time. The visitor neither owns nor extends the lifetime of the
+endpoint or its underlying storage. Mutating an output through the selected
+view and activating or binding an input retain the existing capability and
+lifecycle rules.
+
+Representation and performance
+------------------------------
+
+The implementation is header-only and uses one switch on ``TSTypeKind``.
+Existing collection views are constructed through an internal trusted path
+after that switch so their public kind validation is not repeated. Public
+direct constructors remain checked.
+
+The change adds no data member, vtable, type-record field, operation-table
+slot, registry entry, or runtime dependency. The generated dispatch should be
+equivalent to the existing manual switch plus view construction. A focused
+benchmark compares the two forms on macOS and Linux and records any measurable
+difference before acceptance.
+
+Compatibility
+-------------
+
+The API is additive. Endpoint sizes, ownership, mutation, binding,
+notification, ABI versions, serialisation, and Python behaviour do not change.
+The header is installed with the existing SDK and is available through the
+top-level ``<hgraph/hgraph.h>`` convenience header.
+
+Alternatives
+------------
+
+Virtual ``accept`` and acyclic/double-dispatch visitors
+   Rejected because the current runtime intentionally uses schema, plan, ops,
+   and view type erasure rather than a virtual endpoint class hierarchy.
+
+Caller-written switches
+   Retained where code is dispatching metadata rather than a live endpoint,
+   but repetitive endpoint-view switches should use the common visitor.
+
+Recursive walking
+   Deferred. TSD key selection, live versus modified children, reference
+   following, and cycle handling are policies rather than consequences of
+   single-object dispatch.
+
+``ValueView`` visitation
+   Deferred. Atomic values and open extension types require a broader
+   ``std::visit``-style design and should not enlarge this endpoint RFC.
+
+Acceptance criteria
+-------------------
+
+* All eight semantic kinds dispatch correctly for input and output endpoints.
+* Specialised handlers override the role-level catch-all.
+* ``void`` and common value results work without allocations; reference
+  results and incomplete visitors fail at compile time.
+* Invalid-current-value inputs dispatch, default views fail clearly, and
+  ``REF`` is not followed.
+* Existing JSON endpoint algorithms demonstrate explicit recursive use without
+  semantic changes.
+* A separately built installed-SDK consumer compiles and runs the visitor.
+* Focused performance is equivalent to the corresponding manual switch.
+* The complete native and non-WIP Python compatibility suites pass on macOS
+  and Linux.
+
+Implementation status
+---------------------
+
+No implementation has merged. The RFC status will become ``Accepted`` in the
+same pull request as the public header, tests, documentation, and adoption
+site.

--- a/docs/source/rfc/rfc_0009_time_series_endpoint_visitors.rst
+++ b/docs/source/rfc/rfc_0009_time_series_endpoint_visitors.rst
@@ -144,6 +144,31 @@ equivalent to the existing manual switch plus view construction. A focused
 benchmark compares the two forms on macOS and Linux and records any measurable
 difference before acceptance.
 
+The focused benchmark uses 21 samples of 200,000 dispatches over the same
+``TSB`` output view. It compares a caller-written kind switch plus the public
+checked projection with ``visit`` plus its internal trusted projection:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 28 24 24 24
+
+   * - Host and compiler
+     - Manual median
+     - Visitor median
+     - Visitor difference
+   * - macOS arm64, AppleClang 21.0.0
+     - 7.001 ns/op
+     - 4.387 ns/op
+     - 37.3% faster
+   * - Linux x86_64, Clang 21.1.8
+     - 8.164 ns/op
+     - 4.960 ns/op
+     - 39.2% faster
+
+Both forms reported zero allocations. The result confirms that centralising
+the checked dispatch does not add overhead and avoids revalidating the
+specialised projection after the kind switch.
+
 Compatibility
 -------------
 

--- a/docs/source/rfc/rfc_0009_time_series_endpoint_visitors.rst
+++ b/docs/source/rfc/rfc_0009_time_series_endpoint_visitors.rst
@@ -191,6 +191,5 @@ Acceptance criteria
 Implementation status
 ---------------------
 
-No implementation has merged. The RFC status will become ``Accepted`` in the
-same pull request as the public header, tests, documentation, and adoption
-site.
+The implementation accompanies this RFC in the same pull request. The RFC
+status becomes ``Accepted`` when that pull request merges.

--- a/docs/source/rfc/rfc_0009_time_series_endpoint_visitors.rst
+++ b/docs/source/rfc/rfc_0009_time_series_endpoint_visitors.rst
@@ -105,10 +105,13 @@ handler is absent, a handler accepting the role's erased ``TSInputView`` or
 view is also valid. If neither a specialised nor base handler can accept any
 reachable alternative, the visitor is ill-formed.
 
-Every selected branch returns ``void`` or the same non-reference result type.
-Reference results are rejected because the shape-specific wrapper is a
-temporary borrowed cursor. The visitor forwards the returned value without
-materialising an optional or allocating storage.
+Every selected branch returns ``void`` or the same safe value type. Reference
+results and the lazy ``Range`` / ``KeyValueRange`` types are rejected because
+the shape-specific wrapper is a temporary borrowed cursor. A collection range
+can retain that wrapper as its projection context even though the range itself
+is returned by value. Consume such a range inside the handler or materialise it
+into an owned collection before returning. The visitor forwards accepted
+values without materialising an optional or allocating storage.
 
 Endpoint and reference semantics
 --------------------------------
@@ -128,7 +131,8 @@ The handler receives a borrowed cursor over the same endpoint position and
 evaluation time. The visitor neither owns nor extends the lifetime of the
 endpoint or its underlying storage. Mutating an output through the selected
 view and activating or binding an input retain the existing capability and
-lifecycle rules.
+lifecycle rules. More generally, a user-defined result must not retain a
+pointer or reference to the selected wrapper.
 
 Representation and performance
 ------------------------------
@@ -202,8 +206,8 @@ Acceptance criteria
 
 * All eight semantic kinds dispatch correctly for input and output endpoints.
 * Specialised handlers override the role-level catch-all.
-* ``void`` and common value results work without allocations; reference
-  results and incomplete visitors fail at compile time.
+* ``void`` and common owned-value results work without allocations; reference
+  results, lazy hgraph ranges, and incomplete visitors fail at compile time.
 * Invalid-current-value inputs dispatch, default views fail clearly, and
   ``REF`` is not followed.
 * Existing JSON endpoint algorithms demonstrate explicit recursive use without

--- a/docs/source/user_guide/authoring_nodes_cpp.rst
+++ b/docs/source/user_guide/authoring_nodes_cpp.rst
@@ -497,6 +497,39 @@ null. Build expected test deltas with ``tsb_delta<Schema>(...)`` in schema field
 order. ``std::nullopt`` leaves a field at its canonical default delta: typed-null
 for scalar children, empty delta for collection children.
 
+Visiting an erased endpoint
+---------------------------
+
+When an extension receives a type-erased ``TSInputView`` or ``TSOutputView``,
+use ``hgraph::visit`` to recover its semantic time-series shape without
+repeating a ``TSTypeKind`` switch:
+
+.. code-block:: cpp
+
+   #include <hgraph/types/time_series/visitor.h>
+
+   void describe(const TSInputView &input)
+   {
+       visit(
+           input,
+           [](TSDInputView dict) {
+               // Keyed child selection remains an explicit algorithm policy.
+               for (auto &&[key, child] : dict.items()) { /* ... */ }
+           },
+           [](TSBInputView bundle) {
+               for (auto &&[name, child] : bundle.items()) { /* ... */ }
+           },
+           [](TSInputView leaf_or_other_collection) {
+               // Role-level fallback for every shape not handled above.
+           });
+   }
+
+The selected view is borrowed and move-only. The call visits exactly one
+endpoint: it neither follows ``REF`` values nor recursively walks children.
+All handlers return ``void`` in this example; value-returning handlers must all
+produce the same non-reference type. Invalid-current-value and unbound inputs
+still dispatch from their schema, while a default view with no schema throws.
+
 
 Collections — ``TSS`` / ``TSL`` / ``TSD`` / ``TSW``
 ---------------------------------------------------

--- a/include/hgraph/hgraph.h
+++ b/include/hgraph/hgraph.h
@@ -8,4 +8,5 @@
 #include <hgraph/runtime/runtime.h>
 #include <hgraph/types/primitive_types.h>
 #include <hgraph/types/temporal.h>
+#include <hgraph/types/time_series/visitor.h>
 #include <hgraph/version.h>

--- a/include/hgraph/types/time_series/ts_input/bundle_view.h
+++ b/include/hgraph/types/time_series/ts_input/bundle_view.h
@@ -62,12 +62,18 @@ namespace hgraph
         TSInputView operator[](std::string_view) && = delete;
 
       private:
+        TSBInputView(TSInputView view, detail::TrustedTSEndpointKind)
+            : TSInputTypedView<TSBInputView>(std::move(view))
+        {
+        }
+
         static constexpr std::size_t npos = static_cast<std::size_t>(-1);
 
         [[nodiscard]] std::size_t field_index(std::string_view name) const;
         [[nodiscard]] std::size_t find_field_index(std::string_view name) const noexcept;
         [[nodiscard]] std::string_view key_at(std::size_t index) const noexcept;
 
+        friend struct detail::TSEndpointVisitorAccess;
     };
 }  // namespace hgraph
 

--- a/include/hgraph/types/time_series/ts_input/dict_view.h
+++ b/include/hgraph/types/time_series/ts_input/dict_view.h
@@ -65,6 +65,14 @@ namespace hgraph
         Range<TSInputView> removed_values() && = delete;
         [[nodiscard]] KeyValueRange<ValueView, TSInputView> removed_items() const &;
         KeyValueRange<ValueView, TSInputView> removed_items() && = delete;
+
+      private:
+        TSDInputView(TSInputView view, detail::TrustedTSEndpointKind)
+            : TSInputTypedView<TSDInputView>(std::move(view))
+        {
+        }
+
+        friend struct detail::TSEndpointVisitorAccess;
     };
 }  // namespace hgraph
 

--- a/include/hgraph/types/time_series/ts_input/list_view.h
+++ b/include/hgraph/types/time_series/ts_input/list_view.h
@@ -46,6 +46,14 @@ namespace hgraph
         [[nodiscard]] TSInputView operator[](std::size_t index) &;
         [[nodiscard]] TSInputView operator[](std::size_t index) const &;
         TSInputView operator[](std::size_t) && = delete;
+
+      private:
+        TSLInputView(TSInputView view, detail::TrustedTSEndpointKind)
+            : TSInputTypedView<TSLInputView>(std::move(view))
+        {
+        }
+
+        friend struct detail::TSEndpointVisitorAccess;
     };
 }  // namespace hgraph
 

--- a/include/hgraph/types/time_series/ts_input/set_view.h
+++ b/include/hgraph/types/time_series/ts_input/set_view.h
@@ -36,6 +36,14 @@ namespace hgraph
         [[nodiscard]] Range<ValueView> removed_values() const;
         [[nodiscard]] Range<ValueView>::iterator begin() const;
         [[nodiscard]] Range<ValueView>::iterator end() const;
+
+      private:
+        TSSInputView(TSInputView view, detail::TrustedTSEndpointKind)
+            : TSInputTypedView<TSSInputView>(std::move(view))
+        {
+        }
+
+        friend struct detail::TSEndpointVisitorAccess;
     };
 }  // namespace hgraph
 

--- a/include/hgraph/types/time_series/ts_input/window_view.h
+++ b/include/hgraph/types/time_series/ts_input/window_view.h
@@ -44,6 +44,14 @@ namespace hgraph
         [[nodiscard]] Range<DateTime> value_times() const;
         [[nodiscard]] Range<ValueView>::iterator begin() const;
         [[nodiscard]] Range<ValueView>::iterator end() const;
+
+      private:
+        TSWInputView(TSInputView view, detail::TrustedTSEndpointKind)
+            : TSInputTypedView<TSWInputView>(std::move(view))
+        {
+        }
+
+        friend struct detail::TSEndpointVisitorAccess;
     };
 }  // namespace hgraph
 

--- a/include/hgraph/types/time_series/ts_output/bundle_view.h
+++ b/include/hgraph/types/time_series/ts_output/bundle_view.h
@@ -48,6 +48,14 @@ namespace hgraph
         [[nodiscard]] TSOutputView operator[](std::string_view name) &;
         [[nodiscard]] TSOutputView operator[](std::string_view name) const &;
         TSOutputView operator[](std::string_view) && = delete;
+
+      private:
+        TSBOutputView(TSOutputView view, detail::TrustedTSEndpointKind)
+            : TSOutputTypedView<TSBOutputView>(std::move(view))
+        {
+        }
+
+        friend struct detail::TSEndpointVisitorAccess;
     };
 }  // namespace hgraph
 

--- a/include/hgraph/types/time_series/ts_output/dict_view.h
+++ b/include/hgraph/types/time_series/ts_output/dict_view.h
@@ -58,6 +58,14 @@ namespace hgraph
          * ``ts_key_set_path_component`` addresses it in edges/bindings).
          */
         [[nodiscard]] TSOutputView key_set() const;
+
+      private:
+        TSDOutputView(TSOutputView view, detail::TrustedTSEndpointKind)
+            : TSOutputTypedView<TSDOutputView>(std::move(view))
+        {
+        }
+
+        friend struct detail::TSEndpointVisitorAccess;
     };
 }  // namespace hgraph
 

--- a/include/hgraph/types/time_series/ts_output/list_view.h
+++ b/include/hgraph/types/time_series/ts_output/list_view.h
@@ -35,6 +35,14 @@ namespace hgraph
         [[nodiscard]] TSOutputView operator[](std::size_t index) &;
         [[nodiscard]] TSOutputView operator[](std::size_t index) const &;
         TSOutputView operator[](std::size_t) && = delete;
+
+      private:
+        TSLOutputView(TSOutputView view, detail::TrustedTSEndpointKind)
+            : TSOutputTypedView<TSLOutputView>(std::move(view))
+        {
+        }
+
+        friend struct detail::TSEndpointVisitorAccess;
     };
 }  // namespace hgraph
 

--- a/include/hgraph/types/time_series/ts_output/set_view.h
+++ b/include/hgraph/types/time_series/ts_output/set_view.h
@@ -38,6 +38,14 @@ namespace hgraph
         [[nodiscard]] Range<ValueView>::iterator begin() const;
         [[nodiscard]] Range<ValueView>::iterator end() const;
         [[nodiscard]] TSSDataMutationView begin_mutation(DateTime evaluation_time) const;
+
+      private:
+        TSSOutputView(TSOutputView view, detail::TrustedTSEndpointKind)
+            : TSOutputTypedView<TSSOutputView>(std::move(view))
+        {
+        }
+
+        friend struct detail::TSEndpointVisitorAccess;
     };
 }  // namespace hgraph
 

--- a/include/hgraph/types/time_series/ts_output/window_view.h
+++ b/include/hgraph/types/time_series/ts_output/window_view.h
@@ -44,6 +44,14 @@ namespace hgraph
         [[nodiscard]] Range<ValueView>::iterator begin() const;
         [[nodiscard]] Range<ValueView>::iterator end() const;
         [[nodiscard]] TSWDataMutationView begin_mutation(DateTime evaluation_time) const;
+
+      private:
+        TSWOutputView(TSOutputView view, detail::TrustedTSEndpointKind)
+            : TSOutputTypedView<TSWOutputView>(std::move(view))
+        {
+        }
+
+        friend struct detail::TSEndpointVisitorAccess;
     };
 }  // namespace hgraph
 

--- a/include/hgraph/types/time_series/typed_view.h
+++ b/include/hgraph/types/time_series/typed_view.h
@@ -7,6 +7,24 @@
 
 namespace hgraph
 {
+    namespace detail
+    {
+        struct TSEndpointVisitorAccess;
+
+        /**
+         * Construction token used after endpoint visitation has already
+         * checked the semantic TS kind.
+         *
+         * Only ``TSEndpointVisitorAccess`` can create the token, so public
+         * shape-view construction remains checked.
+         */
+        class TrustedTSEndpointKind
+        {
+            constexpr TrustedTSEndpointKind() noexcept = default;
+            friend struct TSEndpointVisitorAccess;
+        };
+    }  // namespace detail
+
     template <typename Derived, typename EndpointView>
     class TSTypedTimeSeriesView
     {

--- a/include/hgraph/types/time_series/visitor.h
+++ b/include/hgraph/types/time_series/visitor.h
@@ -168,14 +168,33 @@ namespace hgraph
         template <typename Result, typename Visitor, typename SpecialisedView, typename BaseView>
         inline constexpr bool endpoint_branch_same_result_v =
             std::same_as<Result, endpoint_branch_result_t<Visitor, SpecialisedView, BaseView>>;
+
+        template <typename Result> struct TSEndpointBorrowedRangeResult : std::false_type
+        {
+        };
+
+        template <typename Value> struct TSEndpointBorrowedRangeResult<Range<Value>> : std::true_type
+        {
+        };
+
+        template <typename Key, typename Value>
+        struct TSEndpointBorrowedRangeResult<KeyValueRange<Key, Value>> : std::true_type
+        {
+        };
+
+        template <typename Result>
+        inline constexpr bool endpoint_result_safe_v =
+            !std::is_reference_v<Result> &&
+            !TSEndpointBorrowedRangeResult<std::remove_cv_t<Result>>::value;
     }  // namespace detail
 
     /**
      * Visit one input endpoint according to its semantic time-series kind.
      *
      * A shape-specific handler takes precedence over a ``TSInputView``
-     * catch-all. Every reachable handler must return void or the same
-     * non-reference type. The selected wrapper is a temporary borrowed cursor.
+     * catch-all. Every reachable handler must return void or the same safe
+     * value type. References and lazy hgraph ranges are rejected because the
+     * selected wrapper is a temporary borrowed cursor.
      */
     template <typename... Handlers>
     decltype(auto) visit(const TSInputView &view, Handlers &&...handlers)
@@ -201,8 +220,9 @@ namespace hgraph
         else
         {
             using Result = detail::endpoint_branch_result_t<Visitor, TSValueInputView, TSInputView>;
-            static_assert(!std::is_reference_v<Result>, "time-series endpoint visitor cannot return a reference to a "
-                                                        "temporary view");
+            static_assert(detail::endpoint_result_safe_v<Result>,
+                          "time-series endpoint visitor cannot return a reference or lazy hgraph range that may borrow "
+                          "from a temporary view; consume the range in the handler or return an owned collection");
             static_assert(
                 detail::endpoint_branch_same_result_v<Result, Visitor, TSSInputView, TSInputView> &&
                     detail::endpoint_branch_same_result_v<Result, Visitor, TSDInputView, TSInputView> &&
@@ -246,8 +266,9 @@ namespace hgraph
      * Visit one output endpoint according to its semantic time-series kind.
      *
      * A shape-specific handler takes precedence over a ``TSOutputView``
-     * catch-all. Every reachable handler must return void or the same
-     * non-reference type. The selected wrapper is a temporary borrowed cursor.
+     * catch-all. Every reachable handler must return void or the same safe
+     * value type. References and lazy hgraph ranges are rejected because the
+     * selected wrapper is a temporary borrowed cursor.
      */
     template <typename... Handlers>
     decltype(auto) visit(const TSOutputView &view, Handlers &&...handlers)
@@ -274,8 +295,9 @@ namespace hgraph
         else
         {
             using Result = detail::endpoint_branch_result_t<Visitor, TSValueOutputView, TSOutputView>;
-            static_assert(!std::is_reference_v<Result>, "time-series endpoint visitor cannot return a reference to a "
-                                                        "temporary view");
+            static_assert(detail::endpoint_result_safe_v<Result>,
+                          "time-series endpoint visitor cannot return a reference or lazy hgraph range that may borrow "
+                          "from a temporary view; consume the range in the handler or return an owned collection");
             static_assert(
                 detail::endpoint_branch_same_result_v<Result, Visitor, TSSOutputView, TSOutputView> &&
                     detail::endpoint_branch_same_result_v<Result, Visitor, TSDOutputView, TSOutputView> &&

--- a/include/hgraph/types/time_series/visitor.h
+++ b/include/hgraph/types/time_series/visitor.h
@@ -1,0 +1,319 @@
+#ifndef HGRAPH_CPP_ROOT_TIME_SERIES_VISITOR_H
+#define HGRAPH_CPP_ROOT_TIME_SERIES_VISITOR_H
+
+#include <hgraph/types/time_series/ts_input.h>
+#include <hgraph/types/time_series/ts_output.h>
+
+#include <concepts>
+#include <functional>
+#include <stdexcept>
+#include <type_traits>
+#include <utility>
+
+namespace hgraph
+{
+    /**
+     * Shape-tagged borrowed input view for leaf time-series kinds.
+     *
+     * The collection kinds retain their existing specialised view classes.
+     * Like every endpoint view, this object is a transient cursor and does not
+     * extend the lifetime of the endpoint storage.
+     */
+    template <TSTypeKind Kind>
+        requires(Kind == TSTypeKind::TS || Kind == TSTypeKind::REF || Kind == TSTypeKind::SIGNAL)
+    class TSLeafInputView : public TSInputTypedView<TSLeafInputView<Kind>>
+    {
+      public:
+        static constexpr TSTypeKind kind = Kind;
+
+        explicit TSLeafInputView(TSInputView view) : TSInputTypedView<TSLeafInputView<Kind>>(std::move(view))
+        {
+            validate_kind();
+        }
+
+      private:
+        TSLeafInputView(TSInputView view, detail::TrustedTSEndpointKind)
+            : TSInputTypedView<TSLeafInputView<Kind>>(std::move(view))
+        {
+        }
+
+        void validate_kind() const
+        {
+            if (this->schema() == nullptr || this->schema()->kind != Kind)
+            {
+                throw std::invalid_argument("TSLeafInputView requires a matching time-series shape");
+            }
+        }
+
+        friend struct detail::TSEndpointVisitorAccess;
+    };
+
+    /**
+     * Shape-tagged borrowed output view for leaf time-series kinds.
+     *
+     * The collection kinds retain their existing specialised view classes.
+     * Like every endpoint view, this object is a transient cursor and does not
+     * extend the lifetime of the endpoint storage.
+     */
+    template <TSTypeKind Kind>
+        requires(Kind == TSTypeKind::TS || Kind == TSTypeKind::REF || Kind == TSTypeKind::SIGNAL)
+    class TSLeafOutputView : public TSOutputTypedView<TSLeafOutputView<Kind>>
+    {
+      public:
+        static constexpr TSTypeKind kind = Kind;
+
+        explicit TSLeafOutputView(TSOutputView view) : TSOutputTypedView<TSLeafOutputView<Kind>>(std::move(view))
+        {
+            validate_kind();
+        }
+
+      private:
+        TSLeafOutputView(TSOutputView view, detail::TrustedTSEndpointKind)
+            : TSOutputTypedView<TSLeafOutputView<Kind>>(std::move(view))
+        {
+        }
+
+        void validate_kind() const
+        {
+            if (this->schema() == nullptr || this->schema()->kind != Kind)
+            {
+                throw std::invalid_argument("TSLeafOutputView requires a matching time-series shape");
+            }
+        }
+
+        friend struct detail::TSEndpointVisitorAccess;
+    };
+
+    using TSValueInputView = TSLeafInputView<TSTypeKind::TS>;
+    using TSReferenceInputView = TSLeafInputView<TSTypeKind::REF>;
+    using TSSignalInputView = TSLeafInputView<TSTypeKind::SIGNAL>;
+
+    using TSValueOutputView = TSLeafOutputView<TSTypeKind::TS>;
+    using TSReferenceOutputView = TSLeafOutputView<TSTypeKind::REF>;
+    using TSSignalOutputView = TSLeafOutputView<TSTypeKind::SIGNAL>;
+
+    namespace detail
+    {
+        struct TSEndpointVisitorAccess
+        {
+            template <typename View>
+            [[nodiscard]] static View input(const TSInputView &view)
+            {
+                return View{view.borrowed_ref(), TrustedTSEndpointKind{}};
+            }
+
+            template <typename View>
+            [[nodiscard]] static View output(const TSOutputView &view)
+            {
+                return View{view.borrowed_ref(), TrustedTSEndpointKind{}};
+            }
+        };
+
+        template <typename... Handlers> struct TSEndpointOverload : Handlers...
+        {
+            using Handlers::operator()...;
+        };
+
+        template <typename... Handlers> TSEndpointOverload(Handlers...) -> TSEndpointOverload<Handlers...>;
+
+        template <typename Visitor, typename SpecialisedView, typename BaseView>
+        inline constexpr bool endpoint_branch_invocable_v =
+            std::invocable<Visitor &, SpecialisedView> || std::invocable<Visitor &, BaseView>;
+
+        template <typename Visitor, typename SpecialisedView, typename BaseView,
+                  bool HasSpecialised = std::invocable<Visitor &, SpecialisedView>>
+        struct TSEndpointBranchResult;
+
+        template <typename Visitor, typename SpecialisedView, typename BaseView>
+        struct TSEndpointBranchResult<Visitor, SpecialisedView, BaseView, true>
+        {
+            using type = std::invoke_result_t<Visitor &, SpecialisedView>;
+        };
+
+        template <typename Visitor, typename SpecialisedView, typename BaseView>
+        struct TSEndpointBranchResult<Visitor, SpecialisedView, BaseView, false>
+        {
+            using type = std::invoke_result_t<Visitor &, BaseView>;
+        };
+
+        template <typename Visitor, typename SpecialisedView, typename BaseView>
+        using endpoint_branch_result_t = typename TSEndpointBranchResult<Visitor, SpecialisedView, BaseView>::type;
+
+        template <typename SpecialisedView, typename Visitor>
+        decltype(auto) invoke_input_endpoint_visitor(Visitor &visitor, const TSInputView &view)
+        {
+            if constexpr (std::invocable<Visitor &, SpecialisedView>)
+            {
+                return std::invoke(visitor, TSEndpointVisitorAccess::input<SpecialisedView>(view));
+            }
+            else
+            {
+                return std::invoke(visitor, view.borrowed_ref());
+            }
+        }
+
+        template <typename SpecialisedView, typename Visitor>
+        decltype(auto) invoke_output_endpoint_visitor(Visitor &visitor, const TSOutputView &view)
+        {
+            if constexpr (std::invocable<Visitor &, SpecialisedView>)
+            {
+                return std::invoke(visitor, TSEndpointVisitorAccess::output<SpecialisedView>(view));
+            }
+            else
+            {
+                return std::invoke(visitor, view.borrowed_ref());
+            }
+        }
+
+        template <typename Result, typename Visitor, typename SpecialisedView, typename BaseView>
+        inline constexpr bool endpoint_branch_same_result_v =
+            std::same_as<Result, endpoint_branch_result_t<Visitor, SpecialisedView, BaseView>>;
+    }  // namespace detail
+
+    /**
+     * Visit one input endpoint according to its semantic time-series kind.
+     *
+     * A shape-specific handler takes precedence over a ``TSInputView``
+     * catch-all. Every reachable handler must return void or the same
+     * non-reference type. The selected wrapper is a temporary borrowed cursor.
+     */
+    template <typename... Handlers>
+    decltype(auto) visit(const TSInputView &view, Handlers &&...handlers)
+    {
+        static_assert(sizeof...(Handlers) > 0, "time-series endpoint visit requires at least one handler");
+        auto visitor = detail::TSEndpointOverload<std::decay_t<Handlers>...>{std::forward<Handlers>(handlers)...};
+        using Visitor = decltype(visitor);
+
+        constexpr bool complete = detail::endpoint_branch_invocable_v<Visitor, TSValueInputView, TSInputView> &&
+                                  detail::endpoint_branch_invocable_v<Visitor, TSSInputView, TSInputView> &&
+                                  detail::endpoint_branch_invocable_v<Visitor, TSDInputView, TSInputView> &&
+                                  detail::endpoint_branch_invocable_v<Visitor, TSLInputView, TSInputView> &&
+                                  detail::endpoint_branch_invocable_v<Visitor, TSWInputView, TSInputView> &&
+                                  detail::endpoint_branch_invocable_v<Visitor, TSBInputView, TSInputView> &&
+                                  detail::endpoint_branch_invocable_v<Visitor, TSReferenceInputView, TSInputView> &&
+                                  detail::endpoint_branch_invocable_v<Visitor, TSSignalInputView, TSInputView>;
+
+        if constexpr (!complete)
+        {
+            static_assert(complete, "time-series endpoint visitor must handle every input kind directly or "
+                                    "through a TSInputView catch-all");
+        }
+        else
+        {
+            using Result = detail::endpoint_branch_result_t<Visitor, TSValueInputView, TSInputView>;
+            static_assert(!std::is_reference_v<Result>, "time-series endpoint visitor cannot return a reference to a "
+                                                        "temporary view");
+            static_assert(
+                detail::endpoint_branch_same_result_v<Result, Visitor, TSSInputView, TSInputView> &&
+                    detail::endpoint_branch_same_result_v<Result, Visitor, TSDInputView, TSInputView> &&
+                    detail::endpoint_branch_same_result_v<Result, Visitor, TSLInputView, TSInputView> &&
+                    detail::endpoint_branch_same_result_v<Result, Visitor, TSWInputView, TSInputView> &&
+                    detail::endpoint_branch_same_result_v<Result, Visitor, TSBInputView, TSInputView> &&
+                    detail::endpoint_branch_same_result_v<Result, Visitor, TSReferenceInputView, TSInputView> &&
+                    detail::endpoint_branch_same_result_v<Result, Visitor, TSSignalInputView, TSInputView>,
+                "every time-series endpoint visitor branch must return the same type");
+
+            if (view.schema() == nullptr)
+            {
+                throw std::invalid_argument("cannot visit an input endpoint without a time-series schema");
+            }
+
+            switch (view.schema()->kind)
+            {
+            case TSTypeKind::TS:
+                return detail::invoke_input_endpoint_visitor<TSValueInputView>(visitor, view);
+            case TSTypeKind::TSS:
+                return detail::invoke_input_endpoint_visitor<TSSInputView>(visitor, view);
+            case TSTypeKind::TSD:
+                return detail::invoke_input_endpoint_visitor<TSDInputView>(visitor, view);
+            case TSTypeKind::TSL:
+                return detail::invoke_input_endpoint_visitor<TSLInputView>(visitor, view);
+            case TSTypeKind::TSW:
+                return detail::invoke_input_endpoint_visitor<TSWInputView>(visitor, view);
+            case TSTypeKind::TSB:
+                return detail::invoke_input_endpoint_visitor<TSBInputView>(visitor, view);
+            case TSTypeKind::REF:
+                return detail::invoke_input_endpoint_visitor<TSReferenceInputView>(visitor, view);
+            case TSTypeKind::SIGNAL:
+                return detail::invoke_input_endpoint_visitor<TSSignalInputView>(visitor, view);
+            }
+
+            throw std::invalid_argument("cannot visit an input endpoint with an unknown time-series kind");
+        }
+    }
+
+    /**
+     * Visit one output endpoint according to its semantic time-series kind.
+     *
+     * A shape-specific handler takes precedence over a ``TSOutputView``
+     * catch-all. Every reachable handler must return void or the same
+     * non-reference type. The selected wrapper is a temporary borrowed cursor.
+     */
+    template <typename... Handlers>
+    decltype(auto) visit(const TSOutputView &view, Handlers &&...handlers)
+    {
+        static_assert(sizeof...(Handlers) > 0, "time-series endpoint visit requires at least one handler");
+        auto visitor = detail::TSEndpointOverload<std::decay_t<Handlers>...>{std::forward<Handlers>(handlers)...};
+        using Visitor = decltype(visitor);
+
+        constexpr bool complete = detail::endpoint_branch_invocable_v<Visitor, TSValueOutputView, TSOutputView> &&
+                                  detail::endpoint_branch_invocable_v<Visitor, TSSOutputView, TSOutputView> &&
+                                  detail::endpoint_branch_invocable_v<Visitor, TSDOutputView, TSOutputView> &&
+                                  detail::endpoint_branch_invocable_v<Visitor, TSLOutputView, TSOutputView> &&
+                                  detail::endpoint_branch_invocable_v<Visitor, TSWOutputView, TSOutputView> &&
+                                  detail::endpoint_branch_invocable_v<Visitor, TSBOutputView, TSOutputView> &&
+                                  detail::endpoint_branch_invocable_v<Visitor, TSReferenceOutputView, TSOutputView> &&
+                                  detail::endpoint_branch_invocable_v<Visitor, TSSignalOutputView, TSOutputView>;
+
+        if constexpr (!complete)
+        {
+            static_assert(complete, "time-series endpoint visitor must handle every "
+                                    "output kind directly or "
+                                    "through a TSOutputView catch-all");
+        }
+        else
+        {
+            using Result = detail::endpoint_branch_result_t<Visitor, TSValueOutputView, TSOutputView>;
+            static_assert(!std::is_reference_v<Result>, "time-series endpoint visitor cannot return a reference to a "
+                                                        "temporary view");
+            static_assert(
+                detail::endpoint_branch_same_result_v<Result, Visitor, TSSOutputView, TSOutputView> &&
+                    detail::endpoint_branch_same_result_v<Result, Visitor, TSDOutputView, TSOutputView> &&
+                    detail::endpoint_branch_same_result_v<Result, Visitor, TSLOutputView, TSOutputView> &&
+                    detail::endpoint_branch_same_result_v<Result, Visitor, TSWOutputView, TSOutputView> &&
+                    detail::endpoint_branch_same_result_v<Result, Visitor, TSBOutputView, TSOutputView> &&
+                    detail::endpoint_branch_same_result_v<Result, Visitor, TSReferenceOutputView, TSOutputView> &&
+                    detail::endpoint_branch_same_result_v<Result, Visitor, TSSignalOutputView, TSOutputView>,
+                "every time-series endpoint visitor branch must return the same type");
+
+            if (view.schema() == nullptr)
+            {
+                throw std::invalid_argument("cannot visit an output endpoint without a time-series schema");
+            }
+
+            switch (view.schema()->kind)
+            {
+            case TSTypeKind::TS:
+                return detail::invoke_output_endpoint_visitor<TSValueOutputView>(visitor, view);
+            case TSTypeKind::TSS:
+                return detail::invoke_output_endpoint_visitor<TSSOutputView>(visitor, view);
+            case TSTypeKind::TSD:
+                return detail::invoke_output_endpoint_visitor<TSDOutputView>(visitor, view);
+            case TSTypeKind::TSL:
+                return detail::invoke_output_endpoint_visitor<TSLOutputView>(visitor, view);
+            case TSTypeKind::TSW:
+                return detail::invoke_output_endpoint_visitor<TSWOutputView>(visitor, view);
+            case TSTypeKind::TSB:
+                return detail::invoke_output_endpoint_visitor<TSBOutputView>(visitor, view);
+            case TSTypeKind::REF:
+                return detail::invoke_output_endpoint_visitor<TSReferenceOutputView>(visitor, view);
+            case TSTypeKind::SIGNAL:
+                return detail::invoke_output_endpoint_visitor<TSSignalOutputView>(visitor, view);
+            }
+
+            throw std::invalid_argument("cannot visit an output endpoint with an unknown time-series kind");
+        }
+    }
+}  // namespace hgraph
+
+#endif  // HGRAPH_CPP_ROOT_TIME_SERIES_VISITOR_H

--- a/src/hgraph/lib/std/operators/json_impl.cpp
+++ b/src/hgraph/lib/std/operators/json_impl.cpp
@@ -1,4 +1,5 @@
 #include <hgraph/lib/std/operators/impl/json_impl.h>
+#include <hgraph/types/time_series/visitor.h>
 
 #include <fmt/format.h>
 #include <simdjson.h>
@@ -662,11 +663,9 @@ namespace hgraph::stdlib
 
         void write_ts_delta(const TSInputView &ts, std::string &out)
         {
-            const auto *schema = ts.schema();
-            switch (schema->kind)
-            {
-                case TSTypeKind::TSD: {
-                    auto dict  = const_cast<TSInputView &>(ts).as_dict();
+            visit(
+                ts,
+                [&](TSDInputView dict) {
                     bool first = true;
                     out.push_back('{');
                     for (const ValueView key : dict.removed_keys())
@@ -683,11 +682,9 @@ namespace hgraph::stdlib
                         write_ts_delta(child, out);
                     }
                     out.push_back('}');
-                    return;
-                }
-                case TSTypeKind::TSS: {
-                    auto        set     = const_cast<TSInputView &>(ts).as_set();
-                    const auto &element = json_converter(schema->value_schema->element_type);
+                },
+                [&](TSSInputView set) {
+                    const auto &element = json_converter(set.schema()->value_schema->element_type);
                     std::string added;
                     std::string removed;
                     bool        any_added   = false;
@@ -721,10 +718,8 @@ namespace hgraph::stdlib
                         out.push_back(']');
                     }
                     out.push_back('}');
-                    return;
-                }
-                case TSTypeKind::TSL: {
-                    auto list  = const_cast<TSInputView &>(ts).as_list();
+                },
+                [&](TSLInputView list) {
                     bool first = true;
                     out.push_back('{');
                     for (std::size_t index = 0; index < list.size(); ++index)
@@ -736,44 +731,37 @@ namespace hgraph::stdlib
                         write_ts_delta(child, out);
                     }
                     out.push_back('}');
-                    return;
-                }
-                case TSTypeKind::TSB: {
-                    auto bundle = const_cast<TSInputView &>(ts).as_bundle();
-                    bool first  = true;
+                },
+                [&](TSBInputView bundle) {
+                    bool first = true;
                     out.push_back('{');
                     for (std::size_t index = 0; index < bundle.size(); ++index)
                     {
                         auto child = bundle.at(index);
                         if (!child.modified()) { continue; }
                         write_separator(first, out);
-                        out += fmt::format("\"{}\": ", schema->fields()[index].name);
+                        out += fmt::format("\"{}\": ", bundle.schema()->fields()[index].name);
                         write_ts_delta(child, out);
                     }
                     out.push_back('}');
-                    return;
-                }
-                default: {
-                    json_converter(schema->value_schema).write(ts.value(), out);
-                    return;
-                }
-            }
+                },
+                [&](TSInputView leaf) {
+                    json_converter(leaf.schema()->value_schema).write(leaf.value(), out);
+                });
         }
 
         void apply_ts_json(const TSOutputView &out, json_fragment::Cursor &cursor)
         {
-            const auto *schema = out.schema();
-            switch (schema->kind)
-            {
-                case TSTypeKind::TSD: {
+            visit(
+                out,
+                [&](TSDOutputView dict) {
                     if (!json_fragment::consume(cursor, '{'))
                     {
                         json_fragment::fail(cursor, "expected '{' for a TSD");
                     }
-                    auto dict     = out.as_dict();
-                    auto mutation = dict.begin_mutation(out.evaluation_time());
+                    auto mutation = dict.begin_mutation(dict.evaluation_time());
                     if (json_fragment::consume(cursor, '}')) { return; }
-                    const auto *key_meta   = schema->key_type();
+                    const auto *key_meta   = dict.schema()->key_type();
                     const bool  string_key = key_meta == scalar_descriptor<Str>::value_meta();
                     while (true)
                     {
@@ -788,30 +776,30 @@ namespace hgraph::stdlib
                         else
                         {
                             auto element = mutation.at(key.view());
-                            apply_ts_json(TSOutputView{out.output(), element, out.evaluation_time()}, cursor);
+                            apply_ts_json(
+                                TSOutputView{dict.base().output(), element, dict.evaluation_time()},
+                                cursor);
                         }
                         if (json_fragment::consume(cursor, ',')) { continue; }
                         if (json_fragment::consume(cursor, '}')) { break; }
                         json_fragment::fail(cursor, "expected ',' or '}' in a TSD object");
                     }
-                    return;
-                }
-                case TSTypeKind::TSS: {
+                },
+                [&](TSSOutputView set) {
                     if (json_fragment::peek(cursor) == '[')
                     {
                         // A bare array replaces the whole membership.
                         const Value parsed =
-                            json_fragment::parse_value(json_converter(schema->value_schema), cursor);
-                        apply_current_value(out, parsed.view());
+                            json_fragment::parse_value(json_converter(set.schema()->value_schema), cursor);
+                        apply_current_value(set.base(), parsed.view());
                         return;
                     }
                     if (!json_fragment::consume(cursor, '{'))
                     {
                         json_fragment::fail(cursor, "expected '{' or '[' for a TSS");
                     }
-                    auto        set      = out.as_set();
-                    auto        mutation = set.begin_mutation(out.evaluation_time());
-                    const auto &element  = json_converter(schema->value_schema->element_type);
+                    auto        mutation = set.begin_mutation(set.evaluation_time());
+                    const auto &element  = json_converter(set.schema()->value_schema->element_type);
                     if (json_fragment::consume(cursor, '}')) { return; }
                     while (true)
                     {
@@ -836,30 +824,26 @@ namespace hgraph::stdlib
                         if (json_fragment::consume(cursor, '}')) { break; }
                         json_fragment::fail(cursor, "expected ',' or '}' in a set delta");
                     }
-                    return;
-                }
-                case TSTypeKind::TSL: {
+                },
+                [&](TSLOutputView list) {
                     if (json_fragment::peek(cursor) == '[')
                     {
                         const Value parsed =
-                            json_fragment::parse_value(json_converter(schema->value_schema), cursor);
-                        apply_current_value(out, parsed.view());
+                            json_fragment::parse_value(json_converter(list.schema()->value_schema), cursor);
+                        apply_current_value(list.base(), parsed.view());
                         return;
                     }
                     // The index-object form IS the canonical TSL delta (an
                     // index map); its converter reads quoted keys.
                     const Value parsed =
-                        json_fragment::parse_value(json_converter(schema->delta_value_schema), cursor);
-                    apply_delta(out, parsed.view());
-                    return;
-                }
-                default: {
+                        json_fragment::parse_value(json_converter(list.schema()->delta_value_schema), cursor);
+                    apply_delta(list.base(), parsed.view());
+                },
+                [&](TSOutputView leaf) {
                     const Value parsed =
-                        json_fragment::parse_value(json_converter(schema->value_schema), cursor);
-                    apply_current_value(out, parsed.view());
-                    return;
-                }
-            }
+                        json_fragment::parse_value(json_converter(leaf.schema()->value_schema), cursor);
+                    apply_current_value(leaf, parsed.view());
+                });
         }
     }  // namespace json_ts_detail
 

--- a/tests/cpp/CMakeLists.txt
+++ b/tests/cpp/CMakeLists.txt
@@ -216,6 +216,7 @@ hgraph_add_test_objects(hgraph_value_test_objects
     test_temporal.cpp
     test_time_series_reference.cpp
     test_ts_delta.cpp
+    test_ts_endpoint_visitor.cpp
     test_ts_input.cpp
     test_ts_output.cpp
     test_ts_type_ref.cpp

--- a/tests/cpp/test_ts_endpoint_visitor.cpp
+++ b/tests/cpp/test_ts_endpoint_visitor.cpp
@@ -1,0 +1,259 @@
+#include <hgraph/types/metadata/type_registry.h>
+#include <hgraph/types/time_series/endpoint_schema.h>
+#include <hgraph/types/time_series/ts_input.h>
+#include <hgraph/types/time_series/ts_output.h>
+#include <hgraph/types/time_series/visitor.h>
+#include <hgraph/types/value/value.h>
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <array>
+#include <cstdint>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+namespace
+{
+    enum class VisitedKind
+    {
+        Value,
+        Set,
+        Dict,
+        List,
+        Window,
+        Bundle,
+        Reference,
+        Signal,
+    };
+
+    struct VisitorSchemas
+    {
+        const hgraph::TSValueTypeMetaData *value;
+        const hgraph::TSValueTypeMetaData *set;
+        const hgraph::TSValueTypeMetaData *dict;
+        const hgraph::TSValueTypeMetaData *list;
+        const hgraph::TSValueTypeMetaData *window;
+        const hgraph::TSValueTypeMetaData *bundle;
+        const hgraph::TSValueTypeMetaData *reference;
+        const hgraph::TSValueTypeMetaData *signal;
+
+        [[nodiscard]] std::array<const hgraph::TSValueTypeMetaData *, 8> all() const
+        {
+            return {value, set, dict, list, window, bundle, reference, signal};
+        }
+    };
+
+    [[nodiscard]] VisitorSchemas visitor_schemas()
+    {
+        auto &registry = hgraph::TypeRegistry::instance();
+        const auto *integer = registry.register_scalar<std::int32_t>("int32");
+        const auto *value = registry.ts(integer);
+        return VisitorSchemas{
+            .value = value,
+            .set = registry.tss(integer),
+            .dict = registry.tsd(integer, value),
+            .list = registry.tsl(value, 2),
+            .window = registry.tsw(integer, 3, 1),
+            .bundle = registry.tsb("TSEndpointVisitorNestedBundle", {{"value", value}}),
+            .reference = registry.ref(value),
+            .signal = registry.signal(),
+        };
+    }
+
+    [[nodiscard]] VisitedKind classify(const hgraph::TSOutputView &view)
+    {
+        using namespace hgraph;
+        return visit(
+            view, [](TSValueOutputView) { return VisitedKind::Value; }, [](TSSOutputView) { return VisitedKind::Set; },
+            [](TSDOutputView) { return VisitedKind::Dict; }, [](TSLOutputView) { return VisitedKind::List; },
+            [](TSWOutputView) { return VisitedKind::Window; }, [](TSBOutputView) { return VisitedKind::Bundle; },
+            [](TSReferenceOutputView) { return VisitedKind::Reference; },
+            [](TSSignalOutputView) { return VisitedKind::Signal; });
+    }
+
+    [[nodiscard]] VisitedKind classify(const hgraph::TSInputView &view)
+    {
+        using namespace hgraph;
+        return visit(
+            view, [](TSValueInputView) { return VisitedKind::Value; }, [](TSSInputView) { return VisitedKind::Set; },
+            [](TSDInputView) { return VisitedKind::Dict; }, [](TSLInputView) { return VisitedKind::List; },
+            [](TSWInputView) { return VisitedKind::Window; }, [](TSBInputView) { return VisitedKind::Bundle; },
+            [](TSReferenceInputView) { return VisitedKind::Reference; },
+            [](TSSignalInputView) { return VisitedKind::Signal; });
+    }
+}  // namespace
+
+TEST_CASE("TSOutputView visit dispatches all semantic time-series kinds")
+{
+    using namespace hgraph;
+
+    static_assert(!std::is_copy_constructible_v<TSValueOutputView>);
+    static_assert(!std::is_copy_constructible_v<TSReferenceOutputView>);
+    static_assert(!std::is_copy_constructible_v<TSSignalOutputView>);
+    static_assert(TSValueOutputView::kind == TSTypeKind::TS);
+    static_assert(TSReferenceOutputView::kind == TSTypeKind::REF);
+    static_assert(TSSignalOutputView::kind == TSTypeKind::SIGNAL);
+
+    const auto schemas = visitor_schemas();
+    const std::array expected{
+        VisitedKind::Value,  VisitedKind::Set,    VisitedKind::Dict,      VisitedKind::List,
+        VisitedKind::Window, VisitedKind::Bundle, VisitedKind::Reference, VisitedKind::Signal,
+    };
+
+    for (std::size_t index = 0; index < expected.size(); ++index)
+    {
+        TSOutput output{*schemas.all()[index]};
+        auto view = output.view(MIN_ST);
+        CHECK(classify(view) == expected[index]);
+    }
+}
+
+TEST_CASE("TSInputView visit dispatches unbound endpoints by their exposed schema")
+{
+    using namespace hgraph;
+
+    static_assert(!std::is_copy_constructible_v<TSValueInputView>);
+    static_assert(!std::is_copy_constructible_v<TSReferenceInputView>);
+    static_assert(!std::is_copy_constructible_v<TSSignalInputView>);
+    static_assert(TSValueInputView::kind == TSTypeKind::TS);
+    static_assert(TSReferenceInputView::kind == TSTypeKind::REF);
+    static_assert(TSSignalInputView::kind == TSTypeKind::SIGNAL);
+
+    const auto schemas = visitor_schemas();
+    const std::array names{
+        std::string_view{"value"},     std::string_view{"set"},    std::string_view{"dict"},
+        std::string_view{"list"},      std::string_view{"window"}, std::string_view{"bundle"},
+        std::string_view{"reference"}, std::string_view{"signal"},
+    };
+    const std::array expected{
+        VisitedKind::Value,  VisitedKind::Set,    VisitedKind::Dict,      VisitedKind::List,
+        VisitedKind::Window, VisitedKind::Bundle, VisitedKind::Reference, VisitedKind::Signal,
+    };
+
+    std::vector<std::pair<std::string, const TSValueTypeMetaData *>> fields;
+    std::vector<TSEndpointSchema> endpoints;
+    for (std::size_t index = 0; index < names.size(); ++index)
+    {
+        fields.emplace_back(names[index], schemas.all()[index]);
+        endpoints.push_back(TSEndpointSchema::peered(schemas.all()[index]));
+    }
+
+    auto &registry = TypeRegistry::instance();
+    const auto *root_schema = registry.tsb("TSEndpointVisitorInputRoot", fields);
+    const auto endpoint_schema = TSEndpointSchema::non_peered(root_schema, std::move(endpoints));
+    TSInput input = TSInputBuilderFactory::checked_builder_for(*root_schema, endpoint_schema).make_input();
+
+    auto root_view = input.view();
+    auto bundle = root_view.as_bundle();
+    for (std::size_t index = 0; index < names.size(); ++index)
+    {
+        auto child = bundle.field(names[index]);
+        CHECK_FALSE(child.bound());
+        CHECK_FALSE(child.valid());
+        CHECK(classify(child) == expected[index]);
+    }
+}
+
+TEST_CASE("endpoint visit prefers a specialised handler and supports a role "
+          "fallback")
+{
+    using namespace hgraph;
+
+    const auto schemas = visitor_schemas();
+    TSOutput value_output{*schemas.value};
+    TSOutput set_output{*schemas.set};
+    auto value_view = value_output.view(MIN_ST);
+    auto set_view = set_output.view(MIN_ST);
+
+    const auto specialised = [](TSValueOutputView) { return 1; };
+    const auto fallback = [](TSOutputView) { return 2; };
+
+    CHECK(visit(value_view, specialised, fallback) == 1);
+    CHECK(visit(set_view, specialised, fallback) == 2);
+
+    bool called = false;
+    visit(value_view, [&](TSValueOutputView) { called = true; }, [](TSOutputView) {});
+    CHECK(called);
+}
+
+TEST_CASE("endpoint visit keeps references opaque and recursion explicit")
+{
+    using namespace hgraph;
+
+    const auto schemas = visitor_schemas();
+    TSOutput reference_output{*schemas.reference};
+    auto reference_view = reference_output.view(MIN_ST);
+    CHECK(classify(reference_view) == VisitedKind::Reference);
+
+    TSOutput bundle_output{*schemas.bundle};
+    auto bundle_view = bundle_output.view(MIN_ST);
+    const auto child_kind = visit(
+        bundle_view,
+        [](TSBOutputView bundle) {
+            auto child = bundle.field("value");
+            return classify(child);
+        },
+        [](TSOutputView) { return VisitedKind::Signal; });
+    CHECK(child_kind == VisitedKind::Value);
+}
+
+TEST_CASE("endpoint visit preserves output mutation and input binding capabilities")
+{
+    using namespace hgraph;
+
+    const auto schemas = visitor_schemas();
+    const auto time = MIN_ST + TimeDelta{1};
+    TSOutput output{*schemas.value};
+    auto output_view = output.view(time);
+    Value forty_two{std::int32_t{42}};
+
+    visit(
+        output_view,
+        [&](TSValueOutputView selected) {
+            auto mutation = selected.begin_mutation(time);
+            REQUIRE(mutation.copy_value_from(forty_two.view()));
+        },
+        [](TSOutputView) { FAIL("unexpected output visitor fallback"); });
+
+    auto current = output.view(time);
+    REQUIRE(current.valid());
+    CHECK(current.value().checked_as<std::int32_t>() == 42);
+
+    auto &registry = TypeRegistry::instance();
+    const auto *root_schema = registry.tsb("TSEndpointVisitorBindingRoot", {{"value", schemas.value}});
+    const auto endpoint_schema = TSEndpointSchema::non_peered(root_schema, {TSEndpointSchema::peered(schemas.value)});
+    TSInput input = TSInputBuilderFactory::checked_builder_for(*root_schema, endpoint_schema).make_input();
+    auto input_view = input.view();
+    auto input_bundle = input_view.as_bundle();
+    auto child = input_bundle.field("value");
+
+    visit(
+        child, [&](TSValueInputView selected) { selected.bind_output(current); },
+        [](TSInputView) { FAIL("unexpected input visitor fallback"); });
+
+    auto rebound_input_view = input.view(nullptr, time);
+    auto rebound_bundle = rebound_input_view.as_bundle();
+    auto rebound_child = rebound_bundle.field("value");
+    REQUIRE(rebound_child.valid());
+    CHECK(rebound_child.value().checked_as<std::int32_t>() == 42);
+}
+
+TEST_CASE("endpoint visit rejects untyped views and direct leaf construction "
+          "validates kind")
+{
+    using namespace hgraph;
+
+    TSInputView empty_input;
+    TSOutputView empty_output;
+    CHECK_THROWS_AS(visit(empty_input, [](TSInputView) {}), std::invalid_argument);
+    CHECK_THROWS_AS(visit(empty_output, [](TSOutputView) {}), std::invalid_argument);
+
+    const auto schemas = visitor_schemas();
+    TSOutput set_output{*schemas.set};
+    auto set_view = set_output.view(MIN_ST);
+    CHECK_THROWS_AS(TSValueOutputView{set_view.borrowed_ref()}, std::invalid_argument);
+}

--- a/tests/cpp/test_ts_endpoint_visitor.cpp
+++ b/tests/cpp/test_ts_endpoint_visitor.cpp
@@ -180,6 +180,21 @@ TEST_CASE("endpoint visit prefers a specialised handler and supports a role "
     CHECK(called);
 }
 
+TEST_CASE("endpoint visit result contract rejects borrowed lazy ranges")
+{
+    using namespace hgraph;
+
+    static_assert(detail::endpoint_result_safe_v<void>);
+    static_assert(detail::endpoint_result_safe_v<std::vector<TSInputView>>);
+    static_assert(detail::endpoint_result_safe_v<std::vector<TSOutputView>>);
+    static_assert(!detail::endpoint_result_safe_v<TSInputView &>);
+    static_assert(!detail::endpoint_result_safe_v<TSOutputView &>);
+    static_assert(!detail::endpoint_result_safe_v<Range<TSInputView>>);
+    static_assert(!detail::endpoint_result_safe_v<const Range<TSOutputView>>);
+    static_assert(!detail::endpoint_result_safe_v<KeyValueRange<std::string_view, TSInputView>>);
+    static_assert(!detail::endpoint_result_safe_v<const KeyValueRange<std::size_t, TSOutputView>>);
+}
+
 TEST_CASE("endpoint visit keeps references opaque and recursion explicit")
 {
     using namespace hgraph;

--- a/tests/cpp/type_erasure_perf.cpp
+++ b/tests/cpp/type_erasure_perf.cpp
@@ -10,6 +10,7 @@
 #include <hgraph/types/static_node.h>
 #include <hgraph/types/temporal.h>
 #include <hgraph/types/time_series/ts_output.h>
+#include <hgraph/types/time_series/visitor.h>
 #include <hgraph/types/value/value_builder.h>
 
 #include <algorithm>
@@ -40,6 +41,7 @@ namespace
     std::atomic<std::size_t> g_allocations{0};
     std::atomic<std::size_t> g_allocated_bytes{0};
     std::atomic<const hgraph::ValueView *> g_atomic_value_view_input{nullptr};
+    std::atomic<const hgraph::TSOutputView *> g_atomic_ts_output_view_input{nullptr};
     volatile std::uint64_t g_retained_value{0};
     std::uint64_t g_graph_observation{0};
 
@@ -731,6 +733,56 @@ int main()
             }
         });
 
+    auto endpoint_dispatch_view = bundle_output.view(MIN_ST);
+    g_atomic_ts_output_view_input.store(&endpoint_dispatch_view, std::memory_order_release);
+    const auto manual_endpoint_dispatch = [&] {
+        const auto *source = g_atomic_ts_output_view_input.load(std::memory_order_relaxed);
+        auto        candidate = source->borrowed_ref();
+        switch (candidate.schema()->kind)
+        {
+            case TSTypeKind::TS:
+            case TSTypeKind::REF:
+            case TSTypeKind::SIGNAL:
+                return std::uint64_t{0};
+            case TSTypeKind::TSS:
+                return static_cast<std::uint64_t>(candidate.as_set().size());
+            case TSTypeKind::TSD:
+                return static_cast<std::uint64_t>(candidate.as_dict().size());
+            case TSTypeKind::TSL:
+                return static_cast<std::uint64_t>(candidate.as_list().size());
+            case TSTypeKind::TSW:
+                return static_cast<std::uint64_t>(candidate.as_window().size());
+            case TSTypeKind::TSB:
+                return static_cast<std::uint64_t>(candidate.as_bundle().size());
+        }
+        throw std::runtime_error("unknown time-series kind in manual endpoint dispatch");
+    };
+    const auto visitor_endpoint_dispatch = [&] {
+        const auto *source = g_atomic_ts_output_view_input.load(std::memory_order_relaxed);
+        return visit(
+            *source,
+            [](TSSOutputView selected) { return static_cast<std::uint64_t>(selected.size()); },
+            [](TSDOutputView selected) { return static_cast<std::uint64_t>(selected.size()); },
+            [](TSLOutputView selected) { return static_cast<std::uint64_t>(selected.size()); },
+            [](TSWOutputView selected) { return static_cast<std::uint64_t>(selected.size()); },
+            [](TSBOutputView selected) { return static_cast<std::uint64_t>(selected.size()); },
+            [](TSOutputView) { return std::uint64_t{0}; });
+    };
+    require_no_allocations("endpoint_manual_kind_dispatch", 10'000, manual_endpoint_dispatch);
+    require_no_allocations("endpoint_visitor_kind_dispatch", 10'000, visitor_endpoint_dispatch);
+    run_benchmark(
+        "endpoint_manual_kind_dispatch", 200'000, samples, warmup,
+        manual_endpoint_dispatch,
+        [](std::uint64_t value) {
+            if (value != 2) { throw std::runtime_error("manual endpoint dispatch failed"); }
+        });
+    run_benchmark(
+        "endpoint_visitor_kind_dispatch", 200'000, samples, warmup,
+        visitor_endpoint_dispatch,
+        [](std::uint64_t value) {
+            if (value != 2) { throw std::runtime_error("visitor endpoint dispatch failed"); }
+        });
+
     const auto *dynamic_list_meta = registry.tsl(ts_int, 0);
     ListBuilder dynamic_source_builder{ValuePlanFactory::instance().type_for(int_meta)};
     for (const Int value : {Int{59}, Int{60}, Int{61}, Int{62}})
@@ -963,7 +1015,8 @@ int main()
         });
     profiled_graph.stop();
     const auto profile = profiler.snapshot();
-    if (profile.graph_cycles == 0 || profile.entries.size() != 2)
+    if (benchmark_selected("evaluation_profiler_enabled_cycle") &&
+        (profile.graph_cycles == 0 || profile.entries.size() != 2))
     {
         throw std::runtime_error("evaluation profiler benchmark produced no measurements");
     }

--- a/tests/install_consumer/main.cpp
+++ b/tests/install_consumer/main.cpp
@@ -5,6 +5,7 @@
 #include <hgraph/types/metadata/type_record.h>
 #include <hgraph/types/metadata/type_registry.h>
 #include <hgraph/types/type_pointer.h>
+#include <hgraph/types/time_series/visitor.h>
 #include <hgraph/types/value/value.h>
 #include <hgraph/types/value/value_builder.h>
 
@@ -49,6 +50,18 @@ int main()
     }
 
     static_cast<void>(stdlib::register_standard_types(registry));
+
+    const auto *ts_int = registry.ts(scalar_descriptor<Int>::value_meta());
+    TSOutput    output{*ts_int};
+    auto        output_view = output.view(MIN_ST);
+    const bool  visited_value = visit(
+        output_view,
+        [](TSValueOutputView selected) { return selected.schema()->kind == TSTypeKind::TS; },
+        [](TSOutputView) { return false; });
+    if (!visited_value)
+    {
+        throw std::runtime_error("installed endpoint visitor dispatched the wrong time-series kind");
+    }
 
     using TypedFrame = FrameOf<Bundle<"consumer::Row", Field<"value", Int>>,
                                Bundle<"consumer::Metadata", Field<"revision", Int>>>;


### PR DESCRIPTION
## Summary

- add RFC 0009 and a narrow, one-level `hgraph::visit` API for type-erased `TSInputView` and `TSOutputView` endpoints
- dispatch all eight semantic time-series kinds to borrowed specialised views, with a role-level fallback and compile-time result/lifetime checks
- reject reference and lazy `Range` / `KeyValueRange` results that could retain a temporary specialised view; handlers can consume ranges immediately or return owned materialisations
- preserve checked public projections while using a trusted internal projection after the visitor's kind switch
- adopt the visitor in the JSON time-series codec, and document extension-author usage
- add all-kind, invalid/unbound, mutation/binding, fallback precedence, explicit recursion, SDK consumer, and allocation/performance coverage

`ValueView` visitation and recursive walking remain intentionally out of scope.

## Performance

21 samples × 200,000 dispatches over the same `TSB` output view; both paths allocate zero bytes:

| Host | Manual checked switch | `hgraph::visit` | Difference |
| --- | ---: | ---: | ---: |
| macOS arm64, AppleClang 21.0.0 | 7.001 ns/op | 4.387 ns/op | 37.3% faster |
| Linux x86_64, Clang 21.1.8 | 8.164 ns/op | 4.960 ns/op | 39.2% faster |

## Validation

- macOS fresh native acceptance: 1,298/1,298 passed
- macOS cp312 ABI3 wheel under Python 3.14: 1,728 passed, 10 skipped
- OrbStack Ubuntu x86_64 fresh native acceptance with GCC 13.3: 1,298/1,298 passed
- OrbStack Ubuntu x86_64 GCC 13.3 cp312 ABI3 wheel under Python 3.14 with `polars[rtcompat]`: 1,728 passed, 10 skipped
- OrbStack Ubuntu x86_64 GCC 13.3 ASan endpoint-visitor tests: 13 assertions in 5 cases passed
- installed-SDK consumer: passed on macOS; the Linux wheel consumer also compiled and ran when supplied its existing explicit Arrow/Python link/runtime paths
- strict Sphinx build: passed

## Existing Linux toolchain findings

- Clang 18 in the OrbStack Ubuntu VM crashes in its frontend while instantiating unchanged operator-dispatch templates; GCC 13.3 builds and passes the complete native and Python gates at the current head.
- the Linux wheel's existing CMake export omits Arrow and embed-Python dependencies for an executable consumer; this PR does not alter that packaging surface.