### PR TITLE
Fix to_data_frame for reference-valued TSD inputs

### DIFF
--- a/include/hgraph/lib/std/operators/impl/data_frame_impl.h
+++ b/include/hgraph/lib/std/operators/impl/data_frame_impl.h
@@ -227,7 +227,8 @@ namespace hgraph::stdlib
 
     /** ``to_data_frame(ts, ...)`` — a per-tick snapshot frame; the output
         ``Frame[Schema]`` names the columns (dt_col first, TSD adds key_col). */
-    struct to_data_frame_impl
+    template <typename TInputSchema>
+    struct to_data_frame_impl_base
     {
         static constexpr auto name = "to_data_frame";
 
@@ -255,7 +256,7 @@ namespace hgraph::stdlib
             if (out != nullptr) { bind_output(resolution, out); }
         }
 
-        static void start(In<"ts", TsVar<"S">, InputValidity::Unchecked> ts, Scalar<"dt_col", Str> dt_col,
+        static void start(In<"ts", TInputSchema, InputValidity::Unchecked> ts, Scalar<"dt_col", Str> dt_col,
                           Scalar<"key_col", Str> key_col, Scalar<"value_col", Str> value_col,
                           State<ToDataFrameState> state, Out<TsVar<"__out__">> out)
         {
@@ -266,7 +267,7 @@ namespace hgraph::stdlib
             state.set(ToDataFrameState{plan});
         }
 
-        static void eval(In<"ts", TsVar<"S">> ts, Scalar<"dt_col", Str> dt_col,
+        static void eval(In<"ts", TInputSchema> ts, Scalar<"dt_col", Str> dt_col,
                          Scalar<"key_col", Str> key_col, Scalar<"value_col", Str> value_col,
                          State<ToDataFrameState> state, DateTime now, Out<TsVar<"__out__">> out)
         {
@@ -283,6 +284,12 @@ namespace hgraph::stdlib
             state.set(ToDataFrameState{});
         }
     };
+
+    // Bind TSD elements independently so the normal input adaptation path
+    // dereferences reference-valued leaves before the frame is assembled.
+    using to_data_frame_tsd_impl =
+        to_data_frame_impl_base<TSD<ScalarVar<"K">, TsVar<"V">>>;
+    using to_data_frame_impl = to_data_frame_impl_base<TsVar<"S">>;
 
     /** ``group_by(ts, by)`` — partition a Frame TS into TSD[key, TS[Frame]]
         (removed keys emit REMOVE; ``by`` is a column name or tuple of them). */

--- a/python/tests/ported/_operators/test_data_frame_operators.py
+++ b/python/tests/ported/_operators/test_data_frame_operators.py
@@ -15,8 +15,8 @@ import pyarrow as pa
 import pytest
 from frozendict import frozendict as fd, frozendict
 
-from hgraph import from_data_frame, TS, MIN_ST, MIN_TD, TSB, ts_schema, TSD, Frame, COMPOUND_SCALAR, graph, \
-    compound_scalar, to_data_frame, CompoundScalar, REMOVE
+from hgraph import REF, from_data_frame, TS, MIN_ST, MIN_TD, TSB, ts_schema, TSD, Frame, COMPOUND_SCALAR, graph, \
+    compound_scalar, compute_node, const, to_data_frame, CompoundScalar, REMOVE
 from hgraph.adaptors.data_frame import group_by
 from hgraph.test import eval_node
 
@@ -116,6 +116,65 @@ def test_to_data_frame_tsd_k_tsb():
         "a": [1, 1, 2, 1, 3],
         "b": [4, 4, 5, 4, 6]}).sort_by([("date", "ascending"), ("key", "ascending"), ("a", "ascending"), ("b", "ascending")])
     actual = actual.sort_by([("date", "ascending"), ("key", "ascending"), ("a", "ascending"), ("b", "ascending")])
