### PR TITLE
Add exact atomic value visitation

### DIFF
--- a/docs/source/developer_guide/data_structures/plans_and_ops/erased_types.rst
+++ b/docs/source/developer_guide/data_structures/plans_and_ops/erased_types.rst
@@ -344,6 +344,16 @@ selection continue to inspect metadata directly. Use visitation only for
 caller-owned algorithms whose behaviour genuinely varies by a live value
 shape.
 
+``visit_atomic`` refines an ``AtomicView`` for algorithms interested in
+selected registered C++ scalar types. ``atomic_case<T>`` compares the bound
+canonical ``ValueOps`` pointer with ``ops_for<T>()`` and supplies ``const T&``
+to the matching handler. The final optional ``AtomicView`` callable handles
+all other registered scalars; without it, an unmatched type throws.
+``try_visit_atomic`` instead returns ``std::optional<R>`` (or ``bool`` for
+``void`` handlers) so an expected miss remains non-throwing. This is a
+compiler-expanded pointer-comparison chain: it performs no registry lookup,
+string comparison, allocation, numeric coercion, or enum unwrapping.
+
 After the kind switch, the visitor constructs specialised views through a
 trusted internal projection that preserves the original access tag and avoids
 repeating semantic-kind validation. The specialised view still resolves and

--- a/docs/source/rfc/rfc_0010_value_view_visitors.rst
+++ b/docs/source/rfc/rfc_0010_value_view_visitors.rst
@@ -57,6 +57,15 @@ The installed header ``<hgraph/types/value/visitor.h>`` provides:
    template<class... Handlers>
    decltype(auto) visit(const ValueView &value, Handlers&&... handlers);
 
+   template<class T, class Handler>
+   auto atomic_case(Handler&& handler);
+
+   template<class... Options>
+   decltype(auto) visit_atomic(const AtomicView &value, Options&&... options);
+
+   template<class... Cases>
+   auto try_visit_atomic(const AtomicView &value, Cases&&... cases);
+
 Handlers form one overload set. After transparent ``Any`` unwrapping, dispatch
 selects:
 
@@ -109,6 +118,47 @@ Reference results and lazy ``Range`` / ``KeyValueRange`` results are rejected.
 The selected wrapper is a temporary borrowed cursor, and a lazy range can
 retain storage or projection context associated with it. Callers consume the
 range in the handler or return an owned materialisation.
+
+Atomic type visitation
+----------------------
+
+Algorithms interested in selected atomic C++ types use ``atomic_case<T>``.
+The type and handler travel together, followed by an optional ``AtomicView``
+default:
+
+.. code-block:: cpp
+
+   return visit_atomic(
+       scalar,
+       atomic_case<Int>([](const Int &value) {
+           return render_integer(value);
+       }),
+       atomic_case<ExtensionScalar>([](const ExtensionScalar &value) {
+           return render_extension(value);
+       }),
+       [](AtomicView other) {
+           return render_other_atomic(other);
+       });
+
+Each case is an exact canonical-ops match. It does not use C++ callable
+conversion rules, so an ``Int`` value cannot select a ``Float`` case. Nominal
+enum schemas retain their enum-specific ops and therefore select the default
+rather than an ``Int`` case. Independently registered extension scalars
+require no change to the core type list.
+
+The default handler, when present, is an ordinary callable in the final
+position. Without a default, an unmatched valid atomic value raises
+``std::invalid_argument`` containing its schema name. ``try_visit_atomic``
+accepts typed cases only and treats that expected miss as data:
+
+* value-returning handlers produce ``std::optional<R>``;
+* ``void`` handlers produce ``bool``;
+* handler failures and an invalid input view still propagate.
+
+Every typed case and the optional default returns ``void`` or the same exact
+safe type, using the same result contract as the shape and endpoint visitors.
+A non-void ``try_visit_atomic`` result must additionally be movable so its
+``std::optional`` can own it.
 
 Transparent ``Any`` semantics
 -----------------------------
