### PR TITLE
Adopt endpoint visitors in native error traces

### DIFF
--- a/docs/source/rfc/rfc_0009_time_series_endpoint_visitors.rst
+++ b/docs/source/rfc/rfc_0009_time_series_endpoint_visitors.rst
@@ -1,7 +1,7 @@
 RFC 0009: Type-Erased Time-Series Endpoint Visitors
 ====================================================
 
-:Status: Proposed
+:Status: Accepted
 :Author: Howard Henson
 :Created: 2026-07-29
 :Target: Public C++ time-series endpoint views
@@ -220,5 +220,7 @@ Acceptance criteria
 Implementation status
 ---------------------
 
-The implementation accompanies this RFC in the same pull request. The RFC
-status becomes ``Accepted`` when that pull request merges.
+The endpoint visitor and its first JSON codec adoption were accepted in
+PR #193. Native error-trace traversal subsequently adopted the same one-level
+dispatch while retaining its explicit modified-child, reference, depth, and
+cycle policies.

--- a/src/hgraph/runtime/node_error.cpp
+++ b/src/hgraph/runtime/node_error.cpp
@@ -3,9 +3,7 @@
 #include <hgraph/runtime/node.h>
 #include <hgraph/types/metadata/type_registry.h>
 #include <hgraph/types/metadata/value_plan_factory.h>
-#include <hgraph/types/time_series/ts_input/bundle_view.h>
-#include <hgraph/types/time_series/ts_input/dict_view.h>
-#include <hgraph/types/time_series/ts_input/list_view.h>
+#include <hgraph/types/time_series/visitor.h>
 #include <hgraph/types/value/value_builder.h>
 #include <hgraph/util/scope.h>
 
@@ -66,46 +64,34 @@ namespace hgraph
                 return;
             }
 
-            const TSValueTypeMetaData *schema = input.schema();
-            if (schema == nullptr) { return; }
-            switch (schema->kind)
-            {
-                case TSTypeKind::TSB:
-                {
-                    auto bundle = input.as_bundle();
+            if (input.schema() == nullptr) { return; }
+            visit(
+                input,
+                [&](TSBInputView bundle) {
                     for (auto &&[name, child] : bundle.modified_items())
                     {
                         static_cast<void>(name);
                         append_input_sources(out, child, evaluation_time, depth,
                                              capture_values, indent, visited);
                     }
-                    break;
-                }
-                case TSTypeKind::TSL:
-                {
-                    auto list = input.as_list();
+                },
+                [&](TSLInputView list) {
                     for (auto &&[index, child] : list.modified_items())
                     {
                         static_cast<void>(index);
                         append_input_sources(out, child, evaluation_time, depth,
                                              capture_values, indent, visited);
                     }
-                    break;
-                }
-                case TSTypeKind::TSD:
-                {
-                    auto dict = input.as_dict();
+                },
+                [&](TSDInputView dict) {
                     for (auto &&[key, child] : dict.modified_items())
                     {
                         static_cast<void>(key);
                         append_input_sources(out, child, evaluation_time, depth,
                                              capture_values, indent, visited);
                     }
-                    break;
-                }
-                default:
-                    break;
-            }
+                },
+                [](TSInputView) {});
         }
 
         void append_input(std::string &out, std::string_view name, const TSInputView &input,
@@ -162,20 +148,25 @@ namespace hgraph
 
             if (depth == 0 || !node.has_input()) { return; }
             TSInputView input = node.input(evaluation_time);
-            if (input.schema() != nullptr && input.schema()->kind == TSTypeKind::TSB)
-            {
-                auto bundle = input.as_bundle();
-                for (auto &&[name, child] : bundle.items())
-                {
-                    append_input(out, name, child, evaluation_time, depth,
-                                 capture_values, indent + 2, visited);
-                }
-            }
-            else
+            if (input.schema() == nullptr)
             {
                 append_input(out, "input", input, evaluation_time, depth,
                              capture_values, indent + 2, visited);
+                return;
             }
+            visit(
+                input,
+                [&](TSBInputView bundle) {
+                    for (auto &&[name, child] : bundle.items())
+                    {
+                        append_input(out, name, child, evaluation_time, depth,
+                                     capture_values, indent + 2, visited);
+                    }
+                },
+                [&](TSInputView leaf) {
+                    append_input(out, "input", leaf, evaluation_time, depth,
+                                 capture_values, indent + 2, visited);
+                });
         }
     }  // namespace
 

--- a/tests/cpp/test_error_handling.cpp
+++ b/tests/cpp/test_error_handling.cpp
@@ -441,6 +441,60 @@ namespace
         }
     };
 
