### PR TITLE
Instrument runtime registry retention

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -141,6 +141,11 @@ Profiles with ``repetitions > 1`` reuse the same graph callable inside one
 interpreter and record post-GC RSS/USS after every execution. Their report rows
 include first-to-last retained growth, exposing process-lifetime registry or
 cache slopes that independent process samples intentionally hide.
+The hg_cpp process pass also records cold-path node, graph, executor, and common
+type-record cardinalities before the first run and after each teardown. The
+``construct_std__novel_ten`` profile deliberately changes the graph shape on
+each repetition, providing an intentional-growth control for the otherwise
+identical repeated-wiring profiles.
 
 RSS includes Python, native libraries, allocator fragmentation, and runtime
 caches. It is the whole-process ground truth, but it cannot explain ownership.

--- a/benchmarks/memory_orchestrate.py
+++ b/benchmarks/memory_orchestrate.py
@@ -63,6 +63,11 @@ MEMORY_FIELDS = (
     "repeat_growth_mb",
     "repeat_uss_growth_mb",
     "seconds",
+    "node_runtime_types_growth",
+    "graph_programs_growth",
+    "graph_runtime_types_growth",
+    "executor_runtime_types_growth",
+    "type_records_growth",
 )
 
 
@@ -369,6 +374,36 @@ def render(results: dict, inspector: dict, samples: int, interval_ms: float,
             f"{_cell(planned / 1024 if planned is not None else None)} | "
             f"{_cell(dynamic / 1024 if dynamic is not None else None)} |"
         )
+
+    registry_rows = []
+    for profile_id, per_mode in results.items():
+        candidate = per_mode.get("hg-cpp", {})
+        if candidate.get("node_runtime_types_growth") is None:
+            continue
+        registry_rows.append((profile_id, candidate))
+    if registry_rows:
+        lines += [
+            "", "## hg_cpp retained runtime registry growth", "",
+            "Counts are final-minus-pre-run cold-path cardinalities. They are "
+            "process-lifetime structural records, not live graph instances.", "",
+            "| profile | node types | graph programs | graph types | executor types | all type records |",
+            "|---|---:|---:|---:|---:|---:|",
+        ]
+        for profile_id, candidate in registry_rows:
+            cells = [
+                _cell(
+                    candidate.get(f"{field}_growth"),
+                    candidate.get(f"{field}_growth_mad"),
+                )
+                for field in (
+                    "node_runtime_types",
+                    "graph_programs",
+                    "graph_runtime_types",
+                    "executor_runtime_types",
+                    "type_records",
+                )
+            ]
+            lines.append(f"| `{profile_id}` | " + " | ".join(cells) + " |")
 
     lines += ["", "## Interpretation contract", ""]
     for profile_id in results:

--- a/benchmarks/memory_profiles.py
+++ b/benchmarks/memory_profiles.py
@@ -20,6 +20,9 @@ class MemoryProfile:
     growth_axis: str
     expectation: str
     repetitions: int = 1
+    # Rebuild the comparative scenario with a different graph shape on each
+    # repetition.  Zero keeps one identical graph callable for every run.
+    size_step: float = 0.0
 
 
 def _series(
@@ -81,6 +84,20 @@ for suffix, repetitions in (("once", 1), ("ten", 10), ("hundred", 100)):
         ),
         repetitions=repetitions,
     )
