### PR TITLE
Attribute TSS and TSD dynamic storage in Inspector

### DIFF
--- a/docs/source/developer_guide/data_structures/plans_and_ops/time_series.rst
+++ b/docs/source/developer_guide/data_structures/plans_and_ops/time_series.rst
@@ -136,7 +136,8 @@ The implementation uses the following names consistently:
     ``Output`` roles. Data and Output select mutable role-specific ops; an
     owned Input selects the corresponding physical plan under a read-only
     role, while peered positions select target-link storage and ops.
-    ``TS_DATA_OPS_ABI_VERSION`` is 4. ABI 4 represents destructive value
+    ``TS_DATA_OPS_ABI_VERSION`` is 5. ABI 5 adds the cold-path dynamic-storage
+    attribution hook used by Inspector. ABI 4 represented destructive value
     assignment sources as writable ``ValueView`` pointers rather than owning
     ``Value&&`` objects.
 
@@ -447,7 +448,7 @@ runtime implementation identifier. Consequently attach,
 reparent, and invalidation cannot follow a visible TargetLink projection into
 producer-owned storage. This projection is private lifecycle infrastructure;
 it adds no storage-layout cost, and its ops-table ABI contribution is tracked by
-``TS_DATA_OPS_ABI_VERSION``, currently 4.
+``TS_DATA_OPS_ABI_VERSION``, currently 5.
 
 Fixed to-REF alternatives are the exception to the general legacy-alternative
 rule. Their allocation is owned through the canonical Data-role record. At the

--- a/docs/source/developer_guide/memory_utilisation.rst
+++ b/docs/source/developer_guide/memory_utilisation.rst
@@ -48,9 +48,10 @@ They must not be combined into one apparent total.
 
 ``Inspector dynamic bytes``
   Live/reserved nested-graph slot-store bytes reported by map, mesh, switch,
-  TSL map, and reducer implementations. The peak survives graph teardown in
-  the owned snapshot. Current dynamic reporting is a lower bound, not a native
-  heap total.
+  TSL map, and reducer implementations, plus keyed TSS/TSD output storage
+  attributed through the common TSData ops surface. The peak survives graph
+  teardown in the owned snapshot. Current dynamic reporting is a lower bound,
+  not a native heap total.
 
 ``runtime registry growth``
   Final-minus-pre-run counts for retained node runtime types, graph programs,
@@ -101,7 +102,8 @@ source areas were:
    * - Key/value slots and indices
      - ``key_slot_store.h``, ``value_slot_store.h``, and
        ``stable_slot_storage.h``
-     - Nested graph blocks are reported; keys/values/indices are incomplete
+     - TSS/TSD key/value blocks, exact dense-index allocations, bitmaps, and
+       slot bookkeeping are reported
    * - Nested graph policies
      - ``map_node.cpp``, ``reduce_node.cpp``, ``ordered_reduce_node.cpp``,
        ``switch_node.cpp``, ``mesh_node.cpp``, and ``tsl_map_node.cpp``
@@ -178,6 +180,22 @@ address-stability and churn behaviour, not automatically a leak. The bounded
 churn, clear/repopulate, and reactivation profiles distinguish reuse from
 monotonic growth.
 
+TSS and TSD use the same allocation-level distinction. Their cold-path
+``TSDataOps`` hook reports the occupied portion and retained capacity of stable
+key/value blocks, pointer tables, block descriptors, slot and delta bitmaps,
+free/pending vectors, observer-pointer vectors, and the dense hash index. The
+index uses a contained counting allocator, so its values and rebound bucket
+allocations are measured rather than inferred from load factor. TSD recursively
+adds dynamic ownership reported by constructed child TSData. The child's fixed
+storage is already part of the parent value-slot stride and is therefore not
+counted again.
+
+The hook is sampled by Inspector only. It adds no work to graph evaluation and
+does not include allocator headers or fragmentation. A projected TSD key-set
+reports its key-set allocation surface; the owning TSD root reports the full
+dictionary and descendants. Node attribution samples only owned output roots,
+not input aliases or projections.
+
 Unaccounted dynamic ownership
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -186,11 +204,9 @@ Inspector currently reports native dynamic storage only where a node's
 categories are visible to process metrics but are not fully attributed in an
 inspection snapshot:
 
-* key/value slot-store indices, hash-table buckets, key payloads, and value
-  payloads outside nested graph slots;
 * compact and mutable value-container allocations for list, set, map, queue,
   cyclic buffer, string, and compound values;
-* TSD/TSS/TSW data-level dynamic capacity and observer spill storage;
+* TSW data-level dynamic capacity and TSData observer spill storage;
 * input target-link active trees and transient structural-transition objects;
 * wiring builders, signatures, labels, service/adaptor registries, and result
   capture;

--- a/include/hgraph/types/storage_metrics.h
+++ b/include/hgraph/types/storage_metrics.h
@@ -1,0 +1,32 @@
+#ifndef HGRAPH_TYPES_STORAGE_METRICS_H
+#define HGRAPH_TYPES_STORAGE_METRICS_H
+
+#include <cstddef>
+
+namespace hgraph
+{
+    /** Occupied and retained bytes owned by a dynamically allocated storage surface. */
+    struct DynamicStorageMetrics
+    {
+        /** Bytes occupied by live elements and their required indexing metadata. */
+        std::size_t live_bytes{0};
+        /** Complete byte capacity retained by the owner for reuse. */
+        std::size_t reserved_bytes{0};
+
+        constexpr DynamicStorageMetrics &operator+=(const DynamicStorageMetrics &other) noexcept
+        {
+            live_bytes += other.live_bytes;
+            reserved_bytes += other.reserved_bytes;
+            return *this;
+        }
+    };
+
+    [[nodiscard]] constexpr DynamicStorageMetrics operator+(
+        DynamicStorageMetrics lhs, const DynamicStorageMetrics &rhs) noexcept
+    {
+        lhs += rhs;
+        return lhs;
+    }
+}  // namespace hgraph
+
+#endif  // HGRAPH_TYPES_STORAGE_METRICS_H