@@ -191,6 +241,11 @@ the kind has already been checked. Specialised views still resolve and verify
 the operation-table subclass required for their public methods, but they do
 not repeat semantic-kind validation. Public direct constructors remain
 checked.
+
+Atomic type visitation performs one canonical operation-table pointer
+comparison per listed case and directly invokes the first match. It does not
+allocate, query the registry, compare schema strings, unwrap enums, or repeat
+the already-established atomic-kind check.
 
 The endpoint and value visitors share only generic callable composition,
 result selection, and borrowed-result safety traits. Their projection and
@@ -280,9 +335,11 @@ Enumerate known C++ scalar types
    Rejected. Extensions can register scalar types independently, and a closed
    variant would make the core SDK the owner of downstream scalar vocabulary.
 
-Add ``match`` / ``when`` declarative wrappers
-   Deferred. Callable overloads cover the required contract and match the
-   endpoint visitor. A second visitor expression language is not justified.
+Infer atomic types from an ordinary callable overload set
+   Rejected. Numeric conversions can make a handler callable for a type it did
+   not declare, and extracting parameter types is brittle for generic lambdas,
+   overloaded function objects, and function pointers. ``atomic_case<T>``
+   records exact type intent without closing the scalar registry.
 
 Virtual ``accept`` or double dispatch
    Rejected. The runtime intentionally uses schemas, plans, operation tables,
@@ -299,6 +356,10 @@ Acceptance criteria
 * All eight concrete semantic kinds dispatch to the correct specialised view.
 * Registered extension scalar types dispatch through ``AtomicView`` without a
   core type list.
+* ``atomic_case<T>`` selects only the exact registered scalar type; nominal
+  enums and unrelated numeric types fall through.
+* Atomic defaults, strict unmatched errors, value-returning
+  ``try_visit_atomic``, and ``void`` probing are covered.
 * Populated nested ``Any`` boxes dispatch transparently; empty boxes and absent
   payloads fail clearly.
 * Specific handlers take precedence over ``ValueView`` catch-all handlers.
@@ -312,7 +373,7 @@ Acceptance criteria
 * JSON tree and container-length behaviour remain covered through public
   wiring APIs in C++ and Python.
 * A separately built installed-SDK consumer registers and visits an extension
-  scalar through ``Any``.
+  scalar through ``Any`` and ``atomic_case<T>``.
 * Focused performance is equivalent to or better than the corresponding
   caller-written switch, with zero allocations.
 * The complete native and non-WIP Python compatibility suites pass on macOS

--- a/docs/source/user_guide/authoring_nodes_cpp.rst
+++ b/docs/source/user_guide/authoring_nodes_cpp.rst
@@ -559,6 +559,47 @@ of C++ types. An extension handler can use
 ``holds_alternative<ExtensionScalar>()`` and
 ``checked_as<ExtensionScalar>()`` on it.
 
+When an algorithm has handlers for selected atomic C++ types, pair each exact
+type with its handler using ``atomic_case<T>``:
+
+.. code-block:: cpp
+
+   std::string render_scalar(const AtomicView &value)
+   {
+       return visit_atomic(
+           value,
+           atomic_case<Int>([](const Int &number) {
+               return std::to_string(number);
+           }),
+           atomic_case<Str>([](const Str &text) {
+               return text;
+           }),
+           [](AtomicView other) {
+               return other.to_string();
+           });
+   }
+
+The optional final callable handles every unlisted atomic type. If it is
+omitted, an unmatched type throws ``std::invalid_argument`` with its schema
+name. Use ``try_visit_atomic`` when a miss is expected:
+
+.. code-block:: cpp
+
+   auto integer = try_visit_atomic(
+       value,
+       atomic_case<Int>([](const Int &number) {
+           return number;
+       }));
+
+   if (integer) {
+       // integer is std::optional<Int>
+   }
+
+Value-returning cases produce ``std::optional<R>``; ``void`` cases produce a
+``bool`` indicating whether a handler ran. Only an unlisted type is converted
+to an empty/false result. Invalid views and exceptions raised by handlers
+still propagate.
+
 A populated ``Any`` box is transparent to the visitor. Passing the
 ``ValueView`` for an ``Any`` containing an ``ExtensionScalar`` invokes the
 ``AtomicView`` handler for that scalar; nested populated boxes are also

