### PR TITLE
Add type-erased ValueView visitation

### DIFF
--- a/docs/source/developer_guide/data_structures/plans_and_ops/erased_types.rst
+++ b/docs/source/developer_guide/data_structures/plans_and_ops/erased_types.rst
@@ -133,7 +133,7 @@ The erased layer supports direct casting from one view shape to
 another so callers do not need to chain calls to reach a typed
 handle. Two cast families exist:
 
-- **Kind-specialised view casts**: ``as_tuple()``, ``as_bundle()``,
+- **Kind-specialised view casts**: ``as_atomic()``, ``as_tuple()``, ``as_bundle()``,
   ``as_list()``, ``as_set()``, ``as_map()``, ``as_cyclic_buffer()``,
   ``as_queue()``, ``as_any()``, with ``try_as_*`` counterparts that return
   ``std::optional`` and throw nothing.
@@ -150,8 +150,8 @@ do not change the underlying schema or copy the payload. Cross-schema
 adaptation — exposing one schema's value through a different schema —
 is a time-series concern, not a value-layer concern.
 
-Status: the read-only cast family is implemented for tuple, bundle,
-list, set, map, cyclic buffer, and queue views. Mutable-view casts are
+Status: the read-only cast family is implemented for atomic, tuple, bundle,
+list, set, map, cyclic buffer, queue, and Any views. Mutable-view casts are
 implemented as casts from an already-open mutable erased view; opening
 that mutable view is always done by ``begin_mutation()`` and is gated
 by the bound ops table.
@@ -254,6 +254,12 @@ that transition; replacement happens at the ``Value`` level
 Read-only views
 ~~~~~~~~~~~~~~~
 
+``AtomicView``
+    Shape tag for the open-ended atomic kind. It retains the
+    ``ValueView`` scalar access operations rather than enumerating known C++
+    alternatives, so independently registered extension scalars remain
+    first-class.
+
 ``IndexedValueView``
     Base for tuple, bundle, list, cyclic buffer, and queue views.
     Adds ``size()``, ``at(index)``, ``operator[](index)``, and a
@@ -308,6 +314,42 @@ Read-only views
     ``begin_mutation()``) adds ``set(value)`` (replace, deep copy) and
     ``clear()`` (return to empty). Unlike the compact containers, the
     ``Any`` ops allow ``begin_mutation()``, so the box is reassignable.
+
+Value visitation and operation ownership
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+``hgraph::visit`` from ``<hgraph/types/value/visitor.h>`` dispatches a live
+``ValueView`` to ``AtomicView``, ``TupleView``, ``BundleView``, ``ListView``,
+``SetView``, ``MapView``, ``CyclicBufferView``, or ``QueueView``. A
+shape-specific callable takes precedence over a ``ValueView`` catch-all.
+Every reachable branch returns ``void`` or the same safe owned type.
+Reference and lazy hgraph range results are rejected because the selected
+specialised wrapper is a temporary borrowed cursor.
+
+``Any`` is deliberately transparent in this dispatch. The visitor repeatedly
+obtains the contained view until it reaches a concrete semantic shape.
+``AnyView`` remains necessary for box management—empty-state inspection,
+replacement, and clearing—but is not a visitor alternative. An empty box and
+any other absent payload cannot be visited.
+
+Dispatch uses the declared value kind and does not call ``concrete()``.
+Consequently enums remain atomic, shaped arrays remain lists, and owned
+recursive records retain their bundle surface. Concrete projection and
+recursive child walking are caller policies.
+
+The visitor complements rather than replaces value type erasure. Hashing,
+equality, comparison, formatting, conversion, copying, and assignment remain
+in ``ValueOps``. Schema factories, codec planning, and wiring-time overload
+selection continue to inspect metadata directly. Use visitation only for
+caller-owned algorithms whose behaviour genuinely varies by a live value
+shape.
+
+After the kind switch, the visitor constructs specialised views through a
+trusted internal projection that preserves the original access tag and avoids
+repeating semantic-kind validation. The specialised view still resolves and
+checks the operation-table subclass required by its methods. Visiting writable
+storage does not implicitly enter mutation; ``begin_mutation()`` remains an
+explicit transition.
 
 Mutable views (ops-gated)
 ~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/source/rfc/index.rst
+++ b/docs/source/rfc/index.rst
@@ -23,3 +23,4 @@ workflow are defined by :doc:`rfc_0000`.
    rfc_0007_scheduled_duration_tsw_eviction
    rfc_0008_prepared_node_inputs
    rfc_0009_time_series_endpoint_visitors
+   rfc_0010_value_view_visitors