--- a/include/hgraph/types/time_series/ts_data/base_view.h
+++ b/include/hgraph/types/time_series/ts_data/base_view.h
@@ -236,6 +236,9 @@ namespace hgraph
         /** True when this node and all required descendants are valid. */
         [[nodiscard]] bool all_valid() const;
 
+        /** Occupied and retained heap bytes owned by this TSData root and its owned descendants. */
+        [[nodiscard]] DynamicStorageMetrics dynamic_storage_metrics() const noexcept;
+
         /** Shape-erased indexed child projection for TSB/TSL-like data. */
         [[nodiscard]] std::size_t indexed_child_count() const;
         [[nodiscard]] TSDataView indexed_child_at(std::size_t index) const;

--- a/include/hgraph/types/time_series/ts_data/ops.h
+++ b/include/hgraph/types/time_series/ts_data/ops.h
@@ -2,6 +2,7 @@
 #define HGRAPH_CPP_TS_DATA_OPS_H
 
 #include <hgraph/hgraph_export.h>
+#include <hgraph/types/storage_metrics.h>
 #include <hgraph/types/time_series/ts_data/types.h>
 #include <hgraph/types/utils/slot_observer.h>
 #include <hgraph/types/value/value_range.h>
@@ -37,6 +38,10 @@ namespace hgraph
         [[nodiscard]] void *missing_mutable_delta_memory(const void *, void *);
         void noop_reset_delta(const void *, void *);
         void noop_record_child_modified(const void *, void *, std::size_t, DateTime);
+        [[nodiscard]] inline DynamicStorageMetrics no_dynamic_storage_metrics(const void *, const void *) noexcept
+        {
+            return {};
+        }
         [[nodiscard]] bool missing_copy_value_from(const void *, void *, const ValueView &, DateTime);
         [[nodiscard]] bool missing_move_value_from(const void *, void *, ValueView, DateTime);
         [[nodiscard]] Value missing_empty_delta(const TSRoleTypeRef &);
@@ -133,6 +138,10 @@ namespace hgraph
         bool (*has_current_value_impl)(const void *context,
                                        const void *memory) = &ts_data_detail::missing_has_current_value;
         bool (*all_valid_impl)(const void *context, const void *memory) = &ts_data_detail::missing_all_valid;
+        // Cold-path attribution for heap storage owned by this TSData root.
+        DynamicStorageMetrics (*dynamic_storage_metrics_impl)(const void *context,
+                                                               const void *memory) noexcept =
+            &ts_data_detail::no_dynamic_storage_metrics;
         // Optional whole-view projection for aliases whose runtime value
         // binding cannot be represented by this table's fixed layout.
         ValueView (*value_view_impl)(const void *context, const void *memory) = nullptr;

--- a/include/hgraph/types/time_series/ts_type_ref.h
+++ b/include/hgraph/types/time_series/ts_type_ref.h
@@ -14,7 +14,7 @@ namespace hgraph
     struct TSDataOps;
     struct TSParentLink;
 