--- a/include/hgraph/types/value/visitor.h
+++ b/include/hgraph/types/value/visitor.h
@@ -2,10 +2,14 @@
 #define HGRAPH_CPP_ROOT_VALUE_VISITOR_H
 
 #include <hgraph/types/detail/visitor.h>
+#include <hgraph/types/metadata/type_registry.h>
 #include <hgraph/types/value/specialized_views.h>
 
 #include <functional>
+#include <optional>
 #include <stdexcept>
+#include <string>
+#include <tuple>
 #include <type_traits>
 #include <utility>
 
@@ -36,7 +40,289 @@ namespace hgraph
                 return std::invoke(visitor, ValueVisitorAccess::borrow(view));
             }
         }
+
+        template <typename Value, typename Handler> struct AtomicCase
+        {
+            using value_type   = Value;
+            using handler_type = Handler;
+            using result_type  = std::invoke_result_t<handler_type &, const value_type &>;
+
+            handler_type handler;
+
+            [[nodiscard]] bool matches(const AtomicView &view) const noexcept
+            {
+                return view.type().ops() == &ops_for<value_type>();
+            }
+
+            decltype(auto) invoke(const AtomicView &view)
+            {
+                return std::invoke(handler, view.template as<value_type>());
+            }
+        };
+
+        template <typename T> struct IsAtomicCase : std::false_type
+        {
+        };
+
+        template <typename Value, typename Handler>
+        struct IsAtomicCase<AtomicCase<Value, Handler>> : std::true_type
+        {
+        };
+
+        template <typename T>
+        inline constexpr bool is_atomic_case_v = IsAtomicCase<std::remove_cvref_t<T>>::value;
+
+        template <typename... Cases> struct AtomicCasePackTraits;
+
+        template <> struct AtomicCasePackTraits<>
+        {
+            static constexpr bool distinct = true;
+        };
+
+        template <typename First, typename... Rest> struct AtomicCasePackTraits<First, Rest...>
+        {
+            using result_type = typename First::result_type;
+
+            static constexpr bool distinct =
+                ((!std::same_as<typename First::value_type, typename Rest::value_type>) && ...) &&
+                AtomicCasePackTraits<Rest...>::distinct;
+            static constexpr bool same_result =
+                (std::same_as<result_type, typename Rest::result_type> && ...);
+        };
+
+        template <typename Tuple, std::size_t... I>
+        [[nodiscard]] consteval bool tuple_elements_are_atomic_cases(std::index_sequence<I...>)
+        {
+            return (is_atomic_case_v<std::tuple_element_t<I, Tuple>> && ...);
+        }
+
+        template <typename Result, std::size_t I, std::size_t CaseCount, typename Tuple, typename OnMiss>
+        Result dispatch_atomic_cases(const AtomicView &value, Tuple &options, OnMiss &on_miss)
+        {
+            if constexpr (I < CaseCount)
+            {
+                auto &candidate = std::get<I>(options);
+                if (candidate.matches(value)) { return candidate.invoke(value); }
+                return dispatch_atomic_cases<Result, I + 1, CaseCount>(value, options, on_miss);
+            }
+            else
+            {
+                return std::invoke(on_miss);
+            }
+        }
+
+        template <typename Result> struct AtomicTryResult
+        {
+            using type = std::optional<Result>;
+        };
+
+        template <> struct AtomicTryResult<void>
+        {
+            using type = bool;
+        };
+
+        template <typename Result>
+        using atomic_try_result_t = typename AtomicTryResult<Result>::type;
+
+        template <typename Result, std::size_t I, std::size_t CaseCount, typename Tuple>
+        atomic_try_result_t<Result> try_dispatch_atomic_cases(const AtomicView &value, Tuple &cases)
+        {
+            if constexpr (I < CaseCount)
+            {
+                auto &candidate = std::get<I>(cases);
+                if (candidate.matches(value))
+                {
+                    if constexpr (std::is_void_v<Result>)
+                    {
+                        candidate.invoke(value);
+                        return true;
+                    }
+                    else
+                    {
+                        return std::optional<Result>{candidate.invoke(value)};
+                    }
+                }
+                return try_dispatch_atomic_cases<Result, I + 1, CaseCount>(value, cases);
+            }
+            else if constexpr (std::is_void_v<Result>)
+            {
+                return false;
+            }
+            else
+            {
+                return std::nullopt;
+            }
+        }
+
+        template <typename Tuple, std::size_t... I>
+        decltype(auto) visit_atomic_with_default(const AtomicView &value, Tuple &options, std::index_sequence<I...>)
+        {
+            using Cases   = AtomicCasePackTraits<std::tuple_element_t<I, Tuple>...>;
+            using Default = std::tuple_element_t<sizeof...(I), Tuple>;
+
+            static_assert(Cases::distinct, "atomic visitor cannot contain duplicate cases for the same type");
+            static_assert(std::invocable<Default &, AtomicView>,
+                          "atomic visitor default handler must accept AtomicView");
+
+            using Result = std::invoke_result_t<Default &, AtomicView>;
+            static_assert((std::same_as<Result, typename std::tuple_element_t<I, Tuple>::result_type> && ...),
+                          "every atomic visitor branch must return the same type");
+            static_assert(visitor_result_safe_v<Result>,
+                          "atomic visitor cannot return a reference or lazy hgraph range that may borrow "
+                          "from the visited value; return an owned value instead");
+
+            auto on_miss = [&]() -> Result
+            {
+                return std::invoke(std::get<sizeof...(I)>(options), ValueVisitorAccess::project<AtomicView>(value));
+            };
+            return dispatch_atomic_cases<Result, 0, sizeof...(I)>(value, options, on_miss);
+        }
+
+        template <typename Tuple, std::size_t... I>
+        decltype(auto) visit_atomic_without_default(const AtomicView &value, Tuple &cases, std::index_sequence<I...>)
+        {
+            using Cases  = AtomicCasePackTraits<std::tuple_element_t<I, Tuple>...>;
+            using Result = typename Cases::result_type;
+
+            static_assert(Cases::distinct, "atomic visitor cannot contain duplicate cases for the same type");
+            static_assert(Cases::same_result, "every atomic visitor branch must return the same type");
+            static_assert(visitor_result_safe_v<Result>,
+                          "atomic visitor cannot return a reference or lazy hgraph range that may borrow "
+                          "from the visited value; return an owned value instead");
+
+            auto on_miss = [&]() -> Result
+            {
+                throw std::invalid_argument("atomic visitor has no case for value type '" +
+                                            std::string{value.schema()->name()} + "'");
+            };
+            return dispatch_atomic_cases<Result, 0, sizeof...(I)>(value, cases, on_miss);
+        }
+
+        template <typename Tuple, std::size_t... I>
+        auto try_visit_atomic_cases(const AtomicView &value, Tuple &cases, std::index_sequence<I...>)
+        {
+            using Cases  = AtomicCasePackTraits<std::tuple_element_t<I, Tuple>...>;
+            using Result = typename Cases::result_type;
+
+            static_assert(Cases::distinct, "atomic visitor cannot contain duplicate cases for the same type");
+            static_assert(Cases::same_result, "every atomic visitor branch must return the same type");
+            static_assert(visitor_result_safe_v<Result>,
+                          "atomic visitor cannot return a reference or lazy hgraph range that may borrow "
+                          "from the visited value; return an owned value instead");
+            static_assert(std::is_void_v<Result> || std::is_move_constructible_v<Result>,
+                          "a non-void try_visit_atomic result must be movable so std::optional can own it");
+
+            return try_dispatch_atomic_cases<Result, 0, sizeof...(I)>(value, cases);
+        }
     }  // namespace detail