--- a/docs/source/rfc/rfc_0010_value_view_visitors.rst
+++ b/docs/source/rfc/rfc_0010_value_view_visitors.rst
@@ -1,0 +1,319 @@
+RFC 0010: Type-Erased Value Visitors
+====================================
+
+:Status: Proposed
+:Author: Howard Henson
+:Created: 2026-07-30
+:Target: Public C++ value views
+
+Summary
+-------
+
+Add callable-based visitation for a live ``ValueView``. The visitor dispatches
+the erased value's semantic shape to the existing specialised view classes,
+plus a new ``AtomicView`` tag for the open-ended scalar case. Populated
+``Any`` boxes are transparent: the visitor unwraps them until it reaches the
+contained concrete shape. ``AnyView`` remains the explicit API for managing
+the box and is not a visitor alternative.
+
+The implementation uses the existing schema discriminator, operation tables,
+and borrowed view projections. It adds no virtual hierarchy, heap allocation,
+closed list of C++ scalar types, or value-operation slot.
+
+Motivation
+----------
+
+Algorithms that genuinely vary by live value shape currently repeat a switch
+on ``ValueTypeKind`` and construct ``TupleView``, ``MapView``, and the other
+specialised cursors themselves. This is error-prone around open-ended atomic
+types, borrowed lifetimes, mutation capability, polymorphic bindings, and the
+``Any`` box.
+
+The runtime already carries all information needed to perform that dispatch.
+Centralising it gives independently built extensions one checked public
+contract while leaving operations intrinsic to the erased value in
+``ValueOps``.
+
+Ownership boundary
+------------------
+
+Value visitation belongs in the public C++ SDK because independently built
+extensions consume ``ValueView`` and may register their own atomic scalar
+types. C++ remains the source of truth for value schemas, storage, operations,
+and views.
+
+Python receives no new visitor API. Python already performs dynamic dispatch
+over converted values. Existing C++ nodes used through the Python bridge retain
+the same visible behaviour, and production adopters require matching C++ and
+Python compatibility coverage.
+
+Public C++ contract
+-------------------
+
+The installed header ``<hgraph/types/value/visitor.h>`` provides:
+
+.. code-block:: cpp
+
+   template<class... Handlers>
+   decltype(auto) visit(const ValueView &value, Handlers&&... handlers);
+
+Handlers form one overload set. After transparent ``Any`` unwrapping, dispatch
+selects:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 35 65
+
+   * - Declared kind
+     - Handler argument
+   * - ``Atomic``
+     - ``AtomicView``
+   * - ``Tuple``
+     - ``TupleView``
+   * - ``Bundle``
+     - ``BundleView``
+   * - ``List``
+     - ``ListView``
+   * - ``Set``
+     - ``SetView``
+   * - ``Map``
+     - ``MapView``
+   * - ``CyclicBuffer``
+     - ``CyclicBufferView``
+   * - ``Queue``
+     - ``QueueView``
+
+``AtomicView`` is a move-only, two-word tag over ``ValueView``. It does not
+enumerate scalar C++ types. A handler tests or extracts a scalar it understands
+with the existing ``holds_alternative<T>()``, ``try_as<T>()``, and
+``checked_as<T>()`` operations:
+
+.. code-block:: cpp
+
+   return visit(
+       value,
+       [](AtomicView scalar) {
+           if (scalar.holds_alternative<ExtensionScalar>()) {
+               return handle(scalar.checked_as<ExtensionScalar>());
+           }
+           return fallback_scalar(scalar);
+       },
+       [](MapView map) { return handle_map(map); },
+       [](ValueView other) { return handle_other(other); });
+
+A shape-specific handler takes precedence over the ``ValueView`` catch-all.
+Every concrete alternative must be accepted directly or by that catch-all.
+Every selected branch returns ``void`` or the same exact safe value type.
+
+Reference results and lazy ``Range`` / ``KeyValueRange`` results are rejected.
+The selected wrapper is a temporary borrowed cursor, and a lazy range can
+retain storage or projection context associated with it. Callers consume the
+range in the handler or return an owned materialisation.
+
+Transparent ``Any`` semantics
+-----------------------------
+
+``AnyValue`` is the schema and storage concept for an owning dynamic box.
+``AnyView`` exists to inspect or mutate that box:
+
+.. code-block:: cpp
+
+   AnyView box = value.as_any();
+   box.has_value();
+   box.get();
+   box.begin_mutation().set(replacement);
+   box.begin_mutation().clear();
+
+It is not a semantic shape of the value stored inside the box and is therefore
+not a visitor alternative. ``visit`` repeatedly unwraps populated ``Any``
+layers and dispatches the contained value:
+
+.. code-block:: cpp
+
+   Value boxed{any_type()};
+   boxed.as_any().begin_mutation().set(Value{ExtensionScalar{42}});
+
+   visit(boxed.view(), [](AtomicView scalar) {
+       // Receives ExtensionScalar, not AnyView.
+   }, [](ValueView) {});
+
+An empty ``Any`` contains no visitable value and raises
+``std::invalid_argument``. Code whose policy assigns meaning to an empty box
+checks it explicitly through ``AnyView`` before visiting. This keeps absence
+out of the semantic shape set.
+
+Unwrapping is iterative rather than recursive. Nested boxes therefore do not
+consume call stack, and every populated layer is transparent. The contained
+view retains read or write capability derived from its owner. Opening a
+mutation remains explicit; visiting writable storage does not itself enter a
+mutation phase.
+
+Declared shape and polymorphic values
+-------------------------------------
+
+Dispatch uses the live view's declared ``ValueTypeKind``. It does not call
+``ValueView::concrete()``:
+
+* registered and enum scalar schemas dispatch as ``AtomicView``;
+* fixed and shaped arrays dispatch as ``ListView``;
+* structural, named, and owned recursive records dispatch as ``BundleView``;
+* polymorphic concrete projection remains an explicit caller policy.
+
+This matches the specialised view contract. A caller that intentionally wants
+the active concrete representation first calls ``concrete()`` and visits the
+result.
+
+Visitor and type-erasure boundary
+---------------------------------
+
+The visitor is for caller-owned algorithms whose behaviour varies by live
+value shape. It does not replace behaviour already owned by the erased value's
+operations:
+
+* hashing, equality, comparison, formatting, and Python conversion remain in
+  ``ValueOps``;
+* assignment, copying, ownership projection, and concrete projection remain in
+  ``ValueOps`` and ``StoragePlan``;
+* wiring-time schema, overload, codec-plan, and factory selection continue to
+  inspect metadata directly;
+* recursive traversal, key selection, empty-box policy, and polymorphic
+  projection remain explicit algorithm policies.
+
+This prevents visitation from becoming a second type-erasure mechanism or a
+per-tick replacement for decisions that belong at wiring time.
+
+Representation and performance
+------------------------------
+
+The implementation is header-only. It performs a value-kind switch and
+constructs the selected borrowed view through an internal trusted path after
+the kind has already been checked. Specialised views still resolve and verify
+the operation-table subclass required for their public methods, but they do
+not repeat semantic-kind validation. Public direct constructors remain
+checked.
+
+The endpoint and value visitors share only generic callable composition,
+result selection, and borrowed-result safety traits. Their projection and
+dispatch logic remain independent.
+
+The change adds no data member, virtual table, type-record field,
+operation-table slot, registry entry, or runtime dependency.
+``sizeof(ValueView)`` and ``sizeof(AtomicView)`` remain two machine words.
+
+A focused benchmark compares a complete caller-written kind switch with
+``visit`` for an atomic value and a structured value. Each result is the
+median of 21 samples of 200,000 dispatches:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 23 17 17 17 14 12
+
+   * - Platform
+     - Value shape
+     - Manual ns/op
+     - Visitor ns/op
+     - Visitor change
+     - Allocations
+   * - macOS arm64, AppleClang 21
+     - Atomic
+     - 3.378
+     - 2.002
+     - 40.7% faster
+     - 0
+   * - macOS arm64, AppleClang 21
+     - Bundle
+     - 5.522
+     - 3.725
+     - 32.5% faster
+     - 0
+   * - Linux x86_64, GCC 15.2
+     - Atomic
+     - 3.467
+     - 1.728
+     - 50.2% faster
+     - 0
+   * - Linux x86_64, GCC 15.2
+     - Bundle
+     - 6.544
+     - 3.585
+     - 45.2% faster
+     - 0
+
+The visitor's trusted post-switch projection avoids repeating the public
+constructor's semantic-kind validation. Both paths are allocation-free.
+
+Compatibility
+-------------
+
+The API is additive. Existing ``AnyView`` box management, specialised value
+views, mutation rules, value ABI, serialisation, Python conversion, and
+time-series endpoint visitation do not change. The value visitor is also
+available through the top-level ``<hgraph/hgraph.h>`` convenience header.
+
+Initial adoption
+----------------
+
+Two existing live-value algorithms demonstrate the boundary:
+
+* JSON tree conversion uses the visitor for atomic, indexed, and map shape
+  behaviour while preserving its explicit policy for an empty ``Any``;
+* the evaluation path of container length uses the visitor, while its
+  wiring-time overload predicate remains a metadata switch.
+
+Codec-plan synthesis and other metadata-only switches are deliberately not
+converted.
+
+Alternatives
+------------
+
+Expose ``AnyView`` as an alternative
+   Rejected. It describes the dynamic owning box, not the semantic shape of
+   its content. Requiring callers to unwrap it defeats the main dynamic-value
+   use case and allows nested boxes to leak into every algorithm.
+
+Pass atomic values as ``ValueView``
+   Rejected. ``ValueView`` is also the catch-all, so a caller cannot distinguish
+   an atomic handler from fallback handling. ``AtomicView`` supplies shape
+   identity without closing the scalar extension set.
+
+Enumerate known C++ scalar types
+   Rejected. Extensions can register scalar types independently, and a closed
+   variant would make the core SDK the owner of downstream scalar vocabulary.
+
+Add ``match`` / ``when`` declarative wrappers
+   Deferred. Callable overloads cover the required contract and match the
+   endpoint visitor. A second visitor expression language is not justified.
+
+Virtual ``accept`` or double dispatch
+   Rejected. The runtime intentionally uses schemas, plans, operation tables,
+   and borrowed cursors rather than a virtual value hierarchy.
+
+Automatic recursive walking
+   Rejected. Map keys, empty boxes, container order, polymorphic projection,
+   depth, and cycle handling are caller policies. Recursive algorithms call
+   ``visit`` again explicitly.
+
+Acceptance criteria
+-------------------
+
+* All eight concrete semantic kinds dispatch to the correct specialised view.
+* Registered extension scalar types dispatch through ``AtomicView`` without a
+  core type list.
+* Populated nested ``Any`` boxes dispatch transparently; empty boxes and absent
+  payloads fail clearly.
+* Specific handlers take precedence over ``ValueView`` catch-all handlers.
+* Declared enum, fixed-list, and owned-recursive shapes are preserved.
+* Read-only, writable, and mutation capability follow the selected borrowed
+  value without implicit mutation.
+* ``void`` and owned results compile; references, lazy ranges, incomplete
+  handlers, and inconsistent result types fail at compile time.
+* Existing endpoint visitor tests remain unchanged after extracting generic
+  callable traits.
+* JSON tree and container-length behaviour remain covered through public
+  wiring APIs in C++ and Python.
+* A separately built installed-SDK consumer registers and visits an extension
+  scalar through ``Any``.
+* Focused performance is equivalent to or better than the corresponding
+  caller-written switch, with zero allocations.
+* The complete native and non-WIP Python compatibility suites pass on macOS
+  and Linux.

--- a/docs/source/user_guide/authoring_nodes_cpp.rst
+++ b/docs/source/user_guide/authoring_nodes_cpp.rst
@@ -530,6 +530,51 @@ All handlers return ``void`` in this example; value-returning handlers must all
 produce the same non-reference type. Invalid-current-value and unbound inputs
 still dispatch from their schema, while a default view with no schema throws.
 
+Visiting an erased value
+------------------------
+
+Use the value-layer overload of ``hgraph::visit`` when an algorithm varies by
+the live value's semantic shape:
+
+.. code-block:: cpp
+
+   #include <hgraph/types/value/visitor.h>
+
+   std::size_t item_count(const ValueView &value)
+   {
+       return visit(
+           value,
+           [](AtomicView) { return std::size_t{1}; },
+           [](TupleView tuple) { return tuple.size(); },
+           [](BundleView bundle) { return bundle.size(); },
+           [](ListView list) { return list.size(); },
+           [](SetView set) { return set.size(); },
+           [](MapView map) { return map.size(); },
+           [](CyclicBufferView buffer) { return buffer.size(); },
+           [](QueueView queue) { return queue.size(); });
+   }
+
+``AtomicView`` identifies the scalar shape without limiting it to a core list
+of C++ types. An extension handler can use
+``holds_alternative<ExtensionScalar>()`` and
+``checked_as<ExtensionScalar>()`` on it.
+
+A populated ``Any`` box is transparent to the visitor. Passing the
+``ValueView`` for an ``Any`` containing an ``ExtensionScalar`` invokes the
+``AtomicView`` handler for that scalar; nested populated boxes are also
+peeled. An empty ``Any`` has no visitable value and throws
+``std::invalid_argument``. Code assigning meaning to that empty state checks
+``value.as_any().has_value()`` before visiting. ``AnyView`` remains the
+explicit interface for inspecting, replacing, or clearing the box and is not
+a visitor alternative.
+
+The selected view is borrowed and move-only. All reachable handlers return
+``void`` or the same owned value type; references and lazy
+``Range`` / ``KeyValueRange`` results are rejected. Dispatch uses the declared
+value shape and does not call ``concrete()`` or recursively walk children.
+Call those operations and ``visit`` again when they are part of the
+algorithm's policy.
+
 
 Collections — ``TSS`` / ``TSL`` / ``TSD`` / ``TSW``
 ---------------------------------------------------

--- a/include/hgraph/hgraph.h
+++ b/include/hgraph/hgraph.h
@@ -9,4 +9,5 @@
 #include <hgraph/types/primitive_types.h>
 #include <hgraph/types/temporal.h>
 #include <hgraph/types/time_series/visitor.h>