-    inline constexpr std::uint16_t TS_DATA_OPS_ABI_VERSION = 4;
+    inline constexpr std::uint16_t TS_DATA_OPS_ABI_VERSION = 5;
 
     class TSRoleTypeRef
     {

--- a/include/hgraph/types/utils/key_slot_store.h
+++ b/include/hgraph/types/utils/key_slot_store.h
@@ -15,6 +15,7 @@
 #include <memory>
 #include <span>
 #include <stdexcept>
+#include <type_traits>
 #include <utility>
 #include <vector>
 
@@ -228,8 +229,9 @@ namespace hgraph
                 m_value_binding       = std::exchange(other.m_value_binding, {});
                 m_free_slots          = std::move(other.m_free_slots);
                 m_pending_erase_slots = std::move(other.m_pending_erase_slots);
-                m_index_owner         = std::move(other.m_index_owner);
+                // Destroy the current index while its allocation tracker is still alive.
                 m_index               = std::move(other.m_index);
+                m_index_owner         = std::move(other.m_index_owner);
                 if (m_index_owner != nullptr) { m_index_owner->store = this; }
                 other.constructed.clear();
                 other.live.clear();
@@ -257,6 +259,32 @@ namespace hgraph
         [[nodiscard]] std::span<const size_t> pending_erase_slots() const noexcept
         {
             return m_pending_erase_slots;
+        }
+
+        /** Exact occupied/retained heap bytes owned by keys, indices, bitmaps, and bookkeeping. */
+        [[nodiscard]] DynamicStorageMetrics dynamic_storage_metrics() const noexcept
+        {
+            DynamicStorageMetrics result = key_storage.dynamic_storage_metrics(constructed.count());
+            result += constructed.dynamic_storage_metrics();
+            result += live.dynamic_storage_metrics();
+            result += observers.dynamic_storage_metrics();
+            result += vector_metrics(m_free_slots);
+            result += vector_metrics(m_pending_erase_slots);
+
+            if (m_index_owner != nullptr)
+            {
+                result.live_bytes += sizeof(IndexBackPtr);
+                result.reserved_bytes += sizeof(IndexBackPtr);
+            }
+            if (m_index != nullptr)
+            {
+                const size_t live_index_entries = m_index->size();
+                result.live_bytes += sizeof(IndexSet) +
+                                     live_index_entries *
+                                         (sizeof(typename IndexSet::value_type) + sizeof(typename IndexSet::bucket_type));
+                result.reserved_bytes += sizeof(IndexSet) + m_index_owner->allocated_bytes;
+            }
+            return result;
         }
 
         /**
@@ -587,6 +615,46 @@ namespace hgraph
         struct IndexBackPtr
         {
             const KeySlotStore *store{nullptr};
+            size_t              allocated_bytes{0};
+        };
+
+        /** Allocator shared by the dense values and bucket arrays so retained bytes are exact. */
+        template <typename T>
+        struct IndexAllocator
+        {
+            using value_type = T;
+            using propagate_on_container_move_assignment = std::true_type;
+            using is_always_equal = std::false_type;
+
+            IndexBackPtr *owner{nullptr};
+
+            constexpr IndexAllocator() noexcept = default;
+            explicit constexpr IndexAllocator(IndexBackPtr *owner_) noexcept : owner(owner_) {}
+
+            template <typename U>
+            constexpr IndexAllocator(const IndexAllocator<U> &other) noexcept : owner(other.owner) {}
+
+            [[nodiscard]] T *allocate(size_t count)
+            {
+                T *result = std::allocator<T>{}.allocate(count);
+                if (owner != nullptr) { owner->allocated_bytes += count * sizeof(T); }
+                return result;
+            }
+
+            void deallocate(T *memory, size_t count) noexcept
+            {
+                if (owner != nullptr) { owner->allocated_bytes -= count * sizeof(T); }
+                std::allocator<T>{}.deallocate(memory, count);
+            }
+
+            template <typename U>
+            [[nodiscard]] constexpr bool operator==(const IndexAllocator<U> &other) const noexcept
+            {
+                return owner == other.owner;
+            }
+
+            template <typename>
+            friend struct IndexAllocator;
         };
 
         struct IndexHash
@@ -645,7 +713,16 @@ namespace hgraph
             [[nodiscard]] bool operator()(const ValueView &key, size_t slot) const { return (*this)(slot, key); }
         };
 
-        using IndexSet = ankerl::unordered_dense::set<size_t, IndexHash, IndexEqual>;
+        using IndexSet = ankerl::unordered_dense::set<size_t, IndexHash, IndexEqual, IndexAllocator<size_t>>;
+
+        template <typename T>
+        [[nodiscard]] static DynamicStorageMetrics vector_metrics(const std::vector<T> &values) noexcept
+        {
+            return {
+                .live_bytes = values.size() * sizeof(T),
+                .reserved_bytes = values.capacity() * sizeof(T),
+            };
+        }
 
         [[nodiscard]] size_t hash_at_slot(size_t slot) const { return m_ops.hash_key(key_memory(slot)); }
 
@@ -705,7 +782,8 @@ namespace hgraph
 
         [[nodiscard]] std::unique_ptr<IndexSet> make_index() const {
             return std::make_unique<IndexSet>(0, IndexHash{.owner = m_index_owner.get()},
-                                              IndexEqual{.owner = m_index_owner.get()});
+                                              IndexEqual{.owner = m_index_owner.get()},
+                                              IndexAllocator<size_t>{m_index_owner.get()});
         }
 
         void rebuild_index() {

--- a/include/hgraph/types/utils/slot_bitmap.h
+++ b/include/hgraph/types/utils/slot_bitmap.h
@@ -1,6 +1,8 @@
 #ifndef HGRAPH_TYPES_UTILS_SLOT_BITMAP_H
 #define HGRAPH_TYPES_UTILS_SLOT_BITMAP_H
 
+#include <hgraph/types/storage_metrics.h>
+
 #include <algorithm>
 #include <bit>
 #include <cstddef>
@@ -143,6 +145,15 @@ namespace hgraph
                 result += static_cast<std::size_t>(std::popcount(words[index]));
             }
             return result;
+        }
+
+        /** Exact occupied/retained heap bytes for the bitmap words. */
+        [[nodiscard]] DynamicStorageMetrics dynamic_storage_metrics() const noexcept
+        {
+            return {
+                .live_bytes = word_count() * sizeof(std::uint64_t),
+                .reserved_bytes = word_capacity * sizeof(std::uint64_t),
+            };
         }
 
       private:

--- a/include/hgraph/types/utils/slot_observer.h
+++ b/include/hgraph/types/utils/slot_observer.h
@@ -2,6 +2,7 @@
 #define HGRAPH_CPP_ROOT_V2_SLOT_OBSERVER_H
 
 #include <hgraph/hgraph_export.h>
+#include <hgraph/types/storage_metrics.h>
 
 #include <algorithm>
 #include <cassert>
@@ -93,6 +94,15 @@ namespace hgraph
         [[nodiscard]] bool empty() const noexcept { return m_observers.empty(); }
         /** Read-only access to the registered observer pointers. */
         [[nodiscard]] const std::vector<SlotObserver *> &entries() const noexcept { return m_observers; }
