### PR TITLE
Account for endpoint storage and optimize sparse runtime maps

### DIFF
--- a/include/hgraph/types/time_series/ts_data/types.h
+++ b/include/hgraph/types/time_series/ts_data/types.h
@@ -4,6 +4,7 @@
 #include <hgraph/runtime/node_fwd.h>
 #include <hgraph/types/metadata/ts_value_type_meta_data.h>
 #include <hgraph/types/notifiable.h>
+#include <hgraph/types/storage_metrics.h>
 #include <hgraph/types/time_series/endpoint_owner.h>
 #include <hgraph/types/time_series/ts_type_ref.h>
 #include <hgraph/types/value/value_ops.h>
@@ -225,6 +226,9 @@ namespace hgraph
 
         /** Number of observers registered at this level. */
         [[nodiscard]] std::size_t size() const noexcept;
+
+        /** Exact occupied/retained heap bytes for multi-observer storage. */
+        [[nodiscard]] DynamicStorageMetrics dynamic_storage_metrics() const noexcept;
 
         /** Register an observer pointer; null is ignored and duplicates assert. */
         void subscribe(Notifiable *observer);

--- a/include/hgraph/types/time_series/ts_input.h
+++ b/include/hgraph/types/time_series/ts_input.h
@@ -138,6 +138,9 @@ namespace hgraph
         [[nodiscard]] TSInputView view(Notifiable *scheduling_notifier = nullptr,
                                        DateTime evaluation_time = MIN_DT) const;
 
+        /** Dynamic input payload, observer, activation-trie, and target-link storage. */
+        [[nodiscard]] DynamicStorageMetrics dynamic_storage_metrics() const noexcept;
+
       private:
         friend class TSInputView;
         friend class TSBInputView;

--- a/include/hgraph/types/time_series/ts_input/base_view.h
+++ b/include/hgraph/types/time_series/ts_input/base_view.h
@@ -103,6 +103,9 @@ namespace hgraph
         [[nodiscard]] ValueView value() const;
         [[nodiscard]] ValueView delta_value() const;
 
+        /** Dynamic storage owned by this view's complete input endpoint. */
+        [[nodiscard]] DynamicStorageMetrics dynamic_storage_metrics() const noexcept;
+
         /**
          * Convert this input projection to a reference token.
          *

--- a/include/hgraph/types/time_series/ts_input/detail.h
+++ b/include/hgraph/types/time_series/ts_input/detail.h
@@ -5,11 +5,11 @@
 #include <hgraph/types/time_series/ts_input.h>
 
 #include <hgraph/types/time_series/ts_input/target_link.h>
+#include <hgraph/types/utils/small_dense_ptr_map.h>
 
 #include <cstddef>
 #include <memory>
 #include <string_view>
-#include <unordered_map>
 #include <vector>
 
 namespace hgraph::detail
@@ -108,6 +108,7 @@ namespace hgraph::detail
 
         [[nodiscard]] TSInputActiveTarget *child_at(std::size_t slot) const noexcept;
         [[nodiscard]] bool has_any_active() const noexcept;
+        [[nodiscard]] DynamicStorageMetrics dynamic_storage_metrics() const noexcept;
         TSInputActiveTarget &ensure_child(std::size_t slot);
         void subscribe(const TSDataView &observed_, Notifiable *target_notifier);
         void unsubscribe() noexcept;
@@ -117,7 +118,7 @@ namespace hgraph::detail
         bool                 active{false};
         TSDataStorageRef<>   observed{};
         TSInputSchedulingNotifier notifier{};
-        std::unordered_map<std::size_t, std::unique_ptr<TSInputActiveTarget>> children{};
+        SmallDensePtrMap<std::size_t, TSInputActiveTarget> children{};
     };
 
 }  // namespace hgraph::detail

--- a/include/hgraph/types/time_series/ts_input/target_link.h
+++ b/include/hgraph/types/time_series/ts_input/target_link.h
@@ -3,12 +3,12 @@
 
 #include <hgraph/types/time_series/ts_data.h>
 #include <hgraph/types/time_series/ts_output/base_view.h>
+#include <hgraph/types/utils/small_dense_ptr_map.h>
 #include <hgraph/types/utils/slot_observer.h>
 
 #include <cstddef>
 #include <cstdint>
 #include <memory>
-#include <unordered_map>
 
 namespace hgraph::detail
 {
@@ -38,10 +38,11 @@ namespace hgraph::detail
         bool locally_active{false};
         TSInputObservationKind observation_kind{TSInputObservationKind::Value};
         TSOutputHandle observed{};
-        std::unordered_map<std::size_t, std::unique_ptr<TSInputTargetActiveNode>> children{};
+        SmallDensePtrMap<std::size_t, TSInputTargetActiveNode> children{};
 
         [[nodiscard]] TSInputTargetActiveNode *child_at(std::size_t slot_index) const noexcept;
         [[nodiscard]] bool has_any_active() const noexcept;
+        [[nodiscard]] DynamicStorageMetrics dynamic_storage_metrics() const noexcept;
         TSInputTargetActiveNode &ensure_child(std::size_t slot_index);
         void clear_observed() noexcept;
     };
@@ -127,6 +128,7 @@ namespace hgraph::detail
         [[nodiscard]] bool sampled_structural_transition() const noexcept;
         [[nodiscard]] DateTime structural_transition_time() const noexcept;
         [[nodiscard]] const TSInputTargetLinkState *state() const noexcept;
+        [[nodiscard]] DynamicStorageMetrics dynamic_storage_metrics() const noexcept;
 
         TSDataTracking tracking{};
         TSInputTargetLinkState state_;
@@ -148,6 +150,9 @@ namespace hgraph::detail
 
     [[nodiscard]] const TSInputTargetLinkStorage *target_link_storage(const TSDataView &view) noexcept;
     [[nodiscard]] TSInputTargetLinkStorage *mutable_target_link_storage(const TSDataView &view);
+    /** Target-link trie/observer bytes reachable through an input-shaped TSData tree. */
+    [[nodiscard]] DynamicStorageMetrics input_target_link_dynamic_storage_metrics(
+        const TSDataView &view) noexcept;
     [[nodiscard]] const TSValueTypeMetaData *target_link_schema(const TSDataView &view) noexcept;
 
     [[nodiscard]] bool is_target_link_view(const TSDataView &view) noexcept;

--- a/include/hgraph/types/time_series/ts_output.h
+++ b/include/hgraph/types/time_series/ts_output.h
@@ -73,6 +73,9 @@ namespace hgraph
         [[nodiscard]] TSOutputHandle binding_for(const TSOutputView &source,
                                                  const TSValueTypeMetaData &requested_schema) const;
 
+        /** Dynamic output payload, observer, and alternative-binding storage. */
+        [[nodiscard]] DynamicStorageMetrics dynamic_storage_metrics() const noexcept;
+
         /**
          * Stop-time teardown of alternative-store subscriptions/links (the
          * graph stop pass calls this while every producer is alive, so the

--- a/include/hgraph/types/time_series/ts_output/alternative.h
+++ b/include/hgraph/types/time_series/ts_output/alternative.h
@@ -2,9 +2,9 @@
 #define HGRAPH_CPP_TS_OUTPUT_ALTERNATIVE_H
 
 #include <hgraph/types/time_series/ts_output/base_view.h>
+#include <hgraph/types/utils/small_dense_ptr_map.h>
 
 #include <memory>
-#include <unordered_map>
 
 namespace hgraph::detail
 {
@@ -31,6 +31,18 @@ namespace hgraph::detail
         struct ToRefAlternativeState;
         struct RefLinkAlternativeState;
         struct InteriorFromRefAlternativeState;
+        struct ToRefAlternativeDelete
+        {
+            void operator()(ToRefAlternativeState *) const noexcept;
+        };
+        struct RefLinkAlternativeDelete
+        {
+            void operator()(RefLinkAlternativeState *) const noexcept;
+        };
+        struct InteriorFromRefAlternativeDelete
+        {
+            void operator()(InteriorFromRefAlternativeState *) const noexcept;
+        };
 
         TSOutputAlternativeStore() noexcept;
         TSOutputAlternativeStore(const TSOutputAlternativeStore &) = delete;
@@ -52,6 +64,7 @@ namespace hgraph::detail
          * stop-time evaluation time (must not be ``MIN_DT``).
          */
         void release_subscriptions(DateTime release_time) noexcept;
+        [[nodiscard]] DynamicStorageMetrics dynamic_storage_metrics() const noexcept;
         [[nodiscard]] static TimeSeriesReference peered_reference_as(const TSValueTypeMetaData *target_schema,
                                                                      TSOutputHandle target);
         [[nodiscard]] static const TSOutputHandle &peered_reference_target(const TimeSeriesReference &reference);
@@ -88,36 +101,16 @@ namespace hgraph::detail
                                                                const TSOutputView &source,
                                                                const TSValueTypeMetaData &requested_schema);
 
-        std::unordered_map<AlternativeKey, std::unique_ptr<ToRefAlternativeState>, AlternativeKeyHash>
-            to_ref_alternatives_{};
-        std::unordered_map<AlternativeKey, std::unique_ptr<RefLinkAlternativeState>, AlternativeKeyHash>
-            ref_link_alternatives_{};
-        std::unordered_map<AlternativeKey, std::unique_ptr<InteriorFromRefAlternativeState>, AlternativeKeyHash>
+        SmallDensePtrMap<AlternativeKey, ToRefAlternativeState,
+                         ToRefAlternativeDelete, AlternativeKeyHash> to_ref_alternatives_{};
+        SmallDensePtrMap<AlternativeKey, RefLinkAlternativeState,
+                         RefLinkAlternativeDelete, AlternativeKeyHash> ref_link_alternatives_{};
+        SmallDensePtrMap<AlternativeKey, InteriorFromRefAlternativeState,
+                         InteriorFromRefAlternativeDelete, AlternativeKeyHash>
             interior_from_ref_alternatives_{};
     };
 
     void clear_ts_output_alternative_type_cache() noexcept;
 }  // namespace hgraph::detail
-
-namespace std
-{
-    template<>
-    struct default_delete<hgraph::detail::TSOutputAlternativeStore::ToRefAlternativeState>
-    {
-        void operator()(hgraph::detail::TSOutputAlternativeStore::ToRefAlternativeState *) noexcept;
-    };
-
-    template<>
-    struct default_delete<hgraph::detail::TSOutputAlternativeStore::RefLinkAlternativeState>
-    {
-        void operator()(hgraph::detail::TSOutputAlternativeStore::RefLinkAlternativeState *) noexcept;
-    };
-
-    template<>
-    struct default_delete<hgraph::detail::TSOutputAlternativeStore::InteriorFromRefAlternativeState>
-    {
-        void operator()(hgraph::detail::TSOutputAlternativeStore::InteriorFromRefAlternativeState *) noexcept;
-    };
-}  // namespace std
 
 #endif  // HGRAPH_CPP_TS_OUTPUT_ALTERNATIVE_H

--- a/include/hgraph/types/time_series/ts_output/base_view.h
+++ b/include/hgraph/types/time_series/ts_output/base_view.h
@@ -123,6 +123,9 @@ namespace hgraph
         [[nodiscard]] ValueView value() const;
         [[nodiscard]] ValueView delta_value() const;
 
+        /** Dynamic storage owned by this view's complete output endpoint. */
+        [[nodiscard]] DynamicStorageMetrics dynamic_storage_metrics() const noexcept;
+
         /** Modification and validity status. */
         [[nodiscard]] bool bound() const noexcept { return output_ != nullptr && data_.valid(); }
         [[nodiscard]] DateTime last_modified_time() const;

--- a/include/hgraph/types/utils/small_dense_ptr_map.h
+++ b/include/hgraph/types/utils/small_dense_ptr_map.h
@@ -6,25 +6,34 @@
 #include <ankerl/unordered_dense.h>
 
 #include <algorithm>