+#include <hgraph/types/value/visitor.h>
 #include <hgraph/version.h>

--- a/include/hgraph/lib/std/operators/impl/arithmetic_impl.h
+++ b/include/hgraph/lib/std/operators/impl/arithmetic_impl.h
@@ -18,6 +18,7 @@
 #include <hgraph/types/static_node.h>
 #include <hgraph/types/static_schema.h>
 #include <hgraph/types/temporal.h>
+#include <hgraph/types/value/visitor.h>
 
 #include <algorithm>
 #include <chrono>
@@ -879,14 +880,14 @@ namespace hgraph::stdlib
             static void eval(In<"ts", TS<ScalarVar<"T">>> ts, Out<TS<Int>> out)
             {
                 const ValueView value = ts.base().value();
-                switch (value.schema()->value_kind())
-                {
-                    case ValueTypeKind::List: out.set(static_cast<Int>(value.as_list().size())); return;
-                    case ValueTypeKind::Tuple: out.set(static_cast<Int>(value.as_tuple().size())); return;
-                    case ValueTypeKind::Set: out.set(static_cast<Int>(value.as_set().size())); return;
-                    case ValueTypeKind::Map: out.set(static_cast<Int>(value.as_map().size())); return;
-                    default: throw std::logic_error("len_: not a sized container");
-                }
+                const auto size = visit(
+                    value,
+                    [](ListView selected) { return static_cast<Int>(selected.size()); },
+                    [](TupleView selected) { return static_cast<Int>(selected.size()); },
+                    [](SetView selected) { return static_cast<Int>(selected.size()); },
+                    [](MapView selected) { return static_cast<Int>(selected.size()); },
+                    [](ValueView) -> Int { throw std::logic_error("len_: not a sized container"); });
+                out.set(size);
             }
         };
     }  // namespace arithmetic_impl_detail

--- a/include/hgraph/types/detail/visitor.h
+++ b/include/hgraph/types/detail/visitor.h
@@ -1,0 +1,62 @@
+#ifndef HGRAPH_CPP_ROOT_TYPES_DETAIL_VISITOR_H
+#define HGRAPH_CPP_ROOT_TYPES_DETAIL_VISITOR_H
+
+#include <hgraph/types/value/value_range.h>
+
+#include <concepts>
+#include <type_traits>
+
+namespace hgraph::detail
+{
+    template <typename... Handlers> struct VisitorOverload : Handlers...
+    {
+        using Handlers::operator()...;
+    };
+
+    template <typename... Handlers> VisitorOverload(Handlers...) -> VisitorOverload<Handlers...>;
+
+    template <typename Visitor, typename SpecialisedView, typename BaseView>
+    inline constexpr bool visitor_branch_invocable_v =
+        std::invocable<Visitor &, SpecialisedView> || std::invocable<Visitor &, BaseView>;
+
+    template <typename Visitor, typename SpecialisedView, typename BaseView,
+              bool HasSpecialised = std::invocable<Visitor &, SpecialisedView>>
+    struct VisitorBranchResult;
+
+    template <typename Visitor, typename SpecialisedView, typename BaseView>
+    struct VisitorBranchResult<Visitor, SpecialisedView, BaseView, true>
+    {
+        using type = std::invoke_result_t<Visitor &, SpecialisedView>;
+    };
+
+    template <typename Visitor, typename SpecialisedView, typename BaseView>
+    struct VisitorBranchResult<Visitor, SpecialisedView, BaseView, false>
+    {
+        using type = std::invoke_result_t<Visitor &, BaseView>;
+    };
+
+    template <typename Visitor, typename SpecialisedView, typename BaseView>
+    using visitor_branch_result_t = typename VisitorBranchResult<Visitor, SpecialisedView, BaseView>::type;
+
+    template <typename Result, typename Visitor, typename SpecialisedView, typename BaseView>
+    inline constexpr bool visitor_branch_same_result_v =
+        std::same_as<Result, visitor_branch_result_t<Visitor, SpecialisedView, BaseView>>;
+
+    template <typename Result> struct VisitorBorrowedRangeResult : std::false_type
+    {
+    };
+
+    template <typename Value> struct VisitorBorrowedRangeResult<Range<Value>> : std::true_type
+    {
+    };
+
+    template <typename Key, typename Value> struct VisitorBorrowedRangeResult<KeyValueRange<Key, Value>> : std::true_type
+    {
+    };
+
+    template <typename Result>
+    inline constexpr bool visitor_result_safe_v =
+        !std::is_reference_v<Result> && !VisitorBorrowedRangeResult<std::remove_cv_t<Result>>::value;
+}  // namespace hgraph::detail
+
+#endif  // HGRAPH_CPP_ROOT_TYPES_DETAIL_VISITOR_H

--- a/include/hgraph/types/time_series/visitor.h
+++ b/include/hgraph/types/time_series/visitor.h
@@ -1,6 +1,7 @@
 #ifndef HGRAPH_CPP_ROOT_TIME_SERIES_VISITOR_H
 #define HGRAPH_CPP_ROOT_TIME_SERIES_VISITOR_H
 
+#include <hgraph/types/detail/visitor.h>
 #include <hgraph/types/time_series/ts_input.h>
 #include <hgraph/types/time_series/ts_output.h>
 
@@ -109,35 +110,12 @@ namespace hgraph
             }
         };
 
-        template <typename... Handlers> struct TSEndpointOverload : Handlers...
-        {
-            using Handlers::operator()...;
-        };
-
-        template <typename... Handlers> TSEndpointOverload(Handlers...) -> TSEndpointOverload<Handlers...>;
-
         template <typename Visitor, typename SpecialisedView, typename BaseView>
         inline constexpr bool endpoint_branch_invocable_v =
-            std::invocable<Visitor &, SpecialisedView> || std::invocable<Visitor &, BaseView>;
-
-        template <typename Visitor, typename SpecialisedView, typename BaseView,
-                  bool HasSpecialised = std::invocable<Visitor &, SpecialisedView>>
-        struct TSEndpointBranchResult;
+            visitor_branch_invocable_v<Visitor, SpecialisedView, BaseView>;
 
         template <typename Visitor, typename SpecialisedView, typename BaseView>
-        struct TSEndpointBranchResult<Visitor, SpecialisedView, BaseView, true>
-        {
-            using type = std::invoke_result_t<Visitor &, SpecialisedView>;
-        };
-
-        template <typename Visitor, typename SpecialisedView, typename BaseView>
-        struct TSEndpointBranchResult<Visitor, SpecialisedView, BaseView, false>
-        {
-            using type = std::invoke_result_t<Visitor &, BaseView>;
-        };
-
-        template <typename Visitor, typename SpecialisedView, typename BaseView>
-        using endpoint_branch_result_t = typename TSEndpointBranchResult<Visitor, SpecialisedView, BaseView>::type;
+        using endpoint_branch_result_t = visitor_branch_result_t<Visitor, SpecialisedView, BaseView>;
 
         template <typename SpecialisedView, typename Visitor>
         decltype(auto) invoke_input_endpoint_visitor(Visitor &visitor, const TSInputView &view)
@@ -167,25 +145,10 @@ namespace hgraph
 
         template <typename Result, typename Visitor, typename SpecialisedView, typename BaseView>
         inline constexpr bool endpoint_branch_same_result_v =
-            std::same_as<Result, endpoint_branch_result_t<Visitor, SpecialisedView, BaseView>>;
-
-        template <typename Result> struct TSEndpointBorrowedRangeResult : std::false_type
-        {
-        };
-
-        template <typename Value> struct TSEndpointBorrowedRangeResult<Range<Value>> : std::true_type
-        {
-        };
-
-        template <typename Key, typename Value>
-        struct TSEndpointBorrowedRangeResult<KeyValueRange<Key, Value>> : std::true_type
-        {
-        };
+            visitor_branch_same_result_v<Result, Visitor, SpecialisedView, BaseView>;
 
         template <typename Result>
