### PR TITLE
Deduplicate runtime type records for repeated graph wiring

### DIFF
--- a/docs/source/developer_guide/data_structures/schemas/node.rst
+++ b/docs/source/developer_guide/data_structures/schemas/node.rst
@@ -199,7 +199,25 @@ shape as the lower layers:
 ``NodeBuilder``
     Cached construction recipe. It resolves the node schema and endpoint
     annotations to a canonical ``NodeTypeRef``, then constructs ``NodeValue``
-    instances on demand.
+    instances on demand. Static implementations and lifted stateless callables
+    reuse an existing runtime type when their process-stable implementation
+    identity and complete runtime schema match. Derived bindings such as passive
+    inputs and error capture are canonicalised independently, so a changed
+    policy never aliases the original type.
+
+    Callback-backed extensions use ``NodeBuilder::from_descriptor`` by default;
+    each call receives a fresh runtime type because its callbacks may capture
+    builder-specific state. An extension may instead call
+    ``NodeBuilder::from_canonical_descriptor`` with a non-null token that remains
+    alive for the process, but only when every descriptor using that token has
+    interchangeable callbacks and ops. Per-node values belong in builder
+    scalars or runtime storage, not in a canonical callback capture.
+
+    Graph runtime types are likewise reused only when the graph label, ordered
+    node runtime types, edge paths, and push-source boundary all match. Executor
+    runtime types are reused by mode and label. Node labels, scalar values,
+    endpoint bindings, graph state, clocks, and executor options remain
+    instance-owned and are reconstructed for every run.
 
 The C++ runtime supplies callback-backed and specialised ``NodeOps``
 implementations through this structure. Python-authored compute, sink, and

--- a/docs/source/developer_guide/data_structures/schemas/node.rst
+++ b/docs/source/developer_guide/data_structures/schemas/node.rst
@@ -208,10 +208,12 @@ shape as the lower layers:
     Callback-backed extensions use ``NodeBuilder::from_descriptor`` by default;
     each call receives a fresh runtime type because its callbacks may capture
     builder-specific state. An extension may instead call
-    ``NodeBuilder::from_canonical_descriptor`` with a non-null token that remains
-    alive for the process, but only when every descriptor using that token has
-    interchangeable callbacks and ops. Per-node values belong in builder
-    scalars or runtime storage, not in a canonical callback capture.
+    ``NodeBuilder::from_canonical_descriptor`` with a non-null token whose
+    address remains allocated and is not reused until the node runtime registry
+    is cleared. A process-lifetime token is the normal choice. Every descriptor
+    using that token must have interchangeable callbacks and ops. Per-node
+    values belong in builder scalars or runtime storage, not in a canonical
+    callback capture.
 
     Graph runtime types are likewise reused only when the graph label, ordered
     node runtime types, edge paths, and push-source boundary all match. Executor

--- a/include/hgraph/runtime/node.h
+++ b/include/hgraph/runtime/node.h
@@ -382,9 +382,11 @@ namespace hgraph
         /**
          * Build from a descriptor whose callbacks/ops are identified by a
          * process-stable token and may therefore share a canonical runtime
-         * type with equivalent descriptors.  The token must be non-null and
-         * outlive every graph using the descriptor.  Captured per-builder
-         * state must use ``from_descriptor`` instead.
+         * type with equivalent descriptors.  The token must be non-null, and
+         * its address must remain allocated and must not be reused until the
+         * node runtime registry is cleared; a process-lifetime object is the
+         * normal choice.  Captured per-builder state must use
+         * ``from_descriptor`` instead.
          */
         [[nodiscard]] static NodeBuilder
         from_canonical_descriptor(NodeTypeDescriptor descriptor,

--- a/include/hgraph/runtime/node.h
+++ b/include/hgraph/runtime/node.h
@@ -380,6 +380,18 @@ namespace hgraph
                                                          TSEndpointSchema input_endpoint = {});
 
         /**
+         * Build from a descriptor whose callbacks/ops are identified by a
+         * process-stable token and may therefore share a canonical runtime
+         * type with equivalent descriptors.  The token must be non-null and
+         * outlive every graph using the descriptor.  Captured per-builder
+         * state must use ``from_descriptor`` instead.
+         */
+        [[nodiscard]] static NodeBuilder
+        from_canonical_descriptor(NodeTypeDescriptor descriptor,
+                                  const void *runtime_type_id,
+                                  TSEndpointSchema input_endpoint = {});
+
+        /**
          * Typed front-end over ``native``: build this node from a static node
          * implementation ``TImplementation`` (a stateless struct with a static
          * ``eval`` taking ``In<>`` / ``Out<>`` / ``State<>`` parameters, plus
@@ -459,6 +471,10 @@ namespace hgraph
       private:
         friend class NodeValue;
 
+        [[nodiscard]] static NodeBuilder
+        from_descriptor_impl(NodeTypeDescriptor descriptor,
+                             const void *runtime_type_id,
+                             TSEndpointSchema input_endpoint);
         NodeBuilder(NodeTypeRef type, TSEndpointSchema input_endpoint);
 
         NodeTypeRef            type_{};

--- a/include/hgraph/types/lift.h
+++ b/include/hgraph/types/lift.h
@@ -468,6 +468,10 @@ namespace hgraph
 
             NodeTypeDescriptor descriptor;
             descriptor.schema             = std::move(schema);
+            // The lifted implementation and its callbacks are fixed by this
+            // template specialization; values specific to one wired instance
+            // live in the node scalars, not in the callback objects.
+            static const std::byte runtime_type_token{};
             descriptor.callbacks.evaluate = &evaluate_lifted_node_callback<F, Identity>;
             descriptor.ops.evaluate_impl  = &evaluate_lifted_node<F, Identity>;
             if constexpr (arity_v<F> > 0)
@@ -487,7 +491,8 @@ namespace hgraph
                 }
             }
 
-            NodeBuilder builder = NodeBuilder::from_descriptor(std::move(descriptor));
+            NodeBuilder builder = NodeBuilder::from_canonical_descriptor(
+                std::move(descriptor), &runtime_type_token);
             builder.input_endpoint(graph_wiring_detail::input_endpoint_for_sources(
                 input_schema, std::span<const WiringPortRef>{inputs.data(), inputs.size()}));
 

--- a/include/hgraph/types/static_node.h
+++ b/include/hgraph/types/static_node.h
@@ -2195,6 +2195,14 @@ namespace hgraph
         // the framework schedules the node for the start cycle (see node.cpp).
         template <typename T> concept has_schedule_on_start = requires { T::schedule_on_start; };
         template <typename T> concept has_uses_python_values = requires { T::uses_python_values; };
+
+        /** Process-stable token for one stateless static-node implementation.
+         */
+        template <typename TImplementation>
+        [[nodiscard]] const void *static_node_runtime_type_id() noexcept {
+          static const std::byte token{};
+          return &token;
+        }
     }  // namespace static_node_detail
 
     // -----------------------------------------------------------------