+#include <array>
 #include <cassert>
 #include <cstddef>
+#include <cstdint>
 #include <functional>
 #include <memory>
+#include <new>
+#include <span>
+#include <stdexcept>
 #include <type_traits>
 #include <utility>
-#include <vector>
 
 namespace hgraph::detail
 {
     /**
-     * Sparse owner map for stable heap objects.
+     * Compact sparse owner map for stable heap objects.
      *
-     * Runtime ownership tries are predominantly empty or have only a handful
-     * of children.  Those entries stay in a compact linear vector, avoiding an
-     * empty hash table and its bucket allocation.  A ninth entry promotes the
-     * owner to ``ankerl::unordered_dense::map`` so wider nodes retain constant
-     * expected-time lookup.  Promotion and dense-table relocation only move
-     * ``unique_ptr`` values; the owned object addresses remain stable.
+     * The outer handle is one tagged pointer to the active representation's
+     * memory. Empty maps need no allocation; one entry uses a direct holder;
+     * small maps use a compact trailing entry block; wider maps use
+     * ``ankerl::unordered_dense::map``. Representation dispatch is an inline
+     * switch so compilers can inline the selected operation. Only insertion can
+     * replace a non-empty representation.
+     *
+     * Representation changes move ``unique_ptr`` owners, never pointees, so
+     * pointers returned by ``find`` and ``ensure`` remain stable. Small and
+     * dense representations deliberately do not demote after erase, avoiding
+     * churn when keyed runtime structures are reused.
      */
     template <typename Key,
               typename Pointee,
@@ -34,52 +43,178 @@ namespace hgraph::detail
               std::size_t SmallLimit = 8>
     class SmallDensePtrMap
     {
-        static_assert(SmallLimit > 0);
+        static_assert(SmallLimit >= 2);
         static_assert(std::is_nothrow_copy_constructible_v<Key>);
         static_assert(std::is_nothrow_move_constructible_v<Key>);
+        static_assert(std::is_nothrow_move_assignable_v<Key>);
+        static_assert(std::is_nothrow_default_constructible_v<Hash>);
+        static_assert(std::is_nothrow_default_constructible_v<KeyEqual>);
+        static_assert(std::is_nothrow_invocable_r_v<std::size_t, Hash, const Key &>);
 
         using pointer_type = std::unique_ptr<Pointee, Deleter>;
-        using value_type = std::pair<Key, pointer_type>;
-        using SmallStorage = std::vector<value_type>;
         using DenseStorage = ankerl::unordered_dense::map<Key, pointer_type, Hash, KeyEqual>;
+        using value_type = typename DenseStorage::value_type;
+
+        static_assert(std::is_nothrow_default_constructible_v<pointer_type>);
+        static_assert(std::is_nothrow_move_assignable_v<value_type>);
+
+        struct SmallStorage
+        {
+            std::size_t size{0};
+            std::size_t capacity{0};
+
+            [[nodiscard]] static constexpr std::size_t allocation_alignment() noexcept
+            {
+                return std::max(alignof(SmallStorage), alignof(value_type));
+            }
+
+            [[nodiscard]] static constexpr std::size_t entries_offset() noexcept
+            {
+                constexpr std::size_t alignment = alignof(value_type);
+                return (sizeof(SmallStorage) + alignment - 1) & ~(alignment - 1);
+            }
+
+            [[nodiscard]] static constexpr std::size_t allocation_bytes(std::size_t capacity_) noexcept
+            {
+                return entries_offset() + capacity_ * sizeof(value_type);
+            }
+
+            [[nodiscard]] static SmallStorage *create(std::size_t capacity_)
+            {
+                assert(capacity_ >= 2 && capacity_ <= SmallLimit);
+                void *memory = ::operator new(allocation_bytes(capacity_),
+                                              std::align_val_t{allocation_alignment()});
+                return std::construct_at(static_cast<SmallStorage *>(memory),
+                                         SmallStorage{.size = 0, .capacity = capacity_});
+            }
+
+            static void destroy(SmallStorage *storage) noexcept
+            {
+                if (storage == nullptr) { return; }
+                for (std::size_t index = storage->size; index > 0; --index)
+                {
+                    std::destroy_at(storage->entries() + (index - 1));
+                }
+                std::destroy_at(storage);
+                ::operator delete(storage, std::align_val_t{allocation_alignment()});
+            }
+
+            [[nodiscard]] value_type *entries() noexcept
+            {
+                auto *bytes = reinterpret_cast<std::byte *>(this);
+                return std::launder(reinterpret_cast<value_type *>(bytes + entries_offset()));
+            }
+
+            [[nodiscard]] const value_type *entries() const noexcept
+            {
+                const auto *bytes = reinterpret_cast<const std::byte *>(this);
+                return std::launder(reinterpret_cast<const value_type *>(bytes + entries_offset()));
+            }
+
+            [[nodiscard]] std::span<value_type> values() noexcept
+            {
+                return {entries(), size};
+            }
+
+            [[nodiscard]] std::span<const value_type> values() const noexcept
+            {
+                return {entries(), size};
+            }
+
+            void append_key(const Key &key) noexcept
+            {
+                assert(size < capacity);
+                std::construct_at(entries() + size, key, pointer_type{});
+                ++size;
+            }
+
+            void erase_at(std::size_t index) noexcept
+            {
+                assert(index < size);
+                for (std::size_t current = index; current + 1 < size; ++current)
+                {
+                    entries()[current] = std::move(entries()[current + 1]);
+                }
+                std::destroy_at(entries() + (size - 1));
+                --size;
+            }
+        };
+
+        struct SmallStorageDelete
+        {
+            void operator()(SmallStorage *storage) const noexcept { SmallStorage::destroy(storage); }
+        };
+
+        using SmallStorageOwner = std::unique_ptr<SmallStorage, SmallStorageDelete>;
+
+        enum class Representation : std::uint8_t
+        {
+            Empty,
+            Single,
+            Small,
+            Dense,
+        };
+
+        static constexpr std::uintptr_t representation_mask{0x3};
+
+        static_assert(alignof(value_type) > representation_mask);
+        static_assert(alignof(SmallStorage) > representation_mask);
+        static_assert(alignof(DenseStorage) > representation_mask);
 
       public:
         SmallDensePtrMap() noexcept = default;
         SmallDensePtrMap(const SmallDensePtrMap &) = delete;
         SmallDensePtrMap &operator=(const SmallDensePtrMap &) = delete;
-        SmallDensePtrMap(SmallDensePtrMap &&) noexcept = default;
-        SmallDensePtrMap &operator=(SmallDensePtrMap &&) noexcept = default;
-        ~SmallDensePtrMap() = default;
 
-        [[nodiscard]] bool empty() const noexcept { return size() == 0; }
+        SmallDensePtrMap(SmallDensePtrMap &&other) noexcept
+            : tagged_storage_{std::exchange(other.tagged_storage_, 0)}
+        {}
 
-        [[nodiscard]] std::size_t size() const noexcept
+        SmallDensePtrMap &operator=(SmallDensePtrMap &&other) noexcept
         {
-            return dense_ != nullptr ? dense_->size() : small_.size();
+            if (this != &other)
+            {
+                destroy_representation(representation(), storage());
+                tagged_storage_ = std::exchange(other.tagged_storage_, 0);
+            }
+            return *this;
         }
 
-        [[nodiscard]] bool uses_dense_storage() const noexcept { return dense_ != nullptr; }
+        ~SmallDensePtrMap() { destroy_representation(representation(), storage()); }
+
+        [[nodiscard]] bool empty() const noexcept { return size() == 0; }
+        [[nodiscard]] std::size_t size() const noexcept
+        {
+            switch (representation())
+            {
+            case Representation::Empty: return 0;
+            case Representation::Single: return 1;
+            case Representation::Small: return small_size(storage());
+            case Representation::Dense: return dense_size(storage());
+            }
+            return 0;
+        }
+
+        [[nodiscard]] bool uses_dense_storage() const noexcept
+        {
+            return representation() == Representation::Dense;
+        }
 
         [[nodiscard]] Pointee *find(const Key &key) noexcept
         {
-            if (dense_ != nullptr)
-            {
-                const auto it = dense_->find(key);
-                return it != dense_->end() ? it->second.get() : nullptr;
-            }
-            const auto it = find_small(key);
-            return it != small_.end() ? it->second.get() : nullptr;
+            return std::as_const(*this).find(key);
         }
 
         [[nodiscard]] Pointee *find(const Key &key) const noexcept
         {
-            if (dense_ != nullptr)
+            switch (representation())
             {
-                const auto it = dense_->find(key);
-                return it != dense_->end() ? it->second.get() : nullptr;
+            case Representation::Empty: return nullptr;
+            case Representation::Single: return single_find(storage(), key);
+            case Representation::Small: return small_find(storage(), key);
+            case Representation::Dense: return dense_find(storage(), key);
             }
-            const auto it = find_small(key);
-            return it != small_.end() ? it->second.get() : nullptr;
+            return nullptr;
         }
 
         [[nodiscard]] bool contains(const Key &key) const noexcept { return find(key) != nullptr; }
@@ -87,19 +222,14 @@ namespace hgraph::detail
         [[nodiscard]] std::pair<Pointee *, bool> insert(Key key, pointer_type value)
         {
             assert(value != nullptr && "SmallDensePtrMap owns non-null pointees");
-            if (auto *existing = find(key); existing != nullptr) { return {existing, false}; }
-
-            if (dense_ != nullptr)
+            switch (representation())
             {
-                auto [it, inserted] = dense_->emplace(std::move(key), std::move(value));
-                return {it->second.get(), inserted};
+            case Representation::Empty: return nop_insert(*this, std::move(key), std::move(value));
+            case Representation::Single: return single_insert(*this, std::move(key), std::move(value));
+            case Representation::Small: return small_insert(*this, std::move(key), std::move(value));
+            case Representation::Dense: return dense_insert(*this, std::move(key), std::move(value));
             }
-            if (small_.size() < SmallLimit)
-            {
-                small_.emplace_back(std::move(key), std::move(value));
-                return {small_.back().second.get(), true};
-            }
-            return {promote_and_insert(std::move(key), std::move(value)), true};
+            throw std::logic_error("SmallDensePtrMap has an invalid representation");
         }
 
         template <typename Factory>
@@ -107,111 +237,383 @@ namespace hgraph::detail
         {
             if (auto *existing = find(key); existing != nullptr) { return *existing; }
             auto value = std::invoke(std::forward<Factory>(factory));
-            return *insert(Key{key}, std::move(value)).first;
+            assert(value != nullptr && "SmallDensePtrMap owns non-null pointees");
+            return *insert_absent(Key{key}, std::move(value));
         }
 
         [[nodiscard]] bool erase(const Key &key) noexcept
         {
-            if (dense_ != nullptr) { return dense_->erase(key) != 0; }
-            const auto it = find_small(key);
-            if (it == small_.end()) { return false; }
-            small_.erase(it);
-            return true;
+            switch (representation())
+            {
+            case Representation::Empty: return false;
+            case Representation::Single: return single_erase(*this, key);
+            case Representation::Small: return small_erase(*this, key);
+            case Representation::Dense: return dense_erase(*this, key);
+            }
+            return false;
         }
 
         template <typename Function>
         void for_each(Function &&function)
         {
-            if (dense_ != nullptr)
+            for (const auto &[key, value] : entries())
             {
-                for (auto &[key, value] : *dense_) { std::invoke(function, std::as_const(key), *value); }
-                return;
+                std::invoke(function, std::as_const(key), *value);
             }
-            for (auto &[key, value] : small_) { std::invoke(function, std::as_const(key), *value); }
         }
 
         template <typename Function>
         void for_each(Function &&function) const
         {
-            if (dense_ != nullptr)
+            for (const auto &[key, value] : entries())
             {
-                for (const auto &[key, value] : *dense_) { std::invoke(function, key, std::as_const(*value)); }
-                return;
+                std::invoke(function, key, std::as_const(*value));
             }
-            for (const auto &[key, value] : small_) { std::invoke(function, key, std::as_const(*value)); }
         }
 
         template <typename Predicate>
         [[nodiscard]] bool any_of(Predicate &&predicate) const
         {
-            if (dense_ != nullptr)
-            {
-                for (const auto &[key, value] : *dense_)
-                {
-                    if (std::invoke(predicate, key, std::as_const(*value))) { return true; }
-                }
-                return false;
-            }
-            for (const auto &[key, value] : small_)
+            for (const auto &[key, value] : entries())
             {
                 if (std::invoke(predicate, key, std::as_const(*value))) { return true; }
             }
             return false;
         }
 
-        /** Heap bytes owned by the index and entry storage, excluding pointees. */
+        /** Heap bytes owned by the active index/entry representation, excluding pointees. */
         [[nodiscard]] DynamicStorageMetrics dynamic_storage_metrics() const noexcept
         {
-            if (dense_ == nullptr)
+            switch (representation())
             {
-                return {
-                    .live_bytes = small_.size() * sizeof(value_type),
-                    .reserved_bytes = small_.capacity() * sizeof(value_type),
-                };
+            case Representation::Empty: return {};
+            case Representation::Single: return single_metrics(storage());
+            case Representation::Small: return small_metrics(storage());
+            case Representation::Dense: return dense_metrics(storage());
             }
-
-            using bucket_type = typename DenseStorage::bucket_type;
-            return {
-                .live_bytes = sizeof(DenseStorage) +
-                              dense_->size() * (sizeof(value_type) + sizeof(bucket_type)),
-                .reserved_bytes = sizeof(DenseStorage) +
-                                  dense_->values().capacity() * sizeof(value_type) +
-                                  dense_->bucket_count() * sizeof(bucket_type),
-            };
+            return {};
         }
 
       private:
-        [[nodiscard]] typename SmallStorage::iterator find_small(const Key &key) noexcept
+        [[nodiscard]] Representation representation() const noexcept
         {
-            return std::find_if(small_.begin(), small_.end(), [&](const value_type &entry) {
-                return KeyEqual{}(entry.first, key);
-            });
+            return static_cast<Representation>(tagged_storage_ & representation_mask);
         }
 
-        [[nodiscard]] typename SmallStorage::const_iterator find_small(const Key &key) const noexcept
+        [[nodiscard]] void *storage() const noexcept
         {
-            return std::find_if(small_.begin(), small_.end(), [&](const value_type &entry) {
-                return KeyEqual{}(entry.first, key);
-            });
+            return reinterpret_cast<void *>(tagged_storage_ & ~representation_mask);
         }
 
-        [[nodiscard]] Pointee *promote_and_insert(Key key, pointer_type value)
+        void set_storage(Representation representation_, void *storage_) noexcept
         {
-            auto dense = std::make_unique<DenseStorage>(small_.size() + 1, Hash{}, KeyEqual{});
-            for (auto &entry : small_)
+            const auto address = reinterpret_cast<std::uintptr_t>(storage_);
+            assert((address & representation_mask) == 0);
+            assert((representation_ == Representation::Empty) == (storage_ == nullptr));
+            tagged_storage_ = address | static_cast<std::uintptr_t>(representation_);
+        }
+
+        static void destroy_representation(Representation representation_, void *storage_) noexcept
+        {
+            switch (representation_)
             {
-                static_cast<void>(dense->emplace(entry.first, std::move(entry.second)));
+            case Representation::Empty: return;
+            case Representation::Single: single_destroy(storage_); return;
+            case Representation::Small: small_destroy(storage_); return;
+            case Representation::Dense: dense_destroy(storage_); return;
             }
-            auto [inserted, was_inserted] = dense->emplace(std::move(key), std::move(value));
-            static_cast<void>(was_inserted);
-            auto *result = inserted->second.get();
-            SmallStorage{}.swap(small_);
-            dense_ = std::move(dense);
+        }
+
+        [[nodiscard]] std::span<const value_type> entries() const noexcept
+        {
+            switch (representation())
+            {
+            case Representation::Empty: return {};
+            case Representation::Single: return single_const_entries(storage());
+            case Representation::Small: return small_const_entries(storage());
+            case Representation::Dense: return dense_entries(storage());
+            }
+            return {};
+        }
+
+        [[nodiscard]] Pointee *insert_absent(Key key, pointer_type value)
+        {
+            switch (representation())
+            {
+            case Representation::Empty:
+                return nop_insert_absent(*this, std::move(key), std::move(value));
+            case Representation::Single:
+                return single_insert_absent(*this, std::move(key), std::move(value));
+            case Representation::Small:
+                return small_insert_absent(*this, std::move(key), std::move(value));
+            case Representation::Dense:
+                return dense_insert_absent(*this, std::move(key), std::move(value));
+            }
+            throw std::logic_error("SmallDensePtrMap has an invalid representation");
+        }
+
+        [[nodiscard]] static Pointee *linear_find(std::span<const value_type> values,
+                                                  const Key &key) noexcept
+        {
+            const auto found = std::find_if(values.begin(), values.end(), [&](const value_type &entry) {
+                return KeyEqual{}(entry.first, key);
+            });
+            return found != values.end() ? found->second.get() : nullptr;
+        }
+
+        void replace_with(Representation replacement_representation,
+                          void *replacement_storage) noexcept
+        {
+            const Representation old_representation = representation();
+            void *old_storage = storage();
+            set_storage(replacement_representation, replacement_storage);
+            destroy_representation(old_representation, old_storage);
+        }
+
+        [[nodiscard]] static SmallStorageOwner make_small_shell(std::span<const value_type> existing,
+                                                                 const Key &new_key,
+                                                                 std::size_t capacity)
+        {
+            SmallStorageOwner replacement{SmallStorage::create(capacity)};
+            for (const auto &entry : existing) { replacement->append_key(entry.first); }
+            replacement->append_key(new_key);
+            return replacement;
+        }
+
+        static void transfer_existing(std::span<value_type> source,
+                                      std::span<value_type> target) noexcept
+        {
+            assert(source.size() <= target.size());
+            for (std::size_t index = 0; index < source.size(); ++index)
+            {
+                target[index].second = std::move(source[index].second);
+            }
+        }
+
+        // Empty representation.
+        [[nodiscard]] static Pointee *nop_insert_absent(SmallDensePtrMap &owner,
+                                                        Key key,
+                                                        pointer_type value)
+        {
+            auto replacement = std::make_unique<value_type>(std::move(key), std::move(value));
+            auto *result = replacement->second.get();
+            owner.replace_with(Representation::Single, replacement.release());
             return result;
         }
 
-        SmallStorage small_{};
-        std::unique_ptr<DenseStorage> dense_{};
+        [[nodiscard]] static std::pair<Pointee *, bool> nop_insert(SmallDensePtrMap &owner,
+                                                                   Key key,
+                                                                   pointer_type value)
+        {
+            return {nop_insert_absent(owner, std::move(key), std::move(value)), true};
+        }
+
+        // Single-entry representation.
+        static void single_destroy(void *storage) noexcept { delete static_cast<value_type *>(storage); }
+        [[nodiscard]] static std::size_t single_size(const void *) noexcept { return 1; }
+        [[nodiscard]] static Pointee *single_find(const void *storage, const Key &key) noexcept
+        {
+            const auto *entry = static_cast<const value_type *>(storage);
+            return KeyEqual{}(entry->first, key) ? entry->second.get() : nullptr;
+        }
+        [[nodiscard]] static std::span<value_type> single_entries(void *storage) noexcept
+        {
+            return {static_cast<value_type *>(storage), 1};
+        }
+        [[nodiscard]] static std::span<const value_type> single_const_entries(const void *storage) noexcept
+        {
+            return {static_cast<const value_type *>(storage), 1};
+        }
+        [[nodiscard]] static DynamicStorageMetrics single_metrics(const void *) noexcept
+        {
+            return {.live_bytes = sizeof(value_type), .reserved_bytes = sizeof(value_type)};
+        }
+
+        [[nodiscard]] static Pointee *single_insert_absent(SmallDensePtrMap &owner,
+                                                           Key key,
+                                                           pointer_type value)
+        {
+            auto source = single_entries(owner.storage());
+            auto replacement = make_small_shell(source, key, 2);
+            transfer_existing(source, replacement->values());
+            replacement->entries()[1].second = std::move(value);
+            auto *result = replacement->entries()[1].second.get();
+            owner.replace_with(Representation::Small, replacement.release());
+            return result;
+        }
+
+        [[nodiscard]] static std::pair<Pointee *, bool> single_insert(SmallDensePtrMap &owner,
+                                                                      Key key,
+                                                                      pointer_type value)
+        {
+            if (auto *existing = single_find(owner.storage(), key); existing != nullptr)
+            {
+                return {existing, false};
+            }
+            return {single_insert_absent(owner, std::move(key), std::move(value)), true};
+        }
+
+        [[nodiscard]] static bool single_erase(SmallDensePtrMap &owner, const Key &key) noexcept
+        {
+            if (single_find(owner.storage(), key) == nullptr) { return false; }
+            owner.replace_with(Representation::Empty, nullptr);
+            return true;
+        }
+
+        // Compact linear representation.
+        static void small_destroy(void *storage) noexcept
+        {
+            SmallStorage::destroy(static_cast<SmallStorage *>(storage));
+        }
+        [[nodiscard]] static std::size_t small_size(const void *storage) noexcept
+        {
+            return static_cast<const SmallStorage *>(storage)->size;
+        }
+        [[nodiscard]] static Pointee *small_find(const void *storage, const Key &key) noexcept
+        {
+            return linear_find(static_cast<const SmallStorage *>(storage)->values(), key);
+        }
+        [[nodiscard]] static std::span<const value_type> small_const_entries(const void *storage) noexcept
+        {
+            return static_cast<const SmallStorage *>(storage)->values();
+        }
+        [[nodiscard]] static DynamicStorageMetrics small_metrics(const void *storage) noexcept
+        {
+            const auto *small = static_cast<const SmallStorage *>(storage);
+            return {
+                .live_bytes = SmallStorage::allocation_bytes(small->size),
+                .reserved_bytes = SmallStorage::allocation_bytes(small->capacity),
+            };
+        }
+
+        [[nodiscard]] static Pointee *small_insert_absent(SmallDensePtrMap &owner,
+                                                          Key key,
+                                                          pointer_type value)
+        {
+            auto *small = static_cast<SmallStorage *>(owner.storage());
+            if (small->size < SmallLimit)
+            {
+                if (small->size < small->capacity)
+                {
+                    small->append_key(key);
+                    small->entries()[small->size - 1].second = std::move(value);
+                    return small->entries()[small->size - 1].second.get();
+                }
+
+                const std::size_t capacity = std::min(SmallLimit, small->capacity * 2);
+                auto replacement = make_small_shell(small->values(), key, capacity);
+                transfer_existing(small->values(), replacement->values());
+                replacement->entries()[replacement->size - 1].second = std::move(value);
+                auto *result = replacement->entries()[replacement->size - 1].second.get();
+                owner.replace_with(Representation::Small, replacement.release());
+                return result;
+            }
+
+            auto replacement = std::make_unique<DenseStorage>(small->size + 1, Hash{}, KeyEqual{});
+            replacement->reserve(small->size + 1);
+            std::array<pointer_type *, SmallLimit> destination_owners{};
+            std::size_t destination_index = 0;
+            for (const auto &entry : small->values())
+            {
+                auto [destination, inserted] = replacement->emplace(entry.first, pointer_type{});
+                if (!inserted) { throw std::logic_error("SmallDensePtrMap promotion found a duplicate key"); }
+                destination_owners[destination_index++] = std::addressof(destination->second);
+            }
+            auto [new_entry, inserted] = replacement->emplace(key, pointer_type{});
+            if (!inserted) { throw std::logic_error("SmallDensePtrMap promotion found a duplicate key"); }
+
+            destination_index = 0;
+            for (auto &entry : small->values())
+            {
+                *destination_owners[destination_index++] = std::move(entry.second);
+            }
+            new_entry->second = std::move(value);
+            auto *result = new_entry->second.get();
+            owner.replace_with(Representation::Dense, replacement.release());
+            return result;
+        }
+
+        [[nodiscard]] static std::pair<Pointee *, bool> small_insert(SmallDensePtrMap &owner,
+                                                                     Key key,
+                                                                     pointer_type value)
+        {
+            if (auto *existing = small_find(owner.storage(), key); existing != nullptr)
+            {
+                return {existing, false};
+            }
+            return {small_insert_absent(owner, std::move(key), std::move(value)), true};
+        }
+
+        [[nodiscard]] static bool small_erase(SmallDensePtrMap &owner, const Key &key) noexcept
+        {
+            auto *small = static_cast<SmallStorage *>(owner.storage());
+            const auto values = small->values();
+            const auto found = std::find_if(values.begin(), values.end(), [&](const value_type &entry) {
+                return KeyEqual{}(entry.first, key);
+            });
+            if (found == values.end()) { return false; }
+            small->erase_at(static_cast<std::size_t>(found - values.begin()));
+            return true;
+        }
+
+        // Dense representation.
+        static void dense_destroy(void *storage) noexcept { delete static_cast<DenseStorage *>(storage); }
+        [[nodiscard]] static std::size_t dense_size(const void *storage) noexcept
+        {
+            return static_cast<const DenseStorage *>(storage)->size();
+        }
+        [[nodiscard]] static Pointee *dense_find(const void *storage, const Key &key) noexcept
+        {
+            const auto *dense = static_cast<const DenseStorage *>(storage);
+            const auto found = dense->find(key);
+            return found != dense->end() ? found->second.get() : nullptr;
+        }
+        [[nodiscard]] static std::span<const value_type> dense_entries(const void *storage) noexcept
+        {
+            const auto &values = static_cast<const DenseStorage *>(storage)->values();
+            return {values.data(), values.size()};
+        }
+        [[nodiscard]] static DynamicStorageMetrics dense_metrics(const void *storage) noexcept
+        {
+            const auto *dense = static_cast<const DenseStorage *>(storage);
+            using bucket_type = typename DenseStorage::bucket_type;
+            return {
+                .live_bytes = sizeof(DenseStorage) +
+                              dense->size() * (sizeof(value_type) + sizeof(bucket_type)),
+                .reserved_bytes = sizeof(DenseStorage) +
+                                  dense->values().capacity() * sizeof(value_type) +
+                                  dense->bucket_count() * sizeof(bucket_type),
+            };
+        }
+
+        [[nodiscard]] static Pointee *dense_insert_absent(SmallDensePtrMap &owner,
+                                                          Key key,
+                                                          pointer_type value)
+        {
+            auto *dense = static_cast<DenseStorage *>(owner.storage());
+            auto [entry, inserted] = dense->emplace(std::move(key), std::move(value));
+            assert(inserted);
+            return entry->second.get();
+        }
+
+        [[nodiscard]] static std::pair<Pointee *, bool> dense_insert(SmallDensePtrMap &owner,
+                                                                     Key key,
+                                                                     pointer_type value)
+        {
+            auto *dense = static_cast<DenseStorage *>(owner.storage());
+            if (const auto found = dense->find(key); found != dense->end())
+            {
+                return {found->second.get(), false};
+            }
+            return {dense_insert_absent(owner, std::move(key), std::move(value)), true};
+        }
+
+        [[nodiscard]] static bool dense_erase(SmallDensePtrMap &owner, const Key &key) noexcept
+        {
+            return static_cast<DenseStorage *>(owner.storage())->erase(key) != 0;
+        }
+
+        std::uintptr_t tagged_storage_{0};
     };
 }  // namespace hgraph::detail
 