-        inline constexpr bool endpoint_result_safe_v =
-            !std::is_reference_v<Result> &&
-            !TSEndpointBorrowedRangeResult<std::remove_cv_t<Result>>::value;
+        inline constexpr bool endpoint_result_safe_v = visitor_result_safe_v<Result>;
     }  // namespace detail
 
     /**
@@ -200,7 +163,7 @@ namespace hgraph
     decltype(auto) visit(const TSInputView &view, Handlers &&...handlers)
     {
         static_assert(sizeof...(Handlers) > 0, "time-series endpoint visit requires at least one handler");
-        auto visitor = detail::TSEndpointOverload<std::decay_t<Handlers>...>{std::forward<Handlers>(handlers)...};
+        auto visitor = detail::VisitorOverload<std::decay_t<Handlers>...>{std::forward<Handlers>(handlers)...};
         using Visitor = decltype(visitor);
 
         constexpr bool complete = detail::endpoint_branch_invocable_v<Visitor, TSValueInputView, TSInputView> &&
@@ -274,7 +237,7 @@ namespace hgraph
     decltype(auto) visit(const TSOutputView &view, Handlers &&...handlers)
     {
         static_assert(sizeof...(Handlers) > 0, "time-series endpoint visit requires at least one handler");
-        auto visitor = detail::TSEndpointOverload<std::decay_t<Handlers>...>{std::forward<Handlers>(handlers)...};
+        auto visitor = detail::VisitorOverload<std::decay_t<Handlers>...>{std::forward<Handlers>(handlers)...};
         using Visitor = decltype(visitor);
 
         constexpr bool complete = detail::endpoint_branch_invocable_v<Visitor, TSValueOutputView, TSOutputView> &&

--- a/include/hgraph/types/value/specialized_views.h
+++ b/include/hgraph/types/value/specialized_views.h
@@ -149,6 +149,23 @@ namespace hgraph
         }
     }  // namespace specialized_view_detail
 
+    /** Shape-tagged read-only view over an open-ended atomic value. */
+    class AtomicView : public ValueView
+    {
+      public:
+        static constexpr ValueTypeKind kind = ValueTypeKind::Atomic;
+
+        explicit AtomicView(ValueView base)
+            : ValueView(specialized_view_detail::require_kind(std::move(base), kind, "AtomicView"))
+        {
+        }
+
+      private:
+        AtomicView(ValueView base, detail::TrustedValueKind) : ValueView(std::move(base)) {}
+
+        friend struct detail::ValueVisitorAccess;
+    };
+
     /**
      * Base for views over positionally-addressed kinds. Tuple, bundle,
      * fixed-size list, and compact dynamic containers all forward
@@ -255,12 +272,19 @@ namespace hgraph
     class TupleView : public IndexedValueView
     {
       public:
+        static constexpr ValueTypeKind kind = ValueTypeKind::Tuple;
+
         explicit TupleView(ValueView base)
-            : IndexedValueView(specialized_view_detail::require_kind(std::move(base), ValueTypeKind::Tuple, "TupleView"))
+            : IndexedValueView(specialized_view_detail::require_kind(std::move(base), kind, "TupleView"))
         {
         }
 
         [[nodiscard]] MutableTupleView begin_mutation() const;
+
+      private:
+        TupleView(ValueView base, detail::TrustedValueKind) : IndexedValueView(std::move(base)) {}
+
+        friend struct detail::ValueVisitorAccess;
     };
 
     class MutableTupleView : public MutableIndexedValueView
@@ -277,11 +301,13 @@ namespace hgraph
     class BundleView : public IndexedValueView
     {
       public:
+        static constexpr ValueTypeKind kind = ValueTypeKind::Bundle;
+
         using IndexedValueView::at;
         using IndexedValueView::operator[];
 
         explicit BundleView(ValueView base)
-            : IndexedValueView(specialized_view_detail::require_kind(std::move(base), ValueTypeKind::Bundle, "BundleView"))
+            : IndexedValueView(specialized_view_detail::require_kind(std::move(base), kind, "BundleView"))
         {
         }
 
@@ -309,6 +335,11 @@ namespace hgraph
 
         [[nodiscard]] const ValueView field(std::string_view name) const { return at(name); }
         [[nodiscard]] const ValueView operator[](std::string_view name) const { return at(name); }
+
+      private:
+        BundleView(ValueView base, detail::TrustedValueKind) : IndexedValueView(std::move(base)) {}
+
+        friend struct detail::ValueVisitorAccess;
     };
 
     class MutableBundleView : public MutableIndexedValueView
@@ -351,8 +382,10 @@ namespace hgraph
     class ListView : public IndexedValueView
     {
       public:
+        static constexpr ValueTypeKind kind = ValueTypeKind::List;
+
         explicit ListView(ValueView base)
-            : IndexedValueView(specialized_view_detail::require_kind(std::move(base), ValueTypeKind::List, "ListView"))
+            : IndexedValueView(specialized_view_detail::require_kind(std::move(base), kind, "ListView"))
         {
         }
 
@@ -371,6 +404,11 @@ namespace hgraph
             if (empty()) { throw std::out_of_range("ListView::back on empty list"); }
             return at(size() - 1);
         }
+
+      private:
+        ListView(ValueView base, detail::TrustedValueKind) : IndexedValueView(std::move(base)) {}
+
+        friend struct detail::ValueVisitorAccess;
     };
 
     class MutableListView : public MutableIndexedValueView
@@ -491,9 +529,11 @@ namespace hgraph
     class CyclicBufferView : public IndexedValueView
     {
       public:
+        static constexpr ValueTypeKind kind = ValueTypeKind::CyclicBuffer;
+
         explicit CyclicBufferView(ValueView base)
             : IndexedValueView(
-                  specialized_view_detail::require_kind(std::move(base), ValueTypeKind::CyclicBuffer, "CyclicBufferView"))
+                  specialized_view_detail::require_kind(std::move(base), kind, "CyclicBufferView"))
         {
             cyclic_buffer_ops_ = specialized_view_detail::checked_cyclic_buffer_ops(binding(), "CyclicBufferView");
         }
@@ -521,6 +561,14 @@ namespace hgraph
         }
 
       private:
+        CyclicBufferView(ValueView base, detail::TrustedValueKind)
+            : IndexedValueView(std::move(base))
+            , cyclic_buffer_ops_{specialized_view_detail::checked_cyclic_buffer_ops(binding(), "CyclicBufferView")}
+        {
+        }
+
+        friend struct detail::ValueVisitorAccess;
+
         const CyclicBufferValueOps *cyclic_buffer_ops_{nullptr};
     };
 
@@ -559,8 +607,10 @@ namespace hgraph
     class QueueView : public IndexedValueView
     {
       public:
+        static constexpr ValueTypeKind kind = ValueTypeKind::Queue;
+
         explicit QueueView(ValueView base)
-            : IndexedValueView(specialized_view_detail::require_kind(std::move(base), ValueTypeKind::Queue, "QueueView"))
+            : IndexedValueView(specialized_view_detail::require_kind(std::move(base), kind, "QueueView"))
         {
             queue_ops_ = specialized_view_detail::checked_queue_ops(binding(), "QueueView");
         }
@@ -586,6 +636,14 @@ namespace hgraph
         }
 
       private:
+        QueueView(ValueView base, detail::TrustedValueKind)
+            : IndexedValueView(std::move(base))
+            , queue_ops_{specialized_view_detail::checked_queue_ops(binding(), "QueueView")}
+        {
+        }
+
+        friend struct detail::ValueVisitorAccess;
+
         const QueueValueOps *queue_ops_{nullptr};
     };
 
@@ -632,8 +690,10 @@ namespace hgraph
     class SetView : public ValueView
     {
       public:
+        static constexpr ValueTypeKind kind = ValueTypeKind::Set;
+
         explicit SetView(ValueView base)
-            : ValueView(specialized_view_detail::require_kind(std::move(base), ValueTypeKind::Set, "SetView"))
+            : ValueView(specialized_view_detail::require_kind(std::move(base), kind, "SetView"))
         {
             ops_ = specialized_view_detail::checked_set_ops(binding(), "SetView");
         }
@@ -670,6 +730,14 @@ namespace hgraph
         [[nodiscard]] MutableSetView begin_mutation() const;
 
       private:
+        SetView(ValueView base, detail::TrustedValueKind)
+            : ValueView(std::move(base))
+            , ops_{specialized_view_detail::checked_set_ops(binding(), "SetView")}
+        {
+        }
+
+        friend struct detail::ValueVisitorAccess;
+
         const SetValueOps *ops_{nullptr};
     };
 
@@ -736,8 +804,10 @@ namespace hgraph
     class MapView : public ValueView
     {
       public:
+        static constexpr ValueTypeKind kind = ValueTypeKind::Map;
+
         explicit MapView(ValueView base)
-            : ValueView(specialized_view_detail::require_kind(std::move(base), ValueTypeKind::Map, "MapView"))
+            : ValueView(specialized_view_detail::require_kind(std::move(base), kind, "MapView"))
         {
             ops_ = specialized_view_detail::checked_map_ops(binding(), "MapView");
         }
@@ -799,6 +869,14 @@ namespace hgraph
         [[nodiscard]] MutableMapView begin_mutation() const;
 
       private:
+        MapView(ValueView base, detail::TrustedValueKind)
+            : ValueView(std::move(base))
+            , ops_{specialized_view_detail::checked_map_ops(binding(), "MapView")}
+        {
+        }
+
+        friend struct detail::ValueVisitorAccess;
+
         [[nodiscard]] bool key_compatible(const ValueView &key) const noexcept
         {
             return specialized_view_detail::binding_matches(
@@ -943,6 +1021,17 @@ namespace hgraph
     {
         if (!is_indexed()) { throw std::logic_error("ValueView::as_indexed_view on non-indexed view"); }
         return IndexedValueView{borrowed_ref()};
+    }
+
+    inline AtomicView ValueView::as_atomic() const
+    {
+        if (!is_atomic()) { throw std::logic_error("ValueView::as_atomic on non-atomic view"); }
+        return AtomicView{borrowed_ref()};
+    }
+
+    inline std::optional<AtomicView> ValueView::try_as_atomic() const
+    {
+        return is_atomic() ? std::optional<AtomicView>{AtomicView{borrowed_ref()}} : std::nullopt;
     }
 
     inline std::optional<IndexedValueView> ValueView::try_as_indexed_view() const

--- a/include/hgraph/types/value/value.h
+++ b/include/hgraph/types/value/value.h
@@ -15,6 +15,7 @@
 #include <hgraph/types/value/value_view.h>
 
 #include <compare>
+#include <memory>
 #include <optional>
 #include <stdexcept>
 #include <string>
@@ -115,8 +116,11 @@ namespace hgraph
             }
             storage_ = storage_type(*binding.record());
             // The owner has default-constructed the payload; assign the
-            // caller-supplied value into the live storage.
-            *static_cast<T *>(storage_.data()) = std::move(value);
+            // caller-supplied value through the registered lifecycle table.
+            // Besides keeping scalar construction on the erased contract,
+            // this lets the owner select inline or heap storage without a
+            // caller-side typed cast into its inline buffer.
+            binding.move_assign_at(storage_.data(), std::addressof(value));
         }
 
         // Copy and move are inherited from ``ErasedOwner`` — copy
@@ -157,6 +161,11 @@ namespace hgraph
         }
 
         // -- atomic access shortcuts --
+        [[nodiscard]] AtomicView as_atomic() const { return view().as_atomic(); }
+        [[nodiscard]] AtomicView as_atomic() { return view().as_atomic(); }
+        [[nodiscard]] std::optional<AtomicView> try_as_atomic() const { return view().try_as_atomic(); }
+        [[nodiscard]] std::optional<AtomicView> try_as_atomic() { return view().try_as_atomic(); }
+
         template <typename T>
         [[nodiscard]] const T &as() const
         {

--- a/include/hgraph/types/value/value_view.h
+++ b/include/hgraph/types/value/value_view.h
@@ -14,8 +14,24 @@
 
 namespace hgraph
 {
+    namespace detail
+    {
+        struct ValueVisitorAccess;
+
+        /**
+         * Construction token used after value visitation has already checked
+         * the semantic value kind.
+         */
+        class TrustedValueKind
+        {
+            constexpr TrustedValueKind() noexcept = default;
+            friend struct ValueVisitorAccess;
+        };
+    }  // namespace detail
+
     class IndexedValueView;
     class MutableIndexedValueView;
