### PR TITLE
RFC 0008 stage 5: stable prepared input routes

### DIFF
--- a/docs/source/rfc/rfc_0008_prepared_node_inputs.rst
+++ b/docs/source/rfc/rfc_0008_prepared_node_inputs.rst
@@ -469,9 +469,13 @@ ticks, and are relaxed **for static nodes only**:
   count.
 * "The … static-node storage ABIs do not gain fields" is likewise scoped to
   stages 1–4.  The prepared-slot field is private to the static-node path
-  (``NodeStorageField`` plus a static-node-private extended view context); it
-  is not part of the installed extension SDK, whose promotion rules from the
-  original text still apply.
+  (``NodeStorageField``, with the array offset captured by the node's own
+  callbacks); it is not part of the installed extension SDK, whose promotion
+  rules from the original text still apply.  The input-view cursor also gains
+  one non-owning route pointer (``TSInputView`` grows from eight to nine
+  words; the pointer is null everywhere outside the prepared path), which is
+  what lets ordinary property reads resolve through the stable handle instead
+  of re-running route resolution per read.
 
 Prepared-slot contract
 ~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/source/rfc/rfc_0008_prepared_node_inputs.rst
+++ b/docs/source/rfc/rfc_0008_prepared_node_inputs.rst
@@ -1,7 +1,8 @@
 RFC 0008: Prepared Node Invocation
 ==================================
 
-:Status: Proposed
+:Status: Accepted (stages 1–4 implemented; stage 5 specified by the
+         2026-07-29 amendment below)
 :Author: Howard Henson
 :Created: 2026-07-29
 :Target: Node invocation, input routing, and endpoint notification
@@ -214,7 +215,8 @@ Implementation stages
    paths only where profiling shows remaining reconstruction.
 5. Design topology-aware stable input handles in a separate RFC amendment,
    after profiling the remaining path and proving bind, invalidation, map,
-   mesh, and installed-SDK behavior.
+   mesh, and installed-SDK behavior.  *Done: the stage 5 amendment at the end
+   of this document.*
 
 Alternatives considered
 -----------------------
@@ -433,3 +435,104 @@ contained a high outlier; a 15-sample rerun measured 13.387 ms versus the
 The implementation deliberately stops at callback-local preparation.  It does
 not add persistent input handles or change ``TSInputView`` behavior.  The
 stable observed-handle design above remains a separately measured follow-up.
+
+Stage 5 amendment: stable prepared slots (2026-07-29)
+-----------------------------------------------------
+
+Trigger evidence
+~~~~~~~~~~~~~~~~
+
+The condition this RFC set for stage 5 — "if profiling after this change
+still identifies target resolution as a material fixed cost" — is met.  A
+profile of merged main (revision ``0e161e5a``, after stages 1–4, the lifted
+single-projection change, and the observer-notify inline) on the Linux host
+shows the per-tick input substrate as the top of the pure-native profile:
+``input_child_projection`` 6.0 percent, ``resolved_target_at_path`` 2.3
+percent, ``target_link_resolve`` 0.9 percent, and the TSB projection wrappers
+(``at`` / ``size`` / ``as_bundle`` / ``indexed_child_at``) about 5.3 percent
+combined.  The cost is structural: ``input_at`` resolves the slot's target
+once and discards the resolution, then every subsequent property read on the
+returned view re-resolves the route (``resolved_value_data`` reassigns its
+cached target view unconditionally at a target position), so a typical
+``modified()``-then-``value()`` tick performs the full resolution two to
+three times.
+
+Relaxations
+~~~~~~~~~~~
+
+Two stage 1–4 constraints cannot hold for a slot that keeps a pointer across
+ticks, and are relaxed **for static nodes only**:
+
+* "Add no planned storage or persistent borrowed state" now binds stages 1–4
+  alone.  Stage 5 adds one planned static-node storage field: a fixed-size
+  prepared-slot array sized by the implementation's canonical input-slot
+  count.
+* "The … static-node storage ABIs do not gain fields" is likewise scoped to
+  stages 1–4.  The prepared-slot field is private to the static-node path
+  (``NodeStorageField`` plus a static-node-private extended view context); it
+  is not part of the installed extension SDK, whose promotion rules from the
+  original text still apply.
+
+Prepared-slot contract
+~~~~~~~~~~~~~~~~~~~~~~
+
+A prepared slot exists per canonical **actively observed value input** of a
+static node and holds exactly two non-owning words of route state:
+
+* a pointer to the slot's active-trie node (``TSInputTargetActiveNode``),
+  whose ``observed`` output handle the runtime already replaces in place on
+  every topology event; and
+* the slot's target-link storage reference, from which the input cursor is
+  reconstructed so that sampled-rebind blending, structural-transition
+  checks, and link-local tracking reads keep their existing semantics.  The
+  prepared slot removes the per-callback projection walk and the per-read
+  route re-resolution; it must not bypass the cursor.
+
+Lifecycle:
+
+* **Acquire** in a framework-supplied ``start`` callback.  Input activation
+  (``activate_input_slots``) runs before the user ``start`` hook, so the trie
+  node exists; static nodes therefore register start/stop callbacks
+  unconditionally, not only when the implementation declares them.
+* **Clear** in the framework-supplied ``stop`` callback.  Deactivation runs
+  after the user ``stop`` hook, so the trie node is still live at clear time.
+  Nested static children acquire and clear on every child start/stop, which
+  keeps dynamic-slot reuse correct without new bookkeeping.
+* **Validity per use** is the handle's own bound state: source invalidation
+  and ``make_passive`` clear ``observed`` in place while the trie node stays
+  alive, so an unbound handle *is* the fallback signal.  No generation
+  counter is added (the alternative already rejected above).
+
+Non-pruning becomes a contract.  The active-trie pruning helpers
+(``try_prune_child`` / ``try_prune_active_root``) are dead code today; stage
+5 removes them and records the invariant they contradicted: an active-trie
+node, once created, lives until its owning target-link storage is destroyed
+or assigned over.  Storage *move construction* preserves trie-node addresses
+(the tree is repointed in place); copy-assignment and move-assignment into a
+populated link destroy the tree, and both happen only during build-time
+embedding, before any acquire.
+
+Fallbacks (unchanged behaviour)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The stable path applies only where the runtime already trusts the observed
+handle: locally active, value-kind observation, bound.  Everything else keeps
+the existing resolution path, routed at compile time from the selector's
+policy pack (``InputActivity``) with no runtime test:
+
+* passive inputs (never activate, no observed handle);
+* structural selectors (their observed handle is a derived structural view,
+  not the value position);
+* slots whose projection carries no target link (owned storage); and
+* from-REF alternatives and mid-transition reads, which the reconstructed
+  cursor already handles because the prepared slot retains the link storage
+  reference.
+
+Acceptance
+~~~~~~~~~~
+
+The original acceptance criteria apply unchanged, with emphasis on: existing
+bind/rebind/sampled/unbind/forwarding route tests; map and mesh key
+erase/reuse (child start/stop must re-acquire cleanly); source-invalidation
+tests proving the bound-state fallback; and five-sample before/after packs on
+both hosts with the ``hg_cpp / legacy C++`` ratio recorded.

--- a/docs/source/rfc/rfc_0008_prepared_node_inputs.rst
+++ b/docs/source/rfc/rfc_0008_prepared_node_inputs.rst
@@ -481,7 +481,13 @@ Prepared-slot contract
 ~~~~~~~~~~~~~~~~~~~~~~
 
 A prepared slot exists per canonical **actively observed value input** of a
-static node and holds exactly two non-owning words of route state:
+node whose front-end plans the route array — the static-node builder and
+the lifted-kernel builder, which share the machinery in
+``runtime/prepared_input_routes.h``.  Three per-tick consumers read it: the
+static-node invocation frame, the lifted-kernel child projection, and the
+common readiness gate (all other node kinds keep the existing projection
+path unchanged).  Each slot holds exactly two non-owning words of route
+state:
 
 * a pointer to the slot's active-trie node (``TSInputTargetActiveNode``),
   whose ``observed`` output handle the runtime already replaces in place on