--- a/include/hgraph/types/utils/small_dense_ptr_map.h
+++ b/include/hgraph/types/utils/small_dense_ptr_map.h
@@ -1,0 +1,218 @@
+#ifndef HGRAPH_TYPES_UTILS_SMALL_DENSE_PTR_MAP_H
+#define HGRAPH_TYPES_UTILS_SMALL_DENSE_PTR_MAP_H
+
+#include <hgraph/types/storage_metrics.h>
+
+#include <ankerl/unordered_dense.h>
+
+#include <algorithm>
+#include <cassert>
+#include <cstddef>
+#include <functional>
+#include <memory>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+namespace hgraph::detail
+{
+    /**
+     * Sparse owner map for stable heap objects.
+     *
+     * Runtime ownership tries are predominantly empty or have only a handful
+     * of children.  Those entries stay in a compact linear vector, avoiding an
+     * empty hash table and its bucket allocation.  A ninth entry promotes the
+     * owner to ``ankerl::unordered_dense::map`` so wider nodes retain constant
+     * expected-time lookup.  Promotion and dense-table relocation only move
+     * ``unique_ptr`` values; the owned object addresses remain stable.
+     */
+    template <typename Key,
+              typename Pointee,
+              typename Deleter = std::default_delete<Pointee>,
+              typename Hash = ankerl::unordered_dense::hash<Key>,
+              typename KeyEqual = std::equal_to<Key>,
+              std::size_t SmallLimit = 8>
+    class SmallDensePtrMap
+    {
+        static_assert(SmallLimit > 0);
+        static_assert(std::is_nothrow_copy_constructible_v<Key>);
+        static_assert(std::is_nothrow_move_constructible_v<Key>);
+
+        using pointer_type = std::unique_ptr<Pointee, Deleter>;
+        using value_type = std::pair<Key, pointer_type>;
+        using SmallStorage = std::vector<value_type>;
+        using DenseStorage = ankerl::unordered_dense::map<Key, pointer_type, Hash, KeyEqual>;
+
+      public:
+        SmallDensePtrMap() noexcept = default;
+        SmallDensePtrMap(const SmallDensePtrMap &) = delete;
+        SmallDensePtrMap &operator=(const SmallDensePtrMap &) = delete;
+        SmallDensePtrMap(SmallDensePtrMap &&) noexcept = default;
+        SmallDensePtrMap &operator=(SmallDensePtrMap &&) noexcept = default;
+        ~SmallDensePtrMap() = default;
+
+        [[nodiscard]] bool empty() const noexcept { return size() == 0; }
+
+        [[nodiscard]] std::size_t size() const noexcept
+        {
+            return dense_ != nullptr ? dense_->size() : small_.size();
+        }
+
+        [[nodiscard]] bool uses_dense_storage() const noexcept { return dense_ != nullptr; }
+
+        [[nodiscard]] Pointee *find(const Key &key) noexcept
+        {
+            if (dense_ != nullptr)
+            {
+                const auto it = dense_->find(key);
+                return it != dense_->end() ? it->second.get() : nullptr;
+            }
+            const auto it = find_small(key);
+            return it != small_.end() ? it->second.get() : nullptr;
+        }
+
+        [[nodiscard]] Pointee *find(const Key &key) const noexcept
+        {
+            if (dense_ != nullptr)
+            {
+                const auto it = dense_->find(key);
+                return it != dense_->end() ? it->second.get() : nullptr;
+            }
+            const auto it = find_small(key);
+            return it != small_.end() ? it->second.get() : nullptr;
+        }
+
+        [[nodiscard]] bool contains(const Key &key) const noexcept { return find(key) != nullptr; }
+
+        [[nodiscard]] std::pair<Pointee *, bool> insert(Key key, pointer_type value)
+        {
+            assert(value != nullptr && "SmallDensePtrMap owns non-null pointees");
+            if (auto *existing = find(key); existing != nullptr) { return {existing, false}; }
+
+            if (dense_ != nullptr)
+            {
+                auto [it, inserted] = dense_->emplace(std::move(key), std::move(value));
+                return {it->second.get(), inserted};
+            }
+            if (small_.size() < SmallLimit)
+            {
+                small_.emplace_back(std::move(key), std::move(value));
+                return {small_.back().second.get(), true};
+            }
+            return {promote_and_insert(std::move(key), std::move(value)), true};
+        }
+
+        template <typename Factory>
+        [[nodiscard]] Pointee &ensure(const Key &key, Factory &&factory)
+        {
+            if (auto *existing = find(key); existing != nullptr) { return *existing; }
+            auto value = std::invoke(std::forward<Factory>(factory));
+            return *insert(Key{key}, std::move(value)).first;
+        }
+
+        [[nodiscard]] bool erase(const Key &key) noexcept
+        {
+            if (dense_ != nullptr) { return dense_->erase(key) != 0; }
+            const auto it = find_small(key);
+            if (it == small_.end()) { return false; }
+            small_.erase(it);
+            return true;
+        }
+
+        template <typename Function>
+        void for_each(Function &&function)
+        {
+            if (dense_ != nullptr)
+            {
+                for (auto &[key, value] : *dense_) { std::invoke(function, std::as_const(key), *value); }
+                return;
+            }
+            for (auto &[key, value] : small_) { std::invoke(function, std::as_const(key), *value); }
+        }
+
+        template <typename Function>
+        void for_each(Function &&function) const
+        {
+            if (dense_ != nullptr)
+            {
+                for (const auto &[key, value] : *dense_) { std::invoke(function, key, std::as_const(*value)); }
+                return;
+            }
+            for (const auto &[key, value] : small_) { std::invoke(function, key, std::as_const(*value)); }
+        }
+
+        template <typename Predicate>
+        [[nodiscard]] bool any_of(Predicate &&predicate) const
+        {
+            if (dense_ != nullptr)
+            {
+                for (const auto &[key, value] : *dense_)
+                {
+                    if (std::invoke(predicate, key, std::as_const(*value))) { return true; }
+                }
+                return false;
+            }
+            for (const auto &[key, value] : small_)
+            {
+                if (std::invoke(predicate, key, std::as_const(*value))) { return true; }
+            }
+            return false;
+        }
+
+        /** Heap bytes owned by the index and entry storage, excluding pointees. */
+        [[nodiscard]] DynamicStorageMetrics dynamic_storage_metrics() const noexcept
+        {
+            if (dense_ == nullptr)
+            {
+                return {
+                    .live_bytes = small_.size() * sizeof(value_type),
+                    .reserved_bytes = small_.capacity() * sizeof(value_type),
+                };
+            }
+
+            using bucket_type = typename DenseStorage::bucket_type;
+            return {
+                .live_bytes = sizeof(DenseStorage) +
+                              dense_->size() * (sizeof(value_type) + sizeof(bucket_type)),
+                .reserved_bytes = sizeof(DenseStorage) +
+                                  dense_->values().capacity() * sizeof(value_type) +
+                                  dense_->bucket_count() * sizeof(bucket_type),
+            };
+        }
+
+      private:
+        [[nodiscard]] typename SmallStorage::iterator find_small(const Key &key) noexcept
+        {
+            return std::find_if(small_.begin(), small_.end(), [&](const value_type &entry) {
+                return KeyEqual{}(entry.first, key);
+            });
+        }
+
+        [[nodiscard]] typename SmallStorage::const_iterator find_small(const Key &key) const noexcept
+        {
+            return std::find_if(small_.begin(), small_.end(), [&](const value_type &entry) {
+                return KeyEqual{}(entry.first, key);
+            });
+        }
+
+        [[nodiscard]] Pointee *promote_and_insert(Key key, pointer_type value)
+        {
+            auto dense = std::make_unique<DenseStorage>(small_.size() + 1, Hash{}, KeyEqual{});
+            for (auto &entry : small_)
+            {
+                static_cast<void>(dense->emplace(entry.first, std::move(entry.second)));
+            }
+            auto [inserted, was_inserted] = dense->emplace(std::move(key), std::move(value));
+            static_cast<void>(was_inserted);
+            auto *result = inserted->second.get();
+            SmallStorage{}.swap(small_);
+            dense_ = std::move(dense);
+            return result;
+        }
+
+        SmallStorage small_{};
+        std::unique_ptr<DenseStorage> dense_{};
+    };
+}  // namespace hgraph::detail
+
+#endif  // HGRAPH_TYPES_UTILS_SMALL_DENSE_PTR_MAP_H