+    class AtomicView;
     class TupleView;
     class BundleView;
     class ListView;
@@ -292,6 +308,8 @@ namespace hgraph
         }
 
         // -- kind-specialised view casts (definitions in specialised_views.h) --
+        [[nodiscard]] AtomicView as_atomic() const;
+        [[nodiscard]] std::optional<AtomicView> try_as_atomic() const;
         [[nodiscard]] IndexedValueView as_indexed_view() const;
         [[nodiscard]] std::optional<IndexedValueView> try_as_indexed_view() const;
         [[nodiscard]] IndexedValueView as_indexed() const;
@@ -369,6 +387,8 @@ namespace hgraph
 #endif
 
       private:
+        friend struct detail::ValueVisitorAccess;
+
         struct TrustedPointer
         {};
 

--- a/include/hgraph/types/value/visitor.h
+++ b/include/hgraph/types/value/visitor.h
@@ -1,0 +1,127 @@
+#ifndef HGRAPH_CPP_ROOT_VALUE_VISITOR_H
+#define HGRAPH_CPP_ROOT_VALUE_VISITOR_H
+
+#include <hgraph/types/detail/visitor.h>
+#include <hgraph/types/value/specialized_views.h>
+
+#include <functional>
+#include <stdexcept>
+#include <type_traits>
+#include <utility>
+
+namespace hgraph
+{
+    namespace detail
+    {
+        struct ValueVisitorAccess
+        {
+            [[nodiscard]] static ValueView borrow(const ValueView &view) noexcept { return view.borrowed_ref(); }
+
+            template <typename View>
+            [[nodiscard]] static View project(const ValueView &view)
+            {
+                return View{view.borrowed_ref(), TrustedValueKind{}};
+            }
+        };
+
+        template <typename SpecialisedView, typename Visitor>
+        decltype(auto) invoke_value_visitor(Visitor &visitor, const ValueView &view)
+        {
+            if constexpr (std::invocable<Visitor &, SpecialisedView>)
+            {
+                return std::invoke(visitor, ValueVisitorAccess::project<SpecialisedView>(view));
+            }
+            else
+            {
+                return std::invoke(visitor, ValueVisitorAccess::borrow(view));
+            }
+        }
+    }  // namespace detail
+
+    /**
+     * Visit a live erased value according to its semantic value shape.
+     *
+     * ``Any`` is a transparent owning box rather than a visitor alternative:
+     * every populated Any layer is peeled before dispatch. An empty Any has no
+     * value to visit and is rejected.
+     *
+     * A shape-specific handler takes precedence over a ``ValueView`` catch-all.
+     * Every reachable handler must return void or the same safe value type.
+     * References and lazy hgraph ranges are rejected because the selected
+     * wrapper is a temporary borrowed cursor.
+     */
+    template <typename... Handlers>
+    decltype(auto) visit(const ValueView &value, Handlers &&...handlers)
+    {
+        static_assert(sizeof...(Handlers) > 0, "value visit requires at least one handler");
+        auto visitor  = detail::VisitorOverload<std::decay_t<Handlers>...>{std::forward<Handlers>(handlers)...};
+        using Visitor = decltype(visitor);
+
+        constexpr bool complete = detail::visitor_branch_invocable_v<Visitor, AtomicView, ValueView> &&
+                                  detail::visitor_branch_invocable_v<Visitor, TupleView, ValueView> &&
+                                  detail::visitor_branch_invocable_v<Visitor, BundleView, ValueView> &&
+                                  detail::visitor_branch_invocable_v<Visitor, ListView, ValueView> &&
+                                  detail::visitor_branch_invocable_v<Visitor, SetView, ValueView> &&
+                                  detail::visitor_branch_invocable_v<Visitor, MapView, ValueView> &&
+                                  detail::visitor_branch_invocable_v<Visitor, CyclicBufferView, ValueView> &&
+                                  detail::visitor_branch_invocable_v<Visitor, QueueView, ValueView>;
+
+        if constexpr (!complete)
+        {
+            static_assert(complete, "value visitor must handle every concrete value kind directly or "
+                                    "through a ValueView catch-all");
+        }
+        else
+        {
+            using Result = detail::visitor_branch_result_t<Visitor, AtomicView, ValueView>;
+            static_assert(detail::visitor_result_safe_v<Result>,
+                          "value visitor cannot return a reference or lazy hgraph range that may borrow "
+                          "from a temporary view; consume the range in the handler or return an owned collection");
+            static_assert(detail::visitor_branch_same_result_v<Result, Visitor, TupleView, ValueView> &&
+                              detail::visitor_branch_same_result_v<Result, Visitor, BundleView, ValueView> &&
+                              detail::visitor_branch_same_result_v<Result, Visitor, ListView, ValueView> &&
+                              detail::visitor_branch_same_result_v<Result, Visitor, SetView, ValueView> &&
+                              detail::visitor_branch_same_result_v<Result, Visitor, MapView, ValueView> &&
+                              detail::visitor_branch_same_result_v<Result, Visitor, CyclicBufferView, ValueView> &&
+                              detail::visitor_branch_same_result_v<Result, Visitor, QueueView, ValueView>,
+                          "every value visitor branch must return the same type");
+
+            auto current = detail::ValueVisitorAccess::borrow(value);
+            for (;;)
+            {
+                if (!current.valid()) { throw std::invalid_argument("cannot visit a value without a live payload"); }
+
+                const auto kind = current.schema()->try_value_kind();
+                if (!kind.has_value()) { throw std::invalid_argument("cannot visit a value with an unknown value kind"); }
+
+                switch (*kind)
+                {
+                case ValueTypeKind::Atomic:
+                    return detail::invoke_value_visitor<AtomicView>(visitor, current);
+                case ValueTypeKind::Tuple:
+                    return detail::invoke_value_visitor<TupleView>(visitor, current);
+                case ValueTypeKind::Bundle:
+                    return detail::invoke_value_visitor<BundleView>(visitor, current);
+                case ValueTypeKind::List:
+                    return detail::invoke_value_visitor<ListView>(visitor, current);
+                case ValueTypeKind::Set:
+                    return detail::invoke_value_visitor<SetView>(visitor, current);
+                case ValueTypeKind::Map:
+                    return detail::invoke_value_visitor<MapView>(visitor, current);
+                case ValueTypeKind::CyclicBuffer:
+                    return detail::invoke_value_visitor<CyclicBufferView>(visitor, current);
+                case ValueTypeKind::Queue:
+                    return detail::invoke_value_visitor<QueueView>(visitor, current);
+                case ValueTypeKind::Any: {
+                    auto boxed = current.as_any();
+                    if (!boxed.has_value()) { throw std::invalid_argument("cannot visit an empty Any value"); }
+                    current = boxed.get();
+                    break;
+                }
+                }
+            }
+        }
+    }
+}  // namespace hgraph
+
+#endif  // HGRAPH_CPP_ROOT_VALUE_VISITOR_H

--- a/src/hgraph/lib/std/operators/json_impl.cpp
+++ b/src/hgraph/lib/std/operators/json_impl.cpp
@@ -1,5 +1,6 @@
 #include <hgraph/lib/std/operators/impl/json_impl.h>
 #include <hgraph/types/time_series/visitor.h>
+#include <hgraph/types/value/visitor.h>
 
 #include <fmt/format.h>
 #include <simdjson.h>
