### PR TITLE
Centralize target-link structural endpoint semantics

### DIFF
--- a/include/hgraph/types/time_series/ts_input/detail.h
+++ b/include/hgraph/types/time_series/ts_input/detail.h
@@ -28,6 +28,9 @@ namespace hgraph::detail
     [[nodiscard]] const TSDataView &empty_ts_data_view() noexcept;
     void validate_input_view_kind(const TSValueTypeMetaData *schema, TSTypeKind expected, const char *what);
     [[nodiscard]] const TSInputEndpointOps &input_endpoint_ops_for(const TSValueTypeMetaData *schema);
+    [[nodiscard]] TSDataView structural_observation_for(const TSDataView &source);
+    [[nodiscard]] bool has_published_structural_state(const TSDataView &source,
+                                                       DateTime transition_time);
     [[nodiscard]] TSRoleTypeRef output_data_storage_type_for(const TSEndpointSchema &endpoint_schema);
 
     [[nodiscard]] TSInputChildProjection input_child_projection(const TSDataView &parent, std::size_t index);
@@ -58,6 +61,8 @@ namespace hgraph::detail
                                                                std::size_t                index) noexcept;
         using target_child_fn = TSDataView (*)(const TSDataView &parent, std::size_t index);
         using structural_observation_fn = TSDataView (*)(const TSDataView &source);
+        using has_published_structural_state_fn = bool (*)(const TSDataView &source,
+                                                           DateTime transition_time);
         /** Convert a non-peered input projection of this shape to a reference token. */
         using reference_fn = TimeSeriesReference (*)(const TSInputView &view);
 #if HGRAPH_ENABLE_PYTHON_USER_NODES
@@ -78,6 +83,7 @@ namespace hgraph::detail
         child_schema_fn  child_schema{nullptr};
         target_child_fn  target_child{nullptr};
         structural_observation_fn structural_observation{nullptr};
+        has_published_structural_state_fn has_published_structural_state{nullptr};
         reference_fn     reference{nullptr};
 #if HGRAPH_ENABLE_PYTHON_USER_NODES
         to_python_fn       to_python{nullptr};

--- a/src/hgraph/types/time_series/ts_input.cpp
+++ b/src/hgraph/types/time_series/ts_input.cpp
@@ -248,6 +248,36 @@ namespace hgraph
             return source.as_dict().key_set().base();
         }
 
+        [[nodiscard]] bool tss_has_published_structural_state(const TSDataView &source,
+                                                              DateTime transition_time)
+        {
+            const bool modified_now = source.modified(transition_time);
+            auto set = source.as_set();
+            for (std::size_t slot = 0; slot < set.slot_capacity(); ++slot)
+            {
+                if (!set.slot_occupied(slot) || (modified_now && set.slot_added(slot))) { continue; }
+                if (set.slot_live(slot) || set.slot_removed(slot)) { return true; }
+            }
+            return false;
+        }
+
+        [[nodiscard]] bool tsd_has_published_structural_state(const TSDataView &source,
+                                                              DateTime transition_time)
+        {
+            const bool modified_now = source.modified(transition_time);
+            auto dict = source.as_dict();
+            for (std::size_t slot = 0; slot < dict.slot_capacity(); ++slot)
+            {
+                if (!dict.slot_occupied(slot) || (modified_now && dict.slot_added(slot))) { continue; }
+                if (dict.slot_removed(slot) ||
+                    (dict.slot_live(slot) && dict.at_slot(slot).has_current_value()))
+                {
+                    return true;
+                }
+            }
+            return false;
+        }
+
         [[nodiscard]] TimeSeriesReference input_leaf_reference(const TSInputView &view)
         {
             return TimeSeriesReference::empty(view.schema());
@@ -313,6 +343,7 @@ namespace hgraph
             .find_key = &no_endpoint_find_key,
             .child_schema = &no_endpoint_child_schema,
             .structural_observation = &tss_structural_observation,
+            .has_published_structural_state = &tss_has_published_structural_state,
             .reference = &input_leaf_reference,
         };
 