--- a/src/hgraph/runtime/node.cpp
+++ b/src/hgraph/runtime/node.cpp
@@ -1479,8 +1479,8 @@ namespace hgraph
         };
         std::array<TSDataIdentity, 3> attributed_ts_data{};
         std::size_t attributed_count = 0;
-        const auto add_ts_data_storage = [&result, &attributed_ts_data,
-                                          &attributed_count](const TSOutputView &view) noexcept {
+        const auto add_ts_output_storage = [&result, &attributed_ts_data,
+                                            &attributed_count](const TSOutputView &view) noexcept {
             const TSDataView &data = view.data_view();
             const TSDataIdentity identity{
                 .record = data.storage_type().record(),
@@ -1499,7 +1499,7 @@ namespace hgraph
             }
             if (already_attributed) { return; }
             attributed_ts_data[attributed_count++] = identity;
-            const DynamicStorageMetrics metrics = data.dynamic_storage_metrics();
+            const DynamicStorageMetrics metrics = view.dynamic_storage_metrics();
             result.dynamic_live_bytes += metrics.live_bytes;
             result.dynamic_reserved_bytes += metrics.reserved_bytes;
         };
@@ -1512,9 +1512,15 @@ namespace hgraph
         {
             if (has_state()) { add_value_storage(state()); }
             if (has_scalars()) { add_value_storage(scalars()); }
-            if (has_output()) { add_ts_data_storage(output(MIN_DT)); }
-            if (has_error_output()) { add_ts_data_storage(error_output(MIN_DT)); }
-            if (has_recordable_state()) { add_ts_data_storage(recordable_state(MIN_DT)); }
+            if (has_input())
+            {
+                const DynamicStorageMetrics metrics = input(MIN_DT).dynamic_storage_metrics();
+                result.dynamic_live_bytes += metrics.live_bytes;
+                result.dynamic_reserved_bytes += metrics.reserved_bytes;
+            }
+            if (has_output()) { add_ts_output_storage(output(MIN_DT)); }
+            if (has_error_output()) { add_ts_output_storage(error_output(MIN_DT)); }
+            if (has_recordable_state()) { add_ts_output_storage(recordable_state(MIN_DT)); }
         }
         catch (...)
         {

--- a/src/hgraph/types/time_series/ts_data/base_view.cpp
+++ b/src/hgraph/types/time_series/ts_data/base_view.cpp
@@ -13,6 +13,37 @@
 #include <utility>
 
 namespace hgraph {
+namespace {
+DynamicStorageMetrics observer_storage_metrics(const TSDataView &view) noexcept {
+  if (!view.valid()) {
+    return {};
+  }
+  try {
+    DynamicStorageMetrics result =
+        view.tracking().observers.dynamic_storage_metrics();
+    const auto &table = view.ops();
+    const auto *ownership = table.ownership_ops;
+    if (ownership == nullptr) {
+      return result;
+    }
+
+    const std::size_t child_count =
+        ownership->child_count(table.context, view.data());
+    for (std::size_t index = 0; index < child_count; ++index) {
+      const auto child = ownership->child_at(
+          table.context, const_cast<void *>(view.data()), index);
+      if (!child.type || child.data == nullptr) {
+        continue;
+      }
+      result += observer_storage_metrics(TSDataView{child.type, child.data});
+    }
+    return result;
+  } catch (...) {
+    return {};
+  }
+}
+} // namespace
+
 const TSParentLink &TSDataView::parent_link() const {
   return tracking().parent;
 }
@@ -181,7 +212,8 @@ DynamicStorageMetrics TSDataView::dynamic_storage_metrics() const noexcept {
   }
   try {
     const auto &table = ops();
-    return table.dynamic_storage_metrics_impl(table.context, data());
+    return table.dynamic_storage_metrics_impl(table.context, data()) +
+           observer_storage_metrics(*this);
   } catch (...) {
     return {};
   }

--- a/src/hgraph/types/time_series/ts_data/types.cpp
+++ b/src/hgraph/types/time_series/ts_data/types.cpp
@@ -69,6 +69,16 @@ namespace hgraph
         }));
     }
 