@@ -141,26 +142,37 @@ namespace hgraph::stdlib::json_tree
     {
         const auto *meta = value.schema();
         if (meta == json_meta()) { return Value{value}; }
-        switch (meta->value_kind())
+
+        // JSON assigns a concrete meaning to an empty dynamic box. The
+        // general value visitor rejects absence, so preserve that policy here
+        // and let populated boxes recurse into their contained value.
+        if (value.is_any())
         {
-            case ValueTypeKind::Atomic:
-                return box(Value{value});
-            case ValueTypeKind::List:
-            case ValueTypeKind::Tuple: {
-                ListBuilder items{json_value_binding()};
-                const auto values = value.as_indexed_view();
-                for (const auto element : values)
-                {
-                    Value node = to_node(element);
-                    items.push_back_copy(node.view().data());
-                }
-                return box(items.build());
+            auto boxed = value.as_any();
+            return boxed.has_value() ? to_node(boxed.get()) : box(Value{});
+        }
+
+        const auto indexed_to_node = [](const IndexedValueView &values) {
+            ListBuilder items{json_value_binding()};
+            for (const auto element : values)
+            {
+                Value node = to_node(element);
+                items.push_back_copy(node.view().data());
             }
-            case ValueTypeKind::Map: {
+            return box(items.build());
+        };
+
+        return visit(
+            value,
+            [](AtomicView scalar) {
+                return box(Value{static_cast<const ValueView &>(scalar)});
+            },
+            [&](ListView values) { return indexed_to_node(values); },
+            [&](TupleView values) { return indexed_to_node(values); },
+            [](MapView values) {
                 MapBuilder entries{ValuePlanFactory::instance().type_for(
                                        scalar_descriptor<Str>::value_meta()),
                                    json_value_binding()};
-                const auto values = value.as_map();
                 for (const auto [key, item] : values)
                 {
                     Value       key_text;
@@ -183,14 +195,10 @@ namespace hgraph::stdlib::json_tree
                     entries.set_item_copy(key_text.view().data(), node.view().data());
                 }
                 return box(entries.build());
-            }
-            case ValueTypeKind::Any: {
-                auto boxed = value.as_any();
-                return boxed.has_value() ? to_node(boxed.get()) : box(Value{});
-            }
-            default:
+            },
+            [](ValueView) -> Value {
                 throw std::invalid_argument("JSON tree: unsupported value kind");
-        }
+            });
     }
 
     ValueView unbox(const ValueView &node)

--- a/tests/cpp/CMakeLists.txt
+++ b/tests/cpp/CMakeLists.txt
@@ -227,6 +227,7 @@ hgraph_add_test_objects(hgraph_value_test_objects
     test_tsd_proxy.cpp
     test_type_registry.cpp
     test_value.cpp
+    test_value_visitor.cpp
     test_value_types.cpp
 )
 

--- a/tests/cpp/test_std_operators.cpp
+++ b/tests/cpp/test_std_operators.cpp
@@ -81,6 +81,24 @@ namespace
         return Value{compact_list_type(binding, *meta), &storage};
     }
 
+    [[nodiscard]] Value int_set(std::initializer_list<Int> values)
+    {
+        const auto binding =
+            ValuePlanFactory::instance().type_for(scalar_descriptor<Int>::value_meta());
+        SetBuilder builder{binding};
+        for (Int value : values) { builder.insert(value); }
+        return builder.build();
+    }
+
+    [[nodiscard]] Value int_map(std::initializer_list<std::pair<Int, Int>> values)
+    {
+        const auto binding =
+            ValuePlanFactory::instance().type_for(scalar_descriptor<Int>::value_meta());
+        MapBuilder builder{binding, binding};
+        for (const auto &[key, value] : values) { builder.set_item(key, value); }
+        return builder.build();
+    }
+
     [[nodiscard]] Series int_series(std::initializer_list<std::optional<Int>> values)
     {
         arrow::Int64Builder builder;
@@ -1158,6 +1176,21 @@ TEST_CASE("std operators: tuple subtraction accepts a native erased comparator")
                      values<Value>(int_tuple({1, 2, 3, 4, 5})), values<Int>(1),
                      value_fn<SameParity>())),
                  values<Value>(int_tuple({2, 4})));
+}
+
+TEST_CASE("std operators: len_ visits scalar tuple, set, and map values")
+{
+    stdlib::register_standard_operators();
+
+    CHECK_OUTPUT((eval_node<stdlib::len_, TS<HomogeneousTuple<Int>>>(
+                     values<Value>(int_tuple({1, 2, 3}), int_tuple({4})))),
+                 values<Int>(3, 1));
+    CHECK_OUTPUT((eval_node<stdlib::len_, TS<Set<Int>>>(
+                     values<Value>(int_set({1, 2, 2}), int_set({})))),
+                 values<Int>(2, 0));
+    CHECK_OUTPUT((eval_node<stdlib::len_, TS<Map<Int, Int>>>(
+                     values<Value>(int_map({{1, 10}, {2, 20}}), int_map({{3, 30}})))),
+                 values<Int>(2, 1));
 }
 
 TEST_CASE("stdlib nonthrowing schema helpers reject malformed compact kinds")