@@ -3028,7 +3036,10 @@ namespace hgraph
                 }
             }
             descriptor.callbacks = static_node_callbacks<TImplementation>();
-            return NodeBuilder::from_descriptor(std::move(descriptor), std::move(parts.input_endpoint));
+            return NodeBuilder::from_canonical_descriptor(
+                std::move(descriptor),
+                static_node_runtime_type_id<TImplementation>(),
+                std::move(parts.input_endpoint));
         }
     }  // namespace static_node_detail
 

--- a/python/tests/test_registry_snapshot.py
+++ b/python/tests/test_registry_snapshot.py
@@ -1,4 +1,10 @@
+from hgraph import TS, eval_node, graph
 from hgraph.debug import RuntimeRegistrySnapshot, runtime_registry_snapshot
+
+
+@graph
+def _registry_reuse_graph(ts: TS[int]) -> TS[int]:
+    return ts + 1
 
 
 def test_runtime_registry_snapshot_exposes_cold_path_cardinalities():
@@ -14,3 +20,20 @@ def test_runtime_registry_snapshot_exposes_cold_path_cardinalities():
         + snapshot.graph_runtime_types
         + snapshot.executor_runtime_types
     )
+
+
+def test_repeated_equivalent_graph_construction_reuses_runtime_types():
+    assert eval_node(_registry_reuse_graph, [1, 2]) == [2, 3]
+    after_first = runtime_registry_snapshot()
+
+    assert eval_node(_registry_reuse_graph, [1, 2]) == [2, 3]
+    after_repeated = runtime_registry_snapshot()
+
+    assert after_repeated.node_runtime_types == after_first.node_runtime_types
+    assert after_repeated.graph_programs == after_first.graph_programs
+    assert after_repeated.graph_runtime_types == after_first.graph_runtime_types
+    assert (
+        after_repeated.executor_runtime_types
+        == after_first.executor_runtime_types
+    )
+    assert after_repeated.type_records == after_first.type_records

--- a/src/hgraph/runtime/executor.cpp
+++ b/src/hgraph/runtime/executor.cpp
@@ -22,6 +22,7 @@
 #include <mutex>
 #include <stdexcept>
 #include <string>
+#include <unordered_map>
 #include <utility>
 #include <vector>
 
@@ -653,6 +654,23 @@ namespace hgraph
 
         struct ExecutorRuntimeRegistry
         {
+          struct Key {
+            GraphExecutorMode mode{GraphExecutorMode::Simulation};
+            std::string label{};
+
+            [[nodiscard]] bool operator==(const Key &) const noexcept = default;
+          };
+
+          struct KeyHash {
+            [[nodiscard]] std::size_t
+            operator()(const Key &key) const noexcept {
+              std::size_t result = std::hash<std::string>{}(key.label);
+              return result ^
+                     (static_cast<std::size_t>(key.mode) +
+                      0x9e3779b97f4a7c15ULL + (result << 6U) + (result >> 2U));
+            }
+          };
+
             struct Entry
             {
                 GraphExecutorTypeMetaData schema{};
@@ -663,6 +681,11 @@ namespace hgraph
 
             ExecutorTypeRef make_type(const GraphExecutorBuilder &builder)
             {
+              Key key{builder.mode(), std::string{builder.label()}};
+              if (const auto found = canonical_types.find(key);
+                  found != canonical_types.end()) {
+                return found->second;
+              }
                 names.push_back(std::make_unique<std::string>(std::string{builder.label()}));
                 entries.push_back({});
                 auto &entry = entries.back();
@@ -685,6 +708,7 @@ namespace hgraph
                         entry.ops = simulation_executor_ops(&entry.context);
                         entry.type = intern_executor_type(entry.schema, plan, entry.ops,
                                                           "hgraph.executor.simulation");
+                        canonical_types.emplace(std::move(key), entry.type);
                         return entry.type;
                     }
                     case GraphExecutorMode::RealTime: {
@@ -695,6 +719,7 @@ namespace hgraph
                         entry.ops = realtime_executor_ops(&entry.context);
                         entry.type = intern_executor_type(entry.schema, plan, entry.ops,
                                                           "hgraph.executor.realtime");
+                        canonical_types.emplace(std::move(key), entry.type);
                         return entry.type;
                     }
                 }
@@ -703,12 +728,14 @@ namespace hgraph
 
             void clear() noexcept
             {
-                entries.clear();
-                names.clear();
+              canonical_types.clear();
+              entries.clear();
+              names.clear();
             }
 
             std::deque<Entry>                          entries{};
             std::vector<std::unique_ptr<std::string>>  names{};
+            std::unordered_map<Key, ExecutorTypeRef, KeyHash> canonical_types{};
         };
 
         ExecutorRuntimeRegistry &executor_runtime_registry()