+    DynamicStorageMetrics TSDataObserverSet::dynamic_storage_metrics() const noexcept
+    {
+        const auto *entries = many();
+        if (entries == nullptr) { return {}; }
+        return {
+            .live_bytes = sizeof(ObserverList) + entries->entries.size() * sizeof(Notifiable *),
+            .reserved_bytes = sizeof(ObserverList) + entries->entries.capacity() * sizeof(Notifiable *),
+        };
+    }
+
     void TSDataObserverSet::subscribe(Notifiable *observer)
     {
         if (observer == nullptr) { return; }

--- a/src/hgraph/types/time_series/ts_input.cpp
+++ b/src/hgraph/types/time_series/ts_input.cpp
@@ -2436,6 +2436,61 @@ namespace hgraph
             return ::hgraph::input_context_for(data.storage_type()) != nullptr;
         }
 
+        DynamicStorageMetrics input_target_link_dynamic_storage_metrics(
+            const TSDataView &view) noexcept
+        {
+            if (!view.valid()) { return {}; }
+            try
+            {
+                if (const auto *link = target_link_storage(view); link != nullptr)
+                {
+                    return link->dynamic_storage_metrics();
+                }
+                if (view.schema() == nullptr) { return {}; }
+
+                DynamicStorageMetrics result{};
+                switch (view.schema()->kind)
+                {
+                    case TSTypeKind::TSB:
+                    case TSTypeKind::TSL:
+                        for (std::size_t index = 0; index < view.indexed_child_count(); ++index)
+                        {
+                            if (has_input_children(view))
+                            {
+                                auto child = input_child_projection(view, index);
+                                result += input_target_link_dynamic_storage_metrics(
+                                    child.target_link.valid() ? child.target_link : child.visible);
+                            }
+                            else
+                            {
+                                result += input_target_link_dynamic_storage_metrics(
+                                    view.indexed_child_at(index));
+                            }
+                        }
+                        break;
+                    case TSTypeKind::TSD:
+                    {
+                        auto dict = view.as_dict();
+                        for (std::size_t slot = 0; slot < dict.slot_capacity(); ++slot)
+                        {
+                            if (dict.slot_occupied(slot))
+                            {
+                                result += input_target_link_dynamic_storage_metrics(dict.at_slot(slot));
+                            }
+                        }
+                        break;
+                    }
+                    default:
+                        break;
+                }
+                return result;
+            }
+            catch (...)
+            {
+                return {};
+            }
+        }
+
         TSInputChildProjection input_child_projection(const TSDataView &parent, std::size_t index)
         {
             const auto *context = ::hgraph::input_context_for(parent.storage_type());
@@ -2486,23 +2541,31 @@ namespace hgraph
 
         TSInputActiveTarget *TSInputActiveTarget::child_at(std::size_t slot_) const noexcept
         {
-            if (const auto it = children.find(slot_); it != children.end()) { return it->second.get(); }
-            return nullptr;
+            return children.find(slot_);
         }
 
         bool TSInputActiveTarget::has_any_active() const noexcept
         {
             if (active) { return true; }
-            return std::ranges::any_of(children, [](const auto &entry) {
-                return entry.second && entry.second->has_any_active();
+            return children.any_of([](std::size_t, const TSInputActiveTarget &child) {
+                return child.has_any_active();
             });
+        }
+
+        DynamicStorageMetrics TSInputActiveTarget::dynamic_storage_metrics() const noexcept
+        {
+            DynamicStorageMetrics result = children.dynamic_storage_metrics();
+            children.for_each([&](std::size_t, const TSInputActiveTarget &child) {
+                result.live_bytes += sizeof(TSInputActiveTarget);
+                result.reserved_bytes += sizeof(TSInputActiveTarget);
+                result += child.dynamic_storage_metrics();
+            });
+            return result;
         }
 
         TSInputActiveTarget &TSInputActiveTarget::ensure_child(std::size_t slot_)
         {
-            auto &child = children[slot_];
-            if (!child) { child = std::make_unique<TSInputActiveTarget>(this, slot_); }
-            return *child;
+            return children.ensure(slot_, [&] { return std::make_unique<TSInputActiveTarget>(this, slot_); });
         }
 
         void TSInputActiveTarget::subscribe(const TSDataView &observed_, Notifiable *target_notifier)
@@ -2713,6 +2776,24 @@ namespace hgraph
         return type ? TSInputTypeRef::checked(type) : TSInputTypeRef{};
     }
 
+    DynamicStorageMetrics TSInput::dynamic_storage_metrics() const noexcept
+    {
+        DynamicStorageMetrics result{};
+        if (data_.has_value())
+        {
+            const auto view = data_.view();
+            result += view.dynamic_storage_metrics();
+            result += detail::input_target_link_dynamic_storage_metrics(view);
+        }
+        if (active_root_ != nullptr)
+        {
+            result.live_bytes += sizeof(detail::TSInputActiveTarget);
+            result.reserved_bytes += sizeof(detail::TSInputActiveTarget);
+            result += active_root_->dynamic_storage_metrics();
+        }
+        return result;
+    }
+
     NodeView TSInput::owner_node() const
     {
         return has_value() ? data_.view().owner_node() : NodeView{};
@@ -2799,7 +2880,7 @@ namespace hgraph
             }
             const auto slot = active->slot;
             active = parent;
-            active->children.erase(slot);
+            static_cast<void>(active->children.erase(slot));
         }
     }
 

--- a/src/hgraph/types/time_series/ts_input/base_view.cpp
+++ b/src/hgraph/types/time_series/ts_input/base_view.cpp
@@ -448,6 +448,11 @@ namespace hgraph
         throw std::logic_error("TSInputView::delta_value requires a live input view");
     }
 
+    DynamicStorageMetrics TSInputView::dynamic_storage_metrics() const noexcept
+    {
+        return input_ != nullptr ? input_->dynamic_storage_metrics() : DynamicStorageMetrics{};
+    }
+
     TimeSeriesReference TSInputView::reference() const
     {
         const auto *view_schema = schema();

--- a/src/hgraph/types/time_series/ts_input/target_link.cpp
+++ b/src/hgraph/types/time_series/ts_input/target_link.cpp
@@ -107,20 +107,18 @@ namespace hgraph::detail
                               TSInputTargetLinkState::SchedulingNotifier &notifier) noexcept
         {
             unsubscribe_node(node, notifier);
-            for (auto &[slot, child] : node.children)
-            {
-                if (child) { unsubscribe_tree(*child, notifier); }
-            }
+            node.children.for_each([&](std::size_t, TSInputTargetActiveNode &child) {
+                unsubscribe_tree(child, notifier);
+            });
         }
 
         void unsubscribe_tree_noexcept(TSInputTargetActiveNode &node,
                                        TSInputTargetLinkState::SchedulingNotifier &notifier) noexcept
         {
             unsubscribe_handle_noexcept(node.observed, &notifier);
-            for (auto &[slot, child] : node.children)
-            {
-                if (child) { unsubscribe_tree_noexcept(*child, notifier); }
-            }
+            node.children.for_each([&](std::size_t, TSInputTargetActiveNode &child) {
+                unsubscribe_tree_noexcept(child, notifier);
+            });
         }
 
         void replace_observer(const TSOutputHandle &observed,
@@ -139,10 +137,9 @@ namespace hgraph::detail
                                     TSInputTargetLinkState::SchedulingNotifier &replacement) noexcept
         {
             replace_observer(node.observed, &previous, &replacement);
-            for (auto &[slot, child] : node.children)
-            {
-                if (child) { replace_tree_observers(*child, previous, replacement); }
-            }
+            node.children.for_each([&](std::size_t, TSInputTargetActiveNode &child) {
+                replace_tree_observers(child, previous, replacement);
+            });
         }
 
         [[nodiscard]] TSSDataView target_slot_set(const TSInputTargetLinkStorage &link)