@@ -540,3 +546,12 @@ bind/rebind/sampled/unbind/forwarding route tests; map and mesh key
 erase/reuse (child start/stop must re-acquire cleanly); source-invalidation
 tests proving the bound-state fallback; and five-sample before/after packs on
 both hosts with the ``hg_cpp / legacy C++`` ratio recorded.
+
+Focused pinned Linux medians (Core Ultra 7 155H, seven samples per side,
+against main ``a5d1a9b5``): scheduler fan-out +21.0 percent, partial-TSB
++8.2, dense TSD map +6.7, integer arithmetic +6.5, native tick +5.4;
+python-boundary shapes neutral.  Nodes outside the planned-route front-ends
+pay the one-word-wider input view without gaining the cache — measured
+-1.7 percent on the native request-reply service scenario, inside the five
+percent investigation bar; extending route planning to the erased node
+front-ends is the natural follow-up if that cost matters.

--- a/docs/source/rfc/rfc_0008_prepared_node_inputs.rst
+++ b/docs/source/rfc/rfc_0008_prepared_node_inputs.rst
@@ -489,9 +489,9 @@ common readiness gate (all other node kinds keep the existing projection
 path unchanged).  Each slot holds exactly two non-owning words of route
 state:
 
-* a pointer to the slot's active-trie node (``TSInputTargetActiveNode``),
-  whose ``observed`` output handle the runtime already replaces in place on
-  every topology event; and
+* a pointer to the slot's active-trie root node
+  (``TSInputTargetActiveNode``), whose ``observed`` output handle the
+  runtime already replaces in place on every topology event; and
 * the slot's target-link storage reference, from which the input cursor is
   reconstructed so that sampled-rebind blending, structural-transition
   checks, and link-local tracking reads keep their existing semantics.  The
@@ -508,10 +508,15 @@ Lifecycle:
   after the user ``stop`` hook, so the trie node is still live at clear time.
   Nested static children acquire and clear on every child start/stop, which
   keeps dynamic-slot reuse correct without new bookkeeping.
-* **Validity per use** is the handle's own bound state: source invalidation
-  and ``make_passive`` clear ``observed`` in place while the trie node stays
-  alive, so an unbound handle *is* the fallback signal.  No generation
-  counter is added (the alternative already rejected above).
+* **Validity per use** re-checks the full trust condition that
+  ``resolved_target_at_path`` requires — locally active, value-kind
+  observation, bound.  Source invalidation and ``make_passive`` clear
+  ``observed`` in place while the trie node stays alive; a runtime
+  ``make_structural_active`` swaps in a *bound structural* handle on the
+  same node, which the kind check rejects (a bound-only check would expose
+  structural storage as the value route).  Any failed condition falls back
+  to full resolution.  No generation counter is added (the alternative
+  already rejected above).
 
 Non-pruning becomes a contract.  The active-trie pruning helpers
 (``try_prune_child`` / ``try_prune_active_root``) are dead code today; stage

--- a/include/hgraph/runtime/node.h
+++ b/include/hgraph/runtime/node.h
@@ -191,6 +191,12 @@ namespace hgraph
         const MemoryUtils::StoragePlan *plan{nullptr};
     };
 
+    /** Planned field name of the static-node prepared-slot array (RFC 0008
+        stage 5). The layout caches its offset like every standard component,
+        so derived-type rebuilds (error capture, passive inputs) resolve
+        their own layout instead of inheriting a stale offset. */
+    inline constexpr std::string_view node_prepared_inputs_field{"prepared_inputs"};
+
     /**
      * Build (and intern) the node storage plan. Components destroy in
      * **reverse** order, so field placement encodes link direction:
@@ -248,6 +254,11 @@ namespace hgraph
         [[nodiscard]] NodePtr pointer() const noexcept;
         [[nodiscard]] const NodeTypeMetaData *schema() const noexcept;
         [[nodiscard]] void *data() const noexcept;
+        /** The node's planned prepared-slot array (RFC 0008 stage 5), or
+            null when this node type carries none. Type-erased so the node
+            layer stays independent of the static-node header; static nodes
+            cast to their ``PreparedInputSlotRoute`` array. */
+        [[nodiscard]] void *prepared_input_routes() const noexcept;
 
         [[nodiscard]] std::string_view label() const noexcept;
         [[nodiscard]] NodeKind node_kind() const noexcept;

--- a/include/hgraph/runtime/prepared_input_routes.h
+++ b/include/hgraph/runtime/prepared_input_routes.h
@@ -1,0 +1,70 @@
+/**
+ * Prepared input routes (RFC 0008 stage 5) — the shared helpers for node
+ * front-ends that plan a per-slot route array (static nodes, lifted
+ * kernels). One planned array per node with inputs; acquired by a
+ * framework start callback AFTER the user start hook (input activation
+ * precedes both), cleared by the framework stop callback after the user
+ * stop hook (deactivation follows both). Non-owning throughout — validity
+ * is re-checked per use via the trie handle, and the array's offset is
+ * resolved through the node's OWN runtime layout
+ * (``NodeView::prepared_input_routes``), never captured, so derived-type
+ * rebuilds (error capture, passive inputs) relay or drop the field and
+ * every consumer follows automatically.
+ */
+#ifndef HGRAPH_RUNTIME_PREPARED_INPUT_ROUTES_H
+#define HGRAPH_RUNTIME_PREPARED_INPUT_ROUTES_H
+
+#include <hgraph/runtime/node.h>
+#include <hgraph/types/time_series/ts_input/detail.h>
+
+#include <array>
+#include <cstddef>
+
+namespace hgraph
+{
+    template <std::size_t SlotCount>
+    using PreparedRoutesStorage = std::array<detail::PreparedInputSlotRoute, SlotCount>;
+
+    [[nodiscard]] inline detail::PreparedInputSlotRoute *
+    prepared_input_routes_for(const NodeView &view) noexcept
+    {
+        return static_cast<detail::PreparedInputSlotRoute *>(view.prepared_input_routes());
+    }
+
+    /** The planned field for ``SlotCount`` canonical input slots; pass to
+        ``node_storage_plan_for`` as an extra field. */
+    template <std::size_t SlotCount>
+    [[nodiscard]] NodeStorageField prepared_routes_storage_field()
+    {
+        return NodeStorageField{
+            .name = node_prepared_inputs_field,
+            .plan = &MemoryUtils::plan_for<PreparedRoutesStorage<SlotCount>>(),
+        };
+    }
+
+    template <std::size_t SlotCount>
+    void acquire_prepared_input_routes(const NodeView &view, DateTime evaluation_time)
+    {
+        auto *routes = prepared_input_routes_for(view);
+        if (routes == nullptr) { return; }
+        TSInputView root = view.input(evaluation_time);
+        // Only a projectable (owned, child-carrying) root prepares; anything
+        // else leaves the routes empty and every slot falls back to the
+        // per-tick projection.
+        if (!detail::has_input_children(root.data_view())) { return; }
+        for (std::size_t slot = 0; slot < SlotCount; ++slot)
+        {
+            routes[slot] = root.prepare_child_route(slot);
+        }
+    }
+
+    template <std::size_t SlotCount>
+    void clear_prepared_input_routes(const NodeView &view) noexcept
+    {
+        auto *routes = prepared_input_routes_for(view);
+        if (routes == nullptr) { return; }
+        for (std::size_t slot = 0; slot < SlotCount; ++slot) { routes[slot] = {}; }
+    }
+}  // namespace hgraph
+
+#endif  // HGRAPH_RUNTIME_PREPARED_INPUT_ROUTES_H

--- a/include/hgraph/types/lift.h
+++ b/include/hgraph/types/lift.h
@@ -2,6 +2,7 @@
 #define HGRAPH_TYPES_LIFT_H
 
 #include <hgraph/runtime/node.h>
+#include <hgraph/runtime/prepared_input_routes.h>
 #include <hgraph/types/graph_wiring.h>
 #include <hgraph/types/metadata/type_registry.h>
 #include <hgraph/types/static_schema.h>
@@ -386,14 +387,19 @@ namespace hgraph
         }
 
         template <typename F, std::size_t... I>