+    assert actual.equals(expected)
+
+
+def test_to_data_frame_tsd_ref_values_follow_repoints():
+    @compute_node
+    def select_ref(
+        pick_rhs: TS[bool],
+        lhs: REF[TS[float]],
+        rhs: REF[TS[float]],
+    ) -> TSD[str, REF[TS[float]]]:
+        return {"selected": rhs.value if pick_rhs.value else lhs.value}
+
+    @graph
+    def g(pick_rhs: TS[bool]) -> TS[Frame[compound_scalar(date=datetime, key=str, value=float)]]:
+        return to_data_frame(
+            select_ref(pick_rhs, const(1.5), const(2.5)),
+            key_col="key",
+        )
+
+    actual = pa.concat_tables(eval_node(g, pick_rhs=[False, True, False]))
+    expected = pa.table({
+        "date": [_instant(MIN_ST), _instant(MIN_ST + MIN_TD), _instant(MIN_ST + 2 * MIN_TD)],
+        "key": ["selected", "selected", "selected"],
+        "value": [1.5, 2.5, 1.5],
+    })
+    assert actual.equals(expected)
+
+
+def test_to_data_frame_tsd_ref_tsb_values_follow_repoints():
+    schema = ts_schema(a=TS[int], b=TS[str])
+
+    @compute_node
+    def select_ref(
+        pick_rhs: TS[bool],
+        lhs: REF[TSB[schema]],
+        rhs: REF[TSB[schema]],
+    ) -> TSD[str, REF[TSB[schema]]]:
+        return {"selected": rhs.value if pick_rhs.value else lhs.value}
+
+    @graph
+    def g(
+        pick_rhs: TS[bool],
+        lhs: TSB[schema],
+        rhs: TSB[schema],
+    ) -> TS[Frame[compound_scalar(date=datetime, key=str, a=int, b=str)]]:
+        return to_data_frame(select_ref(pick_rhs, lhs, rhs), key_col="key")
+
+    actual = pa.concat_tables(eval_node(
+        g,
+        pick_rhs=[False, True],
+        lhs=[fd(a=1, b="one"), None],
+        rhs=[fd(a=2, b="two"), None],
+    ))
+    expected = pa.table({
+        "date": [_instant(MIN_ST), _instant(MIN_ST + MIN_TD)],
+        "key": ["selected", "selected"],
+        "a": [1, 2],
+        "b": ["one", "two"],
+    })
     assert actual.equals(expected)
 
 

--- a/src/hgraph/lib/std/operators/data_frame_impl.cpp
+++ b/src/hgraph/lib/std/operators/data_frame_impl.cpp
@@ -231,15 +231,17 @@ namespace hgraph::stdlib
                                                            std::string_view key_col,
                                                            std::string_view value_col)
         {
+            auto       &registry = TypeRegistry::instance();
+            const auto *schema   = registry.dereference(ts);
             std::vector<std::pair<std::string, const ValueTypeMetaData *>> fields;
             fields.emplace_back(std::string{dt_col}, datetime_meta());
 
-            const auto *leaf = ts;
-            if (ts->kind == TSTypeKind::TSD)
+            const auto *leaf = schema;
+            if (schema->kind == TSTypeKind::TSD)
             {
-                if (ts->key_type()->value_kind() != ValueTypeKind::Atomic) { return nullptr; }
-                fields.emplace_back(std::string{key_col}, ts->key_type());
-                leaf = ts->element_ts();
+                if (schema->key_type()->value_kind() != ValueTypeKind::Atomic) { return nullptr; }
+                fields.emplace_back(std::string{key_col}, schema->key_type());
+                leaf = schema->element_ts();
             }
             if (leaf->kind == TSTypeKind::TS)
             {
@@ -258,7 +260,6 @@ namespace hgraph::stdlib
             }
             else { return nullptr; }
 
-            auto &registry = TypeRegistry::instance();
             return registry.ts(registry.frame(registry.un_named_bundle(fields)));
         }
 