@@ -324,6 +355,7 @@ namespace hgraph
             .child_schema = &tsd_endpoint_child_schema,
             .target_child = &tsd_target_child_at,
             .structural_observation = &tsd_structural_observation,
+            .has_published_structural_state = &tsd_has_published_structural_state,
             .reference = &input_leaf_reference,
         };
 
@@ -2299,6 +2331,41 @@ namespace hgraph
         const TSInputEndpointOps &input_endpoint_ops_for(const TSValueTypeMetaData *schema)
         {
             return ::hgraph::input_endpoint_ops_for(schema);
+        }
+
+        TSDataView structural_observation_for(const TSDataView &source)
+        {
+            if (!source.valid() || source.schema() == nullptr)
+            {
+                throw std::logic_error("Structural observation requires live TSData with a schema");
+            }
+
+            const auto &ops = input_endpoint_ops_for(source.schema());
+            if (ops.structural_observation == nullptr)
+            {
+                throw std::invalid_argument(
+                    "Structural input activity is not supported for this time-series shape");
+            }
+            return ops.structural_observation(source);
+        }
+
+        bool has_published_structural_state(const TSDataView &source,
+                                            DateTime transition_time)
+        {
+            if (!source.valid() || source.schema() == nullptr) { return false; }
+
+            const auto &ops = input_endpoint_ops_for(source.schema());
+            if (ops.has_published_structural_state == nullptr)
+            {
+                throw std::invalid_argument(
+                    "Published structural state is not supported for this time-series shape");
+            }
+
+            // A previously published empty collection is still structural
+            // state. It must produce a sampled empty transition when a
+            // forwarding endpoint moves to a fresh, currently-unset target.
+            if (!source.modified(transition_time) && source.has_current_value()) { return true; }
+            return ops.has_published_structural_state(source, transition_time);
         }
 
         TSRoleTypeRef output_data_storage_type_for(const TSEndpointSchema &endpoint_schema)