-        bool evaluate_lifted_children(const NodeView &view, TSBInputView &input,
+        bool evaluate_lifted_children(const NodeView &view, TSInputView &root, TSBInputView &input,
                                       DateTime evaluation_time, std::index_sequence<I...>)
         {
             // Project each argument child ONCE per evaluation: at(I) walks
             // the input child projection, and the validity pass plus the
             // value pass previously each paid it — the lifted twin of the
-            // static-node invocation frame (RFC 0008 profile).
-            std::array<TSInputView, sizeof...(I)> children{input.at(I)...};
+            // static-node invocation frame (RFC 0008 profile). Prepared
+            // routes (stage 5) replace even that single walk with the
+            // planned per-slot route cache when acquired.
+            const auto *routes = prepared_input_routes_for(view);
+            std::array<TSInputView, sizeof...(I)> children{
+                (routes != nullptr && routes[I].ready() ? root.child_from_prepared(routes[I])
+                                                        : input.at(I))...};
             if (!(children[I].valid() && ...)) { return true; }
             auto output = view.output(evaluation_time);
 
@@ -414,7 +420,7 @@ namespace hgraph
 
             auto root_input = view.input(evaluation_time);
             auto input      = root_input.as_bundle();
-            return evaluate_lifted_children<F>(view, input, evaluation_time,
+            return evaluate_lifted_children<F>(view, root_input, input, evaluation_time,
                                                std::make_index_sequence<arity_v<F>>{});
         }
 
@@ -464,6 +470,22 @@ namespace hgraph
             descriptor.schema             = std::move(schema);
             descriptor.callbacks.evaluate = &evaluate_lifted_node_callback<F, Identity>;
             descriptor.ops.evaluate_impl  = &evaluate_lifted_node<F, Identity>;
+            if constexpr (arity_v<F> > 0)
+            {
+                // Prepared routes (RFC 0008 stage 5): same planned field and
+                // acquire/clear lifecycle as static nodes.
+                if (input_schema != nullptr)
+                {
+                    const std::array fields{prepared_routes_storage_field<arity_v<F>>()};
+                    descriptor.storage_plan = &node_storage_plan_for(descriptor.schema, fields);
+                    descriptor.callbacks.start = [](const NodeView &node, DateTime evaluation_time) {
+                        acquire_prepared_input_routes<arity_v<F>>(node, evaluation_time);
+                    };
+                    descriptor.callbacks.stop = [](const NodeView &node, DateTime) {
+                        clear_prepared_input_routes<arity_v<F>>(node);
+                    };
+                }
+            }
 
             NodeBuilder builder = NodeBuilder::from_descriptor(std::move(descriptor));
             builder.input_endpoint(graph_wiring_detail::input_endpoint_for_sources(

--- a/include/hgraph/types/static_node.h
+++ b/include/hgraph/types/static_node.h
@@ -14,6 +14,8 @@
 #include <hgraph/types/time_series/ts_data/set_view.h>
 #include <hgraph/types/time_series/endpoint_schema.h>
 #include <hgraph/types/time_series/ts_input/bundle_view.h>
+#include <hgraph/types/time_series/ts_input/detail.h>
+#include <hgraph/util/scope.h>
 #include <hgraph/types/time_series/ts_input/dict_view.h>
 #include <hgraph/types/time_series/ts_input/list_view.h>
 #include <hgraph/types/time_series/ts_input/set_view.h>
@@ -1914,11 +1916,15 @@ namespace hgraph
 
         // Per-hook scratch only. Keeping the roots beyond this frame would
         // retain input-route state across rebind and dynamic-slot lifecycles.
+        // ``routes`` (RFC 0008 stage 5) is the node's planned prepared-slot
+        // array: per-tick slot views rebuild from the cached route instead of
+        // re-walking the projection; an unready route falls back.
         class StaticNodeInvocationFrame
         {
           public:
-            StaticNodeInvocationFrame(const NodeView &view, DateTime evaluation_time)
-                : view_(view), evaluation_time_(evaluation_time)
+            StaticNodeInvocationFrame(const NodeView &view, DateTime evaluation_time,
+                                      const detail::PreparedInputSlotRoute *routes = nullptr)
+                : view_(view), evaluation_time_(evaluation_time), routes_(routes)
             {
             }
 
@@ -1930,6 +1936,10 @@ namespace hgraph
                 if (!input_root_.has_value())
                 {
                     input_root_.emplace(view_.input(evaluation_time_));
+                }
+                if (routes_ != nullptr && routes_[slot].ready())
+                {
+                    return input_root_->child_from_prepared(routes_[slot]);
                 }
                 return input_root_->indexed_child_at(slot);
             }
@@ -1951,6 +1961,7 @@ namespace hgraph
           private:
             const NodeView            &view_;
             DateTime                   evaluation_time_;
+            const detail::PreparedInputSlotRoute *routes_{nullptr};
             std::optional<TSInputView> input_root_{};
             std::optional<BundleView>  scalar_root_{};
         };
@@ -2124,23 +2135,25 @@ namespace hgraph
         template <auto Fn, typename CanonicalArgs, std::size_t... I>
         void invoke_impl(const NodeView &view,
                          DateTime evaluation_time,
+                         const detail::PreparedInputSlotRoute *routes,
                          std::index_sequence<I...>)
         {
             using args = typename fn_traits<decltype(Fn)>::args_tuple;
-            StaticNodeInvocationFrame frame{view, evaluation_time};
+            StaticNodeInvocationFrame frame{view, evaluation_time, routes};
             Fn(provide_arg<selector_of<std::tuple_element_t<I, args>>, CanonicalArgs>(
                 frame)...);
         }
 
         template <auto Fn,
                   typename CanonicalArgs = typename fn_traits<decltype(Fn)>::args_tuple>
-        void invoke(const NodeView &view, DateTime evaluation_time)
+        void invoke(const NodeView &view, DateTime evaluation_time,
+                    const detail::PreparedInputSlotRoute *routes = nullptr)
         {
             using traits = fn_traits<decltype(Fn)>;
             static_assert(std::is_same_v<typename traits::return_type, void>,
                           "Static node hooks must return void");
             invoke_impl<Fn, CanonicalArgs>(
-                view, evaluation_time,
+                view, evaluation_time, routes,
                 std::make_index_sequence<std::tuple_size_v<typename traits::args_tuple>>{});
         }
 
@@ -2812,7 +2825,6 @@ namespace hgraph
         struct StaticNodeBuilderParts
         {
             NodeTypeMetaData schema{};
-            NodeCallbacks    callbacks{};
             TSEndpointSchema input_endpoint{};
             std::string_view implementation_label{};
         };
@@ -2889,28 +2901,104 @@ namespace hgraph
             return schema;
         }
 
+        // ---- prepared input routes (RFC 0008 stage 5) ----
+        // One planned array per static node with inputs; acquired by the
+        // framework start callback AFTER the user start hook (input
+        // activation precedes both), cleared by the framework stop callback
+        // after the user stop hook (deactivation follows both). Non-owning
+        // throughout — validity is re-checked per use via the trie handle.
+        // The array's offset is resolved through the node's OWN runtime
+        // layout (``NodeView::prepared_input_routes``), never captured: a
+        // derived-type rebuild (error capture, passive inputs) relays or
+        // drops the field and the callbacks follow automatically.
+        template <std::size_t SlotCount>
+        using PreparedRoutesStorage = std::array<detail::PreparedInputSlotRoute, SlotCount>;
+
+        [[nodiscard]] inline detail::PreparedInputSlotRoute *
+        prepared_routes(const NodeView &view) noexcept
+        {
+            return static_cast<detail::PreparedInputSlotRoute *>(view.prepared_input_routes());
+        }
+
+        template <std::size_t SlotCount>
+        void acquire_prepared_routes(const NodeView &view, DateTime evaluation_time)
+        {
+            auto *routes = prepared_routes(view);
+            if (routes == nullptr) { return; }
+            TSInputView root = view.input(evaluation_time);
+            // Only a projectable (owned, child-carrying) root prepares;
+            // anything else leaves the routes empty and every slot falls
+            // back to the per-tick projection.
+            if (!detail::has_input_children(root.data_view())) { return; }
+            for (std::size_t slot = 0; slot < SlotCount; ++slot)
+            {
+                routes[slot] = root.prepare_child_route(slot);
+            }
+        }
+
+        template <std::size_t SlotCount>
+        void clear_prepared_routes(const NodeView &view) noexcept
+        {
+            auto *routes = prepared_routes(view);
+            if (routes == nullptr) { return; }
+            for (std::size_t slot = 0; slot < SlotCount; ++slot) { routes[slot] = {}; }
+        }
+
         template <typename TImplementation>
         [[nodiscard]] NodeCallbacks static_node_callbacks()
         {
             using signature_args =
                 typename StaticNodeSignature<TImplementation>::canonical_args;
+            constexpr std::size_t slot_count =
+                StaticNodeSignature<TImplementation>::input_count();
             NodeCallbacks callbacks;
-            callbacks.evaluate = [](const NodeView &view, DateTime evaluation_time) {
-                invoke<&TImplementation::eval, signature_args>(view, evaluation_time);
-            };
-            if constexpr (has_start<TImplementation>)
+            if constexpr (slot_count == 0)
             {
+                callbacks.evaluate = [](const NodeView &view, DateTime evaluation_time) {
+                    invoke<&TImplementation::eval, signature_args>(view, evaluation_time);
+                };
+                if constexpr (has_start<TImplementation>)
+                {
+                    callbacks.start = [](const NodeView &view, DateTime evaluation_time) {
+                        invoke<&TImplementation::start, signature_args>(view, evaluation_time);
+                    };
+                }
+                if constexpr (has_stop<TImplementation>)
+                {
+                    callbacks.stop = [](const NodeView &view, DateTime evaluation_time) {
+                        invoke<&TImplementation::stop, signature_args>(view, evaluation_time);
+                    };
+                }
+                return callbacks;
+            }
+            else
+            {
+                callbacks.evaluate = [](const NodeView &view, DateTime evaluation_time) {
+                    invoke<&TImplementation::eval, signature_args>(view, evaluation_time,
+                                                                   prepared_routes(view));
+                };
                 callbacks.start = [](const NodeView &view, DateTime evaluation_time) {
-                    invoke<&TImplementation::start, signature_args>(view, evaluation_time);
+                    // The user hook runs with the slow path (routes not yet
+                    // acquired); a throwing start leaves nothing behind.
+                    if constexpr (has_start<TImplementation>)
+                    {
+                        invoke<&TImplementation::start, signature_args>(view, evaluation_time);
+                    }
+                    acquire_prepared_routes<slot_count>(view, evaluation_time);
                 };
-            }
-            if constexpr (has_stop<TImplementation>)
-            {
                 callbacks.stop = [](const NodeView &view, DateTime evaluation_time) {
-                    invoke<&TImplementation::stop, signature_args>(view, evaluation_time);
+                    auto clear_routes = UnwindCleanupGuard([&]() noexcept {
+                        clear_prepared_routes<slot_count>(view);
+                    });
+                    if constexpr (has_stop<TImplementation>)
+                    {
+                        invoke<&TImplementation::stop, signature_args>(view, evaluation_time,
+                                                                       prepared_routes(view));
+                    }
+                    clear_routes.complete();
                 };
+                return callbacks;
             }
-            return callbacks;
         }
 
         template <typename TImplementation>
@@ -2926,7 +3014,6 @@ namespace hgraph
             schema.schedule_on_start = schema.schedule_on_start || has_active_reference_input(schema);
             return StaticNodeBuilderParts<TImplementation>{
                 .schema         = std::move(schema),
-                .callbacks      = static_node_callbacks<TImplementation>(),
                 .input_endpoint = signature::input_endpoint(),
                 .implementation_label = static_node_implementation_label<TImplementation>(),
             };
@@ -2948,10 +3035,36 @@ namespace hgraph
             schema.schedule_on_start = schema.schedule_on_start || has_active_reference_input(schema);
             return StaticNodeBuilderParts<TImplementation>{
                 .schema         = std::move(schema),
-                .callbacks      = static_node_callbacks<TImplementation>(),
                 .input_endpoint = signature::input_endpoint(resolution),
                 .implementation_label = static_node_implementation_label<TImplementation>(),
             };
+        }
+        /**
+         * Assemble the node builder from parts (RFC 0008 stage 5): nodes
+         * with inputs take the descriptor path so their storage plan carries
+         * the prepared-slot array, whose offset the callbacks capture.
+         */
+        template <typename TImplementation>
+        [[nodiscard]] NodeBuilder make_static_node_builder(StaticNodeBuilderParts<TImplementation> parts)
+        {
+            using signature = StaticNodeSignature<TImplementation>;
+            NodeTypeDescriptor descriptor;
+            descriptor.schema               = std::move(parts.schema);
+            descriptor.implementation_label = parts.implementation_label;
+            constexpr std::size_t slot_count = signature::input_count();
+            if constexpr (slot_count > 0)
+            {
+                if (descriptor.schema.input_schema != nullptr)
+                {
+                    const std::array fields{NodeStorageField{
+                        .name = node_prepared_inputs_field,
+                        .plan = &MemoryUtils::plan_for<PreparedRoutesStorage<slot_count>>(),
+                    }};
+                    descriptor.storage_plan = &node_storage_plan_for(descriptor.schema, fields);
+                }
+            }
+            descriptor.callbacks = static_node_callbacks<TImplementation>();
+            return NodeBuilder::from_descriptor(std::move(descriptor), std::move(parts.input_endpoint));
         }
     }  // namespace static_node_detail
 