+
+        /** Exact occupied/retained heap bytes for observer pointer storage. */
+        [[nodiscard]] DynamicStorageMetrics dynamic_storage_metrics() const noexcept
+        {
+            return {
+                .live_bytes = m_observers.size() * sizeof(SlotObserver *),
+                .reserved_bytes = m_observers.capacity() * sizeof(SlotObserver *),
+            };
+        }
 
         /** Drop every registered observer without notifying. */
         void clear() noexcept

--- a/include/hgraph/types/utils/stable_slot_storage.h
+++ b/include/hgraph/types/utils/stable_slot_storage.h
@@ -2,6 +2,7 @@
 #define HGRAPH_CPP_ROOT_V2_STABLE_SLOT_STORAGE_H
 
 #include <hgraph/types/utils/memory_utils.h>
+#include <hgraph/types/storage_metrics.h>
 
 #include <algorithm>
 #include <bit>
@@ -206,6 +207,18 @@ namespace hgraph
         [[nodiscard]] size_t alignment() const noexcept { return slot_alignment; }
         /** Allocator used to back this storage. */
         [[nodiscard]] const MemoryUtils::AllocatorOps &allocator() const noexcept { return *m_allocator; }
+
+        /** Exact occupied/retained heap bytes for this slot allocation. */
+        [[nodiscard]] DynamicStorageMetrics dynamic_storage_metrics(size_t constructed_count) const noexcept
+        {
+            const size_t pointer_bytes = slot_count * sizeof(std::byte *);
+            const size_t live_block_metadata = blocks.size() * sizeof(StableSlotBlock);
+            const size_t reserved_block_metadata = blocks.capacity() * sizeof(StableSlotBlock);
+            return {
+                .live_bytes = pointer_bytes + live_block_metadata + constructed_count * slot_stride,
+                .reserved_bytes = pointer_bytes + reserved_block_metadata + slot_count * slot_stride,
+            };
+        }
 
         /** Pointer for ``slot``, or ``nullptr`` if the slot is out of range. */
         [[nodiscard]] std::byte *slot_data(size_t slot) const noexcept

--- a/include/hgraph/types/utils/value_slot_store.h
+++ b/include/hgraph/types/utils/value_slot_store.h
@@ -102,6 +102,16 @@ namespace hgraph
         /** Bound storage plan for the held value type, or ``nullptr`` if unbound. */
         [[nodiscard]] const MemoryUtils::StoragePlan *plan() const noexcept { return m_value_plan; }
 
+        /** Exact occupied/retained heap bytes owned by the value slots. */
+        [[nodiscard]] DynamicStorageMetrics dynamic_storage_metrics() const noexcept
+        {
+            DynamicStorageMetrics result = value_storage.dynamic_storage_metrics(constructed.count());
+            result += updated.dynamic_storage_metrics();
+            result += constructed.dynamic_storage_metrics();
+            result += observers.dynamic_storage_metrics();
+            return result;
+        }
+
         /**
          * Bind this store to ``plan``.
          *
@@ -370,6 +380,12 @@ namespace hgraph
 
         /** Stable storage metadata used to publish debugger-only slot offsets. */
         [[nodiscard]] const ValueSlotStore &debug_values() const noexcept { return m_values; }