--- a/src/hgraph/types/time_series/ts_input/base_view.cpp
+++ b/src/hgraph/types/time_series/ts_input/base_view.cpp
@@ -209,15 +209,23 @@ namespace hgraph
     void TSInputView::InputDataCursor::make_structural_active(
         TSInput *input, Notifiable *scheduling_notifier) const
     {
-        const auto *value_schema = schema();
-        const auto &ops = detail::input_endpoint_ops_for(value_schema);
-        if (ops.structural_observation == nullptr)
+        TSDataView observed{};
+        if (value_live())
         {
-            throw std::invalid_argument("Structural input activity is not supported for this time-series shape");
+            observed = detail::structural_observation_for(value_data);
+        }
+        else
+        {
+            // Unbound target-link positions still accept structural
+            // activation so that a later bind can subscribe them.
+            const auto &ops = detail::input_endpoint_ops_for(schema());
+            if (ops.structural_observation == nullptr)
+            {
+                throw std::invalid_argument(
+                    "Structural input activity is not supported for this time-series shape");
+            }
         }
 
-        TSDataView observed{};
-        if (value_live()) { observed = ops.structural_observation(value_data); }
         if (is_target_position())
         {
             detail::make_target_link_active(raw_data, target_path_node(), observed,

--- a/src/hgraph/types/time_series/ts_input/target_link.cpp
+++ b/src/hgraph/types/time_series/ts_input/target_link.cpp
@@ -152,46 +152,8 @@ namespace hgraph::detail
             {
                 throw std::logic_error("Target-link slot observer requires a bound structural target");
             }
-            if (target.schema()->kind == TSTypeKind::TSD) { return target.as_dict().key_set(); }
-            if (target.schema()->kind == TSTypeKind::TSS) { return target.as_set(); }
-            throw std::logic_error(
-                "Target-link slot observer requires a TSS or TSD target, got " +
-                std::string{target.schema()->name()});
-        }
-
-        [[nodiscard]] bool has_published_structural_key(const TSDataView &target,
-                                                        DateTime transition_time)
-        {
-            if (!target.valid() || target.schema() == nullptr) { return false; }
-            const bool modified_now = target.modified(transition_time);
-            // A previously published empty collection is still structural
-            // state. It must produce a sampled empty transition when a
-            // forwarding endpoint moves to a fresh, currently-unset target.
-            if (!modified_now && target.has_current_value()) { return true; }
-            if (target.schema()->kind == TSTypeKind::TSS)
-            {
-                auto set = target.as_set();
-                for (std::size_t slot = 0; slot < set.slot_capacity(); ++slot)
-                {
-                    if (!set.slot_occupied(slot) || (modified_now && set.slot_added(slot))) { continue; }
-                    if (set.slot_live(slot) || set.slot_removed(slot)) { return true; }
-                }
-                return false;
-            }
-            if (target.schema()->kind == TSTypeKind::TSD)
-            {
-                auto dict = target.as_dict();
-                for (std::size_t slot = 0; slot < dict.slot_capacity(); ++slot)
-                {
-                    if (!dict.slot_occupied(slot) || (modified_now && dict.slot_added(slot))) { continue; }
-                    if (dict.slot_removed(slot) ||
-                        (dict.slot_live(slot) && dict.at_slot(slot).has_current_value()))
-                    {
-                        return true;
-                    }
-                }
-            }
-            return false;
+            auto structural = structural_observation_for(target);
+            return structural.as_set();
         }
 
         [[nodiscard]] bool project_target_path(TSDataView &current,
@@ -232,13 +194,7 @@ namespace hgraph::detail
                 return observed;
             }
 
-            const auto *observed_schema = target_schema_at_node(&schema, &node);
-            const auto &ops = input_endpoint_ops_for(observed_schema);
-            if (ops.structural_observation == nullptr)
-            {
-                throw std::logic_error("Structural input activity is not supported for this time-series shape");
-            }
-            auto structural = ops.structural_observation(observed.data_view());
+            auto structural = structural_observation_for(observed.data_view());
             return TSOutputHandle{link.target_output().output(), std::move(structural)};
         }
 
@@ -521,12 +477,13 @@ namespace hgraph::detail
             throw std::invalid_argument("TSInput target binding schema does not match the input slot schema");
         }
 
-        const bool structural = schema.kind == TSTypeKind::TSS || schema.kind == TSTypeKind::TSD;
+        const bool structural =
+            input_endpoint_ops_for(&schema).structural_observation != nullptr;
         const bool previous_was_valid =
             sampled && state_.target.bound() && state_.target.view(modified_time).valid();
-        const bool previous_has_published_key =
+        const bool previous_has_published_state =
             sampled && structural && state_.target.bound() &&
-            has_published_structural_key(state_.target.data_view(), modified_time);
+            has_published_structural_state(state_.target.data_view(), modified_time);
         if (state_.target.bound()) { detach_target(sampled && structural, modified_time); }
         else if (!sampled || structural_transition_time() != modified_time)
         {
@@ -549,7 +506,7 @@ namespace hgraph::detail
         subscribe_slot_observers();
         resubscribe_active_target(schema);
         const bool publish_sampled_transition =
-            sampled && (output.valid() || previous_was_valid || previous_has_published_key);
+            sampled && (output.valid() || previous_was_valid || previous_has_published_state);
         if (publish_sampled_transition)
         {
             if (structural)
@@ -580,10 +537,10 @@ namespace hgraph::detail
             throw std::invalid_argument("Structural TSInput target unbinding requires an evaluation time");
         }
         if (!state_.target.bound()) { return; }
-        const bool has_published_key =
-            has_published_structural_key(state_.target.data_view(), modified_time);
-        detach_target(has_published_key, modified_time);
-        if (!has_published_key) { return; }
+        const bool has_published_state =
+            has_published_structural_state(state_.target.data_view(), modified_time);
+        detach_target(has_published_state, modified_time);
+        if (!has_published_state) { return; }
         record_key_set_modified(modified_time);
         record_target_modified(modified_time);
     }