@@ -2961,8 +3074,7 @@ namespace hgraph
         auto parts = static_node_detail::static_node_builder_parts<TImplementation>();
         std::string saved_label{label_};
         Value       saved_scalars{std::move(scalars_)};
-        *this = NodeBuilder::native(std::move(parts.schema), std::move(parts.callbacks),
-                                    std::move(parts.input_endpoint), parts.implementation_label);
+        *this = static_node_detail::make_static_node_builder<TImplementation>(std::move(parts));
         if (!saved_label.empty()) { label(std::move(saved_label)); }
         if (saved_scalars.has_value()) { scalars(std::move(saved_scalars)); }
         return *this;
@@ -2974,8 +3086,7 @@ namespace hgraph
         auto parts = static_node_detail::static_node_builder_parts<TImplementation>(resolution);
         std::string saved_label{label_};
         Value       saved_scalars{std::move(scalars_)};
-        *this = NodeBuilder::native(std::move(parts.schema), std::move(parts.callbacks),
-                                    std::move(parts.input_endpoint), parts.implementation_label);
+        *this = static_node_detail::make_static_node_builder<TImplementation>(std::move(parts));
         if (!saved_label.empty()) { label(std::move(saved_label)); }
         if (saved_scalars.has_value()) { scalars(std::move(saved_scalars)); }
         return *this;

--- a/include/hgraph/types/static_node.h
+++ b/include/hgraph/types/static_node.h
@@ -14,6 +14,7 @@
 #include <hgraph/types/time_series/ts_data/set_view.h>
 #include <hgraph/types/time_series/endpoint_schema.h>
 #include <hgraph/types/time_series/ts_input/bundle_view.h>
+#include <hgraph/runtime/prepared_input_routes.h>
 #include <hgraph/types/time_series/ts_input/detail.h>
 #include <hgraph/util/scope.h>
 #include <hgraph/types/time_series/ts_input/dict_view.h>
@@ -2902,48 +2903,9 @@ namespace hgraph
         }
 
         // ---- prepared input routes (RFC 0008 stage 5) ----