+
+        /** Exact occupied/retained heap bytes owned by the mirrored value slots. */
+        [[nodiscard]] DynamicStorageMetrics dynamic_storage_metrics() const noexcept
+        {
+            return m_values.dynamic_storage_metrics();
+        }
 
         /**
          * True when the key slot is constructed. This is the public lifetime

--- a/python/tests/test_inspector.py
+++ b/python/tests/test_inspector.py
@@ -39,6 +39,12 @@ def test_native_inspector_observes_eval_node_and_owns_its_snapshot():
     assert mapped.peak_storage.nested_graph_count == 2
     assert mapped.peak_storage.dynamic_reserved_bytes > 0
     assert mapped.storage.nested_graph_count == 0
+    assert any(
+        entry.kind == InspectionEntityKind.NODE
+        and entry.peak_storage.nested_graph_capacity == 0
+        and entry.peak_storage.dynamic_reserved_bytes > 0
+        for entry in snapshot.entries
+    )
 
     rows = inspection_rows(snapshot)
     assert len(rows) == len(snapshot.entries)

--- a/src/hgraph/runtime/node.cpp
+++ b/src/hgraph/runtime/node.cpp
@@ -1466,10 +1466,25 @@ namespace hgraph
         const NodeOps &node_ops = ops();
         if (node_ops.storage_metrics_impl != nullptr)
         {
-            NodeStorageMetrics dynamic = node_ops.storage_metrics_impl(
+            result = node_ops.storage_metrics_impl(
                 node_ops.extended_view_context, data());
-            dynamic.static_bytes = result.static_bytes;
-            return dynamic;
+            result.static_bytes = type().plan() != nullptr ? type().plan()->layout.size : 0;
+        }
+
+        const auto add_ts_data_storage = [&result](const TSOutputView &view) noexcept {
+            const DynamicStorageMetrics metrics = view.data_view().dynamic_storage_metrics();
+            result.dynamic_live_bytes += metrics.live_bytes;
+            result.dynamic_reserved_bytes += metrics.reserved_bytes;
+        };
+        try
+        {
+            if (has_output()) { add_ts_data_storage(output(MIN_DT)); }
+            if (has_error_output()) { add_ts_data_storage(error_output(MIN_DT)); }
+            if (has_recordable_state()) { add_ts_data_storage(recordable_state(MIN_DT)); }
+        }
+        catch (...)
+        {
+            // Inspector is a cold-path diagnostic and must not affect graph execution.
         }
         return result;
     }

--- a/src/hgraph/types/metadata/ts_data_slot_ops.cpp
+++ b/src/hgraph/types/metadata/ts_data_slot_ops.cpp
@@ -87,6 +87,16 @@ namespace hgraph::ts_data_plan_factory_detail
             return seed;
         }
 
+        template <typename Block, typename Allocator>
+        [[nodiscard]] DynamicStorageMetrics dynamic_bitset_metrics(
+            const sul::dynamic_bitset<Block, Allocator> &bits) noexcept
+        {
+            return {
+                .live_bytes = bits.num_blocks() * sizeof(Block),
+                .reserved_bytes = (bits.capacity() / bits.bits_per_block) * sizeof(Block),
+            };
+        }
+
         template <typename Storage, typename Member>
         [[nodiscard]] std::size_t debug_offset(const Storage &storage, const Member &member) noexcept
         {
@@ -137,6 +147,13 @@ namespace hgraph::ts_data_plan_factory_detail
             [[nodiscard]] KeySlotStore &keys() noexcept { return keys_; }
             [[nodiscard]] std::size_t size() const noexcept { return keys_.size(); }
             [[nodiscard]] std::size_t slot_capacity() const noexcept { return keys_.slot_capacity(); }
+            [[nodiscard]] DynamicStorageMetrics key_set_dynamic_storage_metrics() const noexcept
+            {
+                DynamicStorageMetrics result = keys_.dynamic_storage_metrics();
+                result += dynamic_bitset_metrics(added_);
+                result += dynamic_bitset_metrics(removed_);
+                return result;
+            }
             [[nodiscard]] bool slot_occupied(std::size_t slot) const noexcept { return keys_.slot_constructed(slot); }
             [[nodiscard]] bool slot_live(std::size_t slot) const noexcept { return keys_.slot_live(slot); }
             [[nodiscard]] bool slot_added(std::size_t slot) const noexcept
@@ -355,6 +372,30 @@ namespace hgraph::ts_data_plan_factory_detail
             [[nodiscard]] KeySlotStore &keys() noexcept { return keys_; }
             [[nodiscard]] std::size_t size() const noexcept { return keys_.size(); }
             [[nodiscard]] std::size_t slot_capacity() const noexcept { return keys_.slot_capacity(); }
+            [[nodiscard]] DynamicStorageMetrics key_set_dynamic_storage_metrics() const noexcept
+            {
+                DynamicStorageMetrics result = keys_.dynamic_storage_metrics();
+                result += dynamic_bitset_metrics(added_);
+                result += dynamic_bitset_metrics(removed_);
+                return result;
+            }
+            [[nodiscard]] DynamicStorageMetrics dynamic_storage_metrics() const noexcept
+            {
+                DynamicStorageMetrics result = key_set_dynamic_storage_metrics();
+                result += values_.dynamic_storage_metrics();
+                result += dynamic_bitset_metrics(modified_);
+                result += dynamic_bitset_metrics(value_published_);
+
+                const TSDataOps *child_ops = element_type_.ops();
+                if (child_ops == nullptr) { return result; }
+                for (std::size_t slot = 0; slot < keys_.slot_capacity(); ++slot)
+                {
+                    if (!keys_.slot_constructed(slot)) { continue; }
+                    result += child_ops->dynamic_storage_metrics_impl(
+                        child_ops->context, values_.value_memory(slot));
+                }
+                return result;
+            }
             [[nodiscard]] bool slot_occupied(std::size_t slot) const noexcept { return keys_.slot_constructed(slot); }
             [[nodiscard]] bool slot_live(std::size_t slot) const noexcept { return keys_.slot_live(slot); }
             [[nodiscard]] bool slot_added(std::size_t slot) const noexcept
@@ -1021,6 +1062,7 @@ namespace hgraph::ts_data_plan_factory_detail
                     .mutable_tracking_impl     = &tss_mutable_tracking,
                     .has_current_value_impl    = &tss_has_current_value,
                     .all_valid_impl            = &tss_all_valid,
+                    .dynamic_storage_metrics_impl = &tss_dynamic_storage_metrics,
                     .value_memory_impl         = &tss_value_memory,
                     .mutable_value_memory_impl = &tss_mutable_value_memory,
                     .delta_memory_impl         = &tss_delta_memory,
@@ -1250,6 +1292,12 @@ namespace hgraph::ts_data_plan_factory_detail
             [[nodiscard]] static bool tss_all_valid(const void *, const void *memory) noexcept
             {
                 return storage<Storage>(memory).tracking().last_modified_time != MIN_DT;
+            }
+
+            [[nodiscard]] static DynamicStorageMetrics tss_dynamic_storage_metrics(
+                const void *, const void *memory) noexcept
+            {
+                return storage<Storage>(memory).key_set_dynamic_storage_metrics();
             }
 
             [[nodiscard]] static const void *tss_value_memory(const void *, const void *memory) noexcept
@@ -1978,6 +2026,7 @@ namespace hgraph::ts_data_plan_factory_detail
                 base_ops.mutable_tracking_impl = &tsd_mutable_tracking;
                 base_ops.has_current_value_impl = &tsd_has_current_value;
                 base_ops.all_valid_impl = &tsd_all_valid;
+                base_ops.dynamic_storage_metrics_impl = &tsd_dynamic_storage_metrics;
                 base_ops.value_memory_impl = &tsd_value_memory;
                 base_ops.mutable_value_memory_impl = &tsd_mutable_value_memory;
                 base_ops.delta_memory_impl = &tsd_delta_memory;
@@ -2506,6 +2555,12 @@ namespace hgraph::ts_data_plan_factory_detail
             [[nodiscard]] static const void *tsd_child_at_slot(const void *, const void *memory, std::size_t slot)
             {
                 return storage<TSDSlotStorage>(memory).child_at_slot(slot);
+            }
+
+            [[nodiscard]] static DynamicStorageMetrics tsd_dynamic_storage_metrics(
+                const void *, const void *memory) noexcept
+            {
+                return storage<TSDSlotStorage>(memory).dynamic_storage_metrics();
             }
 
             [[nodiscard]] static bool tsd_slot_modified(const void *, const void *memory, std::size_t slot)

--- a/src/hgraph/types/time_series/ts_data/base_view.cpp
+++ b/src/hgraph/types/time_series/ts_data/base_view.cpp
@@ -175,6 +175,18 @@ bool TSDataView::all_valid() const {
   return table.all_valid_impl(table.context, data());
 }
 
+DynamicStorageMetrics TSDataView::dynamic_storage_metrics() const noexcept {
+  if (!valid()) {
+    return {};
+  }
+  try {
+    const auto &table = ops();
+    return table.dynamic_storage_metrics_impl(table.context, data());
+  } catch (...) {
+    return {};
+  }
+}
+
 std::size_t TSDataView::indexed_child_count() const {
   const auto &table = ops();
   return table.indexed_child_count_impl(table.context, data());

--- a/src/hgraph/types/time_series/ts_type_ref.cpp
+++ b/src/hgraph/types/time_series/ts_type_ref.cpp
@@ -6,6 +6,7 @@
 #include <hgraph/util/scope.h>
 
 #include <stdexcept>
+#include <string>
 #include <vector>
 
 namespace hgraph
@@ -34,7 +35,9 @@ namespace hgraph
             }
             if (record.ops_abi_version != TS_DATA_OPS_ABI_VERSION)
             {
-                throw std::invalid_argument("TSRoleTypeRef requires TSData ops ABI version 4");
+                throw std::invalid_argument(
+                    "TSRoleTypeRef requires TSData ops ABI version " +
+                    std::to_string(TS_DATA_OPS_ABI_VERSION));
             }
             const auto *ops = static_cast<const TSDataOps *>(record.ops);
             if (!migrated_kind(*schema) || ops == nullptr || ops->kind != schema->kind)

--- a/tests/cpp/test_inspector.cpp
+++ b/tests/cpp/test_inspector.cpp
@@ -42,6 +42,8 @@ namespace
                        {Str{"b"}, Int{2}},
                        {Str{"c"}, Int{3}},
                    }));
+            static_cast<void>(wire<stdlib::const_, TSS<Int>>(
+                w, stdlib::make_set<Int>({Int{1}, Int{2}, Int{3}})));
             static_cast<void>(wire<stdlib::map_>(w, fn<InspectAddOne>(), dict));
             static_cast<void>(wire<stdlib::mesh_>(w, fn<InspectAddOne>(), dict));
             static_cast<void>(wire<stdlib::reduce_>(w, fn<stdlib::add_>(), dict));
@@ -164,6 +166,14 @@ TEST_CASE("inspector: native snapshots own hierarchy, timings, schedules and sto
     CHECK(switched.storage.nested_graph_count == 1);
     CHECK(switched.storage.nested_graph_capacity == 2);
     CHECK(switched.storage.dynamic_reserved_bytes == 0);
+
+    const auto keyed_output_nodes = std::ranges::count_if(
+        live.entries, [](const InspectionEntry &entry) {
+            return entry.kind == InspectionEntityKind::Node &&
+                   entry.storage.nested_graph_capacity == 0 &&
+                   entry.storage.dynamic_reserved_bytes > 0;
+        });
+    CHECK(keyed_output_nodes >= 2);
 
     for (const InspectionEntry &entry : live.entries)
     {

--- a/tests/cpp/test_slot_utils.cpp
+++ b/tests/cpp/test_slot_utils.cpp
@@ -212,6 +212,21 @@ TEST_CASE("stable slot storage preserves existing slot addresses across chained 
     CHECK(storage.slot_data(7) != slot1);
 }
 
+TEST_CASE("stable slot storage reports occupied and retained allocation bytes", "[v2 slot utils][memory]")
+{
+    StableSlotStorage storage;
+    storage.reserve_to(8, sizeof(std::int64_t), alignof(std::int64_t));
+
+    const DynamicStorageMetrics metrics = storage.dynamic_storage_metrics(3);
+    CHECK(metrics.live_bytes ==
+          8 * sizeof(std::byte *) + storage.blocks.size() * sizeof(StableSlotBlock) +
+              3 * storage.stride());
+    CHECK(metrics.reserved_bytes ==
+          8 * sizeof(std::byte *) + storage.blocks.capacity() * sizeof(StableSlotBlock) +
+              8 * storage.stride());
+    CHECK(metrics.reserved_bytes >= metrics.live_bytes);
+}
+
 TEST_CASE("stable slot storage rejects layout changes after binding", "[v2 slot utils]") {
     StableSlotStorage storage;
     storage.reserve_to(4, sizeof(std::uint32_t), alignof(std::uint32_t));
@@ -602,6 +617,30 @@ TEST_CASE("key slot store tracks pending removals until explicit erase", "[v2 sl
     REQUIRE(store.try_key<std::int32_t>(second.slot) == nullptr);
 
     CHECK(observer.events == std::vector<std::string>{"capacity:0->4", "insert:0", "insert:1", "remove:1", "erase:1"});
+}
+
+TEST_CASE("key and mirrored value slots report index and payload capacity", "[v2 slot utils][memory]")
+{
+    KeySlotStore keys(MemoryUtils::plan_for<std::int32_t>(), key_slot_store_ops_for<std::int32_t>());
+    KeyMirroredValueSlotStore values(keys, MemoryUtils::plan_for<std::int64_t>());
+
+    const auto empty_keys = keys.dynamic_storage_metrics();
+    const auto empty_values = values.dynamic_storage_metrics();
+    CHECK(empty_keys.reserved_bytes >= empty_keys.live_bytes);
+    CHECK(empty_values.reserved_bytes >= empty_values.live_bytes);
+
+    keys.reserve_to(32);
+    REQUIRE(keys.insert(11).inserted);
+    REQUIRE(keys.insert(22).inserted);
+
+    const auto populated_keys = keys.dynamic_storage_metrics();
+    const auto populated_values = values.dynamic_storage_metrics();
+    CHECK(populated_keys.live_bytes > empty_keys.live_bytes);
+    CHECK(populated_keys.reserved_bytes > empty_keys.reserved_bytes);
+    CHECK(populated_values.live_bytes > empty_values.live_bytes);
+    CHECK(populated_values.reserved_bytes > empty_values.reserved_bytes);
+    CHECK(populated_keys.reserved_bytes >= populated_keys.live_bytes);
+    CHECK(populated_values.reserved_bytes >= populated_values.live_bytes);
 }
 
 TEST_CASE("key slot store mixes type-erased identity hashes", "[v2 slot utils][hash]")

--- a/tests/cpp/test_ts_output.cpp
+++ b/tests/cpp/test_ts_output.cpp
@@ -574,6 +574,60 @@ TEST_CASE("TSOutput TSD move mutation moves keys and child values without remova
     REQUIRE(MoveTrackedScalar::move_assign_count == 2);
 }
 
+TEST_CASE("TSData dynamic storage metrics include TSS capacity and nested TSD children", "[memory]")
+{
+    using namespace hgraph;
+
+    auto       &registry = TypeRegistry::instance();
+    const auto *int_meta = registry.register_scalar<std::int32_t>("int32");
+    const auto *str_meta = registry.register_scalar<std::string>("string");
+    const auto *tss_int = registry.tss(int_meta);
+    const auto *outer_tsd = registry.tsd(str_meta, tss_int);
+    const auto t1 = MIN_ST;
+
+    TSOutput set_output{*tss_int};
+    const auto set_before = set_output.data_view().dynamic_storage_metrics();
+    {
+        auto set_data = set_output.data_view();
+        auto set = set_data.as_set();
+        auto mutation = set.begin_mutation(t1);
+        mutation.reserve(64);
+    }
+    const auto set_after = set_output.data_view().dynamic_storage_metrics();
+    CHECK(set_after.live_bytes > set_before.live_bytes);
+    CHECK(set_after.reserved_bytes > set_before.reserved_bytes);
+    CHECK(set_after.reserved_bytes >= set_after.live_bytes);
+
+    TSOutput outer{*outer_tsd};
+    Value key{std::string{"nested"}};
+    {
+        auto outer_data = outer.data_view();
+        auto dict = outer_data.as_dict();
+        auto mutation = dict.begin_mutation(t1);
+        static_cast<void>(mutation.at(key.view()));
+    }
+
+    auto outer_data = outer.data_view();
+    auto dict = outer_data.as_dict();
+    auto child = dict.at(key.view());
+    const auto outer_before = outer.data_view().dynamic_storage_metrics();
+    const auto child_before = child.dynamic_storage_metrics();
+    {
+        auto child_set = child.as_set();
+        auto mutation = child_set.begin_mutation(t1);
+        mutation.reserve(64);
+    }
+    const auto outer_after = outer.data_view().dynamic_storage_metrics();
+    const auto child_after = child.dynamic_storage_metrics();
+
+    REQUIRE(child_after.reserved_bytes > child_before.reserved_bytes);
+    CHECK(outer_after.reserved_bytes - outer_before.reserved_bytes ==
+          child_after.reserved_bytes - child_before.reserved_bytes);
+    CHECK(outer_after.live_bytes - outer_before.live_bytes ==
+          child_after.live_bytes - child_before.live_bytes);
+    CHECK(outer_after.reserved_bytes >= outer_after.live_bytes);
+}
+
 TEST_CASE("TSOutputHandle stores output identity without evaluation time")
 {
     using namespace hgraph;

--- a/tests/cpp/test_type_erasure_layout.cpp
+++ b/tests/cpp/test_type_erasure_layout.cpp
@@ -67,7 +67,7 @@ TEST_CASE("current type-erasure records retain their baseline layouts")
     static_assert(!HasNoArgumentRemovedValue<TSWDataView>);
     static_assert(HasNoArgumentRemovedValue<TSWInputView>);
     static_assert(sizeof(TSDataView) == sizeof(void *) * 2);
-    static_assert(TS_DATA_OPS_ABI_VERSION == 4);
+    static_assert(TS_DATA_OPS_ABI_VERSION == 5);
     static_assert(sizeof(TSRoleTypeRef) == sizeof(void *));
     static_assert(sizeof(TSDataObserverSet) == sizeof(void *));
     static_assert(sizeof(TSData) == sizeof(void *) * 3);

--- a/tests/install_consumer/main.cpp
+++ b/tests/install_consumer/main.cpp
@@ -5,6 +5,8 @@
 #include <hgraph/types/metadata/type_record.h>
 #include <hgraph/types/metadata/type_registry.h>
 #include <hgraph/types/static_schema.h>
+#include <hgraph/types/storage_metrics.h>
+#include <hgraph/types/time_series/ts_output.h>
 #include <hgraph/types/time_series/visitor.h>
 #include <hgraph/types/type_pointer.h>
 #include <hgraph/types/type_resolution.h>
@@ -38,6 +40,7 @@ int main()
     static_assert(std::is_trivially_copyable_v<TypeRecord>);
     static_assert(std::is_standard_layout_v<AnyPtr>);
     static_assert(std::is_trivially_copyable_v<AnyPtr>);
+    static_assert(TS_DATA_OPS_ABI_VERSION == 5);
     using ConsumerScalar =
         Bundle<"consumer::Scalar", Field<"number", Int>, Field<"label", Str>>;
     using ConsumerBundle = TSBFromScalar<ConsumerScalar>;
@@ -112,6 +115,20 @@ int main()
     if (!visited_value)
     {
         throw std::runtime_error("installed endpoint visitor dispatched the wrong time-series kind");
+    }
+
+    const auto *tss_int = registry.tss(scalar_descriptor<Int>::value_meta());
+    TSOutput set_output{*tss_int};
+    {
+        auto set_data = set_output.data_view();
+        auto set = set_data.as_set();
+        auto mutation = set.begin_mutation(MIN_ST);
+        mutation.reserve(16);
+    }
+    const DynamicStorageMetrics set_storage = set_output.data_view().dynamic_storage_metrics();
+    if (set_storage.live_bytes == 0 || set_storage.reserved_bytes < set_storage.live_bytes)
+    {
+        throw std::runtime_error("installed TSData dynamic storage metrics are unusable");
     }
 
     using TypedFrame = FrameOf<Bundle<"consumer::Row", Field<"value", Int>>,


### PR DESCRIPTION
## Summary

- add a cold-path `DynamicStorageMetrics` hook to the TSData ops surface and advance `TS_DATA_OPS_ABI_VERSION` to 5
- account for TSS/TSD stable key and value blocks, pointer tables, bitmaps, observer/bookkeeping vectors, exact dense-index allocations, and recursively owned child TSData
- aggregate owned output, error-output, and recordable-state storage into Inspector without counting input aliases or projections
- document the attribution boundary and cover native wiring, Python Inspector, type erasure, and the installed SDK

## Why

Inspector previously reported nested-graph slot storage but missed keyed TSData ownership. That made TSS appear to use no dynamic native memory and left a material portion of sparse TSD capacity unattributed. The new hook is sampled only by Inspector and adds no work to normal graph evaluation.

TSD child fixed storage remains part of the parent value-slot stride; recursion adds only each child's dynamic ownership, avoiding double counting. The dense key index uses a contained counting allocator so both values and rebound bucket allocations are measured directly.

External implementations of the TSData ops contract must rebuild for ABI version 5 and may leave the new hook at its zero-reporting default until they can provide exact attribution.

## Measurements

Three fresh-process samples per host, using the existing large memory profiles:

| host | profile | Inspector reserved before | after | newly attributed | process peak before | after |
|---|---|---:|---:|---:|---:|---:|
| macOS / M4 Max | `tss_add_remove_std__large` | 0 | 91,792 B | 91,792 B | 1.80 MiB | 1.75 MiB |
| macOS / M4 Max | `tsd_sparse_large_capacity_std__large` | 33,958,096 B | 39,311,672 B | 5,353,576 B | 106.11 MiB | 106.77 MiB |
| Linux / Core Ultra 7 155H | `tss_add_remove_std__large` | 0 | 91,792 B | 91,792 B | 1.98 MiB | 0.82 MiB |
| Linux / Core Ultra 7 155H | `tsd_sparse_large_capacity_std__large` | 34,860,240 B | 40,213,816 B | 5,353,576 B | 111.21 MiB | 110.31 MiB |

The identical 5,353,576-byte TSD delta across platforms is the newly visible keyed TSData allocation surface; RSS remains within or below the baseline range.

## Validation

- clean native acceptance suite on macOS: 1,322 passed
- clean native acceptance suite on hg-linux/GCC 15: 1,322 passed
- stable-ABI wheel built with Python 3.12 and tested with Python 3.14 on macOS: 1,752 passed, 10 skipped
- stable-ABI wheel built with Python 3.12 and tested with Python 3.14 on hg-linux: 1,752 passed, 10 skipped
- focused hg-linux GCC/ASan key-slot lifecycle and nested TSD/TSS attribution: 226,528 assertions passed
- installed C++ SDK consumer passed with the ABI-5 hook and public metrics type
- Sphinx dummy build passed with warnings as errors
- focused TSS/TSD memory profiles completed on macOS and Linux

Part of #213. Remaining value/container and TSW attribution is tracked by #225.