@@ -218,49 +215,52 @@ namespace hgraph::detail
                 }
             }
 
-            for (auto &[slot_index, child] : node.children)
-            {
-                if (!child) { continue; }
-                static_cast<void>(slot_index);
-                resubscribe_tree(link, schema, *child);
-            }
+            node.children.for_each([&](std::size_t, TSInputTargetActiveNode &child) {
+                resubscribe_tree(link, schema, child);
+            });
         }
     }  // namespace
 
     TSInputTargetActiveNode *TSInputTargetActiveNode::child_at(std::size_t slot_index) const noexcept
     {
-        if (const auto it = children.find(slot_index); it != children.end()) { return it->second.get(); }
-        return nullptr;
+        return children.find(slot_index);
     }
 
     bool TSInputTargetActiveNode::has_any_active() const noexcept
     {
         if (locally_active) { return true; }
-        return std::ranges::any_of(children, [](const auto &entry) {
-            return entry.second && entry.second->has_any_active();
+        return children.any_of([](std::size_t, const TSInputTargetActiveNode &child) {
+            return child.has_any_active();
         });
+    }
+
+    DynamicStorageMetrics TSInputTargetActiveNode::dynamic_storage_metrics() const noexcept
+    {
+        DynamicStorageMetrics result = children.dynamic_storage_metrics();
+        children.for_each([&](std::size_t, const TSInputTargetActiveNode &child) {
+            result.live_bytes += sizeof(TSInputTargetActiveNode);
+            result.reserved_bytes += sizeof(TSInputTargetActiveNode);
+            result += child.dynamic_storage_metrics();
+        });
+        return result;
     }
 
     TSInputTargetActiveNode &TSInputTargetActiveNode::ensure_child(std::size_t slot_index)
     {
-        auto &child = children[slot_index];
-        if (!child)
-        {
-            child = std::make_unique<TSInputTargetActiveNode>();
+        return children.ensure(slot_index, [&] {
+            auto child = std::make_unique<TSInputTargetActiveNode>();
             child->parent = this;
             child->slot = slot_index;
-        }
-        return *child;
+            return child;
+        });
     }
 
     void TSInputTargetActiveNode::clear_observed() noexcept
     {
         observed.reset();
-        for (auto &[slot_index, child] : children)
-        {
-            static_cast<void>(slot_index);
-            if (child) { child->clear_observed(); }
-        }
+        children.for_each([](std::size_t, TSInputTargetActiveNode &child) {
+            child.clear_observed();
+        });
     }
 
     void TSInputTargetLinkState::SchedulingNotifier::set_target(Notifiable *target) noexcept
@@ -859,6 +859,24 @@ namespace hgraph::detail
     const TSInputTargetLinkState *TSInputTargetLinkStorage::state() const noexcept
     {
         return &state_;
+    }
+
+    DynamicStorageMetrics TSInputTargetLinkStorage::dynamic_storage_metrics() const noexcept
+    {
+        DynamicStorageMetrics result = slot_observers_.dynamic_storage_metrics();
+        if (state_.active_root_node != nullptr)
+        {
+            result.live_bytes += sizeof(TSInputTargetActiveNode);
+            result.reserved_bytes += sizeof(TSInputTargetActiveNode);
+            result += state_.active_root_node->dynamic_storage_metrics();
+        }
+        if (structural_transition_ != nullptr)
+        {
+            result.live_bytes += sizeof(StructuralTransition);
+            result.reserved_bytes += sizeof(StructuralTransition);
+            result += structural_transition_->key_set_tracking.observers.dynamic_storage_metrics();
+        }
+        return result;
     }
 
     bool is_target_link_view(const TSDataView &view) noexcept

--- a/src/hgraph/types/time_series/ts_output.cpp
+++ b/src/hgraph/types/time_series/ts_output.cpp
@@ -209,6 +209,18 @@ TSOutput::binding_for(const TSOutputView &source,
   return alternatives_->binding_for(source, requested_schema);
 }
 
+DynamicStorageMetrics TSOutput::dynamic_storage_metrics() const noexcept {
+  DynamicStorageMetrics result = data_.has_value()
+                                     ? data_.view().dynamic_storage_metrics()
+                                     : DynamicStorageMetrics{};
+  if (alternatives_) {
+    result.live_bytes += sizeof(detail::TSOutputAlternativeStore);
+    result.reserved_bytes += sizeof(detail::TSOutputAlternativeStore);
+    result += alternatives_->dynamic_storage_metrics();
+  }
+  return result;
+}
+
 void TSOutput::release_alternative_subscriptions(
     DateTime release_time) const noexcept {
   if (alternatives_) {

--- a/src/hgraph/types/time_series/ts_output/alternative.cpp
+++ b/src/hgraph/types/time_series/ts_output/alternative.cpp
@@ -1622,26 +1622,26 @@ namespace hgraph::detail
 
 }  // namespace hgraph::detail
 
-namespace std
+namespace hgraph::detail
 {
-    void default_delete<hgraph::detail::TSOutputAlternativeStore::ToRefAlternativeState>::operator()(
-        hgraph::detail::TSOutputAlternativeStore::ToRefAlternativeState *p) noexcept
+    void TSOutputAlternativeStore::ToRefAlternativeDelete::operator()(
+        ToRefAlternativeState *p) const noexcept
     {
         delete p;
     }
 
-    void default_delete<hgraph::detail::TSOutputAlternativeStore::RefLinkAlternativeState>::operator()(
-        hgraph::detail::TSOutputAlternativeStore::RefLinkAlternativeState *p) noexcept
+    void TSOutputAlternativeStore::RefLinkAlternativeDelete::operator()(
+        RefLinkAlternativeState *p) const noexcept
     {
         delete p;
     }
 
-    void default_delete<hgraph::detail::TSOutputAlternativeStore::InteriorFromRefAlternativeState>::operator()(
-        hgraph::detail::TSOutputAlternativeStore::InteriorFromRefAlternativeState *p) noexcept
+    void TSOutputAlternativeStore::InteriorFromRefAlternativeDelete::operator()(
+        InteriorFromRefAlternativeState *p) const noexcept
     {
         delete p;
     }
-}  // namespace std
+}  // namespace hgraph::detail
 
 namespace hgraph::detail
 {
@@ -1652,18 +1652,49 @@ namespace hgraph::detail
 
     void TSOutputAlternativeStore::release_subscriptions(DateTime release_time) noexcept
     {
-        for (auto &[key, state] : to_ref_alternatives_)
-        {
-            if (state != nullptr) { state->release_subscriptions(); }
-        }
-        for (auto &[key, state] : ref_link_alternatives_)
-        {
-            if (state != nullptr) { state->release_subscriptions(release_time); }
-        }
-        for (auto &[key, state] : interior_from_ref_alternatives_)
-        {
-            if (state != nullptr) { state->release_subscriptions(release_time); }
-        }
+        to_ref_alternatives_.for_each([](const AlternativeKey &, ToRefAlternativeState &state) {
+            state.release_subscriptions();
+        });
+        ref_link_alternatives_.for_each([&](const AlternativeKey &, RefLinkAlternativeState &state) {
+            state.release_subscriptions(release_time);
+        });
+        interior_from_ref_alternatives_.for_each(
+            [&](const AlternativeKey &, InteriorFromRefAlternativeState &state) {
+                state.release_subscriptions(release_time);
+            });
+    }
+
+    DynamicStorageMetrics TSOutputAlternativeStore::dynamic_storage_metrics() const noexcept
+    {
+        DynamicStorageMetrics result = to_ref_alternatives_.dynamic_storage_metrics();
+        result += ref_link_alternatives_.dynamic_storage_metrics();
+        result += interior_from_ref_alternatives_.dynamic_storage_metrics();
+
+        to_ref_alternatives_.for_each([&](const AlternativeKey &, const ToRefAlternativeState &state) {
+            result.live_bytes += sizeof(ToRefAlternativeState);
+            result.reserved_bytes += sizeof(ToRefAlternativeState);
+            const auto view = state.data.view();
+            result += view.dynamic_storage_metrics();
+            result += input_target_link_dynamic_storage_metrics(view);
+        });
+        ref_link_alternatives_.for_each([&](const AlternativeKey &, const RefLinkAlternativeState &state) {
+            result.live_bytes += sizeof(RefLinkAlternativeState) +
+                                 state.reference_sources.size() * sizeof(TSOutputHandle);
+            result.reserved_bytes += sizeof(RefLinkAlternativeState) +
+                                     state.reference_sources.capacity() * sizeof(TSOutputHandle);
+            const auto view = state.data.view();
+            result += view.dynamic_storage_metrics();
+            result += input_target_link_dynamic_storage_metrics(view);
+        });
+        interior_from_ref_alternatives_.for_each(
+            [&](const AlternativeKey &, const InteriorFromRefAlternativeState &state) {
+                result.live_bytes += sizeof(InteriorFromRefAlternativeState);
+                result.reserved_bytes += sizeof(InteriorFromRefAlternativeState);
+                const auto view = state.data.view();
+                result += view.dynamic_storage_metrics();
+                result += input_target_link_dynamic_storage_metrics(view);
+            });
+        return result;
     }
 
     std::size_t TSOutputAlternativeStore::AlternativeKeyHash::operator()(const AlternativeKey &key) const noexcept
@@ -1752,63 +1783,66 @@ namespace hgraph::detail
                                                             const TSOutputView &source,
                                                             const TSValueTypeMetaData &requested_schema)
     {
-        auto it = to_ref_alternatives_.find(key);
-        if (it == to_ref_alternatives_.end())
+        auto *state = to_ref_alternatives_.find(key);
+        if (state == nullptr)
         {
-            auto state = std::make_unique<ToRefAlternativeState>(requested_schema, source);
-            it = to_ref_alternatives_.emplace(key, std::move(state)).first;
+            std::unique_ptr<ToRefAlternativeState, ToRefAlternativeDelete> inserted{
+                new ToRefAlternativeState(requested_schema, source)};
+            state = to_ref_alternatives_.insert(key, std::move(inserted)).first;
         }
         else
         {
-            if (it->second->requested_schema != &requested_schema)
+            if (state->requested_schema != &requested_schema)
             {
                 throw std::logic_error("TSOutput to-REF alternative cache key resolved to the wrong requested schema");
             }
-            it->second->rebind(source);
+            state->rebind(source);
         }
-        return it->second->handle(source.output());
+        return state->handle(source.output());
     }
 
     TSOutputHandle TSOutputAlternativeStore::from_ref_binding(const AlternativeKey &key,
                                                               const TSOutputView &source,
                                                               const TSValueTypeMetaData &requested_schema)
     {
-        auto it = ref_link_alternatives_.find(key);
-        if (it == ref_link_alternatives_.end())
+        auto *state = ref_link_alternatives_.find(key);
+        if (state == nullptr)
         {
-            auto state = std::make_unique<RefLinkAlternativeState>(requested_schema, source);
-            it = ref_link_alternatives_.emplace(key, std::move(state)).first;
+            std::unique_ptr<RefLinkAlternativeState, RefLinkAlternativeDelete> inserted{
+                new RefLinkAlternativeState(requested_schema, source)};
+            state = ref_link_alternatives_.insert(key, std::move(inserted)).first;
         }
         else
         {
-            if (it->second->requested_schema != &requested_schema)
+            if (state->requested_schema != &requested_schema)
             {
                 throw std::logic_error("TSOutput from-REF alternative cache key resolved to the wrong requested schema");
             }
-            it->second->rebind(source);
+            state->rebind(source);
         }
-        return it->second->handle(source.output());
+        return state->handle(source.output());
     }
 
     TSOutputHandle TSOutputAlternativeStore::from_ref_interior_binding(const AlternativeKey &key,
                                                                        const TSOutputView &source,
                                                                        const TSValueTypeMetaData &requested_schema)
     {
-        auto it = interior_from_ref_alternatives_.find(key);
-        if (it == interior_from_ref_alternatives_.end())
+        auto *state = interior_from_ref_alternatives_.find(key);
+        if (state == nullptr)
         {
-            auto state = std::make_unique<InteriorFromRefAlternativeState>(requested_schema, source);
-            it = interior_from_ref_alternatives_.emplace(key, std::move(state)).first;
+            std::unique_ptr<InteriorFromRefAlternativeState, InteriorFromRefAlternativeDelete> inserted{
+                new InteriorFromRefAlternativeState(requested_schema, source)};
+            state = interior_from_ref_alternatives_.insert(key, std::move(inserted)).first;
         }
         else
         {
-            if (it->second->requested_schema != &requested_schema)
+            if (state->requested_schema != &requested_schema)
             {
                 throw std::logic_error(
                     "TSOutput interior from-REF alternative cache key resolved to the wrong requested schema");
             }
-            it->second->rebind(source);
+            state->rebind(source);
         }
-        return it->second->handle(source.output());
+        return state->handle(source.output());
     }
 }  // namespace hgraph::detail

--- a/src/hgraph/types/time_series/ts_output/base_view.cpp
+++ b/src/hgraph/types/time_series/ts_output/base_view.cpp
@@ -61,6 +61,11 @@ namespace hgraph
         return data_.delta_value(evaluation_time_);
     }
 