--- a/src/hgraph/runtime/graph.cpp
+++ b/src/hgraph/runtime/graph.cpp
@@ -20,6 +20,7 @@
 #include <memory>
 #include <stdexcept>
 #include <type_traits>
+#include <unordered_map>
 #include <utility>
 
 namespace hgraph {
@@ -1080,6 +1081,61 @@ struct GraphRuntimeRegistry {
     GraphTypeRef nested{};
   };
 
+  [[nodiscard]] static std::size_t combine_hash(std::size_t seed,
+                                                std::size_t value) noexcept {
+    return seed ^ (value + 0x9e3779b97f4a7c15ULL + (seed << 6U) + (seed >> 2U));
+  }
+
+  [[nodiscard]] static std::size_t hash_builder(const GraphBuilder &builder) {
+    std::size_t result = std::hash<std::string_view>{}(builder.label());
+    for (const NodeBuilder &node : builder.nodes()) {
+      result = combine_hash(result, std::hash<NodeTypeRef>{}(node.type()));
+    }
+    for (const GraphEdge &edge : builder.edges()) {
+      result = combine_hash(result, edge.source_node);
+      for (const std::size_t component : edge.source_path) {
+        result = combine_hash(result, component);
+      }
+      result = combine_hash(result, edge.target_node);
+      for (const std::size_t component : edge.target_path) {
+        result = combine_hash(result, component);
+      }
+    }
+    return result;
+  }
+
+  [[nodiscard]] static bool edges_equivalent(const GraphEdge &lhs,
+                                             const GraphEdge &rhs) noexcept {
+    return lhs.source_node == rhs.source_node &&
+           lhs.source_path == rhs.source_path &&
+           lhs.target_node == rhs.target_node &&
+           lhs.target_path == rhs.target_path;
+  }
+
+  [[nodiscard]] static bool entry_equivalent(const Entry &entry,
+                                             const GraphBuilder &builder) {
+    if (entry.schema.name() != builder.label() ||
+        entry.schema.nodes.size() != builder.nodes().size() ||
+        entry.schema.edges.size() != builder.edges().size() ||
+        entry.schema.push_source_nodes_end !=
+            compute_push_source_nodes_end(builder)) {
+      return false;
+    }
+    for (std::size_t index = 0; index < builder.nodes().size(); ++index) {
+      if (entry.root_context.node_locations[index].type !=
+          builder.nodes()[index].type()) {
+        return false;
+      }
+    }
+    for (std::size_t index = 0; index < builder.edges().size(); ++index) {
+      if (!edges_equivalent(entry.schema.edges[index],
+                            builder.edges()[index])) {
+        return false;
+      }
+    }
+    return true;
+  }
+
   GraphTypeMetaData make_meta(const GraphBuilder &builder) {
     GraphTypeMetaData meta;
     names.push_back(
@@ -1105,6 +1161,16 @@ struct GraphRuntimeRegistry {
   }
 
   Types make_types(const GraphBuilder &builder) {
+    const std::size_t key = hash_builder(builder);
+    if (const auto found = canonical_entries.find(key);
+        found != canonical_entries.end()) {
+      for (const Entry *candidate : found->second) {
+        if (entry_equivalent(*candidate, builder)) {
+          return Types{candidate->root_type, candidate->nested_type};
+        }
+      }
+    }
+
     entries.push_back({});
     auto &entry = entries.back();
     entry.schema = make_meta(builder);
@@ -1125,6 +1191,7 @@ struct GraphRuntimeRegistry {
       entry.nested_type = intern_graph_type(
           entry.schema, nested_plan, entry.nested_ops, "hgraph.graph.nested");
     }
+    canonical_entries[key].push_back(&entry);
     return Types{entry.root_type, entry.nested_type};
   }
 
@@ -1197,8 +1264,11 @@ struct GraphRuntimeRegistry {
 
   std::deque<Entry> entries{};
   std::vector<std::unique_ptr<std::string>> names{};
+  std::unordered_map<std::size_t, std::vector<const Entry *>>
+      canonical_entries{};
 
   void clear() noexcept {
+    canonical_entries.clear();
     entries.clear();
     names.clear();
   }

--- a/src/hgraph/runtime/node.cpp
+++ b/src/hgraph/runtime/node.cpp
@@ -19,6 +19,7 @@
 #include <memory>
 #include <stdexcept>
 #include <string>
+#include <unordered_map>
 #include <utility>
 
 namespace hgraph
@@ -95,6 +96,7 @@ namespace hgraph
             NodeCallbacks                    callbacks{};
             NodeRuntimeLayout                layout{};
             const MemoryUtils::StoragePlan  *plan{nullptr};
+            const void *runtime_type_id{nullptr};
         };
 
         [[nodiscard]] const NodeRuntimeContext &runtime_context(const void *context)
@@ -892,40 +894,136 @@ namespace hgraph
 
         struct NodeRuntimeRegistry
         {
-            NodeTypeRef make_type(
-                NodeTypeMetaData schema,
-                NodeCallbacks callbacks,
-                const MemoryUtils::StoragePlan &plan,
-                NodeOps ops,
-                std::string_view implementation_label,
-                std::vector<DebugField> debug_fields = {},
-                std::optional<NodeTypeDescriptor::DynamicDebug> dynamic_debug = {})
-            {
-                names.push_back(std::make_unique<std::string>(
-                    schema.display_name != nullptr ? std::string{schema.display_name} : std::string{}));
-                if (!names.back()->empty()) { schema.display_name = names.back()->c_str(); }
-                schema.header = SchemaHeader{TypeFamily::Node,
-                                             static_cast<TypeKind>(schema.node_kind),
-                                             schema.display_name != nullptr && schema.display_name[0] != '\0'
-                                                 ? schema.display_name
-                                                 : "node"};
-
-                contexts.push_back(NodeRuntimeContext{
-                    .callbacks = std::move(callbacks),
-                    .layout = layout_for(plan),
-                    .plan = &plan,
-                });
-                schemas.push_back(std::move(schema));
-                fill_default_ops(ops);
-                ops.context = &contexts.back();
-                ops_storage.push_back(ops);
-
-                return intern_node_type(
-                    schemas.back(), plan, ops_storage.back(), implementation_label, debug_fields,
-                    dynamic_debug.has_value() ? dynamic_debug->key_type : nullptr,
-                    dynamic_debug.has_value() ? dynamic_debug->element_type : nullptr,
-                    dynamic_debug.has_value() ? &dynamic_debug->layout : nullptr);
+          [[nodiscard]] static bool
+          endpoint_schema_equivalent(const TSEndpointSchema &lhs,
+                                     const TSEndpointSchema &rhs) noexcept {
+            if (lhs.empty() || rhs.empty()) {
+              return lhs.empty() == rhs.empty();
             }
+            if (lhs.role() != rhs.role() || lhs.schema() != rhs.schema() ||
+                lhs.child_count() != rhs.child_count()) {
+              return false;
+            }
+            for (std::size_t index = 0; index < lhs.child_count(); ++index) {
+              if (!endpoint_schema_equivalent(lhs.child(index),
+                                              rhs.child(index))) {
+                return false;
+              }
+            }
+            return true;
+          }
+
+          [[nodiscard]] static bool
+          schema_equivalent(const NodeTypeMetaData &lhs,
+                            const NodeTypeMetaData &rhs) noexcept {
+            const std::string_view lhs_name =
+                lhs.display_name != nullptr ? lhs.display_name : "";
+            const std::string_view rhs_name =
+                rhs.display_name != nullptr ? rhs.display_name : "";
+            return lhs_name == rhs_name &&
+                   lhs.input_schema == rhs.input_schema &&
+                   lhs.output_schema == rhs.output_schema &&
+                   endpoint_schema_equivalent(lhs.output_endpoint_schema,
+                                              rhs.output_endpoint_schema) &&
+                   lhs.error_output_schema == rhs.error_output_schema &&
+                   lhs.recordable_state_schema == rhs.recordable_state_schema &&
+                   lhs.state_schema == rhs.state_schema &&
+                   lhs.scalar_schema == rhs.scalar_schema &&
+                   lhs.node_kind == rhs.node_kind &&
+                   lhs.uses_scheduler == rhs.uses_scheduler &&
+                   lhs.uses_global_state == rhs.uses_global_state &&
+                   lhs.uses_evaluation_clock == rhs.uses_evaluation_clock &&
+                   lhs.uses_python_values == rhs.uses_python_values &&
+                   lhs.schedule_on_start == rhs.schedule_on_start &&
+                   lhs.captures_errors == rhs.captures_errors &&
+                   lhs.error_capture == rhs.error_capture &&
+                   lhs.active_inputs == rhs.active_inputs &&
+                   lhs.structural_inputs == rhs.structural_inputs &&
+                   lhs.valid_inputs == rhs.valid_inputs &&
+                   lhs.all_valid_inputs == rhs.all_valid_inputs;
+          }
+
+          [[nodiscard]] NodeTypeRef
+          find_canonical(const void *runtime_type_id,
+                         const NodeTypeMetaData &schema,
+                         const MemoryUtils::StoragePlan &plan,
+                         std::string_view implementation_label,
+                         const std::vector<DebugField> &debug_fields,
+                         const std::optional<NodeTypeDescriptor::DynamicDebug>
+                             &dynamic_debug) const {
+            // Supplied debug descriptors are uncommon and may carry
+            // caller-owned names.  Keep them on the conservative path
+            // until their complete value contract is part of this key.
+            if (runtime_type_id == nullptr || !debug_fields.empty() ||
+                dynamic_debug.has_value()) {
+              return {};
+            }
+            const auto found = canonical_types.find(runtime_type_id);
+            if (found == canonical_types.end()) {
+              return {};
+            }
+            for (const NodeTypeRef candidate : found->second) {
+              if (candidate.plan() == &plan &&
+                  candidate.record()->implementation_name() ==
+                      implementation_label &&
+                  schema_equivalent(*candidate.schema(), schema)) {
+                return candidate;
+              }
+            }
+            return {};
+          }
+
+          NodeTypeRef make_type(NodeTypeMetaData schema,
+                                NodeCallbacks callbacks,
+                                const MemoryUtils::StoragePlan &plan,
+                                NodeOps ops,
+                                std::string_view implementation_label,
+                                const void *runtime_type_id = nullptr,
+                                std::vector<DebugField> debug_fields = {},
+                                std::optional<NodeTypeDescriptor::DynamicDebug>
+                                    dynamic_debug = {}) {
+            if (const NodeTypeRef existing = find_canonical(
+                    runtime_type_id, schema, plan, implementation_label,
+                    debug_fields, dynamic_debug)) {
+              return existing;
+            }
+            names.push_back(std::make_unique<std::string>(
+                schema.display_name != nullptr
+                    ? std::string{schema.display_name}
+                    : std::string{}));
+            if (!names.back()->empty()) {
+              schema.display_name = names.back()->c_str();
+            }
+            schema.header = SchemaHeader{
+                TypeFamily::Node, static_cast<TypeKind>(schema.node_kind),
+                schema.display_name != nullptr && schema.display_name[0] != '\0'
+                    ? schema.display_name
+                    : "node"};
+
+            contexts.push_back(NodeRuntimeContext{
+                .callbacks = std::move(callbacks),
+                .layout = layout_for(plan),
+                .plan = &plan,
+                .runtime_type_id = runtime_type_id,
+            });
+            schemas.push_back(std::move(schema));
+            fill_default_ops(ops);
+            ops.context = &contexts.back();
+            ops_storage.push_back(ops);
+
+            const NodeTypeRef type = intern_node_type(
+                schemas.back(), plan, ops_storage.back(), implementation_label,
+                debug_fields,
+                dynamic_debug.has_value() ? dynamic_debug->key_type : nullptr,
+                dynamic_debug.has_value() ? dynamic_debug->element_type
+                                          : nullptr,
+                dynamic_debug.has_value() ? &dynamic_debug->layout : nullptr);
+            if (runtime_type_id != nullptr && debug_fields.empty() &&
+                !dynamic_debug.has_value()) {
+              canonical_types[runtime_type_id].push_back(type);
+            }
+            return type;
+          }
 
             static void fill_default_ops(NodeOps &ops)
             {
@@ -971,12 +1069,15 @@ namespace hgraph
                 contexts.clear();
                 schemas.clear();
                 names.clear();
+                canonical_types.clear();
             }
 
             std::deque<NodeTypeMetaData>                 schemas{};
             std::deque<NodeRuntimeContext>               contexts{};
             std::deque<NodeOps>                          ops_storage{};
             std::vector<std::unique_ptr<std::string>>    names{};
+            std::unordered_map<const void *, std::vector<NodeTypeRef>>
+                canonical_types{};
         };
 
         NodeRuntimeRegistry &node_runtime_registry()
@@ -1447,36 +1548,57 @@ namespace hgraph
     }
 
     NodeBuilder NodeBuilder::from_descriptor(NodeTypeDescriptor descriptor,
-                                             TSEndpointSchema input_endpoint)
-    {
-        if (descriptor.schema.input_schema != nullptr && !input_endpoint.empty() &&
-            !time_series_schema_equivalent(descriptor.schema.input_schema, input_endpoint.schema()))
-        {
-            throw std::invalid_argument("NodeBuilder input endpoint schema does not match node input schema");
-        }
-        if (descriptor.schema.output_schema != nullptr && !descriptor.schema.output_endpoint_schema.empty() &&
-            !time_series_schema_equivalent(descriptor.schema.output_schema,
-                                           descriptor.schema.output_endpoint_schema.schema()))
-        {
-            throw std::invalid_argument("NodeBuilder output endpoint schema does not match node output schema");
-        }
-        if (descriptor.schema.output_schema == nullptr && !descriptor.schema.output_endpoint_schema.empty())
-        {
-            throw std::invalid_argument("NodeBuilder output endpoint requires a node output schema");
-        }
+                                             TSEndpointSchema input_endpoint) {
+      return from_descriptor_impl(std::move(descriptor), nullptr,
+                                  std::move(input_endpoint));
+    }
 
-        const auto &plan = descriptor.storage_plan != nullptr
-                               ? *descriptor.storage_plan
-                               : node_storage_plan_for(descriptor.schema);
-        const auto type = node_runtime_registry().make_type(
-            std::move(descriptor.schema),
-            std::move(descriptor.callbacks),
-            plan,
-            descriptor.ops,
-            descriptor.implementation_label,
-            std::move(descriptor.debug_fields),
-            std::move(descriptor.dynamic_debug));
-        return NodeBuilder{type, std::move(input_endpoint)};
+    NodeBuilder
+    NodeBuilder::from_canonical_descriptor(NodeTypeDescriptor descriptor,
+                                           const void *runtime_type_id,
+                                           TSEndpointSchema input_endpoint) {
+      if (runtime_type_id == nullptr) {
+        throw std::invalid_argument(
+            "from_canonical_descriptor requires a non-null runtime type id");
+      }
+      return from_descriptor_impl(std::move(descriptor), runtime_type_id,
+                                  std::move(input_endpoint));
+    }
+
+    NodeBuilder
+    NodeBuilder::from_descriptor_impl(NodeTypeDescriptor descriptor,
+                                      const void *runtime_type_id,
+                                      TSEndpointSchema input_endpoint) {
+      if (descriptor.schema.input_schema != nullptr &&
+          !input_endpoint.empty() &&
+          !time_series_schema_equivalent(descriptor.schema.input_schema,
+                                         input_endpoint.schema())) {
+        throw std::invalid_argument("NodeBuilder input endpoint schema does "
+                                    "not match node input schema");
+      }
+      if (descriptor.schema.output_schema != nullptr &&
+          !descriptor.schema.output_endpoint_schema.empty() &&
+          !time_series_schema_equivalent(
+              descriptor.schema.output_schema,
+              descriptor.schema.output_endpoint_schema.schema())) {
+        throw std::invalid_argument("NodeBuilder output endpoint schema does "
+                                    "not match node output schema");
+      }
+      if (descriptor.schema.output_schema == nullptr &&
+          !descriptor.schema.output_endpoint_schema.empty()) {
+        throw std::invalid_argument(
+            "NodeBuilder output endpoint requires a node output schema");
+      }
+
+      const auto &plan = descriptor.storage_plan != nullptr
+                             ? *descriptor.storage_plan
+                             : node_storage_plan_for(descriptor.schema);
+      const auto type = node_runtime_registry().make_type(
+          std::move(descriptor.schema), std::move(descriptor.callbacks), plan,
+          descriptor.ops, descriptor.implementation_label, runtime_type_id,
+          std::move(descriptor.debug_fields),
+          std::move(descriptor.dynamic_debug));
+      return NodeBuilder{type, std::move(input_endpoint)};
     }
 
     NodeBuilder::NodeBuilder(NodeTypeRef type, TSEndpointSchema input_endpoint)
@@ -1584,9 +1706,9 @@ namespace hgraph
             extra_fields.push_back(NodeStorageField{node_prepared_inputs_field, prepared->plan});
         }
         const auto &plan = node_storage_plan_for(schema, extra_fields);
-        const auto type =
-            node_runtime_registry().make_type(std::move(schema), origin.callbacks, plan, NodeOps{},
-                                              type_.record()->implementation_name());
+        const auto type = node_runtime_registry().make_type(
+            std::move(schema), origin.callbacks, plan, NodeOps{},
+            type_.record()->implementation_name(), origin.runtime_type_id);
 
         NodeBuilder result{type, input_endpoint_};
         result.output_endpoint_ = output_endpoint_;
@@ -1649,9 +1771,9 @@ namespace hgraph
             extra_fields.push_back(NodeStorageField{node_prepared_inputs_field, prepared->plan});
         }
         const auto &plan = node_storage_plan_for(schema, extra_fields);
-        const auto type =
-            node_runtime_registry().make_type(std::move(schema), origin.callbacks, plan, node_ops,
-                                              type_.record()->implementation_name());
+        const auto type = node_runtime_registry().make_type(
+            std::move(schema), origin.callbacks, plan, node_ops,
+            type_.record()->implementation_name(), origin.runtime_type_id);
 
         NodeBuilder result{type, input_endpoint_};
         result.output_endpoint_ = output_endpoint_;

--- a/tests/cpp/test_registry_snapshot.cpp
+++ b/tests/cpp/test_registry_snapshot.cpp
@@ -1,7 +1,37 @@
 #include <hgraph/runtime/registry_snapshot.h>
 #include <hgraph/runtime/runtime.h>
+#include <hgraph/types/static_node.h>
 
 #include <catch2/catch_test_macros.hpp>
+
+#include <array>
+#include <cstddef>
+#include <string>
+#include <string_view>
+#include <utility>
+
+namespace {
+using namespace hgraph;
+
+struct RegistryCanonicalNode {
+  static constexpr auto name = "registry_canonical_node";
+  static constexpr std::string_view implementation_label =
+      "test.registry.canonical";
+
+  static void eval(In<"lhs", TS<Int>> lhs, In<"rhs", TS<Int>> rhs,
+                   Out<TS<Int>> out) {
+    out.set(lhs.value() + rhs.value());
+  }
+};
+
+GraphBuilder canonical_graph(std::string label = "registry_canonical_graph") {
+  NodeBuilder node;
+  node.implementation<RegistryCanonicalNode>();
+  GraphBuilder graph;
+  graph.label(std::move(label)).add_node(std::move(node));
+  return graph;
+}
+} // namespace
 
 TEST_CASE("runtime registry snapshot reports retained type cardinalities")
 {
@@ -31,4 +61,123 @@ TEST_CASE("runtime registry snapshot reports retained type cardinalities")
     CHECK(after_executor.executor_runtime_types ==
           initial.executor_runtime_types + 1);
     CHECK(after_executor.type_records > after_graph.type_records);
+}
+
+TEST_CASE("static node runtime types are reused for equivalent descriptors") {
+  using namespace hgraph;
+
+  const RuntimeRegistrySnapshot initial = runtime_registry_snapshot();
+
+  NodeBuilder first;
+  first.implementation<RegistryCanonicalNode>();
+  const RuntimeRegistrySnapshot after_first = runtime_registry_snapshot();
+  REQUIRE(after_first.node_runtime_types == initial.node_runtime_types + 1);
+
+  NodeBuilder repeated;
+  repeated.implementation<RegistryCanonicalNode>();
+  const RuntimeRegistrySnapshot after_repeated = runtime_registry_snapshot();
+  CHECK(repeated.type() == first.type());
+  CHECK(after_repeated.node_runtime_types == after_first.node_runtime_types);
+  CHECK(after_repeated.type_records == after_first.type_records);
+
+  const std::array<std::size_t, 1> passive_rhs{1};
+  const NodeBuilder first_passive = first.with_passive_inputs(passive_rhs);
+  const RuntimeRegistrySnapshot after_first_passive =
+      runtime_registry_snapshot();
+  CHECK(first_passive.type() != first.type());
+  REQUIRE(after_first_passive.node_runtime_types ==
+          after_repeated.node_runtime_types + 1);
+
+  const NodeBuilder repeated_passive =
+      repeated.with_passive_inputs(passive_rhs);
+  const RuntimeRegistrySnapshot after_repeated_passive =
+      runtime_registry_snapshot();
+  CHECK(repeated_passive.type() == first_passive.type());
+  CHECK(after_repeated_passive.node_runtime_types ==
+        after_first_passive.node_runtime_types);
+  CHECK(after_repeated_passive.type_records ==
+        after_first_passive.type_records);
+}
+
+TEST_CASE(
+    "native descriptors without a runtime type identity remain distinct") {
+  using namespace hgraph;
+
+  NodeTypeMetaData first_schema;
+  first_schema.display_name = "uncanonical_native_node";
+  const NodeBuilder first = NodeBuilder::native(std::move(first_schema));
+
+  NodeTypeMetaData second_schema;
+  second_schema.display_name = "uncanonical_native_node";
+  const NodeBuilder second = NodeBuilder::native(std::move(second_schema));
+
+  CHECK(first.type() != second.type());
+}
+
+TEST_CASE(
+    "canonical descriptors require and honor a stable runtime type identity") {
+  using namespace hgraph;
+
+  static const std::byte runtime_type_id{};
+  NodeTypeDescriptor first_descriptor;
+  first_descriptor.schema.display_name = "canonical_native_node";
+  const NodeBuilder first = NodeBuilder::from_canonical_descriptor(
+      std::move(first_descriptor), &runtime_type_id);
+
+  NodeTypeDescriptor repeated_descriptor;
+  repeated_descriptor.schema.display_name = "canonical_native_node";
+  const NodeBuilder repeated = NodeBuilder::from_canonical_descriptor(
+      std::move(repeated_descriptor), &runtime_type_id);
+  CHECK(repeated.type() == first.type());
+
+  NodeTypeDescriptor null_identity_descriptor;
+  CHECK_THROWS_AS(NodeBuilder::from_canonical_descriptor(
+                      std::move(null_identity_descriptor), nullptr),
+                  std::invalid_argument);
+}
+
+TEST_CASE("equivalent graph and executor runtime types are reused") {
+  using namespace hgraph;
+
+  GraphBuilder first_graph = canonical_graph();
+  const GraphTypeRef first_root = first_graph.root_type();
+  const GraphTypeRef first_nested = first_graph.nested_type();
+  const RuntimeRegistrySnapshot after_first_graph = runtime_registry_snapshot();
+
+  GraphBuilder repeated_graph = canonical_graph();
+  CHECK(repeated_graph.root_type() == first_root);
+  CHECK(repeated_graph.nested_type() == first_nested);
+  const RuntimeRegistrySnapshot after_repeated_graph =
+      runtime_registry_snapshot();
+  CHECK(after_repeated_graph.graph_programs ==
+        after_first_graph.graph_programs);
+  CHECK(after_repeated_graph.graph_runtime_types ==
+        after_first_graph.graph_runtime_types);
+
+  GraphBuilder differently_named_graph =
+      canonical_graph("registry_other_graph");
+  CHECK(differently_named_graph.root_type() != first_root);
+  const RuntimeRegistrySnapshot after_other_graph = runtime_registry_snapshot();
+  CHECK(after_other_graph.graph_programs ==
+        after_first_graph.graph_programs + 1);
+
+  GraphExecutorBuilder first_executor;
+  first_executor.label("registry_executor").graph_builder(canonical_graph());
+  const ExecutorTypeRef first_executor_type = first_executor.type();
+  const RuntimeRegistrySnapshot after_first_executor =
+      runtime_registry_snapshot();
+
+  GraphExecutorBuilder repeated_executor;
+  repeated_executor.label("registry_executor").graph_builder(canonical_graph());
+  CHECK(repeated_executor.type() == first_executor_type);
+  const RuntimeRegistrySnapshot after_repeated_executor =
+      runtime_registry_snapshot();
+  CHECK(after_repeated_executor.executor_runtime_types ==
+        after_first_executor.executor_runtime_types);
+
+  GraphExecutorBuilder realtime_executor;
+  realtime_executor.label("registry_executor")
+      .mode(GraphExecutorMode::RealTime)
+      .graph_builder(canonical_graph());
+  CHECK(realtime_executor.type() != first_executor_type);
 }

--- a/tests/install_consumer/main.cpp
+++ b/tests/install_consumer/main.cpp
@@ -1,12 +1,13 @@
 #include <hgraph/lib/std/standard_types.h>
+#include <hgraph/runtime/node.h>
 #include <hgraph/runtime/registry_snapshot.h>
 #include <hgraph/types/frame.h>
-#include <hgraph/types/static_schema.h>
-#include <hgraph/types/type_resolution.h>
 #include <hgraph/types/metadata/type_record.h>
 #include <hgraph/types/metadata/type_registry.h>
-#include <hgraph/types/type_pointer.h>
+#include <hgraph/types/static_schema.h>
 #include <hgraph/types/time_series/visitor.h>
+#include <hgraph/types/type_pointer.h>
+#include <hgraph/types/type_resolution.h>
 #include <hgraph/types/value/any_ops.h>
 #include <hgraph/types/value/value.h>
 #include <hgraph/types/value/value_builder.h>
@@ -14,6 +15,7 @@
 
 #include <arrow/api.h>
 
+#include <cstddef>
 #include <cstdint>
 #include <stdexcept>
 #include <type_traits>
@@ -52,6 +54,20 @@ int main()
     {
         throw std::runtime_error(
             "installed runtime registry snapshot did not observe seeded types");
+    }
+
+    static const std::byte consumer_node_type_id{};
+    NodeTypeDescriptor first_node_descriptor;
+    first_node_descriptor.schema.display_name = "consumer_canonical_node";
+    const NodeBuilder first_node = NodeBuilder::from_canonical_descriptor(
+        std::move(first_node_descriptor), &consumer_node_type_id);
+    NodeTypeDescriptor repeated_node_descriptor;
+    repeated_node_descriptor.schema.display_name = "consumer_canonical_node";
+    const NodeBuilder repeated_node = NodeBuilder::from_canonical_descriptor(
+        std::move(repeated_node_descriptor), &consumer_node_type_id);
+    if (repeated_node.type() != first_node.type()) {
+      throw std::runtime_error(
+          "installed canonical node descriptor did not reuse its runtime type");
     }
 
     Value value{std::int32_t{41}};


### PR DESCRIPTION
## Summary

- add a process-stable identity path for stateless native node descriptors and reuse matching node runtime records before allocating schema/context/ops backing storage
- structurally canonicalize graph runtime types and reuse executor runtime types while keeping labels, scalars, endpoints, graph state, clocks, and executor options instance-owned
- preserve fresh types for arbitrary callback-backed descriptors unless an extension explicitly opts in with `NodeBuilder::from_canonical_descriptor`
- add C++, Python public-wiring, installed-SDK, and developer-documentation coverage

This is the Phase 2 ownership correction tracked by #213. It does not close that umbrella issue.

## Root cause

Repeated public wiring reconstructed and published fresh node, graph, and executor runtime types even when the program was identical. Those records intentionally have process lifetime, so ten identical executions retained 700 node runtime types, 10 graph programs, 20 graph runtime types, 10 executor types, and 748 total type records.

The correction establishes identity before allocation. Reuse is conservative: a node token must be process-stable, the complete runtime schema, endpoint shape, storage plan, and implementation label must match, and custom debug descriptors remain on the fresh path. Hash collisions in graph lookup are resolved by full structural comparison.

## Memory evidence

Three fresh-process exact-wheel samples per scenario and platform:

| Scenario, 10 executions | Before registry growth | After registry growth | Before first-to-last RSS/USS | After median first-to-last RSS/USS |
|---|---|---|---:|---:|
| identical, macOS | node 700; graph 10/20; executor 10; records 748 | node 4; graph 1/2; executor 1; records 25, flat after first | ~1.09 / ~1.09 MiB | 0.031 / 0.031 MiB |
| identical, Linux | node 700; graph 10/20; executor 10; records 748 | node 4; graph 1/2; executor 1; records 25, flat after first | 1.043 / 1.101 MiB | 0.039 / 0.039 MiB |
| novel programs, macOS | node 2,373; graph 10/20; executor 10; records 2,421 | node 4; graph 10/20; executor 1; records 43 | ~4.11 / ~4.11 MiB | 0.984 / 0.984 MiB |
| novel programs, Linux | node 2,373; graph 10/20; executor 10; records 2,421 | node 4; graph 10/20; executor 1; records 43 | 4.328 / 4.265 MiB | 1.032 / 1.027 MiB |

The intentionally novel control continues to create ten distinct graph programs and twenty graph runtime types. That demonstrates that the implementation removes redundant runtime identities without collapsing different programs.

## Validation

- macOS native fresh preset: 1,319 passed
- macOS stable-ABI wheel on Python 3.14: 1,752 passed, 10 skipped
- macOS installed-SDK consumer: passed
- native Linux fresh preset: 1,319 passed
- Linux stable-ABI wheel on Python 3.14: 1,752 passed, 10 skipped
- Linux ASan Python/C++ registry regression: 2 passed
- `git diff --check` and `git clang-format --diff origin/main`: clean