+    using TracePair = TSB<"TracePair",
+                          Field<"lhs", TS<Int>>,
+                          Field<"rhs", TS<Int>>>;
+
+    struct ThrowOnZeroBundle
+    {
+        static constexpr auto name = "throw_on_zero_bundle";
+
+        static void eval(In<"values", TracePair> values, Out<TS<Int>> out)
+        {
+            auto lhs = values.template field<"lhs">();
+            auto rhs = values.template field<"rhs">();
+            if (rhs.value() == 0) { throw std::runtime_error("bundle zero"); }
+            out.set(lhs.value() / rhs.value());
+        }
+    };
+
+    struct StructuredBundleCaptureTraceGraph
+    {
+        static constexpr auto name = "structured_bundle_capture_trace_graph";
+
+        static Port<TS<Str>> compose(Wiring &w, Port<TS<Int>> lhs, Port<TS<Int>> rhs)
+        {
+            auto output = wire<ThrowOnZeroBundle>(w, {{"lhs", lhs}, {"rhs", rhs}});
+            auto error = exception_time_series(
+                output, ErrorCaptureOptions{.trace_back_depth = 2, .capture_values = true});
+            return wire<ErrorTraceOf>(w, error);
+        }
+    };
+
+    struct ThrowOnZeroList
+    {
+        static constexpr auto name = "throw_on_zero_list";
+
+        static void eval(In<"values", TSL<TS<Int>, 2>> values, Out<TS<Int>> out)
+        {
+            if (values[1].value() == 0) { throw std::runtime_error("list zero"); }
+            out.set(values[0].value() / values[1].value());
+        }
+    };
+
+    struct StructuredListCaptureTraceGraph
+    {
+        static constexpr auto name = "structured_list_capture_trace_graph";
+
+        static Port<TS<Str>> compose(Wiring &w, Port<TS<Int>> lhs, Port<TS<Int>> rhs)
+        {
+            auto output = wire<ThrowOnZeroList>(w, {lhs, rhs});
+            auto error = exception_time_series(
+                output, ErrorCaptureOptions{.trace_back_depth = 2, .capture_values = true});
+            return wire<ErrorTraceOf>(w, error);
+        }
+    };
+
     struct DirectCaptureDepthZeroGraph
     {
         static constexpr auto name = "direct_capture_depth_zero_graph";
@@ -673,6 +727,26 @@ TEST_CASE("error handling: capture options include the failed node and input val
     REQUIRE(depth_zero[0].has_value());
     CHECK(depth_zero[0]->find("throw_on_negative") != std::string::npos);
     CHECK(depth_zero[0]->find("*x*") == std::string::npos);
+}
+
+TEST_CASE("error handling: activation traces traverse structurally wired endpoint inputs")
+{
+    using namespace hgraph;
+    using namespace hgraph::testing;
+
+    const auto bundle = eval_node<StructuredBundleCaptureTraceGraph>(
+        values<Int>(9), values<Int>(0));
+    REQUIRE(bundle[0].has_value());
+    CHECK(bundle[0]->find("throw_on_zero_bundle") != std::string::npos);
+    CHECK(bundle[0]->find("*values*: value={lhs: 9, rhs: 0}") != std::string::npos);
+    CHECK(bundle[0]->find("replay") != std::string::npos);
+
+    const auto list = eval_node<StructuredListCaptureTraceGraph>(
+        values<Int>(9), values<Int>(0));
+    REQUIRE(list[0].has_value());
+    CHECK(list[0]->find("throw_on_zero_list") != std::string::npos);
+    CHECK(list[0]->find("*values*: value=[9, 0]") != std::string::npos);
+    CHECK(list[0]->find("replay") != std::string::npos);
 }
 
 TEST_CASE("error handling: try_except propagates child graph pauses")


### PR DESCRIPTION
## Summary

- replace the native error-trace walker's remaining endpoint-kind switches with the accepted one-level `hgraph::visit` API
- preserve the walker's existing modified-child, reference-following, depth, and cycle policies
- add public-wiring regression coverage for structured bundle and list activation traces
- mark RFC 0009 accepted and record this second production adoption

## Why

The endpoint visitor introduced in PR #193 should own semantic kind dispatch. Leaving diagnostic traversal on a parallel manual switch duplicated that responsibility and made it easier for future endpoint kinds to diverge. This change adopts the public visitor without expanding the accepted boundary into recursive or scalar-value visitation.

## Impact

Error formatting and traversal behavior are unchanged. The implementation now exercises the same checked, exhaustive dispatch surface used by the JSON codec, and regression tests prove structured inputs still include their values and upstream replay nodes.

## Validation

### macOS

- fresh CMake configure, clean build, and complete native suite: **1301 passed**
- stable-ABI wheel built with Python 3.12 and complete non-WIP suite run in fresh Python 3.14: **1730 passed, 10 skipped**
  - the first run hit the known catalogue real-time timing flake once; the isolated retry and complete rerun both passed
- Sphinx warning-as-error dummy build: **passed**

### Linux (`hg-linux`)

- isolated worktree; fresh Clang 21 configure, clean build, and complete native suite: **1301 passed**
- stable-ABI wheel built with Python 3.12 and complete non-WIP suite run in fresh Python 3.14 with Polars rtcompat: **1730 passed, 10 skipped**

The host-default GCC 15 build also compiled the changed runtime and tests, but the complete gate remains blocked by pre-existing optimizer warnings treated as errors in `tests/cpp/test_json.cpp`; the full Linux acceptance gate therefore used Clang 21.