--- a/tests/cpp/test_value_visitor.cpp
+++ b/tests/cpp/test_value_visitor.cpp
@@ -1,0 +1,272 @@
+#include <hgraph/types/metadata/type_registry.h>
+#include <hgraph/types/metadata/value_plan_factory.h>
+#include <hgraph/types/value/any_ops.h>
+#include <hgraph/types/value/value.h>
+#include <hgraph/types/value/value_builder.h>
+#include <hgraph/types/value/visitor.h>
+
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_string.hpp>
+
+#include <cstdint>
+#include <string>
+#include <type_traits>
+#include <vector>
+
+namespace
+{
+    struct VisitorExtensionScalar
+    {
+        std::int32_t value{0};
+    };
+
+    enum class VisitedValueKind
+    {
+        Atomic,
+        Tuple,
+        Bundle,
+        List,
+        Set,
+        Map,
+        CyclicBuffer,
+        Queue,
+    };
+
+    [[nodiscard]] VisitedValueKind classify(const hgraph::ValueView &value)
+    {
+        using namespace hgraph;
+        return visit(
+            value, [](AtomicView) { return VisitedValueKind::Atomic; }, [](TupleView) { return VisitedValueKind::Tuple; },
+            [](BundleView) { return VisitedValueKind::Bundle; }, [](ListView) { return VisitedValueKind::List; },
+            [](SetView) { return VisitedValueKind::Set; }, [](MapView) { return VisitedValueKind::Map; },
+            [](CyclicBufferView) { return VisitedValueKind::CyclicBuffer; }, [](QueueView) { return VisitedValueKind::Queue; });
+    }
+}  // namespace
+
+TEST_CASE("ValueView visit dispatches every concrete semantic value kind")
+{
+    using namespace hgraph;
+
+    static_assert(!std::is_copy_constructible_v<AtomicView>);
+    static_assert(AtomicView::kind == ValueTypeKind::Atomic);
+    static_assert(TupleView::kind == ValueTypeKind::Tuple);
+    static_assert(BundleView::kind == ValueTypeKind::Bundle);
+    static_assert(ListView::kind == ValueTypeKind::List);
+    static_assert(SetView::kind == ValueTypeKind::Set);
+    static_assert(MapView::kind == ValueTypeKind::Map);
+    static_assert(CyclicBufferView::kind == ValueTypeKind::CyclicBuffer);
+    static_assert(QueueView::kind == ValueTypeKind::Queue);
+    static_assert(sizeof(AtomicView) == sizeof(ValueView));
+
+    auto       &registry       = TypeRegistry::instance();
+    auto       &factory        = ValuePlanFactory::instance();
+    const auto *extension_meta = registry.register_scalar<VisitorExtensionScalar>("value_visitor_extension_scalar");
+    const auto *int_meta       = registry.register_scalar<std::int32_t>("int32");
+    const auto  int_binding    = factory.type_for(int_meta);
+
+    Value atomic{VisitorExtensionScalar{7}};
+    CHECK(classify(atomic.view()) == VisitedValueKind::Atomic);
+    visit(
+        atomic.view(),
+        [](AtomicView selected)
+        {
+            REQUIRE(selected.holds_alternative<VisitorExtensionScalar>());
+            CHECK(selected.checked_as<VisitorExtensionScalar>().value == 7);
+        },
+        [](ValueView) { FAIL("custom scalar did not dispatch as AtomicView"); });
+
+    const auto tuple_binding = factory.type_for(registry.tuple({extension_meta, int_meta}));
+    Value      tuple{tuple_binding};
+    CHECK(classify(tuple.view()) == VisitedValueKind::Tuple);
+
+    const auto bundle_binding =
+        factory.type_for(registry.bundle("ValueVisitorBundle", {{"extension", extension_meta}, {"number", int_meta}}));
+    Value bundle{bundle_binding};
+    CHECK(classify(bundle.view()) == VisitedValueKind::Bundle);
+
+    const auto fixed_list_binding = factory.type_for(registry.list(int_meta, 2));
+    Value      fixed_list{fixed_list_binding};
+    CHECK(classify(fixed_list.view()) == VisitedValueKind::List);
+
+    const auto shaped_array_binding = factory.type_for(registry.array(int_meta, 2));
+    Value      shaped_array{shaped_array_binding};
+    REQUIRE(shaped_array.view().schema()->is_shaped_array());
+    CHECK(classify(shaped_array.view()) == VisitedValueKind::List);
+
+    SetBuilder set_builder{int_binding};
+    set_builder.insert<std::int32_t>(1);
+    Value set = set_builder.build();
+    CHECK(classify(set.view()) == VisitedValueKind::Set);
+
+    MapBuilder map_builder{int_binding, int_binding};
+    map_builder.set_item<std::int32_t, std::int32_t>(1, 2);
+    Value map = map_builder.build();
+    CHECK(classify(map.view()) == VisitedValueKind::Map);
+
+    CyclicBufferBuilder cyclic_builder{int_binding, 2};
+    cyclic_builder.push_back<std::int32_t>(1);
+    Value cyclic = cyclic_builder.build();
+    CHECK(classify(cyclic.view()) == VisitedValueKind::CyclicBuffer);
+
+    QueueBuilder queue_builder{int_binding, 2};
+    queue_builder.push<std::int32_t>(1);
+    Value queue = queue_builder.build();
+    CHECK(classify(queue.view()) == VisitedValueKind::Queue);
+}
+
+TEST_CASE("value visit prefers shape handlers over the ValueView fallback")
+{
+    using namespace hgraph;
+
+    auto &registry = TypeRegistry::instance();
+    registry.register_scalar<VisitorExtensionScalar>("value_visitor_extension_scalar");
+    registry.register_scalar<std::int32_t>("int32");
+
+    Value      atomic{VisitorExtensionScalar{3}};
+    const auto specialised = [](AtomicView) { return 1; };
+    const auto fallback    = [](ValueView) { return 2; };
+
+    CHECK(visit(atomic.view(), specialised, fallback) == 1);
+
+    ListBuilder builder{registry.scalar_type<std::int32_t>()};
+    builder.push_back<std::int32_t>(4);
+    Value list = builder.build();
+    CHECK(visit(list.view(), specialised, fallback) == 2);
+
+    bool called = false;
+    visit(atomic.view(), [&](AtomicView) { called = true; }, [](ValueView) {});
+    CHECK(called);
+}
+
+TEST_CASE("value visit transparently unwraps populated Any boxes")
+{
+    using namespace hgraph;
+
+    auto &registry = TypeRegistry::instance();
+    registry.register_scalar<VisitorExtensionScalar>("value_visitor_extension_scalar");
+
+    Value scalar{VisitorExtensionScalar{11}};
+    Value inner{any_type()};
+    inner.as_any().begin_mutation().set(scalar.view());
+    Value outer{any_type()};
+    outer.as_any().begin_mutation().set(std::move(inner));
+
+    CHECK(classify(outer.view()) == VisitedValueKind::Atomic);
+
+    bool       any_handler_called = false;
+    const auto result             = visit(
+        outer.view(), [](AtomicView selected) { return selected.checked_as<VisitorExtensionScalar>().value; },
+        [&](AnyView)
+        {
+            any_handler_called = true;
+            return std::int32_t{-1};
+        },
+        [](ValueView) { return std::int32_t{-2}; });
+    CHECK(result == 11);
+    CHECK_FALSE(any_handler_called);
+
+    Value empty{any_type()};
+    REQUIRE_THROWS_WITH(visit(empty.view(), [](ValueView) {}), "cannot visit an empty Any value");
+}
+
+TEST_CASE("value visit preserves access capability through trusted projections")
+{
+    using namespace hgraph;
+
+    auto &registry = TypeRegistry::instance();
+    registry.register_scalar<VisitorExtensionScalar>("value_visitor_extension_scalar");
+
+    Value scalar{VisitorExtensionScalar{5}};
+    auto  mutation = scalar.begin_mutation();
+    visit(
+        mutation,
+        [](AtomicView selected)
+        {
+            REQUIRE(selected.mutable_payload());
+            selected.checked_mutable_as<VisitorExtensionScalar>().value = 6;
+        },
+        [](ValueView) { FAIL("unexpected mutation fallback"); });
+    CHECK(scalar.view().checked_as<VisitorExtensionScalar>().value == 6);
+
+    Value boxed{any_type()};
+    boxed.as_any().begin_mutation().set(scalar.view());
+    auto box_mutation = boxed.begin_mutation();
+    visit(
+        box_mutation,
+        [](AtomicView selected)
+        {
+            REQUIRE(selected.writable_payload());
+            CHECK_FALSE(selected.mutable_payload());
+            auto selected_mutation                                               = selected.begin_mutation();
+            selected_mutation.checked_mutable_as<VisitorExtensionScalar>().value = 7;
+        },
+        [](ValueView) { FAIL("unexpected boxed mutation fallback"); });
+    CHECK(boxed.as_any().get().checked_as<VisitorExtensionScalar>().value == 7);
+
+    const Value &read_only_box = boxed;
+    visit(
+        read_only_box.view(),
+        [](AtomicView selected)
+        {
+            CHECK_FALSE(selected.writable_payload());
+            CHECK_FALSE(selected.mutable_payload());
+        },
+        [](ValueView) { FAIL("unexpected read-only fallback"); });
+}
+
+TEST_CASE("value visit rejects absent payloads and direct AtomicView validates "
+          "kind")
+{
+    using namespace hgraph;
+
+    auto       &registry       = TypeRegistry::instance();
+    const auto *extension_meta = registry.register_scalar<VisitorExtensionScalar>("value_visitor_extension_scalar");
+    const auto *int_meta       = registry.register_scalar<std::int32_t>("int32");
+
+    ValueView empty;
+    REQUIRE_THROWS_WITH(visit(empty, [](ValueView) {}), "cannot visit a value without a live payload");
+
+    Value typed_null{*extension_meta};
+    CHECK(typed_null.view().bound());
+    CHECK_FALSE(typed_null.view().valid());
+    REQUIRE_THROWS_WITH(visit(typed_null.view(), [](ValueView) {}), "cannot visit a value without a live payload");
+
+    Value list{ValuePlanFactory::instance().type_for(registry.list(int_meta, 2))};
+    CHECK_THROWS_AS(AtomicView{list.view()}, std::logic_error);
+}
+
+TEST_CASE("value visit result contract rejects references and borrowed lazy ranges")
+{
+    using namespace hgraph;
+
+    static_assert(detail::visitor_result_safe_v<void>);
+    static_assert(detail::visitor_result_safe_v<std::string>);
+    static_assert(detail::visitor_result_safe_v<std::vector<Value>>);
+    static_assert(!detail::visitor_result_safe_v<ValueView &>);
+    static_assert(!detail::visitor_result_safe_v<const AtomicView &>);
+    static_assert(!detail::visitor_result_safe_v<Range<ValueView>>);
+    static_assert(!detail::visitor_result_safe_v<const Range<ValueView>>);
+    static_assert(!detail::visitor_result_safe_v<KeyValueRange<ValueView, ValueView>>);
+}
+
+TEST_CASE("value visit uses declared enum and owned-bundle shapes")
+{
+    using namespace hgraph;
+
+    auto       &registry    = TypeRegistry::instance();
+    const auto *integer     = registry.register_scalar<std::int64_t>("int");
+    const auto *enumeration = registry.enum_type("ValueVisitorEnum", {{"First", 1}, {"Second", 2}});
+
+    Value enum_value{ValuePlanFactory::instance().type_for(enumeration)};
+    CHECK(classify(enum_value.view()) == VisitedValueKind::Atomic);
+
+    const auto *recursive =
+        registry.recursive_bundle("tests.value_visitor", "RecursiveValue", {{"value", integer}, {"next", nullptr}});
+    const auto *owned = recursive->fields[1].type;
+    REQUIRE(owned != nullptr);
+    REQUIRE(owned->is_owned());
+
+    Value empty_owner{ValuePlanFactory::instance().type_for(owned)};
+    CHECK(classify(empty_owner.view()) == VisitedValueKind::Bundle);
+    CHECK(empty_owner.view().schema() == owned);
+}

--- a/tests/cpp/type_erasure_perf.cpp
+++ b/tests/cpp/type_erasure_perf.cpp
@@ -12,6 +12,7 @@
 #include <hgraph/types/time_series/ts_output.h>
 #include <hgraph/types/time_series/visitor.h>
 #include <hgraph/types/value/value_builder.h>
+#include <hgraph/types/value/visitor.h>
 
 #include <algorithm>
 #include <atomic>
@@ -684,6 +685,61 @@ int main()
             }
         });
 
