### PR TITLE
Issue #203: prepared routes for python fast-compute args and retained service captures

### DIFF
--- a/docs/source/rfc/rfc_0008_prepared_node_inputs.rst
+++ b/docs/source/rfc/rfc_0008_prepared_node_inputs.rst
@@ -483,10 +483,14 @@ Prepared-slot contract
 A prepared slot exists per canonical **actively observed value input** of a
 node whose front-end plans the route array — the static-node builder and
 the lifted-kernel builder, which share the machinery in
-``runtime/prepared_input_routes.h``.  Three per-tick consumers read it: the
-static-node invocation frame, the lifted-kernel child projection, and the
-common readiness gate (all other node kinds keep the existing projection
-path unchanged).  Each slot holds exactly two non-owning words of route
+``runtime/prepared_input_routes.h``.  Per-tick consumers (issue #203 extended
+the original three): the static-node invocation frame, the lifted-kernel
+child projection, the common readiness gate, the python fast-compute cache
+(one route per ts-arg below the args root, acquired at node start), and the
+retained capture views of the service and shared-output nodes
+(``TSInputView::routed_child_at`` — a retained view carrying its route
+resolves reads through the trie handle).  All other node kinds keep the
+existing projection path unchanged.  Each slot holds exactly two non-owning words of route
 state:
 
 * a pointer to the slot's active-trie root node

--- a/include/hgraph/types/time_series/ts_input/base_view.h
+++ b/include/hgraph/types/time_series/ts_input/base_view.h
@@ -155,6 +155,11 @@ namespace hgraph
          */
         [[nodiscard]] detail::PreparedInputSlotRoute prepare_child_route(std::size_t index) const;
         [[nodiscard]] TSInputView child_from_prepared(const detail::PreparedInputSlotRoute &route) const;
+        /** One-shot convenience for RETAINED child views (issue #203): the
+            projected child carries its prepared route, so subsequent reads
+            resolve through the trie handle instead of re-running route
+            resolution. Equivalent to ``indexed_child_at`` in behaviour. */
+        [[nodiscard]] TSInputView routed_child_at(std::size_t index) const;
 
         [[nodiscard]] TSSInputView as_set() &;
         [[nodiscard]] TSSInputView as_set() const &;