-        // One planned array per static node with inputs; acquired by the
-        // framework start callback AFTER the user start hook (input
-        // activation precedes both), cleared by the framework stop callback
-        // after the user stop hook (deactivation follows both). Non-owning
-        // throughout — validity is re-checked per use via the trie handle.
-        // The array's offset is resolved through the node's OWN runtime
-        // layout (``NodeView::prepared_input_routes``), never captured: a
-        // derived-type rebuild (error capture, passive inputs) relays or
-        // drops the field and the callbacks follow automatically.
-        template <std::size_t SlotCount>
-        using PreparedRoutesStorage = std::array<detail::PreparedInputSlotRoute, SlotCount>;
-
-        [[nodiscard]] inline detail::PreparedInputSlotRoute *
-        prepared_routes(const NodeView &view) noexcept
-        {
-            return static_cast<detail::PreparedInputSlotRoute *>(view.prepared_input_routes());
-        }
-
-        template <std::size_t SlotCount>
-        void acquire_prepared_routes(const NodeView &view, DateTime evaluation_time)
-        {
-            auto *routes = prepared_routes(view);
-            if (routes == nullptr) { return; }
-            TSInputView root = view.input(evaluation_time);
-            // Only a projectable (owned, child-carrying) root prepares;
-            // anything else leaves the routes empty and every slot falls
-            // back to the per-tick projection.
-            if (!detail::has_input_children(root.data_view())) { return; }
-            for (std::size_t slot = 0; slot < SlotCount; ++slot)
-            {
-                routes[slot] = root.prepare_child_route(slot);
-            }
-        }
-
-        template <std::size_t SlotCount>
-        void clear_prepared_routes(const NodeView &view) noexcept
-        {
-            auto *routes = prepared_routes(view);
-            if (routes == nullptr) { return; }
-            for (std::size_t slot = 0; slot < SlotCount; ++slot) { routes[slot] = {}; }
-        }
-
+        // Shared machinery in <hgraph/runtime/prepared_input_routes.h>;
+        // acquired after the user start hook, cleared after the user stop
+        // hook, offset resolved through the node's own runtime layout.
         template <typename TImplementation>
         [[nodiscard]] NodeCallbacks static_node_callbacks()
         {
@@ -2975,7 +2937,7 @@ namespace hgraph
             {
                 callbacks.evaluate = [](const NodeView &view, DateTime evaluation_time) {
                     invoke<&TImplementation::eval, signature_args>(view, evaluation_time,
-                                                                   prepared_routes(view));
+                                                                   prepared_input_routes_for(view));
                 };
                 callbacks.start = [](const NodeView &view, DateTime evaluation_time) {
                     // The user hook runs with the slow path (routes not yet
@@ -2984,16 +2946,16 @@ namespace hgraph
                     {
                         invoke<&TImplementation::start, signature_args>(view, evaluation_time);
                     }
-                    acquire_prepared_routes<slot_count>(view, evaluation_time);
+                    acquire_prepared_input_routes<slot_count>(view, evaluation_time);
                 };
                 callbacks.stop = [](const NodeView &view, DateTime evaluation_time) {
                     auto clear_routes = UnwindCleanupGuard([&]() noexcept {
-                        clear_prepared_routes<slot_count>(view);
+                        clear_prepared_input_routes<slot_count>(view);
                     });
                     if constexpr (has_stop<TImplementation>)
                     {
                         invoke<&TImplementation::stop, signature_args>(view, evaluation_time,
-                                                                       prepared_routes(view));
+                                                                       prepared_input_routes_for(view));
                     }
                     clear_routes.complete();
                 };
@@ -3056,10 +3018,7 @@ namespace hgraph
             {
                 if (descriptor.schema.input_schema != nullptr)
                 {
-                    const std::array fields{NodeStorageField{
-                        .name = node_prepared_inputs_field,
-                        .plan = &MemoryUtils::plan_for<PreparedRoutesStorage<slot_count>>(),
-                    }};
+                    const std::array fields{prepared_routes_storage_field<slot_count>()};
                     descriptor.storage_plan = &node_storage_plan_for(descriptor.schema, fields);
                 }
             }

--- a/include/hgraph/types/time_series/ts_input/base_view.h
+++ b/include/hgraph/types/time_series/ts_input/base_view.h
@@ -19,6 +19,25 @@ namespace hgraph
         struct TSInputChildProjection;
         struct TSInputTargetActiveNode;
         struct TSInputViewOps;
+
+        /**
+         * A prepared canonical-slot route (RFC 0008 stage 5): the per-tick
+         * cache that replaces the projection walk for a static node's input
+         * slot. ``data`` is the slot's target-link storage (target slots) or
+         * its owned input storage (non-target slots); ``observed`` points at
+         * the active-trie root's in-place-updated output handle when the slot
+         * is actively observed. Non-owning throughout: acquired after input
+         * activation, cleared before deactivation, validity re-checked per
+         * use via ``observed->bound()``.
+         */
+        struct PreparedInputSlotRoute
+        {
+            TSDataStorageRef<>    data{};
+            const TSOutputHandle *observed{nullptr};
+            bool                  target{false};
+
+            [[nodiscard]] bool ready() const noexcept { return data.has_value(); }
+        };
     }
 
     class TSInput;
@@ -122,6 +141,17 @@ namespace hgraph
         /** Shape-erased indexed child projection for TSB/TSL-like inputs. */
         [[nodiscard]] TSInputView indexed_child_at(std::size_t index) const;
 
+        /**
+         * RFC 0008 stage 5 (static-node implementation detail — not a stable
+         * extension API). ``prepare_child_route`` captures the slot's route
+         * once, after input activation; ``child_from_prepared`` rebuilds the
+         * slot view from that cache without the per-tick projection walk. The
+         * route is non-owning; behaviour is identical to
+         * ``indexed_child_at`` for every binding/invalidation state.
+         */
+        [[nodiscard]] detail::PreparedInputSlotRoute prepare_child_route(std::size_t index) const;
+        [[nodiscard]] TSInputView child_from_prepared(const detail::PreparedInputSlotRoute &route) const;
+
         [[nodiscard]] TSSInputView as_set() &;
         [[nodiscard]] TSSInputView as_set() const &;
         void as_set() && = delete;
@@ -200,6 +230,11 @@ namespace hgraph
             // A TU-local sentinel denotes a target-link root; real pointers
             // denote descendant path nodes. Null denotes non-target storage.
             detail::TSInputTargetActiveNode *target_node{nullptr};