+
+    /**
+     * Associate one exact registered scalar type with its handler.
+     *
+     * The wrapper makes type selection explicit and avoids the implicit
+     * conversions that an ordinary callable overload set could admit.
+     */
+    template <typename T, typename Handler>
+    [[nodiscard]] auto atomic_case(Handler &&handler)
+    {
+        using Value         = std::remove_cvref_t<T>;
+        using StoredHandler = std::decay_t<Handler>;
+
+        static_assert(std::is_object_v<Value> && !std::is_array_v<Value>,
+                      "atomic_case<T> requires a non-array object type");
+        static_assert(std::invocable<StoredHandler &, const Value &>,
+                      "atomic_case<T> handler must accept const T&");
+
+        return detail::AtomicCase<Value, StoredHandler>{StoredHandler{std::forward<Handler>(handler)}};
+    }
+
+    /**
+     * Visit an atomic value using exact typed cases.
+     *
+     * A final ordinary callable is the optional ``AtomicView`` default. With
+     * no default, an unhandled registered scalar type raises
+     * ``std::invalid_argument``. Every branch returns void or the same exact
+     * safe value type.
+     */
+    template <typename... Options>
+    decltype(auto) visit_atomic(const AtomicView &value, Options &&...options)
+    {
+        constexpr std::size_t option_count = sizeof...(Options);
+        if constexpr (option_count == 0)
+        {
+            static_assert(option_count > 0, "visit_atomic requires at least one typed case or a default handler");
+        }
+        else
+        {
+            using OptionTuple = std::tuple<std::decay_t<Options>...>;
+            using LastOption  = std::tuple_element_t<option_count - 1, OptionTuple>;
+            constexpr bool has_default      = !detail::is_atomic_case_v<LastOption>;
+            constexpr std::size_t case_count = has_default ? option_count - 1 : option_count;
+            constexpr bool valid_cases =
+                detail::tuple_elements_are_atomic_cases<OptionTuple>(std::make_index_sequence<case_count>{});
+
+            if constexpr (!valid_cases)
+            {
+                static_assert(valid_cases,
+                              "visit_atomic requires typed atomic_case<T> options followed by at most one default");
+            }
+            else
+            {
+                if (!value.valid())
+                {
+                    throw std::invalid_argument("cannot visit an atomic value without a live payload");
+                }
+
+                auto stored = OptionTuple{std::forward<Options>(options)...};
+                if constexpr (has_default)
+                {
+                    return detail::visit_atomic_with_default(value, stored,
+                                                             std::make_index_sequence<case_count>{});
+                }
+                else
+                {
+                    return detail::visit_atomic_without_default(value, stored,
+                                                                std::make_index_sequence<case_count>{});
+                }
+            }
+        }
+    }
+
+    /**
+     * Attempt exact typed visitation without treating an unlisted atomic type
+     * as an error. Returns ``std::optional<R>`` for value-returning handlers
+     * and ``bool`` for void handlers.
+     */
+    template <typename... Cases>
+    auto try_visit_atomic(const AtomicView &value, Cases &&...cases)
+    {
+        constexpr std::size_t case_count = sizeof...(Cases);
+        if constexpr (case_count == 0)
+        {
+            static_assert(case_count > 0, "try_visit_atomic requires at least one typed case");
+        }
+        else
+        {
+            using CaseTuple = std::tuple<std::decay_t<Cases>...>;
+            constexpr bool valid_cases =
+                detail::tuple_elements_are_atomic_cases<CaseTuple>(std::make_index_sequence<case_count>{});
+
+            if constexpr (!valid_cases)
+            {
+                static_assert(valid_cases, "try_visit_atomic accepts only atomic_case<T> options");
+            }
+            else
+            {
+                if (!value.valid())
+                {
+                    throw std::invalid_argument("cannot visit an atomic value without a live payload");
+                }
+
+                auto stored = CaseTuple{std::forward<Cases>(cases)...};
+                return detail::try_visit_atomic_cases(value, stored, std::make_index_sequence<case_count>{});
+            }
+        }
+    }
 
     /**
      * Visit a live erased value according to its semantic value shape.

--- a/tests/cpp/header_compile_check.cpp
+++ b/tests/cpp/header_compile_check.cpp
@@ -3,6 +3,8 @@
 // compiler chases through the heavier portions of memory_utils, the
 // slot stores, and intern_table.
 
+#include <hgraph/types/value/visitor.h>
+
 #include <hgraph/types/metadata/ts_data_plan_factory.h>
 #include <hgraph/types/metadata/ts_value_type_meta_data.h>
 #include <hgraph/types/metadata/type_meta_data.h>

--- a/tests/cpp/test_value_visitor.cpp
+++ b/tests/cpp/test_value_visitor.cpp
@@ -9,6 +9,8 @@
 #include <catch2/matchers/catch_matchers_string.hpp>
 
 #include <cstdint>
+#include <memory>
+#include <optional>
 #include <string>
 #include <type_traits>
 #include <vector>
@@ -249,6 +251,121 @@ TEST_CASE("value visit result contract rejects references and borrowed lazy rang
     static_assert(!detail::visitor_result_safe_v<KeyValueRange<ValueView, ValueView>>);
 }
 
+TEST_CASE("atomic value visit dispatches exact typed cases and an optional default")
+{
+    using namespace hgraph;
+
+    auto &registry = TypeRegistry::instance();
+    registry.register_scalar<VisitorExtensionScalar>("value_visitor_extension_scalar");
+    registry.register_scalar<std::int32_t>("int32");
+    registry.register_scalar<std::int64_t>("int");
+
+    Value      extension{VisitorExtensionScalar{17}};
+    AtomicView selected{extension.view()};
+
+    const auto result = visit_atomic(
+        selected, atomic_case<std::int32_t>([](const std::int32_t &) { return std::string{"integer"}; }),
+        atomic_case<VisitorExtensionScalar>(
+            [](const VisitorExtensionScalar &value) { return std::string{"extension:"} + std::to_string(value.value); }),
+        [](AtomicView) { return std::string{"other"}; });
+    CHECK(result == "extension:17");
+
+    Value      integer{std::int32_t{23}};
+    AtomicView integer_view{integer.view()};
+    CHECK(visit_atomic(
+              integer_view,
+              atomic_case<std::int32_t>([](const std::int32_t &value) { return value + 1; }),
+              atomic_case<VisitorExtensionScalar>([](const VisitorExtensionScalar &value) { return value.value; }),
+              [](AtomicView) { return std::int32_t{-1}; }) == 24);
+    CHECK(visit_atomic(
+        integer_view, atomic_case<std::int64_t>([](const std::int64_t &) { return false; }),
+        [](AtomicView) { return true; }));
+
+    CHECK(visit_atomic(selected, [](AtomicView fallback)
+                       { return fallback.checked_as<VisitorExtensionScalar>().value; }) == 17);
+}
+
+TEST_CASE("atomic value visit without a default is strict")
+{
+    using namespace hgraph;
+
+    auto &registry = TypeRegistry::instance();
+    registry.register_scalar<VisitorExtensionScalar>("value_visitor_extension_scalar");
+    registry.register_scalar<std::int32_t>("int32");
+
+    Value      extension{VisitorExtensionScalar{31}};
+    AtomicView selected{extension.view()};
+
+    CHECK(visit_atomic(
+              selected,
+              atomic_case<VisitorExtensionScalar>(
+                  [](const VisitorExtensionScalar &value) { return value.value; })) == 31);
+
+    bool invoked = false;
+    visit_atomic(
+        selected, atomic_case<VisitorExtensionScalar>([&](const VisitorExtensionScalar &) { invoked = true; }));
+    CHECK(invoked);
+
+    REQUIRE_THROWS_WITH(
+        visit_atomic(selected,
+                     atomic_case<std::int32_t>([](const std::int32_t &value) { return value; })),
+        "atomic visitor has no case for value type 'value_visitor_extension_scalar'");
+    REQUIRE_THROWS_WITH(
+        visit_atomic(selected, atomic_case<std::int32_t>([](const std::int32_t &) {})),
+        "atomic visitor has no case for value type 'value_visitor_extension_scalar'");
+}
+
+TEST_CASE("try atomic value visit reports value and void matches without throwing")
+{
+    using namespace hgraph;
+
+    auto &registry = TypeRegistry::instance();
+    registry.register_scalar<VisitorExtensionScalar>("value_visitor_extension_scalar");
+    registry.register_scalar<std::int32_t>("int32");
+
+    Value      extension{VisitorExtensionScalar{41}};
+    AtomicView selected{extension.view()};
+
+    auto found = try_visit_atomic(
+        selected, atomic_case<VisitorExtensionScalar>(
+                      [](const VisitorExtensionScalar &value) { return value.value + 1; }));
+    STATIC_REQUIRE(std::same_as<decltype(found), std::optional<std::int32_t>>);
+    REQUIRE(found.has_value());
+    CHECK(*found == 42);
+
+    auto missing = try_visit_atomic(
+        selected, atomic_case<std::int32_t>([](const std::int32_t &value) { return value; }));
+    STATIC_REQUIRE(std::same_as<decltype(missing), std::optional<std::int32_t>>);
+    CHECK_FALSE(missing.has_value());
+
+    bool invoked = false;
+    const bool handled = try_visit_atomic(
+        selected, atomic_case<VisitorExtensionScalar>([&](const VisitorExtensionScalar &value)
+                                                       { invoked = value.value == 41; }));
+    CHECK(handled);
+    CHECK(invoked);
+
+    invoked = false;
+    const bool ignored = try_visit_atomic(
+        selected, atomic_case<std::int32_t>([&](const std::int32_t &) { invoked = true; }));
+    CHECK_FALSE(ignored);
+    CHECK_FALSE(invoked);
+
+    auto owned = try_visit_atomic(
+        selected, atomic_case<VisitorExtensionScalar>([](const VisitorExtensionScalar &value)
+                                                       { return std::make_unique<std::int32_t>(value.value); }));
+    STATIC_REQUIRE(std::same_as<decltype(owned), std::optional<std::unique_ptr<std::int32_t>>>);
+    REQUIRE(owned.has_value());
+    CHECK(**owned == 41);
+
+    REQUIRE_THROWS_AS(
+        try_visit_atomic(
+            selected,
+            atomic_case<VisitorExtensionScalar>([](const VisitorExtensionScalar &) -> std::int32_t
+                                                 { throw std::runtime_error("handler failed"); })),
+        std::runtime_error);
+}
+
 TEST_CASE("value visit uses declared enum and owned-bundle shapes")
 {
     using namespace hgraph;
@@ -259,6 +376,12 @@ TEST_CASE("value visit uses declared enum and owned-bundle shapes")
 
     Value enum_value{ValuePlanFactory::instance().type_for(enumeration)};
     CHECK(classify(enum_value.view()) == VisitedValueKind::Atomic);
+    AtomicView enum_view{enum_value.view()};
+    CHECK(visit_atomic(
+        enum_view, atomic_case<std::int64_t>([](const std::int64_t &) { return false; }),
+        [](AtomicView) { return true; }));
+    CHECK_FALSE(try_visit_atomic(
+        enum_view, atomic_case<std::int64_t>([](const std::int64_t &) {})));
 
     const auto *recursive =
         registry.recursive_bundle("tests.value_visitor", "RecursiveValue", {{"value", integer}, {"next", nullptr}});

--- a/tests/cpp/type_erasure_perf.cpp
+++ b/tests/cpp/type_erasure_perf.cpp
@@ -740,6 +740,38 @@ int main()
             if (value != 41) { throw std::runtime_error("visitor atomic value dispatch failed"); }
         });
 
+    const auto manual_atomic_type_dispatch = [&] {
+        const auto *source = g_atomic_value_view_input.load(std::memory_order_relaxed);
+        const auto selected = source->as_atomic();
+        if (selected.type().ops() == &ops_for<Int>())
+        {
+            return static_cast<std::uint64_t>(selected.as<Int>());
+        }
+        return std::uint64_t{0};
+    };
+    const auto typed_atomic_visitor_dispatch = [&] {
+        const auto *source = g_atomic_value_view_input.load(std::memory_order_relaxed);
+        return visit_atomic(
+            source->as_atomic(),
+            atomic_case<Int>(
+                [](const Int &value) { return static_cast<std::uint64_t>(value); }),
+            [](AtomicView) { return std::uint64_t{0}; });
+    };
+    require_no_allocations("value_manual_atomic_type_dispatch", 10'000, manual_atomic_type_dispatch);
+    require_no_allocations("value_typed_atomic_visitor_dispatch", 10'000, typed_atomic_visitor_dispatch);
+    run_benchmark(
+        "value_manual_atomic_type_dispatch", 200'000, samples, warmup,
+        manual_atomic_type_dispatch,
+        [](std::uint64_t value) {
+            if (value != 41) { throw std::runtime_error("manual atomic type dispatch failed"); }
+        });
+    run_benchmark(
+        "value_typed_atomic_visitor_dispatch", 200'000, samples, warmup,
+        typed_atomic_visitor_dispatch,
+        [](std::uint64_t value) {
+            if (value != 41) { throw std::runtime_error("typed atomic visitor dispatch failed"); }
+        });
+
     TSOutput scalar_output{*ts_int};
     {
         auto mutation = scalar_output.begin_mutation(MIN_ST);

--- a/tests/install_consumer/main.cpp
+++ b/tests/install_consumer/main.cpp
@@ -66,8 +66,11 @@ int main()
     const bool visited_extension = visit(
         boxed.view(),
         [](AtomicView selected) {
-            return selected.holds_alternative<ConsumerExtensionScalar>() &&
-                   selected.checked_as<ConsumerExtensionScalar>().value == 17;
+            return visit_atomic(
+                selected,
+                atomic_case<ConsumerExtensionScalar>(
+                    [](const ConsumerExtensionScalar &value) { return value.value == 17; }),
+                [](AtomicView) { return false; });
         },
         [](ValueView) { return false; });
     if (!visited_extension)


### PR DESCRIPTION
## Summary

- add `atomic_case<T>`, `visit_atomic`, and `try_visit_atomic` for exact typed dispatch over `AtomicView`
- preserve the open extension-scalar registry, nominal enum behavior, and transparent outer `Any` visitation
- add native API coverage, installed-SDK coverage, documentation, and a focused dispatch benchmark

## Why

`AtomicView` needed the scalar peer of the existing type-erased value visitor. Ordinary overload resolution would admit implicit conversions, while a closed `std::variant`-style scalar list would prevent independently built extensions from participating. The new cases record exact operation-table identity, so dispatch remains type-safe and open without per-call registry lookups.

Strict visitation throws for an unmatched value when no default is supplied. A final default handler receives the original `AtomicView`. `try_visit_atomic` provides the non-throwing match form (`std::optional<R>` for value handlers and `bool` for `void` handlers); handler exceptions still propagate.

## Impact

This extends the installed public C++ SDK. It does not introduce new Python runtime semantics or a separate Python implementation. Exact matching means numeric conversions are not inferred, and nominal enums do not match their underlying integer type.

## Performance

The focused benchmark reports zero allocations. Representative dispatch results:

- macOS / AppleClang: manual ops-pointer dispatch 1.934 ns/op; typed visitor 1.978 ns/op
- Linux / GCC: manual ops-pointer dispatch 0.650 ns/op; typed visitor 0.647 ns/op

## Validation

- macOS fresh native suite: 1313/1313 passed
- hg-linux fresh native suite: 1313/1313 passed
- macOS Python 3.14 non-WIP suite from a Python 3.12 stable-ABI wheel: 1730 passed, 10 skipped
- hg-linux Python 3.14 non-WIP suite from a Python 3.12 stable-ABI wheel with Polars rtcompat: 1730 passed, 10 skipped
- installed-SDK consumer, public-header compile check, and Sphinx warnings-as-errors build passed

## Stack

This PR is intentionally based on #205 (`agent/value-view-visitor-final`) because it extends that visitor foundation. It can be retargeted to `main` after #205 merges.