+PROFILES["construct_std__novel_ten"] = MemoryProfile(
+    group="Process lifetime",
+    label="Repeated novel graph programs - ten",
+    scenario="construct_std",
+    cycle_scale=1.0,
+    size_scale=0.1,
+    growth_axis="distinct graph programs",
+    expectation=(
+        "registry cardinality should grow for intentionally different graph "
+        "programs, distinguishing legitimate retention from identical rewiring"
+    ),
+    repetitions=10,
+    size_step=0.02,
+)
 for suffix, repetitions in (("once", 1), ("ten", 10), ("fifty", 50)):
     PROFILES[f"service_adaptor_py__repeat_{suffix}"] = MemoryProfile(
         group="Process lifetime",

--- a/benchmarks/memory_runner.py
+++ b/benchmarks/memory_runner.py
@@ -18,6 +18,13 @@ import psutil
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
 _MIB = 1024 * 1024
+_REGISTRY_FIELDS = (
+    "node_runtime_types",
+    "graph_programs",
+    "graph_runtime_types",
+    "executor_runtime_types",
+    "type_records",
+)
 
 
 def _mb(value: int | float) -> float:
@@ -50,6 +57,19 @@ def _full_memory(process: psutil.Process) -> dict[str, float | None]:
         result["uss_mb"] = _mb(full.uss) if hasattr(full, "uss") else None
         result["pss_mb"] = _mb(full.pss) if hasattr(full, "pss") else None
     return result
+
+
+def _runtime_registry_snapshot() -> dict[str, int] | None:
+    """Capture hg_cpp-only cold-path counts without requiring Inspector."""
+    try:
+        from hgraph.debug import runtime_registry_snapshot
+    except (ImportError, AttributeError):
+        return None
+    snapshot = runtime_registry_snapshot()
+    return {
+        field: int(getattr(snapshot, field))
+        for field in _REGISTRY_FIELDS
+    }
 
 
 class _PeakRssSampler:
@@ -98,6 +118,7 @@ def _base_result(profile_id, profile, scenario, process_start) -> dict:
         "scenario_group": scenario.group,
         "cycle_scale": profile.cycle_scale,
         "size_scale": profile.size_scale,
+        "size_step": profile.size_step,
         "use_cpp": os.environ.get("HGRAPH_USE_CPP", ""),
         "source_fingerprint": os.environ.get(
             "HGRAPH_BENCHMARK_SOURCE_FINGERPRINT", ""
@@ -127,12 +148,20 @@ def run_process(profile_id, profile, scenario, interval_ms: float,
     graph_fn, cycles = scenario.build(profile.cycle_scale, profile.size_scale)
     gc.collect()
     pre_run = _full_memory(process)
+    pre_run_registry = _runtime_registry_snapshot()
     cycles_per_run = cycles
+    total_cycles = 0
     post_gc_series = []
     post_gc_uss_series = []
+    registry_series = []
     t0 = time.perf_counter()
     with _PeakRssSampler(process, interval_ms / 1000.0) as sampler:
-        for _ in range(profile.repetitions):
+        for repetition in range(profile.repetitions):
+            if repetition and profile.size_step:
+                graph_fn, cycles = scenario.build(
+                    profile.cycle_scale,
+                    profile.size_scale + repetition * profile.size_step,
+                )
             start = hg.MIN_ST
             end = start + (cycles + 2) * hg.MIN_TD
             output = hg.run_graph(
@@ -146,14 +175,16 @@ def run_process(profile_id, profile, scenario, interval_ms: float,
             checkpoint = _full_memory(process)
             post_gc_series.append(checkpoint["rss_mb"])
             post_gc_uss_series.append(checkpoint["uss_mb"])
+            registry_series.append(_runtime_registry_snapshot())
+            total_cycles += cycles
     seconds = time.perf_counter() - t0
     post_gc = checkpoint
 
     peak_mb = _mb(sampler.peak_bytes)
-    return {
+    result = {
         "ok": True,
         "measurement": "process",
-        "cycles": cycles_per_run * profile.repetitions,
+        "cycles": total_cycles,
         "cycles_per_run": cycles_per_run,
         "seconds": round(seconds, 6),
         "ready_rss_mb": ready["rss_mb"],
@@ -180,6 +211,8 @@ def run_process(profile_id, profile, scenario, interval_ms: float,
         ),
         "post_gc_rss_series_mb": post_gc_series,
         "post_gc_uss_series_mb": post_gc_uss_series,
+        "pre_run_registry": pre_run_registry,
+        "post_gc_registry_series": registry_series,
         "repeat_growth_mb": round(
             post_gc_series[-1] - post_gc_series[0], 3
         ),
@@ -191,6 +224,14 @@ def run_process(profile_id, profile, scenario, interval_ms: float,
         "sampling_interval_ms": interval_ms,
         "rss_samples": sampler.samples,
     }
+    final_registry = registry_series[-1] if registry_series else None
+    for field in _REGISTRY_FIELDS:
+        result[f"{field}_growth"] = (
+            final_registry[field] - pre_run_registry[field]
+            if final_registry is not None and pre_run_registry is not None
+            else None
+        )
+    return result
 
 
 def run_inspector(profile_id, profile, scenario) -> dict:

--- a/docs/source/developer_guide/memory_utilisation.rst
+++ b/docs/source/developer_guide/memory_utilisation.rst
@@ -13,6 +13,8 @@ campaign in ``benchmarks/memory_orchestrate.py`` produces:
   hgraph C++, and hg_cpp;
 * growth series for graph size, duration, cardinality, retained capacity, and
   client count;
+* hg_cpp process-lifetime runtime-registry cardinalities for identical and
+  intentionally novel graph wiring;
 * an independent native ``Inspector`` snapshot for planned and dynamic graph
   storage; and
 * raw JSON containing every sample and the largest native dynamic owners.
@@ -50,6 +52,13 @@ They must not be combined into one apparent total.
   the owned snapshot. Current dynamic reporting is a lower bound, not a native
   heap total.
 
+``runtime registry growth``
+  Final-minus-pre-run counts for retained node runtime types, graph programs,
+  graph runtime types, executor runtime types, and all common type records.
+  These cold-path counts are captured without Inspector through
+  ``runtime_registry_snapshot()``. They describe process-lifetime structural
+  ownership, not live graph instances or allocated bytes.
+
 The process pass never attaches Inspector. Inspector retains an owned record
 and strings for every graph/node it observes, so using it during RSS sampling
 would change the quantity being measured. Each profile and each sample runs in
@@ -58,6 +67,10 @@ next graph's delta. For repeated-lifecycle profiles, the Inspector pass runs
 one execution and reports the per-graph structural footprint; only the
 uninstrumented process pass is used to infer cross-execution retention because
 Inspector would retain its own records across those executions.
+The identical repeated-wiring profiles reuse one graph callable. The novel
+control rebuilds ``construct_std`` with a different graph shape on each run,
+so legitimate growth for new programs is visible separately from avoidable
+growth when an unchanged program is wired again.
 
 Static ownership audit
 ----------------------

--- a/include/hgraph/runtime/registry_snapshot.h
+++ b/include/hgraph/runtime/registry_snapshot.h
@@ -1,0 +1,35 @@
+#ifndef HGRAPH_RUNTIME_REGISTRY_SNAPSHOT_H
+#define HGRAPH_RUNTIME_REGISTRY_SNAPSHOT_H
+
+#include <hgraph/hgraph_export.h>
+
+#include <cstddef>
+
+namespace hgraph
+{
+    /**
+     * Cold-path cardinalities for process-lifetime runtime registries.
+     *
+     * Runtime type records deliberately have stable addresses and therefore
+     * outlive individual graph executions.  This snapshot makes that retained
+     * structural state observable without attaching a lifecycle observer or
+     * adding work to graph evaluation.  Call it only while graph wiring is
+     * quiescent; the runtime registries themselves are wiring-thread owned.
+     */
+    struct HGRAPH_EXPORT RuntimeRegistrySnapshot
+    {
+        std::size_t node_runtime_types{0};
+        std::size_t graph_programs{0};
+        std::size_t graph_runtime_types{0};
+        std::size_t executor_runtime_types{0};
+        std::size_t type_records{0};
+
+        [[nodiscard]] constexpr bool operator==(
+            const RuntimeRegistrySnapshot &) const noexcept = default;
+    };
+
+    /** Capture current process-lifetime runtime registry cardinalities. */
+    [[nodiscard]] HGRAPH_EXPORT RuntimeRegistrySnapshot runtime_registry_snapshot();
+}  // namespace hgraph
+
+#endif  // HGRAPH_RUNTIME_REGISTRY_SNAPSHOT_H

--- a/include/hgraph/runtime/runtime.h
+++ b/include/hgraph/runtime/runtime.h
@@ -16,6 +16,7 @@
 #include <hgraph/runtime/ordered_reduce_node.h>
 #include <hgraph/runtime/executor.h>
 #include <hgraph/runtime/push_source_node.h>
+#include <hgraph/runtime/registry_snapshot.h>
 #include <hgraph/runtime/switch_node.h>
 #include <hgraph/runtime/map_node.h>
 #include <hgraph/runtime/reduce_node.h>

--- a/include/hgraph/types/metadata/type_record_registry.h
+++ b/include/hgraph/types/metadata/type_record_registry.h
@@ -42,6 +42,8 @@ namespace hgraph
 
         [[nodiscard]] const TypeRecord &intern(const TypeRecordDefinition &definition);
         [[nodiscard]] const TypeRecord *find(const TypeRecordKey &key) const noexcept;
+        /** Cold-path cardinality used by registry diagnostics. */
+        [[nodiscard]] std::size_t size() const noexcept;
         void reset() noexcept;
 
     private:

--- a/python/hgraph/debug/__init__.py
+++ b/python/hgraph/debug/__init__.py
@@ -11,6 +11,8 @@ from _hgraph import (
     InspectionSnapshot,
     Inspector,
     NodeStorageMetrics,
+    RuntimeRegistrySnapshot,
+    runtime_registry_snapshot,
 )
 
 
@@ -52,5 +54,7 @@ __all__ = [
     "InspectionSnapshot",
     "Inspector",
     "NodeStorageMetrics",
+    "RuntimeRegistrySnapshot",
     "inspection_rows",
+    "runtime_registry_snapshot",
 ]

--- a/python/py_wiring.cpp
+++ b/python/py_wiring.cpp
@@ -7,6 +7,8 @@
 #include "py_wiring.h"
 #include "py_bindings.h"
 
+#include <hgraph/runtime/registry_snapshot.h>
+
 #include <spdlog/sinks/base_sink.h>
 
 #include <mutex>
@@ -839,6 +841,14 @@ namespace hgraph::python_bridge
         .def(nb::init<std::size_t>(), nb::arg("recent_window") = 100)
         .def("snapshot", &Inspector::snapshot)
         .def("reset", &Inspector::reset);
+    nb::class_<RuntimeRegistrySnapshot>(m, "RuntimeRegistrySnapshot")
+        .def_ro("node_runtime_types", &RuntimeRegistrySnapshot::node_runtime_types)
+        .def_ro("graph_programs", &RuntimeRegistrySnapshot::graph_programs)
+        .def_ro("graph_runtime_types", &RuntimeRegistrySnapshot::graph_runtime_types)
+        .def_ro("executor_runtime_types", &RuntimeRegistrySnapshot::executor_runtime_types)
+        .def_ro("type_records", &RuntimeRegistrySnapshot::type_records);
+    m.def("runtime_registry_snapshot", &runtime_registry_snapshot,
+          "Capture cold-path process-lifetime runtime registry cardinalities.");
 
     nb::class_<WiringTracer>(m, "WiringTracer")
         .def(nb::init<std::string, bool, bool>(), nb::arg("filter") = "",

--- a/python/tests/test_memory_benchmark_harness.py
+++ b/python/tests/test_memory_benchmark_harness.py
@@ -39,6 +39,11 @@ def _sample(peak, retained, ready=100.0):
         "retained_uss_increment_mb": retained,
         "repeat_growth_mb": 0.0,
         "repeat_uss_growth_mb": 0.0,
+        "node_runtime_types_growth": None,
+        "graph_programs_growth": None,
+        "graph_runtime_types_growth": None,
+        "executor_runtime_types_growth": None,
+        "type_records_growth": None,
         "seconds": 1.0,
     }
 
@@ -51,6 +56,7 @@ def test_memory_profiles_reference_stable_scenarios_and_have_growth_context():
         assert profile.expectation
         assert profile.cycle_scale > 0
         assert profile.size_scale > 0
+        assert profile.size_step >= 0
 
 
 def test_memory_samples_use_median_and_preserve_raw_samples():
@@ -151,6 +157,29 @@ def test_process_lifetime_profiles_report_first_to_last_growth():
     assert "hgraph C++ first-to-last growth" in report
     assert "hg_cpp first-to-last growth" in report
     assert "1.0 +/- 0.0 | 0.5 +/- 0.0" in report
+
+
+def test_hg_cpp_registry_growth_is_reported_separately_from_live_memory():
+    candidate = _sample(3.0, 3.0)
+    candidate.update(
+        node_runtime_types_growth=42,
+        graph_programs_growth=10,
+        graph_runtime_types_growth=10,
+        executor_runtime_types_growth=10,
+        type_records_growth=72,
+    )
+    report = memory.render(
+        {"construct_std__repeat_ten": {
+            "hg-cpp": memory.aggregate_samples([candidate] * 3),
+        }},
+        {},
+        samples=3,
+        interval_ms=5.0,
+    )
+
+    assert "retained runtime registry growth" in report
+    assert "process-lifetime structural records" in report
+    assert "42.0 +/- 0.0 | 10.0 +/- 0.0 | 10.0 +/- 0.0" in report
 
 
 def test_memory_baseline_cache_requires_exact_identity(tmp_path):

--- a/python/tests/test_registry_snapshot.py
+++ b/python/tests/test_registry_snapshot.py
@@ -1,0 +1,16 @@
+from hgraph.debug import RuntimeRegistrySnapshot, runtime_registry_snapshot
+
+
+def test_runtime_registry_snapshot_exposes_cold_path_cardinalities():
+    snapshot = runtime_registry_snapshot()
+
+    assert isinstance(snapshot, RuntimeRegistrySnapshot)
+    assert snapshot.node_runtime_types >= 0
+    assert snapshot.graph_programs >= 0
+    assert snapshot.graph_runtime_types >= snapshot.graph_programs
+    assert snapshot.executor_runtime_types >= 0
+    assert snapshot.type_records >= (
+        snapshot.node_runtime_types
+        + snapshot.graph_runtime_types
+        + snapshot.executor_runtime_types
+    )

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -21,6 +21,7 @@ set(HGRAPH_RUNTIME_SOURCES
     hgraph/runtime/push_source_node.cpp
     hgraph/runtime/race_tsd_node.cpp
     hgraph/runtime/reduce_node.cpp
+    hgraph/runtime/registry_snapshot.cpp
     hgraph/runtime/service_node.cpp
     hgraph/runtime/shared_output_node.cpp
     hgraph/runtime/switch_node.cpp

--- a/src/hgraph/runtime/executor.cpp
+++ b/src/hgraph/runtime/executor.cpp
@@ -1,5 +1,8 @@
 #include <hgraph/runtime/diagnostic_path.h>
 #include <hgraph/runtime/executor.h>
+
+#include "registry_snapshot_detail.h"
+
 #include <hgraph/runtime/lifecycle_observer.h>
 #include <hgraph/runtime/logger.h>
 #include <hgraph/types/metadata/type_record_registry.h>
@@ -1195,6 +1198,11 @@ namespace hgraph
     void clear_executor_runtime_types() noexcept
     {
         executor_runtime_registry().clear();
+    }
+
+    std::size_t detail::executor_runtime_type_count() noexcept
+    {
+        return executor_runtime_registry().entries.size();
     }
 
 }  // namespace hgraph

--- a/src/hgraph/runtime/graph.cpp
+++ b/src/hgraph/runtime/graph.cpp
@@ -1,4 +1,7 @@
 #include <hgraph/runtime/graph.h>
+
+#include "registry_snapshot_detail.h"
+
 #include <hgraph/types/metadata/type_realization.h>
 #include <hgraph/types/metadata/type_registry.h>
 
@@ -1895,6 +1898,19 @@ GraphValue GraphBuilder::make_nested_graph(
 void clear_graph_runtime_types() noexcept {
   clear_debug_descriptors(TypeFamily::Graph);
   graph_runtime_registry().clear();
+}
+
+std::size_t detail::graph_program_count() noexcept {
+  return graph_runtime_registry().entries.size();
+}
+
+std::size_t detail::graph_runtime_type_count() noexcept {
+  std::size_t count = 0;
+  for (const auto &entry : graph_runtime_registry().entries) {
+    count += entry.root_type ? 1U : 0U;
+    count += entry.nested_type ? 1U : 0U;
+  }
+  return count;
 }
 
 } // namespace hgraph

--- a/src/hgraph/runtime/node.cpp
+++ b/src/hgraph/runtime/node.cpp
@@ -1,5 +1,7 @@
 #include <hgraph/runtime/node.h>
 
+#include "registry_snapshot_detail.h"
+
 #include <hgraph/runtime/executor.h>
 #include <hgraph/runtime/graph.h>
 #include <hgraph/runtime/node_error.h>
@@ -1723,6 +1725,11 @@ namespace hgraph
     {
         clear_debug_descriptors(TypeFamily::Node);
         node_runtime_registry().clear();
+    }
+
+    std::size_t detail::node_runtime_type_count() noexcept
+    {
+        return node_runtime_registry().schemas.size();
     }
 
 }  // namespace hgraph

--- a/src/hgraph/runtime/registry_snapshot.cpp
+++ b/src/hgraph/runtime/registry_snapshot.cpp
@@ -1,0 +1,18 @@
+#include <hgraph/runtime/registry_snapshot.h>
+#include <hgraph/types/metadata/type_record_registry.h>
+
+#include "registry_snapshot_detail.h"
+
+namespace hgraph
+{
+    RuntimeRegistrySnapshot runtime_registry_snapshot()
+    {
+        return RuntimeRegistrySnapshot{
+            .node_runtime_types = detail::node_runtime_type_count(),
+            .graph_programs = detail::graph_program_count(),
+            .graph_runtime_types = detail::graph_runtime_type_count(),
+            .executor_runtime_types = detail::executor_runtime_type_count(),
+            .type_records = TypeRecordRegistry::instance().size(),
+        };
+    }
+}  // namespace hgraph

--- a/src/hgraph/runtime/registry_snapshot_detail.h
+++ b/src/hgraph/runtime/registry_snapshot_detail.h
@@ -1,0 +1,14 @@
+#ifndef HGRAPH_RUNTIME_REGISTRY_SNAPSHOT_DETAIL_H
+#define HGRAPH_RUNTIME_REGISTRY_SNAPSHOT_DETAIL_H
+
+#include <cstddef>
+
+namespace hgraph::detail
+{
+    [[nodiscard]] std::size_t node_runtime_type_count() noexcept;
+    [[nodiscard]] std::size_t graph_program_count() noexcept;
+    [[nodiscard]] std::size_t graph_runtime_type_count() noexcept;
+    [[nodiscard]] std::size_t executor_runtime_type_count() noexcept;
+}  // namespace hgraph::detail
+
+#endif  // HGRAPH_RUNTIME_REGISTRY_SNAPSHOT_DETAIL_H

--- a/src/hgraph/types/metadata/type_record_registry.cpp
+++ b/src/hgraph/types/metadata/type_record_registry.cpp
@@ -135,6 +135,12 @@ namespace hgraph
         return found == m_entries.end() ? nullptr : &found->second->record;
     }
 
+    std::size_t TypeRecordRegistry::size() const noexcept
+    {
+        std::lock_guard lock(m_mutex);
+        return m_entries.size();
+    }
+
     void TypeRecordRegistry::reset() noexcept
     {
         std::lock_guard lock(m_mutex);

--- a/tests/cpp/CMakeLists.txt
+++ b/tests/cpp/CMakeLists.txt
@@ -152,6 +152,7 @@ hgraph_add_test_objects(hgraph_runtime_test_objects
     test_node_scheduler.cpp
     test_realtime_execution.cpp
     test_ref_executor.cpp
+    test_registry_snapshot.cpp
     test_service_node.cpp
     test_shared_output_node.cpp
     test_simulation_execution.cpp

--- a/tests/cpp/test_registry_snapshot.cpp
+++ b/tests/cpp/test_registry_snapshot.cpp
@@ -1,0 +1,34 @@
+#include <hgraph/runtime/registry_snapshot.h>
+#include <hgraph/runtime/runtime.h>
+
+#include <catch2/catch_test_macros.hpp>
+
+TEST_CASE("runtime registry snapshot reports retained type cardinalities")
+{
+    using namespace hgraph;
+
+    const RuntimeRegistrySnapshot initial = runtime_registry_snapshot();
+
+    NodeTypeMetaData schema;
+    schema.display_name = "registry_snapshot_probe";
+    const NodeBuilder node = NodeBuilder::native(std::move(schema));
+    const RuntimeRegistrySnapshot after_node = runtime_registry_snapshot();
+    CHECK(after_node.node_runtime_types == initial.node_runtime_types + 1);
+    CHECK(after_node.type_records > initial.type_records);
+
+    GraphBuilder graph;
+    graph.label("registry_snapshot_graph").add_node(node);
+    static_cast<void>(graph.root_type());
+    const RuntimeRegistrySnapshot after_graph = runtime_registry_snapshot();
+    CHECK(after_graph.graph_programs == initial.graph_programs + 1);
+    CHECK(after_graph.graph_runtime_types == initial.graph_runtime_types + 2);
+    CHECK(after_graph.type_records > after_node.type_records);
+
+    GraphExecutorBuilder executor;
+    executor.label("registry_snapshot_executor").graph_builder(std::move(graph));
+    static_cast<void>(executor.type());
+    const RuntimeRegistrySnapshot after_executor = runtime_registry_snapshot();
+    CHECK(after_executor.executor_runtime_types ==
+          initial.executor_runtime_types + 1);
+    CHECK(after_executor.type_records > after_graph.type_records);
+}

--- a/tests/install_consumer/main.cpp
+++ b/tests/install_consumer/main.cpp
@@ -1,4 +1,5 @@
 #include <hgraph/lib/std/standard_types.h>
+#include <hgraph/runtime/registry_snapshot.h>
 #include <hgraph/types/frame.h>
 #include <hgraph/types/static_schema.h>
 #include <hgraph/types/type_resolution.h>
@@ -44,6 +45,14 @@ int main()
 
     auto &registry = TypeRegistry::instance();
     registry.register_scalar<std::int32_t>("int32");
+
+    const RuntimeRegistrySnapshot runtime_registries =
+        runtime_registry_snapshot();
+    if (runtime_registries.type_records == 0)
+    {
+        throw std::runtime_error(
+            "installed runtime registry snapshot did not observe seeded types");
+    }
 
     Value value{std::int32_t{41}};
     auto view = value.view();


### PR DESCRIPTION
## Summary

- add a public, cold-path `RuntimeRegistrySnapshot` for retained node, graph, executor, and common type-record cardinalities, with matching Python debug exposure
- record registry state before execution and after every teardown in the memory campaign
- add an intentionally novel graph-shape control beside identical repeated wiring
- report retained registry growth separately from live/process memory and document the measurement contract
- cover the C++ API, Python bridge, benchmark rendering, and installed-SDK consumer

## Why

Issue #213 identified repeated graph lifecycle growth as the primary memory defect candidate, but RSS/USS alone could not distinguish allocator retention from process-lifetime structural ownership. This adds quiescent diagnostics without attaching Inspector or adding per-tick work, so the ownership mechanism can be measured before changing stable-address runtime records.

## Findings

Ten runs give identical registry counts on macOS and native Linux:

| profile | node types | graph programs | graph types | executor types | all type records |
|---|---:|---:|---:|---:|---:|
| identical graph, ten runs | 700 | 10 | 20 | 10 | 748 |
| novel graph shapes, ten runs | 2,373 | 10 | 20 | 10 | 2,421 |

The identical graph retains exactly 70 new node runtime types on every rewire. Of the 748 common records retained over ten runs, 730 are the counted node/graph/executor runtime types; the remaining 18 occur on first use. RSS and USS move together:

- macOS identical: about 1.09 MiB first-to-last; novel: about 4.11 MiB
- Linux identical: 1.04 MiB RSS / 1.10 MiB USS; novel: 4.33 MiB RSS / 4.27 MiB USS

This disproves the narrower hypothesis that backing records are allocated and then discarded after canonical type reuse: reconstructed runtime types themselves are entering the process-lifetime registries. Node runtime types dominate. The next ownership change should therefore establish stable descriptor/program identity before allocating and publishing runtime records (or scope them to a safe lifetime), while preserving the stable addresses required by live graphs.

This PR intentionally establishes the measurement and regression surface; it does not yet change registry ownership.

Progresses #213.

## Validation

macOS (Apple Silicon):

- fresh native configure, clean build, and full C++ suite: 1,315/1,315 passed
- Python 3.12 stable-ABI wheel installed into fresh Python 3.14 environment: 1,751 passed, 10 skipped
- installed SDK consumer: 1/1 passed
- one pre-existing real-time catalogue timing test failed on the first Python run, passed alone immediately, and the complete rerun passed

Native Linux (hg-linux, x86_64, GCC 15):

- fresh native configure, clean build, and full C++ suite: 1,315/1,315 passed
- Python 3.12 stable-ABI wheel installed into fresh Python 3.14 environment: 1,751 passed, 10 skipped
- identical and novel memory controls reproduced the same registry cardinalities as macOS