+            // Prepared-route fast path (RFC 0008 stage 5): set only by
+            // ``child_from_prepared``. Points at the active-trie root's
+            // in-place-updated handle; ``bound()`` false falls back to the
+            // full resolution, so rebind/invalidation semantics are kept.
+            const TSOutputHandle *route_observed{nullptr};
         };
 
         TSInputView(TSInput                         *input,

--- a/include/hgraph/types/time_series/ts_input/base_view.h
+++ b/include/hgraph/types/time_series/ts_input/base_view.h
@@ -24,17 +24,21 @@ namespace hgraph
          * A prepared canonical-slot route (RFC 0008 stage 5): the per-tick
          * cache that replaces the projection walk for a static node's input
          * slot. ``data`` is the slot's target-link storage (target slots) or
-         * its owned input storage (non-target slots); ``observed`` points at
-         * the active-trie root's in-place-updated output handle when the slot
-         * is actively observed. Non-owning throughout: acquired after input
-         * activation, cleared before deactivation, validity re-checked per
-         * use via ``observed->bound()``.
+         * its owned input storage (non-target slots); ``route`` points at the
+         * active-trie root, whose ``observed`` handle the runtime updates in
+         * place. Non-owning throughout: acquired after input activation,
+         * cleared before deactivation. Validity is re-checked per use with
+         * the SAME trust condition as ``resolved_target_at_path`` —
+         * locally active, value-kind observation, bound — because a runtime
+         * ``make_structural_active()`` replaces the same node's handle with
+         * a bound STRUCTURAL view (``bound()`` alone would expose the wrong
+         * shape as the value route).
          */
         struct PreparedInputSlotRoute
         {
-            TSDataStorageRef<>    data{};
-            const TSOutputHandle *observed{nullptr};
-            bool                  target{false};
+            TSDataStorageRef<>                     data{};
+            const detail::TSInputTargetActiveNode *route{nullptr};
+            bool                                   target{false};
 
             [[nodiscard]] bool ready() const noexcept { return data.has_value(); }
         };
@@ -231,10 +235,12 @@ namespace hgraph
             // denote descendant path nodes. Null denotes non-target storage.
             detail::TSInputTargetActiveNode *target_node{nullptr};
             // Prepared-route fast path (RFC 0008 stage 5): set only by
-            // ``child_from_prepared``. Points at the active-trie root's
-            // in-place-updated handle; ``bound()`` false falls back to the
-            // full resolution, so rebind/invalidation semantics are kept.
-            const TSOutputHandle *route_observed{nullptr};
+            // ``child_from_prepared``. Points at the active-trie root; reads
+            // re-check locally-active + value-kind + bound (the
+            // ``resolved_target_at_path`` trust condition) and fall back to
+            // full resolution otherwise, so rebind/invalidation/activity-kind
+            // switches keep exact semantics.
+            const detail::TSInputTargetActiveNode *route_node{nullptr};
         };
 
         TSInputView(TSInput                         *input,

--- a/include/hgraph/types/time_series/ts_input/detail.h
+++ b/include/hgraph/types/time_series/ts_input/detail.h
@@ -1,6 +1,7 @@
 #ifndef HGRAPH_CPP_TS_INPUT_DETAIL_H
 #define HGRAPH_CPP_TS_INPUT_DETAIL_H
 
+#include <hgraph/hgraph_export.h>
 #include <hgraph/types/time_series/ts_input.h>
 
 #include <hgraph/types/time_series/ts_input/target_link.h>
@@ -32,8 +33,11 @@ namespace hgraph::detail
     [[nodiscard]] TSInputChildProjection input_child_projection(const TSDataView &parent, std::size_t index);
 
     /** True when ``data`` is INPUT-SHAPED (holds per-child target links) —
-        e.g. a from-REF alternative's projected data. */
-    [[nodiscard]] bool has_input_children(const TSDataView &data) noexcept;
+        e.g. a from-REF alternative's projected data. Exported: the prepared
+        route acquire template (runtime/prepared_input_routes.h) instantiates
+        in downstream modules (the python bridge builds its own static
+        nodes). */
+    [[nodiscard]] HGRAPH_EXPORT bool has_input_children(const TSDataView &data) noexcept;
 
     struct TSInputViewOps
     {

--- a/include/hgraph/types/time_series/ts_input/target_link.h
+++ b/include/hgraph/types/time_series/ts_input/target_link.h
@@ -21,6 +21,15 @@ namespace hgraph::detail
     struct TSInputTargetLinkState;
     struct TSInputTargetLinkStorage;
 
+    /**
+     * Non-pruning invariant (RFC 0008 stage 5): an active-trie node, once
+     * created, lives until its owning ``TSInputTargetLinkStorage`` is
+     * destroyed or assigned over. Deactivation (``make_passive``) resets
+     * ``observed`` in place but keeps the node; storage move-construction
+     * repoints the tree without relocating nodes. Prepared input slots hold
+     * non-owning pointers into this trie and rely on that stability, with
+     * ``observed.bound()`` as their per-use validity check.
+     */
     struct TSInputTargetActiveNode
     {
         TSInputTargetActiveNode *parent{nullptr};
@@ -33,7 +42,6 @@ namespace hgraph::detail
         [[nodiscard]] TSInputTargetActiveNode *child_at(std::size_t slot_index) const noexcept;
         [[nodiscard]] bool has_any_active() const noexcept;
         TSInputTargetActiveNode &ensure_child(std::size_t slot_index);
-        bool try_prune_child(std::size_t slot_index);
         void clear_observed() noexcept;
     };
 
@@ -60,7 +68,6 @@ namespace hgraph::detail
         void source_invalidated(const TSDataTracking *source) noexcept override;
         [[nodiscard]] TSInputTargetActiveNode *active_root() const noexcept;
         [[nodiscard]] TSInputTargetActiveNode &ensure_active_root();
-        void try_prune_active_root();
         void clear_active_observed() noexcept;
         void unsubscribe_active_tree() noexcept;
 

--- a/include/hgraph/types/time_series/ts_input/target_link.h
+++ b/include/hgraph/types/time_series/ts_input/target_link.h
@@ -27,8 +27,9 @@ namespace hgraph::detail
      * destroyed or assigned over. Deactivation (``make_passive``) resets
      * ``observed`` in place but keeps the node; storage move-construction
      * repoints the tree without relocating nodes. Prepared input slots hold
-     * non-owning pointers into this trie and rely on that stability, with
-     * ``observed.bound()`` as their per-use validity check.
+     * non-owning pointers into this trie and rely on that stability; their
+     * per-use trust check mirrors ``resolved_target_at_path`` (locally
+     * active, value-kind observation, bound).
      */
     struct TSInputTargetActiveNode
     {

--- a/src/hgraph/runtime/node.cpp
+++ b/src/hgraph/runtime/node.cpp
@@ -558,13 +558,26 @@ namespace hgraph
                 return input.valid();
             }
 
+            // Prepared routes (RFC 0008 stage 5): the readiness gate is a
+            // per-tick projection consumer too — when the node planned a
+            // route array (sized to the TSB field count), gate checks
+            // rebuild slot views from the cache.
+            const auto *routes = static_cast<const detail::PreparedInputSlotRoute *>(
+                view.prepared_input_routes());
+            const auto slot_view = [&](std::size_t slot) {
+                if (routes != nullptr && routes[slot].ready())
+                {
+                    return input.child_from_prepared(routes[slot]);
+                }
+                return input.indexed_child_at(slot);
+            };
             const auto checked_slot = [&](std::size_t slot) {
                 if (slot >= schema->field_count())
                 {
                     throw std::out_of_range(
                         "Node input selector is out of range");
                 }
-                return input.indexed_child_at(slot);
+                return slot_view(slot);
             };
 
             const auto &valid_slots = node_schema->valid_inputs;
@@ -579,7 +592,7 @@ namespace hgraph
             {
                 for (std::size_t slot = 0; slot < schema->field_count(); ++slot)
                 {
-                    if (!input.indexed_child_at(slot).valid()) { return false; }
+                    if (!slot_view(slot).valid()) { return false; }
                 }
             }
 

--- a/src/hgraph/runtime/node.cpp
+++ b/src/hgraph/runtime/node.cpp
@@ -75,6 +75,7 @@ namespace hgraph
             std::size_t evaluation_clock_offset{npos};
             std::size_t error_output_offset{npos};
             std::size_t recordable_state_offset{npos};
+            std::size_t prepared_inputs_offset{npos};
 
             [[nodiscard]] bool has_input() const noexcept { return input_offset != npos; }
             [[nodiscard]] bool has_output() const noexcept { return output_offset != npos; }
@@ -456,6 +457,7 @@ namespace hgraph
                 {"evaluation_clock", &NodeRuntimeLayout::evaluation_clock_offset},
                 {"error_output", &NodeRuntimeLayout::error_output_offset},
                 {"recordable_state", &NodeRuntimeLayout::recordable_state_offset},
+                {node_prepared_inputs_field.data(), &NodeRuntimeLayout::prepared_inputs_offset},
             };
             for (const auto &[name, member] : optional_components)
             {
@@ -1204,6 +1206,16 @@ namespace hgraph
     }
     void *NodeView::data() const noexcept { return const_cast<void *>(pointer_.data()); }
 
+    void *NodeView::prepared_input_routes() const noexcept
+    {
+        if (!valid()) { return nullptr; }
+        const NodeOps &table = ops();
+        if (table.context == nullptr) { return nullptr; }
+        const auto &context = *static_cast<const NodeRuntimeContext *>(table.context);
+        if (context.layout.prepared_inputs_offset == NodeRuntimeLayout::npos) { return nullptr; }
+        return MemoryUtils::advance(data(), context.layout.prepared_inputs_offset);
+    }
+
     std::string_view NodeView::label() const noexcept
     {
         return ops().label_impl(ops().context, data());
@@ -1544,7 +1556,17 @@ namespace hgraph
         schema.captures_errors     = true;
         schema.error_capture       = options;
 
-        const auto &plan = node_storage_plan_for(schema);
+        // Preserve non-standard planned fields (the prepared-slot array):
+        // callbacks resolve the field's offset through the rebuilt layout,
+        // never from the origin plan.
+        std::vector<NodeStorageField> extra_fields;
+        if (const auto *prepared = origin.plan != nullptr
+                                       ? origin.plan->find_component(node_prepared_inputs_field)
+                                       : nullptr)
+        {
+            extra_fields.push_back(NodeStorageField{node_prepared_inputs_field, prepared->plan});
+        }
+        const auto &plan = node_storage_plan_for(schema, extra_fields);
         const auto type =
             node_runtime_registry().make_type(std::move(schema), origin.callbacks, plan, NodeOps{},
                                               type_.record()->implementation_name());
@@ -1600,7 +1622,15 @@ namespace hgraph
         }
         schema.active_inputs = std::move(active);
 
-        const auto &plan = node_storage_plan_for(schema);
+        // Preserve non-standard planned fields (see with_error_capture).
+        std::vector<NodeStorageField> extra_fields;
+        if (const auto *prepared = origin.plan != nullptr
+                                       ? origin.plan->find_component(node_prepared_inputs_field)
+                                       : nullptr)
+        {
+            extra_fields.push_back(NodeStorageField{node_prepared_inputs_field, prepared->plan});
+        }
+        const auto &plan = node_storage_plan_for(schema, extra_fields);
         const auto type =
             node_runtime_registry().make_type(std::move(schema), origin.callbacks, plan, node_ops,
                                               type_.record()->implementation_name());

--- a/src/hgraph/types/time_series/ts_input/base_view.cpp
+++ b/src/hgraph/types/time_series/ts_input/base_view.cpp
@@ -38,8 +38,10 @@ namespace hgraph
 
     TSInputView::InputDataCursor TSInputView::InputDataCursor::borrowed_ref() const noexcept
     {
-        return InputDataCursor{value_data.borrowed_ref(), raw_data.borrowed_ref(), target_node,
+        InputDataCursor cursor{value_data.borrowed_ref(), raw_data.borrowed_ref(), target_node,
                                Classification::Known};
+        cursor.route_observed = route_observed;
+        return cursor;
     }
 
     bool TSInputView::InputDataCursor::has_storage() const noexcept
@@ -86,6 +88,15 @@ namespace hgraph
 
     const TSDataView &TSInputView::InputDataCursor::resolved_value_data() const noexcept
     {
+        // Prepared route (RFC 0008 stage 5): the trie node's handle is
+        // replaced in place on every topology event, so a bound handle IS the
+        // current target; unbound falls through to the full resolution
+        // (which also serves rebuilding after source invalidation).
+        if (route_observed != nullptr && route_observed->bound())
+        {
+            value_data = route_observed->data_view();
+            return value_data;
+        }
         if (is_target_position()) { value_data = detail::target_link_resolve(raw_data, target_path_node()); }
         return value_data;
     }
@@ -696,6 +707,49 @@ namespace hgraph
         auto *target_node = projection.target_link.valid() ? target_root_marker() : nullptr;
         return TSInputView{input_, std::move(projection.visible), std::move(projection.target_link), target_node,
                            scheduling_notifier_, evaluation_time_, InputDataCursor::Classification::Known};
+    }
+
+    detail::PreparedInputSlotRoute TSInputView::prepare_child_route(std::size_t index) const
+    {
+        detail::PreparedInputSlotRoute route;
+        auto parent     = data_.value_data.borrowed_ref();
+        auto projection = detail::input_child_projection(parent, index);
+        if (projection.target_link.valid())
+        {
+            route.data   = projection.target_link.storage_ref();
+            route.target = true;
+            const auto *storage = detail::target_link_storage(projection.target_link);
+            const auto *state   = storage != nullptr ? storage->state() : nullptr;
+            const auto *root    = state != nullptr ? state->active_root() : nullptr;
+            // Mirror ``resolved_target_at_path``'s trust conditions at acquire
+            // time; a runtime make_passive/make_active toggle keeps working
+            // because it resets/re-sets the SAME in-place handle.
+            if (root != nullptr && root->locally_active &&
+                root->observation_kind == detail::TSInputObservationKind::Value)
+            {
+                route.observed = &root->observed;
+            }
+        }
+        else { route.data = projection.visible.storage_ref(); }
+        return route;
+    }
+
+    TSInputView TSInputView::child_from_prepared(const detail::PreparedInputSlotRoute &route) const
+    {
+        if (!route.target)
+        {
+            return TSInputView{input_, TSDataView{route.data}, TSDataView{}, nullptr,
+                               scheduling_notifier_, evaluation_time_,
+                               InputDataCursor::Classification::Known};
+        }
+        // Empty value seed: every read resolves through the cursor (the
+        // prepared route or the full resolution), exactly as the projected
+        // slow path does.
+        TSInputView view{input_, TSDataView{}, TSDataView{route.data}, target_root_marker(),
+                         scheduling_notifier_, evaluation_time_,
+                         InputDataCursor::Classification::Known};
+        view.data_.route_observed = route.observed;
+        return view;
     }
 
 }  // namespace hgraph