@@ -267,11 +268,12 @@ namespace hgraph::stdlib
         {
             auto        plan     = std::make_unique<ToFramePlan>();
             const auto *columns  = frame_columns_schema(out.schema()->value_schema, "to_data_frame");
+            const auto *schema   = TypeRegistry::instance().dereference(ts.schema());
             plan->row_meta       = columns;
             plan->converter      = &table_converter(columns);
-            plan->dict           = ts.schema()->kind == TSTypeKind::TSD;
+            plan->dict           = schema->kind == TSTypeKind::TSD;
 
-            const auto *leaf = plan->dict ? ts.schema()->element_ts() : ts.schema();
+            const auto *leaf = plan->dict ? schema->element_ts() : schema;
             const auto *leaf_bundle =
                 leaf->kind == TSTypeKind::TSB ? leaf->value_schema : nullptr;
 
@@ -1362,6 +1364,7 @@ namespace hgraph::stdlib
     void register_data_frame_operators()
     {
         register_overload<from_data_frame, from_data_frame_impl>();
+        register_overload<to_data_frame, to_data_frame_tsd_impl>();
         register_overload<to_data_frame, to_data_frame_impl>();
         register_overload<group_by, group_by_impl>();
         register_overload<sorted_, sorted_frame_impl>();

--- a/tests/cpp/test_data_frame_operators.cpp
+++ b/tests/cpp/test_data_frame_operators.cpp
@@ -11,6 +11,7 @@
 
 #include <catch2/catch_test_macros.hpp>
 
+#include <array>
 #include <chrono>
 #include <cstdint>
 #include <memory>
@@ -39,6 +40,12 @@ namespace
                                 Field<"c", Int>>;
     using KeyedRow = Bundle<"tests.data_frame::KeyedRow", Field<"a", Int>,
                             Field<"b", Int>, Field<"key", Str>>;
+    using ScalarRefFrameRow =
+        UnNamedBundle<Field<"date", DateTime>, Field<"key", Str>, Field<"value", Float>>;
+    using RefBundle = UnNamedTSB<Field<"a", TS<Int>>, Field<"b", TS<Str>>>;
+    using BundleRefFrameRow =
+        UnNamedBundle<Field<"date", DateTime>, Field<"key", Str>, Field<"a", Int>,
+                      Field<"b", Str>>;
 
     void require_arrow(const arrow::Status &status)
     {
@@ -309,6 +316,115 @@ namespace
                         TS<FrameOf<KeyedRow>>>(w, ts, Str{"key"});
         }
     };
+
+    struct SelectScalarRefDict
+    {
+        static constexpr auto name = "select_scalar_ref_dict";
+
+        static void eval(In<"pick_rhs", TS<Bool>> pick_rhs,
+                         In<"lhs", REF<TS<Float>>> lhs,
+                         In<"rhs", REF<TS<Float>>> rhs,
+                         Out<TSD<Str, REF<TS<Float>>>> out)
+        {
+            out.set(Str{"selected"}, pick_rhs.value() ? rhs.value() : lhs.value());
+        }
+    };
+
+    struct ScalarRefToFrameGraph
+    {
+        static constexpr auto name = "scalar_ref_to_frame_graph";
+
+        static Port<TS<FrameOf<ScalarRefFrameRow>>> compose(
+            Wiring &w, Port<TS<Bool>> pick_rhs, Port<TS<Float>> lhs, Port<TS<Float>> rhs)
+        {
+            auto refs = wire<SelectScalarRefDict>(w, pick_rhs, lhs, rhs);
+            return wire<stdlib::to_data_frame, TS<FrameOf<ScalarRefFrameRow>>>(
+                w, refs, Str{"date"}, Str{"key"}, Str{"value"});
+        }
+    };
+
+    struct SelectBundleRefDict
+    {
+        static constexpr auto name = "select_bundle_ref_dict";
+
+        static void eval(In<"pick_rhs", TS<Bool>> pick_rhs,
+                         In<"lhs", REF<RefBundle>> lhs,
+                         In<"rhs", REF<RefBundle>> rhs,
+                         Out<TSD<Str, REF<RefBundle>>> out)
+        {
+            out.set(Str{"selected"}, pick_rhs.value() ? rhs.value() : lhs.value());
+        }
+    };
+
+    struct BundleRefToFrameGraph
+    {
+        static constexpr auto name = "bundle_ref_to_frame_graph";
+
+        static Port<TS<FrameOf<BundleRefFrameRow>>> compose(
+            Wiring &w, Port<TS<Bool>> pick_rhs, Port<TS<Int>> lhs_a, Port<TS<Str>> lhs_b,
+            Port<TS<Int>> rhs_a, Port<TS<Str>> rhs_b)
+        {
+            auto lhs  = stdlib::to_tsb<RefBundle>(w, lhs_a, lhs_b);
+            auto rhs  = stdlib::to_tsb<RefBundle>(w, rhs_a, rhs_b);
+            auto refs = wire<SelectBundleRefDict>(w, pick_rhs, lhs, rhs);
+            return wire<stdlib::to_data_frame, TS<FrameOf<BundleRefFrameRow>>>(
+                w, refs, Str{"date"}, Str{"key"}, Str{"value"});
+        }
+    };
+}
+
+TEST_CASE("data frame operators: to_data_frame dereferences scalar TSD values across repoints")
+{
+    stdlib::register_standard_operators();
+    const auto result = eval_node<ScalarRefToFrameGraph>(
+        values<Bool>(false, true, false),
+        values<Float>(1.5, none, none),
+        values<Float>(2.5, none, none));
+
+    REQUIRE(result.size() == 3);
+    const std::array<Float, 3> expected{1.5, 2.5, 1.5};
+    for (std::size_t index = 0; index < result.size(); ++index)
+    {
+        REQUIRE(result[index].has_value());
+        CHECK(frame_rows(*result[index]) == 1);
+        CHECK(frame_cell(*result[index], "key", scalar_descriptor<Str>::value_meta(), 0)
+                  .view()
+                  .checked_as<Str>() == "selected");
+        CHECK(frame_cell(*result[index], "value", scalar_descriptor<Float>::value_meta(), 0)
+                  .view()
+                  .checked_as<Float>() == expected[index]);
+    }
+}
+
+TEST_CASE("data frame operators: to_data_frame dereferences TSB-valued TSD references")
+{
+    stdlib::register_standard_operators();
+    const auto result = eval_node<BundleRefToFrameGraph>(
+        values<Bool>(false, true),
+        values<Int>(1, none), values<Str>("one", none),
+        values<Int>(2, none), values<Str>("two", none));
+
+    REQUIRE(result.size() == 2);
+    for (std::size_t index = 0; index < result.size(); ++index)
+    {
+        REQUIRE(result[index].has_value());
+        CHECK(frame_rows(*result[index]) == 1);
+        CHECK(frame_cell(*result[index], "key", scalar_descriptor<Str>::value_meta(), 0)
+                  .view()
+                  .checked_as<Str>() == "selected");
+    }
+    CHECK(frame_cell(*result[0], "a", scalar_descriptor<Int>::value_meta(), 0)
+              .view()
+              .checked_as<Int>() == 1);
+    CHECK(frame_cell(*result[0], "b", scalar_descriptor<Str>::value_meta(), 0)
+              .view()
+              .checked_as<Str>() == "one");
+    CHECK(frame_cell(*result[1], "a", scalar_descriptor<Int>::value_meta(), 0)
+              .view()
+              .checked_as<Int>() == 2);
+    CHECK(frame_cell(*result[1], "b", scalar_descriptor<Str>::value_meta(), 0)
+              .view()
+              .checked_as<Str>() == "two");
 }
 
 TEST_CASE("data frame operators: sorted_ orders rows through the native wiring path")