--- a/tests/cpp/test_ts_input.cpp
+++ b/tests/cpp/test_ts_input.cpp
@@ -1,6 +1,8 @@
+#include <hgraph/lib/std/value_util.h>
 #include <hgraph/types/metadata/ts_data_plan_factory.h>
 #include <hgraph/types/metadata/type_registry.h>
 #include <hgraph/types/time_series/ts_input.h>
+#include <hgraph/types/time_series/ts_input/detail.h>
 #include <hgraph/types/value/value.h>
 
 #include <catch2/catch_test_macros.hpp>
@@ -1214,6 +1216,191 @@ TEST_CASE("TSInput shape casts return endpoint views for slot collections")
 
     active_set.make_passive();
     active_dict_child.make_passive();
+}
+
+TEST_CASE("TSInput endpoint operations own structural projections")
+{
+    using namespace hgraph;
+
+    auto       &registry = TypeRegistry::instance();
+    auto       &factory = TSDataPlanFactory::instance();
+    const auto *int_meta = registry.register_scalar<std::int32_t>("int32");
+    const auto *ts_int = registry.ts(int_meta);
+    const auto *tss = registry.tss(int_meta);
+    const auto *tsd = registry.tsd(int_meta, ts_int);
+
+    TSData set_data{factory.data_type_for(tss)};
+    auto set_source = set_data.view();
+    auto set_structural = detail::structural_observation_for(set_source);
+    REQUIRE(set_structural.data() == set_source.data());
+    REQUIRE(set_structural.schema() == tss);
+
+    TSData dict_data{factory.data_type_for(tsd)};
+    auto dict_source = dict_data.view();
+    auto expected_key_set = dict_source.as_dict().key_set().base();
+    auto dict_structural = detail::structural_observation_for(dict_source);
+    REQUIRE(dict_structural.data() == expected_key_set.data());
+    REQUIRE(dict_structural.schema() == expected_key_set.schema());
+    REQUIRE(dict_structural.schema()->kind == TSTypeKind::TSS);
+
+    TSData scalar_data{factory.data_type_for(ts_int)};
+    REQUIRE_THROWS_AS(detail::structural_observation_for(scalar_data.view()),
+                      std::invalid_argument);
+    REQUIRE_THROWS_AS(detail::structural_observation_for(TSDataView{}),
+                      std::logic_error);
+}
+
+TEST_CASE("TSInput structural activation survives an unbound target link")
+{
+    using namespace hgraph;
+
+    auto       &registry = TypeRegistry::instance();
+    const auto *int_meta = registry.register_scalar<std::int32_t>("int32");
+    const auto *ts_int = registry.ts(int_meta);
+    const auto *tss = registry.tss(int_meta);
+    const auto *tsd = registry.tsd(int_meta, ts_int);
+    const auto t1 = MIN_ST;
+    const auto t2 = t1 + TimeDelta{1};
+
+    TSInput set_input{TSInputBuilderFactory::checked_builder_for(
+        *tss, TSEndpointSchema::peered(tss))};
+    TSInput dict_input{TSInputBuilderFactory::checked_builder_for(
+        *tsd, TSEndpointSchema::peered(tsd))};
+    TSInput scalar_input{TSInputBuilderFactory::checked_builder_for(
+        *ts_int, TSEndpointSchema::peered(ts_int))};
+    TSOutput set_output{*tss};
+    TSOutput dict_output{*tsd};
+    RecordingNotifiable set_notifications;
+    RecordingNotifiable dict_notifications;
+    RecordingNotifiable scalar_notifications;
+
+    auto active_set = set_input.view(&set_notifications, t1);
+    auto active_dict = dict_input.view(&dict_notifications, t1);
+    active_set.make_structural_active();
+    active_dict.make_structural_active();
+    REQUIRE(active_set.active());
+    REQUIRE(active_dict.active());
+
+    auto unsupported = scalar_input.view(&scalar_notifications, t1);
+    REQUIRE_THROWS_AS(unsupported.make_structural_active(), std::invalid_argument);
+
+    auto set_binding = set_input.view(nullptr, t1);
+    auto dict_binding = dict_input.view(nullptr, t1);
+    set_binding.bind_output(set_output.view(t1));
+    dict_binding.bind_output(dict_output.view(t1));
+
+    Value key{std::int32_t{7}};
+    Value value{std::int32_t{42}};
+    {
+        auto data = set_output.data_view();
+        auto mutation = data.as_set().begin_mutation(t2);
+        REQUIRE(mutation.add(key.view()));
+    }
+    {
+        auto data = dict_output.data_view();
+        auto mutation = data.as_dict().begin_mutation(t2);
+        auto child = mutation.at(key.view());
+        auto child_mutation = child.begin_mutation(t2);
+        REQUIRE(child_mutation.copy_value_from(value.view()));
+    }
+
+    REQUIRE(set_notifications.notified == std::vector<DateTime>{t2});
+    REQUIRE(dict_notifications.notified == std::vector<DateTime>{t2});
+
+    active_set.make_passive();
+    active_dict.make_passive();
+}
+
+TEST_CASE("TSInput endpoint operations preserve published structural state semantics")
+{
+    using namespace hgraph;
+
+    auto       &registry = TypeRegistry::instance();
+    auto       &factory = TSDataPlanFactory::instance();
+    const auto *int_meta = registry.register_scalar<std::int32_t>("int32");
+    const auto *ts_int = registry.ts(int_meta);
+    const auto *tss = registry.tss(int_meta);
+    const auto *tsd = registry.tsd(int_meta, ts_int);
+    const auto t1 = MIN_ST;
+    const auto t2 = t1 + TimeDelta{1};
+    const auto t3 = t2 + TimeDelta{1};
+    const auto t4 = t3 + TimeDelta{1};
+    const auto t5 = t4 + TimeDelta{1};
+    Value key{std::int32_t{7}};
+    Value other_key{std::int32_t{8}};
+    Value value{std::int32_t{42}};
+
+    TSData set_data{factory.data_type_for(tss)};
+    auto set_source = set_data.view();
+    auto set = set_source.as_set();
+    REQUIRE_FALSE(detail::has_published_structural_state(set_source, t1));
+    {
+        auto empty = stdlib::make_set<std::int32_t>({});
+        auto mutation = set.begin_mutation(t1);
+        REQUIRE(mutation.copy_value_from(empty.view()));
+    }
+    REQUIRE_FALSE(detail::has_published_structural_state(set_source, t1));
+    REQUIRE(detail::has_published_structural_state(set_source, t2));
+    {
+        auto mutation = set.begin_mutation(t2);
+        REQUIRE(mutation.add(key.view()));
+    }
+    REQUIRE_FALSE(detail::has_published_structural_state(set_source, t2));
+    {
+        auto mutation = set.begin_mutation(t3);
+        REQUIRE(mutation.remove(key.view()));
+    }
+    REQUIRE(detail::has_published_structural_state(set_source, t3));
+
+    TSData empty_dict_data{factory.data_type_for(tsd)};
+    auto empty_dict_source = empty_dict_data.view();
+    {
+        auto empty = stdlib::make_map<std::int32_t, std::int32_t>({});
+        auto mutation = empty_dict_source.as_dict().begin_mutation(t1);
+        REQUIRE(mutation.copy_value_from(empty.view()));
+    }
+    REQUIRE_FALSE(detail::has_published_structural_state(empty_dict_source, t1));
+    REQUIRE(detail::has_published_structural_state(empty_dict_source, t2));
+
+    TSData dict_data{factory.data_type_for(tsd)};
+    auto dict_source = dict_data.view();
+    auto dict = dict_source.as_dict();
+    {
+        auto mutation = dict.begin_mutation(t1);
+        static_cast<void>(mutation.at(key.view()));
+    }
+    REQUIRE_FALSE(detail::has_published_structural_state(dict_source, t1));
+    REQUIRE(detail::has_published_structural_state(dict_source, t2));
+    {
+        auto mutation = dict.begin_mutation(t2);
+        static_cast<void>(mutation.at(other_key.view()));
+    }
+    REQUIRE_FALSE(detail::has_published_structural_state(dict_source, t2));
+    {
+        auto mutation = dict.begin_mutation(t3);
+        auto child = mutation.at(key.view());
+        auto child_mutation = child.begin_mutation(t3);
+        REQUIRE(child_mutation.copy_value_from(value.view()));
+    }
+    REQUIRE_FALSE(detail::has_published_structural_state(dict_source, t3));
+    REQUIRE(detail::has_published_structural_state(dict_source, t4));
+    {
+        auto child = dict.at(key.view());
+        auto mutation = child.begin_mutation(t4);
+        REQUIRE(mutation.invalidate());
+    }
+    REQUIRE_FALSE(detail::has_published_structural_state(dict_source, t4));
+    {
+        auto mutation = dict.begin_mutation(t5);
+        REQUIRE(mutation.erase(key.view()));
+    }
+    REQUIRE(detail::has_published_structural_state(dict_source, t5));
+
+    TSData scalar_data{factory.data_type_for(ts_int)};
+    REQUIRE_THROWS_AS(
+        detail::has_published_structural_state(scalar_data.view(), t1),
+        std::invalid_argument);
+    REQUIRE_FALSE(detail::has_published_structural_state(TSDataView{}, t1));
 }
 
 TEST_CASE("TSW input removed value is limited to the current evaluation cycle")