--- a/src/hgraph/types/time_series/ts_input/base_view.cpp
+++ b/src/hgraph/types/time_series/ts_input/base_view.cpp
@@ -40,7 +40,7 @@ namespace hgraph
     {
         InputDataCursor cursor{value_data.borrowed_ref(), raw_data.borrowed_ref(), target_node,
                                Classification::Known};
-        cursor.route_observed = route_observed;
+        cursor.route_node = route_node;
         return cursor;
     }
 
@@ -89,12 +89,18 @@ namespace hgraph
     const TSDataView &TSInputView::InputDataCursor::resolved_value_data() const noexcept
     {
         // Prepared route (RFC 0008 stage 5): the trie node's handle is
-        // replaced in place on every topology event, so a bound handle IS the
-        // current target; unbound falls through to the full resolution
-        // (which also serves rebuilding after source invalidation).
-        if (route_observed != nullptr && route_observed->bound())
+        // replaced in place on every topology event, so a TRUSTED handle IS
+        // the current target. Trust means the same three conditions
+        // ``resolved_target_at_path`` requires — locally active, value-kind
+        // observation, bound — because a runtime ``make_structural_active()``
+        // swaps in a bound STRUCTURAL handle on this same node. Anything
+        // else falls through to the full resolution (which also serves
+        // rebuilding after source invalidation).
+        if (route_node != nullptr && route_node->locally_active &&
+            route_node->observation_kind == detail::TSInputObservationKind::Value &&
+            route_node->observed.bound())
         {
-            value_data = route_observed->data_view();
+            value_data = route_node->observed.data_view();
             return value_data;
         }
         if (is_target_position()) { value_data = detail::target_link_resolve(raw_data, target_path_node()); }
@@ -720,15 +726,12 @@ namespace hgraph
             route.target = true;
             const auto *storage = detail::target_link_storage(projection.target_link);
             const auto *state   = storage != nullptr ? storage->state() : nullptr;
-            const auto *root    = state != nullptr ? state->active_root() : nullptr;
-            // Mirror ``resolved_target_at_path``'s trust conditions at acquire
-            // time; a runtime make_passive/make_active toggle keeps working
-            // because it resets/re-sets the SAME in-place handle.
-            if (root != nullptr && root->locally_active &&
-                root->observation_kind == detail::TSInputObservationKind::Value)
-            {
-                route.observed = &root->observed;
-            }
+            // The trie root pointer is stable for the storage's lifetime
+            // (non-pruning contract); the trust conditions are re-checked at
+            // EVERY read, not frozen here, so runtime activity toggles
+            // (make_passive / make_active / make_structural_active) keep
+            // exact semantics.
+            route.route = state != nullptr ? state->active_root() : nullptr;
         }
         else { route.data = projection.visible.storage_ref(); }
         return route;
@@ -748,7 +751,7 @@ namespace hgraph
         TSInputView view{input_, TSDataView{}, TSDataView{route.data}, target_root_marker(),
                          scheduling_notifier_, evaluation_time_,
                          InputDataCursor::Classification::Known};
-        view.data_.route_observed = route.observed;
+        view.data_.route_node = route.route;
         return view;
     }
 

--- a/src/hgraph/types/time_series/ts_input/target_link.cpp
+++ b/src/hgraph/types/time_series/ts_input/target_link.cpp
@@ -297,15 +297,6 @@ namespace hgraph::detail
         return *child;
     }
 