--- a/python/py_nodes.cpp
+++ b/python/py_nodes.cpp
@@ -367,6 +367,21 @@ struct PyFastComputeCache {
   PyTimeSeries *input_wrapper{nullptr};
   std::array<PyObject *, 2> pair_objects{};
   std::array<PyTimeSeries *, 2> pair_wrappers{};
+  // Per-ts-arg prepared routes below the args root (issue #203): acquired
+  // once at start, non-owning (trie handles update in place; the read-side
+  // trust condition re-checks per use). Indexed by ts-arg position.
+  std::vector<hgraph::detail::PreparedInputSlotRoute> arg_routes{};
+
+  /** Project ts-arg ``slot`` from ``args_root`` through the prepared route
+      when ready; the plain per-tick projection otherwise. */
+  [[nodiscard]] TSInputView arg_at(const TSInputView &args_root,
+                                   TSBInputView &bundle,
+                                   std::size_t slot) const {
+    if (slot < arg_routes.size() && arg_routes[slot].ready()) {
+      return args_root.child_from_prepared(arg_routes[slot]);
+    }
+    return bundle[slot];
+  }
 
   [[nodiscard]] bool direct() const noexcept {
     return shape.kw_names.empty() && shape.layout.size() == 1 &&
@@ -619,7 +634,8 @@ struct PyFastComputeStateRef {
   return true;
 }
 
-[[nodiscard]] bool py_assemble_fast_args(std::string_view layout,
+[[nodiscard]] bool py_assemble_fast_args(const PyFastComputeCache &cache,
+                                         std::string_view layout,
                                          const TSInputView &args,
                                          const ValueView &scalars,
                                          const PyTsLease &lease,
@@ -638,7 +654,8 @@ struct PyFastComputeStateRef {
     case 'a':
     case 'A': {
       nb::object ts_obj;
-      if (!py_make_ts_arg(kind, bundle[ts_index++], lease, ts_obj)) {
+      if (!py_make_ts_arg(kind, cache.arg_at(args, bundle, ts_index++), lease,
+                          ts_obj)) {
         return false;
       }
       call_args.append(ts_obj);
@@ -1000,13 +1017,31 @@ struct py_fast_compute_node {
          shape.layout.front() == 'T' || shape.layout.front() == 'U' ||
          shape.layout.front() == 'a' || shape.layout.front() == 'A');
     TSInputView cached_input = args.base().borrowed_ref();
+    // Acquire the level-2 prepared routes (issue #203): the args root is
+    // owned child-carrying storage, so each ts-arg slot's route is stable
+    // for the node's lifetime and the retained/per-tick views built from it
+    // resolve reads through the trie handle.
+    std::vector<hgraph::detail::PreparedInputSlotRoute> arg_routes;
+    if (detail::has_input_children(cached_input.data_view())) {
+      std::size_t ts_count = 0;
+      for (const char kind : shape.layout) {
+        if (kind != 's') { ++ts_count; }
+      }
+      arg_routes.reserve(ts_count);
+      for (std::size_t slot = 0; slot < ts_count; ++slot) {
+        arg_routes.push_back(cached_input.prepare_child_route(slot));
+      }
+    }
     if (direct) {
       auto bundle = cached_input.as_bundle();
-      cached_input = bundle[0];
+      cached_input = !arg_routes.empty() && arg_routes[0].ready()
+                         ? cached_input.child_from_prepared(arg_routes[0])
+                         : bundle[0];
     }
     auto cache = std::make_unique<PyFastComputeCache>(
         fn.value().record, std::move(shape), std::move(cached_input),
         scalars.value(), out.handle(), global_state);
+    cache->arg_routes = std::move(arg_routes);
     state.set(PyFastComputeStateRef{cache.get()});
     static_cast<void>(cache.release());
   }
@@ -1044,9 +1079,11 @@ struct py_fast_compute_node {
         nb::object lhs;
         nb::object rhs;
         if (!py_make_cached_pair_ts_arg(*cache, 0, cache->shape.layout[0],
-                                        bundle[0], lease, lhs) ||
+                                        cache->arg_at(input, bundle, 0), lease,
+                                        lhs) ||
             !py_make_cached_pair_ts_arg(*cache, 1, cache->shape.layout[1],
-                                        bundle[1], lease, rhs)) {
+                                        cache->arg_at(input, bundle, 1), lease,
+                                        rhs)) {
           return;
         }
         if (py_has_active_runtime_global_state()) {
@@ -1064,8 +1101,8 @@ struct py_fast_compute_node {
       } else {
         TSInputView input = cache->input.borrowed_ref(now);
         nb::list call_args;
-        if (!py_assemble_fast_args(cache->shape.layout, input, cache->scalars,
-                                   lease, call_args)) {
+        if (!py_assemble_fast_args(*cache, cache->shape.layout, input,
+                                   cache->scalars, lease, call_args)) {
           return;
         }
         auto call_kwargs = py_peel_kwargs(call_args, cache->shape.kw_names);

--- a/src/hgraph/runtime/service_node.cpp
+++ b/src/hgraph/runtime/service_node.cpp
@@ -380,7 +380,9 @@ namespace hgraph
 
             auto input         = capture.input(evaluation_time);
             auto bundle        = input.as_bundle();
-            storage.input      = bundle.at(0);
+            // Retained view: carry the prepared route so per-tick reads
+            // resolve through the trie handle (issue #203).
+            storage.input      = input.routed_child_at(0);
             auto subscriptions = bundle.at(1);
             if (!subscriptions.bound())
             {
@@ -404,7 +406,7 @@ namespace hgraph
 
             auto input    = capture.input(evaluation_time);
             auto bundle   = input.as_bundle();
-            storage.input = bundle.at(0);
+            storage.input = input.routed_child_at(0);
             auto requests = bundle.at(1);
             auto request_id = bundle.at(2);
             if (!requests.bound())

--- a/src/hgraph/runtime/shared_output_node.cpp
+++ b/src/hgraph/runtime/shared_output_node.cpp
@@ -129,7 +129,8 @@ namespace hgraph
 
             auto input       = view.input(evaluation_time);
             auto bundle      = input.as_bundle();
-            storage.input    = bundle.at(0);
+            // Retained view: carry the prepared route (issue #203).
+            storage.input    = input.routed_child_at(0);
             auto source_input = bundle.at(1);
 
             NodeView source = source_input.bound_output().owner_node();

--- a/src/hgraph/types/time_series/ts_input/base_view.cpp
+++ b/src/hgraph/types/time_series/ts_input/base_view.cpp
@@ -737,6 +737,14 @@ namespace hgraph
         return route;
     }
 
+    TSInputView TSInputView::routed_child_at(std::size_t index) const
+    {
+        if (!detail::has_input_children(data_.value_data)) { return indexed_child_at(index); }
+        auto route = prepare_child_route(index);
+        if (route.ready()) { return child_from_prepared(route); }
+        return indexed_child_at(index);
+    }
+
     TSInputView TSInputView::child_from_prepared(const detail::PreparedInputSlotRoute &route) const
     {
         if (!route.target)


### PR DESCRIPTION
## What (closes #203, stages A+B)

Extends RFC 0008 stage-5 route planning to the remaining measured per-tick projection consumers:

- **Stage A — python fast-compute args** (`python/py_nodes.cpp`): the fast-compute cache acquires one prepared route per ts-arg below the args root at node start (the args root is owned child-carrying storage, so routes are stable for the node's lifetime). The direct cached view is built through its route — retained-view reads then resolve via the trie handle — and the pair/general fast paths project each tick's children from the cache instead of re-walking the projection.
- **Stage B — routed retained views** (`TSInputView::routed_child_at`, applied to the subscription-key/request-input capture storages and the shared-output input): a retained child view now carries its prepared route, so its per-tick reads take the stable-handle path. Behaviour is identical to `indexed_child_at`; the stage-5 per-read trust condition and fallback apply unchanged.

RFC 0008's consumer list updated in the same change.

## Measurements (pinned hg-linux, 7 samples/side vs main, verified-content worktrees)

| scenario | change | ratio vs legacy (before → est. after) |
|---|---|---|
| tsd_dense_py | **+7.6%** | ×0.86 → ~×0.93 |
| reduce_tsd_python_combiner | **+6.1%** | ×0.75 → ~×0.80 |
| service_adaptor_py | **+3.6%** | ×0.85 → ~×0.88 |
| service_request_reply_std | **+2.2%** | recovers the stage-5 -1.7% |
| tick_py / tick_std (controls) | +0.8% / +1.8% | neutral within box variance |

The residual gap to parity on the python scenarios is the conversion round-trip — issue #204's territory (the mirror design), not routing.

Measurement note: the first A/B round was invalid — the branch had been reset to main by a concurrent worker mid-measurement, so it compared main to main; this round re-verified the test worktree's tip and content markers before running.

## Gates

- C++ suite: 1310/1310 (includes the stage-5 trust-condition regression test). No layout changes; the underlying route machinery was ASAN-verified in #200 and this PR only composes those primitives.
- python: 1730 passed / 10 skipped; ported: 1147 passed / 9 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)