### PR DESCRIPTION
Closes #201

## What changed

- Added type-erased endpoint operations for structural projection and published structural-state detection.
- Routed TSS and TSD target-link structural observation through those endpoint capabilities.
- Removed the target-link layer's direct `TSTypeKind::TSS` / `TSTypeKind::TSD` dispatch and its local published-key scanner.
- Kept unbound target-link positions structurally activatable so a later bind subscribes correctly.
- Added focused native coverage for TSS/TSD projections, unbound-to-bound activation, empty publications, additions, removals, unmaterialized TSD slots, child publication/invalidation, and unsupported shapes.

## Why

The target-link implementation was independently interpreting TSS and TSD structure even though endpoint shape behavior already belongs to the type-erased input operation table. That duplicated structural semantics at the forwarding layer and made new structural endpoint implementations require edits outside their own operation definitions.

The endpoint table is now the single dispatch boundary. Target links ask the endpoint for its structural observation and whether prior structural state must be represented during sampled rebind/unbind transitions. Existing empty/add/remove and TSD child-publication behavior is preserved.

## Impact

There is no public API or storage-layout change. The change is internal to input endpoint dispatch and makes structural forwarding extensible without adding more concrete shape switches to target-link code.

## Validation

- macOS fresh native acceptance preset: **1,314/1,314 passed**.
- macOS Python 3.12 stable-ABI wheel installed into fresh Python 3.14: **1,741 passed, 10 skipped**.
- `hg-linux` GCC 15 fresh native acceptance preset: **1,314/1,314 passed**.
- `hg-linux` Python 3.12 stable-ABI wheel installed into fresh Python 3.14 with `polars[rtcompat]`: **1,741 passed, 10 skipped**.

The first macOS Python run hit the known real-time catalogue deadline flake in `test_catalogue_subscribe_routes_json_source`. That exact test then passed 5/5 focused reruns, and the complete Python suite passed on rerun.