### PR TITLE
Parity discovery: API-surface audit subcommand

### DIFF
--- a/tools/parity/cli.py
+++ b/tools/parity/cli.py
@@ -9,6 +9,7 @@ import sys
 from pathlib import Path
 
 from .campaign import render_campaign_markdown, run_campaign
+from .surface import compare_surfaces, probe_surface, render_surface_markdown
 from .catalog import catalogue_json, validate_recipe
 from .compare import compare_outcomes
 from .coverage import coverage_json, render_coverage_markdown
@@ -192,6 +193,19 @@ def command_coverage(args) -> int:
     return 0
 
 
+def command_surface(args) -> int:
+    environments = _prepare(args)
+    reference = probe_surface(environments.reference_python)
+    candidate = probe_surface(environments.candidate_python)
+    report = compare_surfaces(reference, candidate)
+    output_dir = Path(args.output_dir) if args.output_dir else PARITY_ROOT / "results" / "surface"
+    output_dir.mkdir(parents=True, exist_ok=True)
+    (output_dir / "surface.json").write_text(json.dumps(report, indent=2, sort_keys=True) + "\n")
+    (output_dir / "surface.md").write_text(render_surface_markdown(report))
+    print(render_surface_markdown(report))
+    return 0 if not report["findings"] or args.exit_zero else 1
+
+
 def command_campaign(args) -> int:
     profile_defaults = CAMPAIGN_PROFILES[args.profile]
     examples = (
@@ -356,6 +370,12 @@ def build_parser() -> argparse.ArgumentParser:
     campaign.add_argument("--exit-zero", action="store_true")
     _environment_arguments(campaign)
     campaign.set_defaults(func=command_campaign)
+
+    surface = subparsers.add_parser("surface")
+    surface.add_argument("--output-dir")
+    surface.add_argument("--exit-zero", action="store_true")
+    _environment_arguments(surface)
+    surface.set_defaults(func=command_surface)
 
     publish = subparsers.add_parser("publish-issues")
     publish.add_argument("reports", nargs="+")

--- a/tools/parity/cli.py
+++ b/tools/parity/cli.py
@@ -5,11 +5,19 @@ from __future__ import annotations
 import argparse
 import datetime as dt
 import json
+import subprocess
 import sys
 from pathlib import Path
 
 from .campaign import render_campaign_markdown, run_campaign
-from .surface import compare_surfaces, probe_surface, render_surface_markdown
+from .surface import (
+    SURFACE_EXTRA_DEPENDENCIES,
+    classify_findings,
+    compare_surfaces,
+    load_known_surface,
+    probe_surface,
+    render_surface_markdown,
+)
 from .catalog import catalogue_json, validate_recipe
 from .compare import compare_outcomes
 from .coverage import coverage_json, render_coverage_markdown
@@ -195,15 +203,32 @@ def command_coverage(args) -> int:
 
 def command_surface(args) -> int:
     environments = _prepare(args)
+    if args.with_extras:
+        # One shared dependency list into BOTH environments: adaptor imports
+        # become symmetric by construction, so the deep adaptor surfaces are
+        # audited instead of skipped.
+        for python in (environments.reference_python, environments.candidate_python):
+            subprocess.run(
+                ["uv", "pip", "install", "--python", str(python),
+                 *SURFACE_EXTRA_DEPENDENCIES],
+                check=True,
+                capture_output=True,
+                text=True,
+            )
     reference = probe_surface(environments.reference_python)
     candidate = probe_surface(environments.candidate_python)
     report = compare_surfaces(reference, candidate)
+    known_path = Path(args.known) if args.known else Path(__file__).with_name("surface_known.json")
+    rules = load_known_surface(known_path) if known_path.exists() else []
+    actionable, accepted = classify_findings(report["findings"], rules)
+    report["actionable"] = actionable
+    report["accepted"] = accepted
     output_dir = Path(args.output_dir) if args.output_dir else PARITY_ROOT / "results" / "surface"
     output_dir.mkdir(parents=True, exist_ok=True)
     (output_dir / "surface.json").write_text(json.dumps(report, indent=2, sort_keys=True) + "\n")
     (output_dir / "surface.md").write_text(render_surface_markdown(report))
     print(render_surface_markdown(report))
-    return 0 if not report["findings"] or args.exit_zero else 1
+    return 0 if not report["actionable"] or args.exit_zero else 1
 
 
 def command_campaign(args) -> int:
@@ -374,6 +399,8 @@ def build_parser() -> argparse.ArgumentParser:
     surface = subparsers.add_parser("surface")
     surface.add_argument("--output-dir")
     surface.add_argument("--exit-zero", action="store_true")
+    surface.add_argument("--with-extras", action="store_true")
+    surface.add_argument("--known")
     _environment_arguments(surface)
     surface.set_defaults(func=command_surface)
 

--- a/tools/parity/surface.py
+++ b/tools/parity/surface.py
@@ -14,10 +14,30 @@ import in the candidate.
 
 from __future__ import annotations
 
+import fnmatch
 import json
 import subprocess
 from pathlib import Path
 from typing import Any
+
+#: One shared dependency list for ``--with-extras``: installed into BOTH
+#: environments so adaptor imports are symmetric by construction (the two
+#: packages spell their extras differently — upstream ``web``/``messaging``
+#: vs the candidate's per-adaptor extras — so extras names cannot be used).
+SURFACE_EXTRA_DEPENDENCIES: tuple[str, ...] = (
+    "tornado>=6.5",
+    "perspective-python<5.0.0",
+    "requests",
+    "pandas>=2.0",
+    "kafka-python>=2.1.5",
+    "boto3>=1.34",
+    "deltalake>=1.0",
+    "polars>=1.32",
+    "sqlalchemy>=2.0",
+    "duckdb>=1.4",
+    "connectorx>=0.4.5",
+    "adbc-driver-snowflake>=1.8",
+)
 
 _PROBE = r"""
 import importlib, inspect, json, pkgutil, re, sys
@@ -208,11 +228,67 @@ def compare_surfaces(
     }
 
 
+def _finding_side(finding: dict[str, Any]) -> str | None:
+    if finding["kind"] == "import-asymmetry":
+        return "reference" if finding.get("reference_error") else "candidate"
+    return finding.get("side")
+
+
+def load_known_surface(path: Path | str) -> list[dict[str, Any]]:
+    data = json.loads(Path(path).read_text())
+    rules = data["rules"] if isinstance(data, dict) else data
+    for rule in rules:
+        if "reason" not in rule:
+            raise ValueError(f"surface known-rule missing a reason: {rule}")
+    return rules
+
+
+def classify_findings(
+    findings: list[dict[str, Any]], rules: list[dict[str, Any]]
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    """Split findings into (actionable, accepted-with-reason)."""
+
+    def matches(rule: dict[str, Any], finding: dict[str, Any]) -> bool:
+        if not fnmatch.fnmatchcase(finding["module"], rule.get("module", "*")):
+            return False
+        if "name" in rule and not fnmatch.fnmatchcase(
+            finding.get("name", ""), rule["name"]
+        ):
+            return False
+        if rule.get("kind", "*") not in ("*", finding["kind"]):
+            return False
+        if "side" in rule and rule["side"] != _finding_side(finding):
+            return False
+        return True
+
+    actionable: list[dict[str, Any]] = []
+    accepted: list[dict[str, Any]] = []
+    for finding in findings:
+        rule = next((r for r in rules if matches(r, finding)), None)
+        if rule is None:
+            actionable.append(finding)
+        else:
+            accepted.append({**finding, "accepted_reason": rule["reason"]})
+    return actionable, accepted
+
+
 def render_surface_markdown(report: dict[str, Any]) -> str:
     lines = ["# API surface parity", ""]
-    findings = report["findings"]
-    lines.append(f"Modules compared: {len(report['modules_compared'])}; findings: {len(findings)}")
+    findings = report.get("actionable", report["findings"])
+    accepted = report.get("accepted", [])
+    lines.append(
+        f"Modules compared: {len(report['modules_compared'])}; "
+        f"actionable findings: {len(findings)}; accepted (known): {len(accepted)}"
+    )
     lines.append("")
+    if accepted:
+        reasons: dict[str, int] = {}
+        for entry in accepted:
+            reasons[entry["accepted_reason"]] = reasons.get(entry["accepted_reason"], 0) + 1
+        lines.append("Accepted by reason:")
+        for reason, count in sorted(reasons.items()):
+            lines.append(f"- {count} — {reason}")
+        lines.append("")
     by_module: dict[str, list[dict[str, Any]]] = {}
     for finding in findings:
         by_module.setdefault(finding["module"], []).append(finding)

--- a/tools/parity/surface.py
+++ b/tools/parity/surface.py
@@ -20,7 +20,14 @@ from pathlib import Path
 from typing import Any
 
 _PROBE = r"""
-import importlib, inspect, json, pkgutil, sys
+import importlib, inspect, json, pkgutil, re, sys
+
+_ADDRESS = re.compile(r" at 0x[0-9a-fA-F]+")
+
+def _default_repr(value):
+    # Identity sentinels (``object()`` defaults) repr with a process-local
+    # address; normalize so two probes of the same implementation agree.
+    return _ADDRESS.sub("", repr(value))
 
 def describe_callable(obj):
     try:
@@ -32,7 +39,7 @@ def describe_callable(obj):
         params.append({
             "name": p.name,
             "kind": str(p.kind),
-            "default": repr(p.default) if p.default is not inspect.Parameter.empty else None,
+            "default": _default_repr(p.default) if p.default is not inspect.Parameter.empty else None,
         })
     return {"signature": params}
 
@@ -53,6 +60,12 @@ def describe_module(name):
             surface[name_] = {"kind": "missing-attr"}
             continue
         if inspect.isclass(obj):
+            # The constructor IS public API: required-parameter changes must
+            # surface even when the method map is unchanged.
+            try:
+                constructor = describe_callable(obj)
+            except BaseException:  # noqa: BLE001
+                constructor = {"signature": None}
             methods = {}
             for m in sorted(dir(obj)):
                 if m.startswith("_"):
@@ -63,7 +76,8 @@ def describe_module(name):
                         methods[m] = describe_callable(getattr(obj, m))
                     except BaseException:  # noqa: BLE001
                         methods[m] = {"signature": None}
-            surface[name_] = {"kind": "class", "methods": methods}
+            surface[name_] = {"kind": "class", "methods": methods,
+                              "constructor": constructor.get("signature")}
         elif callable(obj):
             entry = describe_callable(obj)
             entry["kind"] = "callable"
@@ -73,12 +87,22 @@ def describe_module(name):
     return {"surface": surface, "has_all": exported is not None}
 
 modules = ["hgraph", "hgraph.test", "hgraph.adaptors"]
-try:
-    import hgraph.adaptors as _adaptors
-    for info in pkgutil.iter_modules(_adaptors.__path__):
-        modules.append(f"hgraph.adaptors.{info.name}")
-except BaseException as error:  # noqa: BLE001
-    pass
+
+def _collect(package_name):
+    # Recursive discovery: nested paths (hgraph.adaptors.sql.sql_connection)
+    # break independently of their parent package. Each discovered module is
+    # probed via describe_module, which contains its own import guard.
+    try:
+        package = importlib.import_module(package_name)
+    except BaseException:  # noqa: BLE001
+        return
+    for info in pkgutil.iter_modules(getattr(package, "__path__", [])):
+        qualified = f"{package_name}.{info.name}"
+        modules.append(qualified)
+        if info.ispkg:
+            _collect(qualified)
+
+_collect("hgraph.adaptors")
 
 print(json.dumps({name: describe_module(name) for name in sorted(set(modules))}))
 """
@@ -151,6 +175,14 @@ def compare_surfaces(
                     "candidate": _signature_key(c),
                 })
             if r.get("kind") == "class":
+                if r.get("constructor") != c.get("constructor"):
+                    findings.append({
+                        "module": module,
+                        "name": f"{name}.__init__",
+                        "kind": "constructor-signature-mismatch",
+                        "reference": r.get("constructor"),
+                        "candidate": c.get("constructor"),
+                    })
                 rm, cm = r.get("methods", {}), c.get("methods", {})
                 for method in sorted(set(rm) | set(cm)):
                     mr, mc = rm.get(method), cm.get(method)

--- a/tools/parity/surface.py
+++ b/tools/parity/surface.py
@@ -1,0 +1,193 @@
+"""API-surface parity audit (issue-discovery campaign, 2026-07).
+
+Behavioral fuzzing cannot see a mis-ported API: a missing function, a
+renamed parameter, a changed default, or an adaptor module that fails to
+import never produces a differential trace — the wiring just breaks in
+client code. This audit compares the PUBLIC SURFACE of ``hgraph`` and
+every ``hgraph.adaptors`` submodule between the reference and candidate
+environments: exported names, callable signatures (parameters, kinds,
+defaults), class methods, and module importability. Asymmetric import
+failures are findings, not errors — heavy adaptor dependencies are meant
+to be lazy-imported, so a module that imports in the reference must
+import in the candidate.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+from typing import Any
+
+_PROBE = r"""
+import importlib, inspect, json, pkgutil, sys
+
+def describe_callable(obj):
+    try:
+        signature = inspect.signature(obj)
+    except (ValueError, TypeError):
+        return {"signature": None}
+    params = []
+    for p in signature.parameters.values():
+        params.append({
+            "name": p.name,
+            "kind": str(p.kind),
+            "default": repr(p.default) if p.default is not inspect.Parameter.empty else None,
+        })
+    return {"signature": params}
+
+def describe_module(name):
+    try:
+        module = importlib.import_module(name)
+    except BaseException as error:  # noqa: BLE001 - import asymmetry IS the finding
+        return {"import_error": f"{type(error).__name__}: {error}"}
+    exported = getattr(module, "__all__", None)
+    names = exported if exported is not None else [
+        n for n in dir(module) if not n.startswith("_")
+    ]
+    surface = {}
+    for name_ in sorted(set(names)):
+        try:
+            obj = getattr(module, name_)
+        except AttributeError:
+            surface[name_] = {"kind": "missing-attr"}
+            continue
+        if inspect.isclass(obj):
+            methods = {}
+            for m in sorted(dir(obj)):
+                if m.startswith("_"):
+                    continue
+                attr = inspect.getattr_static(obj, m, None)
+                if callable(attr) or isinstance(attr, (staticmethod, classmethod)):
+                    try:
+                        methods[m] = describe_callable(getattr(obj, m))
+                    except BaseException:  # noqa: BLE001
+                        methods[m] = {"signature": None}
+            surface[name_] = {"kind": "class", "methods": methods}
+        elif callable(obj):
+            entry = describe_callable(obj)
+            entry["kind"] = "callable"
+            surface[name_] = entry
+        else:
+            surface[name_] = {"kind": type(obj).__name__}
+    return {"surface": surface, "has_all": exported is not None}
+
+modules = ["hgraph", "hgraph.test", "hgraph.adaptors"]
+try:
+    import hgraph.adaptors as _adaptors
+    for info in pkgutil.iter_modules(_adaptors.__path__):
+        modules.append(f"hgraph.adaptors.{info.name}")
+except BaseException as error:  # noqa: BLE001
+    pass
+
+print(json.dumps({name: describe_module(name) for name in sorted(set(modules))}))
+"""
+
+
+def probe_surface(python: Path | str) -> dict[str, Any]:
+    result = subprocess.run(
+        [str(python), "-c", _PROBE],
+        capture_output=True,
+        text=True,
+        timeout=300,
+        check=True,
+    )
+    return json.loads(result.stdout)
+
+
+def _signature_key(entry: dict[str, Any]) -> Any:
+    return entry.get("signature")
+
+
+def compare_surfaces(
+    reference: dict[str, Any], candidate: dict[str, Any]
+) -> dict[str, Any]:
+    findings: list[dict[str, Any]] = []
+    for module in sorted(set(reference) | set(candidate)):
+        ref, cand = reference.get(module), candidate.get(module)
+        if ref is None or cand is None:
+            findings.append({
+                "module": module,
+                "kind": "module-missing",
+                "side": "candidate" if cand is None else "reference",
+            })
+            continue
+        ref_err, cand_err = ref.get("import_error"), cand.get("import_error")
+        if ref_err or cand_err:
+            if bool(ref_err) != bool(cand_err):
+                findings.append({
+                    "module": module,
+                    "kind": "import-asymmetry",
+                    "reference_error": ref_err,
+                    "candidate_error": cand_err,
+                })
+            continue
+        ref_surface, cand_surface = ref["surface"], cand["surface"]
+        for name in sorted(set(ref_surface) | set(cand_surface)):
+            r, c = ref_surface.get(name), cand_surface.get(name)
+            if r is None or c is None:
+                findings.append({
+                    "module": module,
+                    "name": name,
+                    "kind": "name-missing",
+                    "side": "candidate" if c is None else "reference",
+                })
+                continue
+            if r.get("kind") != c.get("kind"):
+                findings.append({
+                    "module": module,
+                    "name": name,
+                    "kind": "kind-mismatch",
+                    "reference": r.get("kind"),
+                    "candidate": c.get("kind"),
+                })
+                continue
+            if r.get("kind") == "callable" and _signature_key(r) != _signature_key(c):
+                findings.append({
+                    "module": module,
+                    "name": name,
+                    "kind": "signature-mismatch",
+                    "reference": _signature_key(r),
+                    "candidate": _signature_key(c),
+                })
+            if r.get("kind") == "class":
+                rm, cm = r.get("methods", {}), c.get("methods", {})
+                for method in sorted(set(rm) | set(cm)):
+                    mr, mc = rm.get(method), cm.get(method)
+                    if mr is None or mc is None:
+                        findings.append({
+                            "module": module,
+                            "name": f"{name}.{method}",
+                            "kind": "method-missing",
+                            "side": "candidate" if mc is None else "reference",
+                        })
+                    elif _signature_key(mr) != _signature_key(mc):
+                        findings.append({
+                            "module": module,
+                            "name": f"{name}.{method}",
+                            "kind": "method-signature-mismatch",
+                            "reference": _signature_key(mr),
+                            "candidate": _signature_key(mc),
+                        })
+    return {
+        "schema_version": 1,
+        "modules_compared": sorted(set(reference) | set(candidate)),
+        "findings": findings,
+    }
+
+
+def render_surface_markdown(report: dict[str, Any]) -> str:
+    lines = ["# API surface parity", ""]
+    findings = report["findings"]
+    lines.append(f"Modules compared: {len(report['modules_compared'])}; findings: {len(findings)}")
+    lines.append("")
+    by_module: dict[str, list[dict[str, Any]]] = {}
+    for finding in findings:
+        by_module.setdefault(finding["module"], []).append(finding)
+    for module, entries in sorted(by_module.items()):
+        lines.append(f"## {module}")
+        for entry in entries:
+            detail = {k: v for k, v in entry.items() if k != "module"}
+            lines.append(f"- `{json.dumps(detail, sort_keys=True)}`")
+        lines.append("")
+    return "\n".join(lines) + "\n"

--- a/tools/parity/surface_known.json
+++ b/tools/parity/surface_known.json
@@ -1,0 +1,34 @@
+{
+  "rules": [
+    {
+      "module": "hgraph",
+      "kind": "name-missing",
+      "side": "candidate",
+      "reason": "hgraph's curated __all__ is the recorded API contract (parity_matrix.rst); upstream's un-curated dir() surface is not a target"
+    },
+    {
+      "module": "*",
+      "kind": "name-missing",
+      "side": "reference",
+      "reason": "candidate-side additions are allowed API extensions"
+    },
+    {
+      "module": "*",
+      "kind": "method-missing",
+      "side": "reference",
+      "reason": "candidate-side additions are allowed API extensions"
+    },
+    {
+      "module": "*",
+      "kind": "module-missing",
+      "side": "reference",
+      "reason": "candidate-only modules are allowed API extensions"
+    },
+    {
+      "module": "*",
+      "kind": "import-asymmetry",
+      "side": "reference",
+      "reason": "reference-side import failure (upstream bug or optional dependency absent from the reference environment)"
+    }
+  ]
+}


### PR DESCRIPTION
Part of the issue-discovery coverage campaign. Behavioral fuzzing cannot see a mis-ported API — a missing method, renamed parameter, changed default, or an adaptor that fails to import breaks client wiring without ever producing a differential trace. `python -m tools.parity surface` closes that blind spot: it probes `hgraph`, `hgraph.test`, and every `hgraph.adaptors.*` submodule in both harness environments and diffs exported names, signatures (parameter names/kinds/defaults), class methods, and importability.

First run findings (vs released hgraph, before any noise filtering):
- **`adaptors.data_frame`** (both sides import — all genuine): `DATA_FRAME_SOURCE` missing in the candidate; `DataStore`/`DataConnectionStore` `register_instance`/`release_instance` missing; **14 signature mismatches** across the `*_from_data_source` family, `group_by`/`ungroup`/`with_columns`/`concat`/`sorted_`/`replay_data_frame`.
- **`adaptors.run_graph_on_thread`**: 3 missing methods + 2 signature drifts.
- Upstream's `json` and `data_catalogue` adaptors fail to import on Python 3.14 (`frozen dataclass` TypeError) while ours import — an upstream-side finding worth knowing.
- Remaining import asymmetries are reference-env optional deps (kafka/boto3/tornado/perspective/snowflake not installed) — a `--with-extras` reference env is the follow-up for full-depth adaptor audits.
- The `hgraph` top-module count (945) is dominated by the deliberate curated-`__all__` policy plus upstream's un-curated `dir()` surface; a `surface_known.json` accepted-deviations filter (mirroring `known_divergences.json`) is the next increment so the audit output is actionable-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)