-    bool TSInputTargetActiveNode::try_prune_child(std::size_t slot_index)
-    {
-        const auto it = children.find(slot_index);
-        if (it == children.end()) { return false; }
-        if (it->second && it->second->has_any_active()) { return false; }
-        children.erase(it);
-        return true;
-    }
-
     void TSInputTargetActiveNode::clear_observed() noexcept
     {
         observed.reset();
@@ -386,11 +377,6 @@ namespace hgraph::detail
     {
         if (!active_root_node) { active_root_node = std::make_unique<TSInputTargetActiveNode>(); }
         return *active_root_node;
-    }
-
-    void TSInputTargetLinkState::try_prune_active_root()
-    {
-        if (active_root_node && !active_root_node->has_any_active()) { active_root_node.reset(); }
     }
 
     void TSInputTargetLinkState::clear_active_observed() noexcept

--- a/tests/cpp/test_ts_input.cpp
+++ b/tests/cpp/test_ts_input.cpp
@@ -1351,3 +1351,68 @@ TEST_CASE("TSW ranges use stable ops contexts across data and endpoint roles")
     auto canonical_view = data.view();
     require_ranges(canonical_view.as_window());
 }
+
+TEST_CASE("prepared routes re-check the observation kind before the fast path")
+{
+    using namespace hgraph;
+
+    // RFC 0008 stage 5 regression (review catch): a runtime
+    // make_structural_active() replaces the SAME trie node's observed handle
+    // with a bound STRUCTURAL view; a bound-only fast path would then expose
+    // structural storage as the value route. The prepared read must mirror
+    // resolved_target_at_path's full trust condition and fall back.
+    auto       &registry = TypeRegistry::instance();
+    const auto *int_meta = registry.register_scalar<std::int32_t>("int32");
+    const auto *ts_int   = registry.ts(int_meta);
+    // TSD: its structural observation is the KEY SET — genuinely different
+    // storage from the value target (a TSS's structural view is the set
+    // itself, which could not distinguish the routes).
+    const auto *tsd      = registry.tsd(int_meta, ts_int);
+    const auto *root     = registry.tsb("PreparedRouteKindRoot", {{"s", tsd}});
+
+    const auto input_schema =
+        TSEndpointSchema::non_peered(root, {TSEndpointSchema::peered(tsd)});
+
+    TSOutput output{*tsd};
+    TSInput  input{TSInputBuilderFactory::checked_builder_for(*root, input_schema)};
+
+    auto binding_root   = input.view();
+    auto binding_bundle = binding_root.as_bundle();
+    binding_bundle.field("s").bind_output(output.view());
+
+    RecordingNotifiable recorder;
+    auto active_root   = input.view(&recorder);
+    auto active_bundle = active_root.as_bundle();
+    active_bundle.field("s").make_active();
+
+    const auto t = MIN_ST + TimeDelta{5};
+    auto root_view = input.view(nullptr, t);
+    auto route     = root_view.prepare_child_route(0);
+    REQUIRE(route.ready());
+    REQUIRE(route.target);
+
+    const auto require_matches_slow_path = [&] {
+        auto fast = root_view.child_from_prepared(route);
+        auto slow = root_view.indexed_child_at(0);
+        REQUIRE(fast.data_view().data() == slow.data_view().data());
+        REQUIRE(fast.data_view().schema() == slow.data_view().schema());
+    };
+
+    // Value-kind active: the fast path serves the value target.
+    require_matches_slow_path();
+
+    // Switch the SAME slot to structural observation: the trie node's
+    // handle is now a bound structural view — the prepared read must
+    // reject it and resolve the value route exactly like the slow path.
+    active_bundle.field("s").make_structural_active();
+    require_matches_slow_path();
+
+    // Passive: observed reset in place — fall back again.
+    active_bundle.field("s").make_passive();
+    require_matches_slow_path();
+
+    // Re-activated value observation: the fast path resumes on the same
+    // stable trie node.
+    active_bundle.field("s").make_active();
+    require_matches_slow_path();
+}

--- a/tests/cpp/test_type_erasure_layout.cpp
+++ b/tests/cpp/test_type_erasure_layout.cpp
@@ -84,14 +84,16 @@ TEST_CASE("current type-erasure records retain their baseline layouts")
 #endif
     static_assert(sizeof(TSOutputHandle) == sizeof(void *) * 3);
     static_assert(sizeof(TSOutputView) == sizeof(void *) * 4);
-    static_assert(sizeof(TSInputView) == sizeof(void *) * 8);
+    // 8 -> 9 words (RFC 0008 stage 5 amendment): the input cursor carries a
+    // non-owning prepared-route pointer (null outside the prepared path).
+    static_assert(sizeof(TSInputView) == sizeof(void *) * 9);
     static_assert(sizeof(IndexedTSDataView) == sizeof(void *) * 2);
     static_assert(sizeof(TSBDataView) == sizeof(void *) * 2);
     static_assert(sizeof(TSLDataView) == sizeof(void *) * 2);
     static_assert(sizeof(TSBOutputView) == sizeof(void *) * 4);
     static_assert(sizeof(TSLOutputView) == sizeof(void *) * 4);
-    static_assert(sizeof(TSBInputView) == sizeof(void *) * 8);
-    static_assert(sizeof(TSLInputView) == sizeof(void *) * 8);
+    static_assert(sizeof(TSBInputView) == sizeof(void *) * 9);
+    static_assert(sizeof(TSLInputView) == sizeof(void *) * 9);
     static_assert(sizeof(TSOutput) == sizeof(void *) * 5);
     static_assert(sizeof(TSInput) == sizeof(void *) * 7);
     static_assert(sizeof(FixedTSDataFieldLayout) == sizeof(void *) * 3);


### PR DESCRIPTION
## What

Implements the RFC 0008 stage-5 amendment (written in this PR, same change — `rfc_0008_prepared_node_inputs.rst`): per-slot **prepared input routes** that replace the per-tick projection walk and per-read route re-resolution with a planned, non-owning cache whose validity is the active-trie handle's own bound state.

- **Route cache** (`ts_input/base_view.{h,cpp}`): `detail::PreparedInputSlotRoute` = the slot's link-storage ref + a pointer to the active-trie root's in-place-updated `TSOutputHandle observed`. `TSInputView::prepare_child_route` captures it once (post-activation); `child_from_prepared` rebuilds the slot view from it per tick. The input cursor gains one route pointer (`TSInputView` 8→9 words, recorded in the amendment + layout pins): property reads resolve through the handle when bound and fall back to full resolution otherwise — so rebind (in-place replace), source invalidation (in-place reset), and passive/active toggles keep exact semantics, including for retained views.
- **Non-pruning contract** (`target_link.{h,cpp}`): the dead `try_prune_child`/`try_prune_active_root` helpers are removed and the invariant they contradicted is documented — a trie node lives until its owning link storage is destroyed or assigned over.
- **Planning + lifecycle** (`runtime/prepared_input_routes.h`, new): one planned node-storage field (`prepared_inputs`), acquired by a framework start callback after the user `start` hook, cleared after the user `stop` hook. The offset is resolved through the node's own runtime layout (`NodeView::prepared_input_routes()`), **never captured** — `with_error_capture` / `with_passive_inputs` rebuild plans, and both now preserve the field (the C++ error-handling suite caught the captured-offset variant as a segfault; this design makes the class of bug impossible).
- **Consumers**: the static-node invocation frame, the lifted-kernel child projection (`lift.h`), and the common readiness gate (`node.cpp::ready_to_evaluate`). Everything else keeps the existing path untouched.

## Measurements (pinned hg-linux 155H, 7 samples/side vs main `a5d1a9b5`)

| scenario | main (s) | branch (s) | change |
|---|---|---|---|
| scheduler_fan_out_std | 1.5599 | 1.2326 | **+21.0%** |
| type_tsb_partial_fields_std | 0.5021 | 0.4609 | **+8.2%** |
| tsd_dense_std | 1.6862 | 1.5732 | **+6.7%** |
| type_int_std | 0.2014 | 0.1884 | **+6.5%** |
| tick_std | 0.4675 | 0.4423 | **+5.4%** |
| tick_py | 0.3534 | 0.3513 | +0.6% (neutral) |
| service_request_reply_std | 0.6759 | 0.6871 | -1.7% |

The service scenario runs erased nodes that don't plan routes yet but pay the one-word-wider view — inside the RFC's 5% investigation bar; extending planning to the erased front-ends is the recorded follow-up.

## Gates

- C++ suite: 1301/1301 (including the error-capture tests that caught the interim offset bug)
- ASAN+UBSAN full suite: 1301/1301
- python: 1730 passed / 10 skipped; ported: 1147 passed / 9 skipped
- Five-sample full packs (both hosts) per the acceptance criteria: running, results to follow as a comment before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)