+    const auto manual_atomic_value_dispatch = [&] {
+        const auto *source = g_atomic_value_view_input.load(std::memory_order_relaxed);
+        switch (source->schema()->value_kind())
+        {
+        case ValueTypeKind::Atomic:
+            return static_cast<std::uint64_t>(source->as_atomic().checked_as<Int>());
+        case ValueTypeKind::Tuple:
+            return static_cast<std::uint64_t>(source->as_tuple().size());
+        case ValueTypeKind::Bundle:
+            return static_cast<std::uint64_t>(source->as_bundle().size());
+        case ValueTypeKind::List:
+            return static_cast<std::uint64_t>(source->as_list().size());
+        case ValueTypeKind::Set:
+            return static_cast<std::uint64_t>(source->as_set().size());
+        case ValueTypeKind::Map:
+            return static_cast<std::uint64_t>(source->as_map().size());
+        case ValueTypeKind::CyclicBuffer:
+            return static_cast<std::uint64_t>(source->as_cyclic_buffer().size());
+        case ValueTypeKind::Queue:
+            return static_cast<std::uint64_t>(source->as_queue().size());
+        case ValueTypeKind::Any:
+            throw std::runtime_error("unexpected Any in manual atomic value dispatch");
+        }
+        throw std::runtime_error("unknown kind in manual atomic value dispatch");
+    };
+    const auto visitor_atomic_value_dispatch = [&] {
+        const auto *source = g_atomic_value_view_input.load(std::memory_order_relaxed);
+        return visit(
+            *source,
+            [](AtomicView selected) {
+                return static_cast<std::uint64_t>(selected.checked_as<Int>());
+            },
+            [](TupleView selected) { return static_cast<std::uint64_t>(selected.size()); },
+            [](BundleView selected) { return static_cast<std::uint64_t>(selected.size()); },
+            [](ListView selected) { return static_cast<std::uint64_t>(selected.size()); },
+            [](SetView selected) { return static_cast<std::uint64_t>(selected.size()); },
+            [](MapView selected) { return static_cast<std::uint64_t>(selected.size()); },
+            [](CyclicBufferView selected) { return static_cast<std::uint64_t>(selected.size()); },
+            [](QueueView selected) { return static_cast<std::uint64_t>(selected.size()); });
+    };
+    require_no_allocations("value_manual_atomic_dispatch", 10'000, manual_atomic_value_dispatch);
+    require_no_allocations("value_visitor_atomic_dispatch", 10'000, visitor_atomic_value_dispatch);
+    run_benchmark(
+        "value_manual_atomic_dispatch", 200'000, samples, warmup,
+        manual_atomic_value_dispatch,
+        [](std::uint64_t value) {
+            if (value != 41) { throw std::runtime_error("manual atomic value dispatch failed"); }
+        });
+    run_benchmark(
+        "value_visitor_atomic_dispatch", 200'000, samples, warmup,
+        visitor_atomic_value_dispatch,
+        [](std::uint64_t value) {
+            if (value != 41) { throw std::runtime_error("visitor atomic value dispatch failed"); }
+        });
+
     TSOutput scalar_output{*ts_int};
     {
         auto mutation = scalar_output.begin_mutation(MIN_ST);
@@ -719,6 +775,66 @@ int main()
             throw std::runtime_error("composite TS setup failed");
         }
     }
+
+    auto bundle_value_view = bundle_output.view(MIN_ST).value();
+    g_atomic_value_view_input.store(&bundle_value_view, std::memory_order_release);
+    const auto manual_bundle_value_dispatch = [&] {
+        const auto *source = g_atomic_value_view_input.load(std::memory_order_relaxed);
+        switch (source->schema()->value_kind())
+        {
+        case ValueTypeKind::Atomic:
+            return static_cast<std::uint64_t>(source->as_atomic().checked_as<Int>());
+        case ValueTypeKind::Tuple:
+            return static_cast<std::uint64_t>(source->as_tuple().size());
+        case ValueTypeKind::Bundle:
+            return static_cast<std::uint64_t>(source->as_bundle().size());
+        case ValueTypeKind::List:
+            return static_cast<std::uint64_t>(source->as_list().size());
+        case ValueTypeKind::Set:
+            return static_cast<std::uint64_t>(source->as_set().size());
+        case ValueTypeKind::Map:
+            return static_cast<std::uint64_t>(source->as_map().size());
+        case ValueTypeKind::CyclicBuffer:
+            return static_cast<std::uint64_t>(source->as_cyclic_buffer().size());
+        case ValueTypeKind::Queue:
+            return static_cast<std::uint64_t>(source->as_queue().size());
+        case ValueTypeKind::Any:
+            throw std::runtime_error("unexpected Any in manual bundle value dispatch");
+        }
+        throw std::runtime_error("unknown kind in manual bundle value dispatch");
+    };
+    const auto visitor_bundle_value_dispatch = [&] {
+        const auto *source = g_atomic_value_view_input.load(std::memory_order_relaxed);
+        return visit(
+            *source,
+            [](BundleView selected) {
+                return static_cast<std::uint64_t>(selected.size());
+            },
+            [](AtomicView selected) {
+                return static_cast<std::uint64_t>(selected.checked_as<Int>());
+            },
+            [](TupleView selected) { return static_cast<std::uint64_t>(selected.size()); },
+            [](ListView selected) { return static_cast<std::uint64_t>(selected.size()); },
+            [](SetView selected) { return static_cast<std::uint64_t>(selected.size()); },
+            [](MapView selected) { return static_cast<std::uint64_t>(selected.size()); },
+            [](CyclicBufferView selected) { return static_cast<std::uint64_t>(selected.size()); },
+            [](QueueView selected) { return static_cast<std::uint64_t>(selected.size()); });
+    };
+    require_no_allocations("value_manual_bundle_dispatch", 10'000, manual_bundle_value_dispatch);
+    require_no_allocations("value_visitor_bundle_dispatch", 10'000, visitor_bundle_value_dispatch);
+    run_benchmark(
+        "value_manual_bundle_dispatch", 200'000, samples, warmup,
+        manual_bundle_value_dispatch,
+        [](std::uint64_t value) {
+            if (value != 2) { throw std::runtime_error("manual bundle value dispatch failed"); }
+        });
+    run_benchmark(
+        "value_visitor_bundle_dispatch", 200'000, samples, warmup,
+        visitor_bundle_value_dispatch,
+        [](std::uint64_t value) {
+            if (value != 2) { throw std::runtime_error("visitor bundle value dispatch failed"); }
+        });
+
     run_benchmark(
         "fixed_composite_ts_child_read", 50000, samples, warmup,
         [&] {

--- a/tests/install_consumer/main.cpp
+++ b/tests/install_consumer/main.cpp
@@ -6,14 +6,24 @@
 #include <hgraph/types/metadata/type_registry.h>
 #include <hgraph/types/type_pointer.h>
 #include <hgraph/types/time_series/visitor.h>
+#include <hgraph/types/value/any_ops.h>
 #include <hgraph/types/value/value.h>
 #include <hgraph/types/value/value_builder.h>
+#include <hgraph/types/value/visitor.h>
 
 #include <arrow/api.h>
 
 #include <cstdint>
 #include <stdexcept>
 #include <type_traits>
+
+namespace
+{
+    struct ConsumerExtensionScalar
+    {
+        std::int32_t value{0};
+    };
+}
 
 int main()
 {
@@ -47,6 +57,22 @@ int main()
     if (value.view().checked_as<std::int32_t>() != 73)
     {
         throw std::runtime_error("installed target mutation round-trip failed");
+    }
+
+    registry.register_scalar<ConsumerExtensionScalar>("consumer::ExtensionScalar");
+    Value extension{ConsumerExtensionScalar{17}};
+    Value boxed{any_type()};
+    boxed.as_any().begin_mutation().set(extension.view());
+    const bool visited_extension = visit(
+        boxed.view(),
+        [](AtomicView selected) {
+            return selected.holds_alternative<ConsumerExtensionScalar>() &&
+                   selected.checked_as<ConsumerExtensionScalar>().value == 17;
+        },
+        [](ValueView) { return false; });
+    if (!visited_extension)
+    {
+        throw std::runtime_error("installed value visitor did not unwrap and dispatch the extension scalar");
     }
 
     static_cast<void>(stdlib::register_standard_types(registry));


### PR DESCRIPTION
## Summary

- add RFC 0010 and a public callable-based `hgraph::visit(const ValueView&, ...)` API for all eight concrete value shapes
- introduce an open-ended `AtomicView` shape tag and transparently unwrap populated `Any` boxes while retaining explicit `AnyView` box management
- centralize handler composition/result safety with the existing time-series visitor without changing endpoint visitor behavior
- adopt value visitation in JSON tree conversion and the runtime path of `len_`
- route scalar construction through the registered erased lifecycle table, avoiding GCC 15's invalid inline-buffer cast diagnostics while preserving move-assignment semantics

## Why

Live-value algorithms currently repeat `ValueTypeKind` switches, construct specialized views themselves, and independently decide how `Any` should behave. That duplicates kind validation and makes extension scalars, borrowed lifetimes, and nested boxes easy to mishandle. The new visitor centralizes shape dispatch while leaving intrinsic operations in `ValueOps` and wiring-time decisions in schema metadata.

`Any` is treated as an owning value box rather than a visitor alternative: populated boxes are iteratively unwrapped to their contained semantic shape, and empty boxes fail clearly. `AtomicView` does not enumerate scalar C++ types, so independently registered extension scalars remain first-class.

## Validation

- macOS fresh native acceptance: 1,310/1,310 passed
- macOS stable-ABI wheel built with Python 3.12, tested with Python 3.14: 1,730 passed, 10 skipped
- Linux GCC 15 fresh native acceptance: 1,310/1,310 passed
- Linux stable-ABI wheel built with Python 3.12, tested with Python 3.14 and Polars rtcompat: 1,730 passed, 10 skipped
- Linux GCC 15 ASan+UBSan native suite: 1,310/1,310 passed
- installed-SDK consumer: passed, including an externally registered scalar visited through `Any`
- Sphinx documentation with warnings as errors: passed

## Performance

Focused complete-switch comparisons use 21 samples of 200,000 dispatches and report zero allocations:

| Platform | Shape | Manual | Visitor | Change |
|---|---:|---:|---:|---:|
| macOS arm64 / AppleClang 21 | Atomic | 3.378 ns/op | 2.002 ns/op | 40.7% faster |
| macOS arm64 / AppleClang 21 | Bundle | 5.522 ns/op | 3.725 ns/op | 32.5% faster |
| Linux x86_64 / GCC 15.2 | Atomic | 3.467 ns/op | 1.728 ns/op | 50.2% faster |
| Linux x86_64 / GCC 15.2 | Bundle | 6.544 ns/op | 3.585 ns/op | 45.2% faster |

RFC 0010 remains `Proposed` until the implementation is reviewed and merged, following the repository RFC process.