### PR DESCRIPTION
## Summary

Fix `to_data_frame` for `TSD` inputs whose values are `REF` leaves, including references to scalar series and bundles. Reference repoints now produce frames containing the current target values instead of failing with a schema mismatch.

Fixes #194.

## Root cause

Output schema resolution already treated references as transparent, but the generic `TsVar` implementation bound the complete raw `TSD[K, REF[V]]` input. At evaluation time the row converter therefore received `TimeSeriesReference` values while the resolved frame schema expected `V`.

## Changes

- add a TSD-specific overload pattern that binds the element schema independently, allowing the normal input adaptation path to dereference reference-valued leaves
- canonicalize reference schemas when resolving the frame output and constructing the start-time conversion plan
- add public C++ wiring regressions for scalar and bundle-valued references across repoints
- add equivalent Python `eval_node` compatibility regressions

## Validation

macOS (AppleClang):

- fresh native configure, clean build, and full CTest suite: 1,300 passed
- stable-ABI wheel built with Python 3.12 and full non-WIP suite run with Python 3.14: 1,730 passed, 10 skipped

Linux (Ubuntu 24.04 OrbStack, GCC 13.3):

- fresh native configure, clean build, and full CTest suite: 1,300 passed
- stable-ABI wheel built with Python 3.12 and full non-WIP suite run with Python 3.14 plus `polars[rtcompat]`: 1,730 passed, 10 skipped