+    DynamicStorageMetrics TSOutputView::dynamic_storage_metrics() const noexcept
+    {
+        return output_ != nullptr ? output_->dynamic_storage_metrics() : DynamicStorageMetrics{};
+    }
+
     DateTime TSOutputView::last_modified_time() const
     {
         return data_.last_modified_time();

--- a/tests/cpp/CMakeLists.txt
+++ b/tests/cpp/CMakeLists.txt
@@ -211,6 +211,7 @@ hgraph_add_test_objects(hgraph_value_test_objects
     test_runtime_value_view.cpp
     test_schema_examples.cpp
     test_scope.cpp
+    test_small_dense_ptr_map.cpp
     test_slot_utils.cpp
     test_specialized_views.cpp
     test_static_schema.cpp

--- a/tests/cpp/test_inspector.cpp
+++ b/tests/cpp/test_inspector.cpp
@@ -166,7 +166,9 @@ TEST_CASE("inspector: native snapshots own hierarchy, timings, schedules and sto
     const InspectionEntry &switched = entry_containing(live, "switch");
     CHECK(switched.storage.nested_graph_count == 1);
     CHECK(switched.storage.nested_graph_capacity == 2);
-    CHECK(switched.storage.dynamic_reserved_bytes == 0);
+    CHECK(switched.storage.dynamic_live_bytes > 0);
+    CHECK(switched.storage.dynamic_reserved_bytes >=
+          switched.storage.dynamic_live_bytes);
 
     const auto keyed_output_nodes = std::ranges::count_if(
         live.entries, [](const InspectionEntry &entry) {

--- a/tests/cpp/test_small_dense_ptr_map.cpp
+++ b/tests/cpp/test_small_dense_ptr_map.cpp
@@ -1,0 +1,69 @@
+#include <catch2/catch_test_macros.hpp>
+
+#include <hgraph/types/utils/small_dense_ptr_map.h>
+
+#include <cstddef>
+#include <memory>
+#include <vector>
+
+namespace
+{
+    struct Entry
+    {
+        explicit Entry(int value_) : value{value_} {}
+        int value{0};
+    };
+}
+
+TEST_CASE("SmallDensePtrMap keeps small ownership maps allocation-efficient", "[small-dense-ptr-map]")
+{
+    hgraph::detail::SmallDensePtrMap<std::size_t, Entry> values;
+
+    CHECK(values.empty());
+    CHECK_FALSE(values.uses_dense_storage());
+    CHECK(values.dynamic_storage_metrics().reserved_bytes == 0);
+
+    auto &first = values.ensure(2, [] { return std::make_unique<Entry>(20); });
+    CHECK(first.value == 20);
+    CHECK(values.find(2) == &first);
+    CHECK(&values.ensure(2, [] { return std::make_unique<Entry>(99); }) == &first);
+    CHECK(values.size() == 1);
+    CHECK_FALSE(values.uses_dense_storage());
+    CHECK(values.dynamic_storage_metrics().live_bytes > 0);
+}
+
+TEST_CASE("SmallDensePtrMap promotes without relocating owned objects", "[small-dense-ptr-map]")
+{
+    hgraph::detail::SmallDensePtrMap<std::size_t, Entry> values;
+    std::vector<Entry *> stable;
+    for (std::size_t key = 0; key < 8; ++key)
+    {
+        stable.push_back(&values.ensure(key, [key] { return std::make_unique<Entry>(static_cast<int>(key)); }));
+    }
+
+    CHECK_FALSE(values.uses_dense_storage());
+    auto &ninth = values.ensure(8, [] { return std::make_unique<Entry>(8); });
+    CHECK(values.uses_dense_storage());
+    CHECK(values.size() == 9);
+    CHECK(values.find(8) == &ninth);
+    for (std::size_t key = 0; key < stable.size(); ++key)
+    {
+        CHECK(values.find(key) == stable[key]);
+    }
+
+    CHECK(values.erase(3));
+    CHECK_FALSE(values.erase(3));
+    CHECK(values.find(3) == nullptr);
+
+    std::size_t visited = 0;
+    values.for_each([&](std::size_t, const Entry &) { ++visited; });
+    CHECK(visited == 8);
+    std::size_t predicates = 0;
+    CHECK(values.any_of([&](std::size_t, const Entry &) {
+        ++predicates;
+        return true;
+    }));
+    CHECK(predicates == 1);
+    CHECK(values.dynamic_storage_metrics().reserved_bytes >=
+          values.dynamic_storage_metrics().live_bytes);
+}

--- a/tests/cpp/test_small_dense_ptr_map.cpp
+++ b/tests/cpp/test_small_dense_ptr_map.cpp
@@ -13,11 +13,26 @@ namespace
         explicit Entry(int value_) : value{value_} {}
         int value{0};
     };
+
+    struct TrackedEntry
+    {
+        explicit TrackedEntry(int value_) : value{value_} { ++alive; }
+        ~TrackedEntry() { --alive; }
+
+        TrackedEntry(const TrackedEntry &) = delete;
+        TrackedEntry &operator=(const TrackedEntry &) = delete;
+
+        int value{0};
+        static inline int alive{0};
+    };
 }
 
 TEST_CASE("SmallDensePtrMap keeps small ownership maps allocation-efficient", "[small-dense-ptr-map]")
 {
-    hgraph::detail::SmallDensePtrMap<std::size_t, Entry> values;
+    using Map = hgraph::detail::SmallDensePtrMap<std::size_t, Entry>;
+    STATIC_REQUIRE(sizeof(Map) == sizeof(void *));
+
+    Map values;
 
     CHECK(values.empty());
     CHECK_FALSE(values.uses_dense_storage());
@@ -29,19 +44,34 @@ TEST_CASE("SmallDensePtrMap keeps small ownership maps allocation-efficient", "[
     CHECK(&values.ensure(2, [] { return std::make_unique<Entry>(99); }) == &first);
     CHECK(values.size() == 1);
     CHECK_FALSE(values.uses_dense_storage());
-    CHECK(values.dynamic_storage_metrics().live_bytes > 0);
+    const auto single_metrics = values.dynamic_storage_metrics();
+    CHECK(single_metrics.live_bytes > 0);
+    CHECK(single_metrics.live_bytes == single_metrics.reserved_bytes);
+
+    CHECK(values.erase(2));
+    CHECK(values.empty());
+    CHECK(values.dynamic_storage_metrics().reserved_bytes == 0);
 }
 
 TEST_CASE("SmallDensePtrMap promotes without relocating owned objects", "[small-dense-ptr-map]")
 {
     hgraph::detail::SmallDensePtrMap<std::size_t, Entry> values;
     std::vector<Entry *> stable;
+    std::vector<std::size_t> reserved;
     for (std::size_t key = 0; key < 8; ++key)
     {
         stable.push_back(&values.ensure(key, [key] { return std::make_unique<Entry>(static_cast<int>(key)); }));
+        reserved.push_back(values.dynamic_storage_metrics().reserved_bytes);
     }
 
     CHECK_FALSE(values.uses_dense_storage());
+    CHECK(reserved[1] > reserved[0]);
+    CHECK(reserved[2] > reserved[1]);
+    CHECK(reserved[3] == reserved[2]);
+    CHECK(reserved[4] > reserved[3]);
+    CHECK(reserved[5] == reserved[4]);
+    CHECK(reserved[6] == reserved[4]);
+    CHECK(reserved[7] == reserved[4]);
     auto &ninth = values.ensure(8, [] { return std::make_unique<Entry>(8); });
     CHECK(values.uses_dense_storage());
     CHECK(values.size() == 9);
@@ -66,4 +96,93 @@ TEST_CASE("SmallDensePtrMap promotes without relocating owned objects", "[small-
     CHECK(predicates == 1);
     CHECK(values.dynamic_storage_metrics().reserved_bytes >=
           values.dynamic_storage_metrics().live_bytes);
+}
+
+TEST_CASE("SmallDensePtrMap reuses promoted storage after erase", "[small-dense-ptr-map]")
+{
+    hgraph::detail::SmallDensePtrMap<std::size_t, Entry> values;
+    for (std::size_t key = 0; key < 4; ++key)
+    {
+        static_cast<void>(values.ensure(key, [key] {
+            return std::make_unique<Entry>(static_cast<int>(key));
+        }));
+    }
+    const auto small_reserved = values.dynamic_storage_metrics().reserved_bytes;
+
+    for (std::size_t key = 0; key < 4; ++key) { CHECK(values.erase(key)); }
+    CHECK(values.empty());
+    CHECK_FALSE(values.uses_dense_storage());
+    CHECK(values.dynamic_storage_metrics().reserved_bytes == small_reserved);
+
+    auto &replacement = values.ensure(10, [] { return std::make_unique<Entry>(10); });
+    CHECK(values.find(10) == &replacement);
+    CHECK(values.dynamic_storage_metrics().reserved_bytes == small_reserved);
+}
+
+TEST_CASE("SmallDensePtrMap move operations preserve pointees and release prior ownership",
+          "[small-dense-ptr-map]")
+{
+    CHECK(TrackedEntry::alive == 0);
+    {
+        using Map = hgraph::detail::SmallDensePtrMap<std::size_t, TrackedEntry>;
+        Map source;
+        std::vector<TrackedEntry *> stable;
+        for (std::size_t key = 0; key < 9; ++key)
+        {
+            stable.push_back(&source.ensure(key, [key] {
+                return std::make_unique<TrackedEntry>(static_cast<int>(key));
+            }));
+        }
+        CHECK(TrackedEntry::alive == 9);
+
+        Map moved{std::move(source)};
+        CHECK(source.empty());
+        CHECK(source.dynamic_storage_metrics().reserved_bytes == 0);
+        CHECK(moved.uses_dense_storage());
+        for (std::size_t key = 0; key < stable.size(); ++key)
+        {
+            CHECK(moved.find(key) == stable[key]);
+        }
+
+        Map destination;
+        static_cast<void>(destination.ensure(100, [] {
+            return std::make_unique<TrackedEntry>(100);
+        }));
+        CHECK(TrackedEntry::alive == 10);
+        destination = std::move(moved);
+        CHECK(TrackedEntry::alive == 9);
+        CHECK(moved.empty());
+        for (std::size_t key = 0; key < stable.size(); ++key)
+        {
+            CHECK(destination.find(key) == stable[key]);
+        }
+    }
+    CHECK(TrackedEntry::alive == 0);
+}
+
+TEST_CASE("SmallDensePtrMap iteration preserves keys and exposes pointees", "[small-dense-ptr-map]")
+{
+    hgraph::detail::SmallDensePtrMap<std::size_t, Entry> values;
+    for (std::size_t key = 0; key < 3; ++key)
+    {
+        static_cast<void>(values.ensure(key, [key] {
+            return std::make_unique<Entry>(static_cast<int>(key));
+        }));
+    }
+
+    values.for_each([](std::size_t key, Entry &entry) {
+        entry.value += static_cast<int>(key + 10);
+    });
+
+    const auto &const_values = values;
+    int total = 0;
+    const_values.for_each([&](std::size_t, const Entry &entry) { total += entry.value; });
+    CHECK(total == 36);
+
+    std::size_t predicates = 0;
+    CHECK(const_values.any_of([&](std::size_t key, const Entry &entry) {
+        ++predicates;
+        return key == 1 && entry.value == 12;
+    }));
+    CHECK(predicates <= values.size());
 }

--- a/tests/cpp/test_time_series_reference.cpp
+++ b/tests/cpp/test_time_series_reference.cpp
@@ -497,8 +497,13 @@ TEST_CASE("TimeSeriesReference: output alternatives are keyed by starting view a
     }
 
     auto source = target.view(MIN_ST);
+    const auto before_alternatives = target.dynamic_storage_metrics();
     auto named_ref_handle = source.binding_for(*ref_named);
     auto structural_ref_handle = source.binding_for(*ref_structural);
+    const auto after_alternatives = target.dynamic_storage_metrics();
+
+    CHECK(after_alternatives.live_bytes > before_alternatives.live_bytes);
+    CHECK(after_alternatives.reserved_bytes > before_alternatives.reserved_bytes);
 
     REQUIRE(named_ref_handle.schema() == ref_named);
     REQUIRE(structural_ref_handle.schema() == ref_structural);

--- a/tests/cpp/test_ts_input.cpp
+++ b/tests/cpp/test_ts_input.cpp
@@ -183,6 +183,60 @@ TEST_CASE("TSInput builds a non-peered TSB root with nested peered terminals")
     REQUIRE(nested_leaf.value().checked_as<std::int32_t>() == 42);
 }
 
+TEST_CASE("TSInput dynamic storage metrics include activation and target-link tries", "[memory]")
+{
+    using namespace hgraph;
+
+    auto       &registry = TypeRegistry::instance();
+    const auto *int_meta = registry.register_scalar<std::int32_t>("int32");
+    const auto *ts_int = registry.ts(int_meta);
+    const auto *root = registry.tsb("TSInputMetricsRoot", {{"value", ts_int}});
+    const auto endpoint = TSEndpointSchema::non_peered(
+        root, {TSEndpointSchema::peered(ts_int)});
+
+    TSInput input{TSInputBuilderFactory::checked_builder_for(*root, endpoint)};
+    TSOutput output{*ts_int};
+    auto binding_root = input.view();
+    auto binding = binding_root.as_bundle();
+    binding.field("value").bind_output(output.view());
+    const auto passive = input.dynamic_storage_metrics();
+
+    RecordingNotifiable notifier;
+    auto active_root = input.view(&notifier);
+    auto active = active_root.as_bundle();
+    active.field("value").make_active();
+    const auto active_metrics = input.dynamic_storage_metrics();
+    CHECK(active_metrics.live_bytes > passive.live_bytes);
+    CHECK(active_metrics.reserved_bytes > passive.reserved_bytes);
+    CHECK(active_metrics.reserved_bytes >= active_metrics.live_bytes);
+}
+
+TEST_CASE("TSInput dynamic storage metrics do not follow borrowed output storage", "[memory]")
+{
+    using namespace hgraph;
+
+    auto       &registry = TypeRegistry::instance();
+    const auto *int_meta = registry.register_scalar<std::int32_t>("int32");
+    const auto *ts_int = registry.ts(int_meta);
+
+    TSOutput output{*ts_int};
+    RecordingNotifiable first;
+    RecordingNotifiable second;
+    output.subscribe(&first);
+    output.subscribe(&second);
+    REQUIRE(output.dynamic_storage_metrics().live_bytes > 0);
+
+    TSInput input{TSInputBuilderFactory::checked_builder_for(
+        *ts_int, TSEndpointSchema::peered(ts_int))};
+    input.view().bind_output(output.view());
+
+    CHECK(input.dynamic_storage_metrics().live_bytes == 0);
+    CHECK(input.dynamic_storage_metrics().reserved_bytes == 0);
+
+    output.unsubscribe(&second);
+    output.unsubscribe(&first);
+}
+
 TEST_CASE("TSInput construction uses generic endpoint annotations")
 {
     using namespace hgraph;

--- a/tests/cpp/test_ts_output.cpp
+++ b/tests/cpp/test_ts_output.cpp
@@ -628,6 +628,34 @@ TEST_CASE("TSData dynamic storage metrics include TSS capacity and nested TSD ch
     CHECK(outer_after.reserved_bytes >= outer_after.live_bytes);
 }
 
+TEST_CASE("TSOutput dynamic storage metrics include multi-observer allocation", "[memory]")
+{
+    using namespace hgraph;
+
+    auto       &registry = TypeRegistry::instance();
+    const auto *int_meta = registry.register_scalar<std::int32_t>("int32");
+    TSOutput output{*registry.ts(int_meta)};
+    RecordingNotifiable first;
+    RecordingNotifiable second;
+
+    const auto empty = output.dynamic_storage_metrics();
+    output.subscribe(&first);
+    const auto single = output.dynamic_storage_metrics();
+    CHECK(single.live_bytes == empty.live_bytes);
+    CHECK(single.reserved_bytes == empty.reserved_bytes);
+
+    output.subscribe(&second);
+    const auto many = output.dynamic_storage_metrics();
+    CHECK(many.live_bytes > single.live_bytes);
+    CHECK(many.reserved_bytes >= many.live_bytes);
+
+    output.unsubscribe(&second);
+    output.unsubscribe(&first);
+    const auto cleared = output.dynamic_storage_metrics();
+    CHECK(cleared.live_bytes == empty.live_bytes);
+    CHECK(cleared.reserved_bytes == empty.reserved_bytes);
+}
+
 TEST_CASE("TSOutputHandle stores output identity without evaluation time")
 {
     using namespace hgraph;


### PR DESCRIPTION
## Summary

This draft combines the two related parts of the runtime-memory investigation:

- expose recursive dynamic-storage accounting for TSData observers, TSInput activation/target-link state, and TSOutput alternative stores through NodeView/Inspector
- replace five persistent sparse ownership maps with a compact adaptive owner map

The final map is one tagged pointer. It has four representations:

1. empty: no allocation
2. single: one direct key/owner holder
3. small: a compact trailing block growing through capacities 2, 4, and 8
4. dense: an ankerl::unordered_dense::map from the ninth entry onward

Representation changes move unique_ptr owners, not pointees, so runtime addresses remain stable. Small and dense holders retain capacity after erase to avoid lifecycle churn.

Generated benchmark artifacts are intentionally not committed.

## Why tagged dispatch

The initial implementation used an inline vector/dense branch and occupied 32 bytes. A direct type-ops implementation reduced that to two pointers and removed the explicit branch, but controlled Linux testing found that GCC did not devirtualize the function-pointer calls: selected runtime workloads regressed by 25-40%.

The final tagged pointer keeps the representation-erased storage model while using an inline switch that the compiler can optimize. It occupies 8 bytes, restores Linux performance, and improves memory further. This is the benchmark-driven adjustment to the design proposed in review.

## Converted runtime maps

1. TSInputActiveTarget::children
2. TSInputTargetActiveNode::children
3. TSOutputAlternativeStore::to_ref_alternatives_
4. TSOutputAlternativeStore::ref_link_alternatives_
5. TSOutputAlternativeStore::interior_from_ref_alternatives_

No remaining std::unordered_map found by the audit is an owning field of executor, graph, node, or time-series runtime storage. Remaining uses are wiring-local containers, registries/caches, record/replay state, or optional Inspector/EvaluationProfiler indices.

## Performance evidence

The original PR implementation had already completed reverse-order five-sample A/B across all 68 workloads, showing performance parity overall and gains in wide/sparse cases.

For the final rewrite, a same-session Linux A/B against that implementation covered 12 affected and diagnostic workloads. Median delta was -0.46% and mean delta was -0.42% (negative is faster), with a range from -4.06% to +2.60%. Notable results were sparse TSD -4.06%, large retained-capacity TSD -3.69%, mesh -2.16%, construction -0.48%, fan-out -0.43%, and fan-in -0.69%.

The final implementation also completed the full 68-workload packs on macOS and Linux. The deliberately measured but rejected ops-table variant is not the code in this PR.

## Memory evidence

The graph inspector gives deterministic owned-byte comparisons against the first PR implementation:

| Linux profile | before | final | delta |
|---|---:|---:|---:|
| map handle | 32 B | 8 B | -75.0% |
| large construction graph | 728,680 B | 581,824 B | -20.2% |
| native hot-loop graph | 520 B | 424 B | -18.5% |
| large sparse retained capacity | 51,094,712 B | 49,174,592 B | -3.8% |
| long capacity growth | 9,904,936 B | 9,520,816 B | -3.9% |
| large keyed switch | 1,408,120 B | 1,369,552 B | -2.7% |
| large mesh | 1,166,592 B | 1,109,256 B | -4.9% |

The complete 59-profile RSS and inspector packs passed on both macOS and Linux. Duration/churn profiles remained bounded and cardinality profiles remained monotonic.

## Inspector follow-up

The new accounting makes previously invisible endpoint storage measurable. The 20,000-key sparse diagnostic creates 100,006 inspection entries and exposes a separate cold-path concern: Inspector recursively refreshes storage metrics after evaluations, making that diagnostic take several minutes. Normal graph execution does not call this path. A future improvement should cache/version storage metrics on structural transitions or add a storage-sampling policy.

## Validation

- macOS fresh native acceptance preset: 1,340/1,340 passed
- macOS Python 3.14 stable-ABI wheel: 1,760 passed, 10 skipped
- Linux GCC 15 fresh native acceptance preset: 1,340/1,340 passed
- Linux Python 3.14 stable-ABI wheel with Polars rtcompat: 1,760 passed, 10 skipped
- Linux AddressSanitizer Python suite: 1,760 passed, 10 skipped
- full 68-workload performance packs: macOS and Linux
- full 59-profile memory/Inspector packs: macOS and Linux
- focused adaptive-map tests: 79 assertions across empty, single, small, dense, promotion, erase/reuse, move, stable-address, iteration, and ownership cases
- git diff --check: passed

The first macOS Python run hit the known real-time catalogue timing flake after 1,759 passing tests. The exact test passed on replay, followed by the clean full result above.

## Review choices

This remains a draft so the implementation and trade-offs can be reviewed before choosing a direction:

1. accept the full accounting plus adaptive-map change
2. retain the accounting but drop the adaptive-map experiment
3. retain the adaptive maps but split/defer the extended accounting
4. adjust the promotion threshold or holder strategy after reviewing the evidence
