### PR TITLE
Use tagged dispatch and compact storage for stable slots

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,6 +18,7 @@ permissions:
   contents: read
 
 env:
+  GCC_VERSION: "14"
   SCCACHE_GHA_ENABLED: "true"
 
 jobs:
@@ -238,7 +239,9 @@ jobs:
         shell: bash
         run: |
           g++ --version
-          test "$(g++ -dumpfullversion -dumpversion | cut -d. -f1)" -ge 14
+          test "$(g++ -dumpfullversion -dumpversion | cut -d. -f1)" -eq "$GCC_VERSION"
+          echo "CC=$(command -v gcc)" >> "$GITHUB_ENV"
+          echo "CXX=$(command -v g++)" >> "$GITHUB_ENV"
           /opt/python/cp312-cp312/bin/python --version
       - name: Install wheel build tools
         run: /opt/python/cp312-cp312/bin/python -m pip install --upgrade build abi3audit auditwheel
@@ -351,6 +354,16 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
+      - name: Configure GCC 14 for the installed C++ consumer
+        if: runner.os == 'Linux' && matrix.python-version == '3.12'
+        shell: bash
+        run: |
+          cc_path="$(command -v "gcc-$GCC_VERSION")"
+          cxx_path="$(command -v "g++-$GCC_VERSION")"
+          test "$("$cxx_path" -dumpfullversion -dumpversion | cut -d. -f1)" -eq "$GCC_VERSION"
+          echo "CC=$cc_path" >> "$GITHUB_ENV"
+          echo "CXX=$cxx_path" >> "$GITHUB_ENV"
+          "$cxx_path" --version
       - name: Install uv
         run: python -m pip install --upgrade uv
       - uses: actions/download-artifact@v7
@@ -461,13 +474,16 @@ jobs:
           echo "CC=/usr/bin/clang" >> "$GITHUB_ENV"
           echo "CXX=/usr/bin/clang++" >> "$GITHUB_ENV"
           /usr/bin/clang++ --version
-      - name: Configure GCC 13 on Linux
+      - name: Configure GCC 14 on Linux
         if: runner.os == 'Linux'
         shell: bash
         run: |
-          echo "CC=gcc-13" >> "$GITHUB_ENV"
-          echo "CXX=g++-13" >> "$GITHUB_ENV"
-          g++-13 --version
+          cc_path="$(command -v "gcc-$GCC_VERSION")"
+          cxx_path="$(command -v "g++-$GCC_VERSION")"
+          test "$("$cxx_path" -dumpfullversion -dumpversion | cut -d. -f1)" -eq "$GCC_VERSION"
+          echo "CC=$cc_path" >> "$GITHUB_ENV"
+          echo "CXX=$cxx_path" >> "$GITHUB_ENV"
+          "$cxx_path" --version
       - name: Install native build dependencies
         run: python -m pip install --upgrade "cmake>=3.26" ninja "pyarrow>=24,<25"
       - name: Expose Arrow runtime libraries
@@ -501,6 +517,15 @@ jobs:
         uses: mozilla-actions/sccache-action@v0.0.10
         with:
           version: v0.15.0
+      - name: Configure GCC 14
+        shell: bash
+        run: |
+          cc_path="$(command -v "gcc-$GCC_VERSION")"
+          cxx_path="$(command -v "g++-$GCC_VERSION")"
+          test "$("$cxx_path" -dumpfullversion -dumpversion | cut -d. -f1)" -eq "$GCC_VERSION"
+          echo "CC=$cc_path" >> "$GITHUB_ENV"
+          echo "CXX=$cxx_path" >> "$GITHUB_ENV"
+          "$cxx_path" --version
       - uses: mamba-org/setup-micromamba@v3
         with:
           environment-name: hgraph-native

--- a/.github/workflows/parity-nightly.yml
+++ b/.github/workflows/parity-nightly.yml
@@ -12,6 +12,9 @@ concurrency:
 permissions:
   contents: read
 
+env:
+  GCC_VERSION: "14"
+
 jobs:
   build-candidate:
     name: Build candidate wheel
@@ -24,6 +27,15 @@ jobs:
         uses: mozilla-actions/sccache-action@v0.0.10
         with:
           version: v0.15.0
+      - name: Configure GCC 14
+        shell: bash
+        run: |
+          cc_path="$(command -v "gcc-$GCC_VERSION")"
+          cxx_path="$(command -v "g++-$GCC_VERSION")"
+          test "$("$cxx_path" -dumpfullversion -dumpversion | cut -d. -f1)" -eq "$GCC_VERSION"
+          echo "CC=$cc_path" >> "$GITHUB_ENV"
+          echo "CXX=$cxx_path" >> "$GITHUB_ENV"
+          "$cxx_path" --version
       - uses: actions/setup-python@v6
         with:
           python-version: "3.12"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -147,6 +147,9 @@ the edited documentation, commands, links, or configuration directly.
   explicit erased-ownership pattern. Do not make the semantic facade hold a
   `std::variant` of concrete strategies; reserve variants for cases where
   the closed sum type is itself part of the contract.
+- Keep erased ops pointers non-null. Default and moved-from objects bind a
+  canonical no-op table, so ordinary queries dispatch through the contract
+  instead of branching around a missing implementation.
 - Publish explicit data-only inspection views when debugger metadata needs
   representation details. Debuggers must not infer private implementation
   member layouts or decode standard-library containers.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -134,6 +134,19 @@ the edited documentation, commands, links, or configuration directly.
 - Preserve type information and ownership explicitly across type-erased APIs;
   do not extend a temporary's lifetime through a reference.
 
+## Type-Erased Strategy Boundaries
+
+- Put a reusable type-erased contract in its own clearly named public header.
+  Keep concrete representation strategies in files under an ``impl`` boundary;
+  semantic owners should depend on the contract, not name a strategy directly.
+- Select a concrete strategy once from immutable wiring-time or plan metadata.
+  Keep any required dispatch inside the type-erased contract; do not scatter
+  representation-policy branches through semantic owners or leak strategy-
+  specific containers into the public surface.
+- Publish explicit data-only inspection views when debugger metadata needs
+  representation details. Debuggers must not infer private implementation
+  member layouts or decode standard-library containers.
+
 ## Test Guidelines
 
 - C++ tests live under `tests/cpp`; Python compatibility tests live under

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -137,12 +137,16 @@ the edited documentation, commands, links, or configuration directly.
 ## Type-Erased Strategy Boundaries
 
 - Put a reusable type-erased contract in its own clearly named public header.
-  Keep concrete representation strategies in files under an ``impl`` boundary;
+  Keep concrete representation strategies in files under an `impl` boundary;
   semantic owners should depend on the contract, not name a strategy directly.
 - Select a concrete strategy once from immutable wiring-time or plan metadata.
   Keep any required dispatch inside the type-erased contract; do not scatter
   representation-policy branches through semantic owners or leak strategy-
   specific containers into the public surface.
+- Represent strategy polymorphism with the project's passive ops-table plus
+  explicit erased-ownership pattern. Do not make the semantic facade hold a
+  `std::variant` of concrete strategies; reserve variants for cases where
+  the closed sum type is itself part of the contract.
 - Publish explicit data-only inspection views when debugger metadata needs
   representation details. Debuggers must not infer private implementation
   member layouts or decode standard-library containers.

--- a/benchmarks/results/stable-slot-representation-20260801-mac-issue228.md
+++ b/benchmarks/results/stable-slot-representation-20260801-mac-issue228.md
@@ -79,41 +79,63 @@ pointers, while every weaker alignment retains the existing bitmap
 representation without padding. Parent-tracked trivial values and the inline
 state byte remain benchmark-only alternatives.
 
-The production façade was rerun at 31 samples after replacing its closed
-`std::variant` with the project's passive ops-table and explicit
-`ErasedOwner` pattern. The direct rows isolate each representation; the
-production rows add the alignment-selected, type-erased façade used by TSS,
-TSD, nested graph storage, and mutable collection storage.
+The first production façade was rerun at 31 samples after replacing its closed
+`std::variant` with a passive ops table and explicit `ErasedOwner`. The direct
+rows isolate each representation; the rejected ops-table rows show why that
+otherwise clean boundary required another measured refinement.
 
 | Payload | Measurement | Representation B/slot | Allocations | Sequential live read ns | Random live read ns | Remove/resurrect ns per transition | Erase/reinsert ns per transition |
 |---|---|---:|---:|---:|---:|---:|---:|
 | aligned non-trivial, 8 B / align 8 | direct bitmap baseline | 16.251 | 7 | 0.396 | 1.017 | 1.183 | 3.422 |
 | aligned non-trivial, 8 B / align 8 | direct tagged pointer | 16.001 | 5 | 0.332 | 0.995 | 1.312 | 2.696 |
-| aligned non-trivial, 8 B / align 8 | production tagged façade | 16.002 | 6 | 1.508 | 1.909 | 2.548 | 4.129 |
+| aligned non-trivial, 8 B / align 8 | rejected ops-table tagged façade | 16.002 | 6 | 1.508 | 1.909 | 2.548 | 4.129 |
 | packed non-trivial, 9 B / align 1 | direct bitmap baseline | 17.251 | 7 | 0.382 | 1.005 | 1.190 | 3.331 |
-| packed non-trivial, 9 B / align 1 | production bitmap façade | 17.253 | 8 | 1.520 | 1.984 | 2.587 | 4.602 |
+| packed non-trivial, 9 B / align 1 | rejected ops-table bitmap façade | 17.253 | 8 | 1.520 | 1.984 | 2.587 | 4.602 |
 
-For aligned storage, the production representation removes the two lifecycle
+For aligned storage, the selected representation removes the two lifecycle
 bitmap allocations but adds one fixed 64-byte strategy allocation. The net
 result is one fewer allocation and a 0.249 B/slot saving at this capacity,
 without changing payload stride. The weak-alignment strategy object is 112
 bytes and one allocation; its per-slot footprint remains effectively the
 bitmap footprint.
 
-The indirect passive-ops call is measurable in these deliberately tiny loops.
-Against the direct bitmap baseline, aligned production sequential/random reads
-were 281%/88% slower, remove/resurrect was 115% slower, and erase/reinsert was
-21% slower. The packed bitmap façade showed the same shape. This is the cost of
-keeping semantic owners independent of the closed set of concrete strategies;
-the type-erased boundary is not a zero-cost abstraction in an isolated slot
-operation benchmark.
+The indirect passive-ops call was measurable in these deliberately tiny loops.
+The tagged-dispatch result from #233 motivated an equivalent stable-slot
+prototype: one pointer carries private nop/tagged/bitmap tags and each operation
+uses an inline switch. The common aligned implementation uses tag `00`.
 
-These figures isolate the boundary and therefore make it a larger fraction of
-the measured work than it is for owners that also hash keys, publish observers,
-run destructors, and maintain free/pending queues. They establish both the
-fixed memory cost and the per-call dispatch cost of the reusable type-erased
-boundary; an owner-level benchmark remains the appropriate follow-up before
-further hot-path changes.
+GCC 14.3 on physical `hg-linux`, seven reverse-order process runs with 15
+within-process samples, produced these means of process medians:
+
+| Payload/dispatch | Sequential read ns | Random read ns | Remove/resurrect ns | Erase/reinsert ns |
+|---|---:|---:|---:|---:|
+| aligned ops table | 1.904 | 2.671 | 2.315 | 5.747 |
+| aligned tagged dispatch | 0.393 | 0.733 | 1.313 | 4.005 |
+| packed ops table | 2.735 | 2.974 | 2.878 | 6.800 |
+| packed tagged dispatch | 0.989 | 1.078 | 1.995 | 5.189 |
+
+Aligned operations improved by 30-79%; bitmap-backed operations improved by
+24-64%. The result was insensitive to process order and reproduced on macOS.
+The final façade therefore retains the erased semantic surface and separate
+implementation classes, but replaces indirect ops calls with the private
+tagged switch. Its handle shrinks from four words to one while allocator-owned
+strategy size, payload stride, and allocation count remain unchanged.
+
+A second GCC 14.3 A/B used the merged-main runtime around the store rather than
+isolated slot calls. Five reverse-order processes with seven within-process
+samples produced:
+
+| Runtime workload | Ops-table ns/op | Tagged-dispatch ns/op | Delta |
+|---|---:|---:|---:|
+| dynamic TSL construct/grow four | 386.225 | 356.361 | -7.7% |
+| sparse TSD source cycle | 608.021 | 576.374 | -5.2% |
+| alternating switch nested-graph lifecycle | 114,363.330 | 111,652.110 | -2.4% |
+| dense 1,000-key TSD source cycle | 80,107.790 | 78,606.856 | -1.9% |
+| sparse dynamic TSL source cycle | 419.734 | 418.110 | -0.4% |
+
+The selected owner-level workloads therefore preserve the isolated direction:
+construction and sparse slot activity gain most, while a workload dominated by
+other graph work is effectively flat-to-positive.
 
 ## Reproduction
 

--- a/benchmarks/results/stable-slot-representation-20260801-mac-issue228.md
+++ b/benchmarks/results/stable-slot-representation-20260801-mac-issue228.md
@@ -1,0 +1,156 @@
+# Stable-slot lifecycle representation trial
+
+- Issue: [#228](https://github.com/hhenson/hg_cpp/issues/228)
+- Date: 2026-08-01T02:14:21Z
+- Host: macOS 26.5.2, Apple M4 Max (arm64)
+- Compiler: AppleClang 21.0.0, `-O3 -DNDEBUG`
+- Prototype base revision: `a08db52b9541a87c78b85c28c52cc9960e128112`
+- Capacity: 65,536 slots
+- Samples: 15 in one process; reported timings are medians
+
+This is a test-only prototype. It reuses `StableSlotBlock` for chained stable
+payload allocations and compares:
+
+1. the current-shape pointer table plus constructed/live bitmaps;
+2. a two-bit tagged pointer (`00` live, `01` pending erase, `10` staged,
+   `11` free);
+3. parent-tracked trivial storage, which removes the constructed bitmap; and
+4. one lifecycle byte stored immediately after a weakly aligned non-trivial
+   payload.
+
+All variants implement stable growth, staged-publication rollback,
+remove/resurrect, deferred erase, and slot reuse.
+
+## Memory and timing matrix
+
+`Representation B/slot` includes payload stride, the slot pointer/lifecycle
+index, and block descriptors. `Total B/slot` additionally includes the common
+prototype free-slot and pending-erase vectors, both pre-reserved to capacity.
+Allocation counts include the payload block, slot index/bitmap allocations,
+the two common management vectors, and the block-descriptor vector.
+
+| Payload | Representation | Stride | Representation B/slot | Total B/slot | Allocations | Sequential live read ns | Random live read ns | Remove/resurrect ns per transition | Erase/reinsert ns per transition |
+|---|---|---:|---:|---:|---:|---:|---:|---:|---:|
+| aligned non-trivial, 8 B / align 8 | bitmap | 8 | 16.251 | 32.251 | 7 | 0.468 | 0.993 | 1.082 | 2.739 |
+| aligned non-trivial, 8 B / align 8 | tagged-8 | 8 | 16.001 | 32.001 | 5 | 0.310 | 0.889 | 1.203 | 2.609 |
+| packed trivial, 9 B / align 1 | bitmap | 9 | 17.251 | 33.251 | 7 | 0.378 | 0.926 | 1.133 | 2.814 |
+| packed trivial, 9 B / align 1 | parent-tracked | 9 | 17.126 | 33.126 | 6 | 0.373 | 0.928 | 1.453 | 3.257 |
+| packed trivial, 9 B / align 1 | tagged-8 | 16 | 24.001 | 40.001 | 5 | 0.325 | 0.918 | 1.225 | 2.684 |
+| packed non-trivial, 9 B / align 1 | bitmap | 9 | 17.251 | 33.251 | 7 | 0.375 | 0.938 | 1.163 | 3.594 |
+| packed non-trivial, 9 B / align 1 | state byte | 10 | 18.001 | 34.001 | 5 | 0.355 | 1.007 | 2.314 | 2.754 |
+| packed non-trivial, 9 B / align 1 | tagged-4 | 12 | 20.001 | 36.001 | 5 | 0.355 | 0.927 | 1.176 | 4.997 |
+| packed non-trivial, 9 B / align 1 | tagged-8 | 16 | 24.001 | 40.001 | 5 | 0.352 | 0.933 | 1.241 | 2.757 |
+
+## Initial conclusions
+
+- The tagged-pointer representation is the leading candidate when the payload
+  is already pointer-aligned. It removes 0.25 B/slot and two allocations in
+  this model. Here it improved sequential live reads by 34% and random live
+  reads by 10%, while remove/resurrect was 11% slower.
+- Parent-tracked trivial storage is the byte-minimising weak-alignment choice.
+  It saves 0.125 B/slot and one allocation without padding the payload. The
+  lifecycle mutation paths were slower in this run, so this should remain a
+  compile-time specialization rather than the universal representation.
+- The state byte does what the proposal intended relative to forced
+  pointer-alignment: it uses 18.001 B/slot versus 24.001 B/slot for tagged-8
+  and removes the standalone lifecycle allocations. It does **not** beat the
+  compact two-bitmap baseline on total bytes: one byte per slot costs more than
+  two bits per slot, producing 18.001 versus 17.251 B/slot here.
+- State-byte remove/resurrect was roughly twice the bitmap cost. Its erase path
+  was faster, and its single index allocation may still be useful when
+  allocation count/locality matters more than the extra 0.75 B/slot.
+- The tagged-4 erase/reinsert result remained materially slower on repeat. It
+  is an exploratory negative control; the proposed production boundary should
+  remain natural `size_t`/pointer alignment unless a separate investigation
+  explains this result.
+
+The prototype's compile-time footprint selector therefore chooses tagged
+pointers for naturally pointer-aligned values, parent-tracked state for weakly
+aligned trivial values, and retains bitmaps for weakly aligned non-trivial
+values. The explicit state byte remains available for further locality and
+allocation-count experiments rather than being selected on byte footprint.
+
+## Production façade verification
+
+The implemented `StableSlotStore` deliberately uses the simpler two-way
+policy selected for #228: naturally pointer-aligned layouts use tagged
+pointers, while every weaker alignment retains the existing bitmap
+representation without padding. Parent-tracked trivial values and the inline
+state byte remain benchmark-only alternatives.
+
+The production façade was rerun at 31 samples after migrating the real slot
+owners. The direct rows isolate each representation; the production rows add
+the alignment-selected, type-erased façade used by TSS, TSD, nested graph
+storage, and mutable collection storage.
+
+| Payload | Measurement | Representation B/slot | Allocations | Sequential live read ns | Random live read ns | Remove/resurrect ns per transition | Erase/reinsert ns per transition |
+|---|---|---:|---:|---:|---:|---:|---:|
+| aligned non-trivial, 8 B / align 8 | direct bitmap baseline | 16.251 | 7 | 0.382 | 1.019 | 1.058 | 3.463 |
+| aligned non-trivial, 8 B / align 8 | direct tagged pointer | 16.001 | 5 | 0.336 | 1.016 | 1.320 | 2.711 |
+| aligned non-trivial, 8 B / align 8 | production tagged façade | 16.001 | 5 | 0.377 | 1.023 | 1.129 | 5.049 |
+| packed non-trivial, 9 B / align 1 | direct bitmap baseline | 17.251 | 7 | 0.388 | 1.013 | 1.346 | 3.179 |
+| packed non-trivial, 9 B / align 1 | production bitmap façade | 17.251 | 7 | 0.382 | 1.012 | 1.934 | 5.225 |
+
+For aligned storage, the production representation removes the two lifecycle
+bitmap allocations and 0.25 B/slot without changing payload stride. Live-read
+cost is effectively unchanged from the bitmap baseline in this run. The raw
+transition microbenchmarks expose façade dispatch overhead: remove/resurrect
+was 6.7% slower and erase/reinsert was 45.8% slower. The weak-alignment façade
+preserves the bitmap footprint and read cost, with the same dispatch overhead
+visible when lifecycle transitions are measured in isolation.
+
+These mutation figures are conservative for the actual owners because the
+microbenchmark excludes key hashing, observer publication, destructor work,
+and free/pending queue maintenance. They establish the cost of the reusable
+type-erased boundary itself; an owner-level benchmark is the appropriate
+follow-up if lifecycle transitions become measurable in an application hot
+path.
+
+## Reproduction
+
+```sh
+cmake --preset cpp --fresh
+cmake --build --preset cpp --target hgraph_stable_slot_representation_perf --parallel
+./cmake-build-cpp/tests/cpp/hgraph_stable_slot_representation_perf
+```
+
+Useful controls:
+
+```sh
+HGRAPH_STABLE_SLOT_PERF_CAPACITY=65536 \
+HGRAPH_STABLE_SLOT_PERF_SAMPLES=31 \
+HGRAPH_STABLE_SLOT_PERF_FILTER=aligned8 \
+./cmake-build-cpp/tests/cpp/hgraph_stable_slot_representation_perf
+```
+
+The benchmark intentionally excludes the key-to-slot hash index and complete
+TSS/TSD/TSL wiring. The production rows do exercise the reusable store façade
+now used by those owners.
+
+## Validation
+
+Historical prototype validation:
+
+- Prototype lifecycle coverage: 108 assertions in 8 test cases.
+- Full native Release suite: 1,339/1,339 passed.
+- Stable-ABI wheel built with Python 3.12 and tested with Python 3.14.6:
+  1,754 passed, 10 skipped (`not wip`).
+- Focused AppleClang ASan + UBSan run: all prototype tests passed.
+
+Production implementation validation after migrating the real owners:
+
+- Fresh macOS native Release suite: 1,343/1,343 passed.
+- Fresh Linux native Release suite under GCC 15: 1,343/1,343 passed.
+- Stable-ABI wheel built with Python 3.12 and tested from fresh Python 3.14
+  environments on macOS and Linux: 1,760 passed, 10 skipped (`not wip`) on
+  each platform.
+- The macOS installed-SDK consumer compiled and passed using the public
+  `StableSlotStore` header and both alignment strategies.
+- Focused AppleClang ASan + UBSan lifecycle suite: 200/200 passed. Leak
+  detection is not supported by the macOS ASan runtime and was disabled.
+- The complete Linux Python compatibility suite passed under GCC 15 ASan +
+  UBSan: 1,760 passed, 10 skipped. Leak detection was disabled for the
+  process-wide Python run, following the documented sanitizer workflow.
+- Debugger common-layer tests: 12/12 passed; the native debugger fixture also
+  passed as part of the full Release suite.
+- Sphinx documentation build with warnings treated as errors: passed.

--- a/benchmarks/results/stable-slot-representation-20260801-mac-issue228.md
+++ b/benchmarks/results/stable-slot-representation-20260801-mac-issue228.md
@@ -27,7 +27,8 @@ remove/resurrect, deferred erase, and slot reuse.
 index, and block descriptors. `Total B/slot` additionally includes the common
 prototype free-slot and pending-erase vectors, both pre-reserved to capacity.
 Allocation counts include the payload block, slot index/bitmap allocations,
-the two common management vectors, and the block-descriptor vector.
+the two common management vectors, and the block-descriptor vector. Production
+rows additionally include the fixed erased strategy object.
 
 | Payload | Representation | Stride | Representation B/slot | Total B/slot | Allocations | Sequential live read ns | Random live read ns | Remove/resurrect ns per transition | Erase/reinsert ns per transition |
 |---|---|---:|---:|---:|---:|---:|---:|---:|---:|
@@ -78,33 +79,41 @@ pointers, while every weaker alignment retains the existing bitmap
 representation without padding. Parent-tracked trivial values and the inline
 state byte remain benchmark-only alternatives.
 
-The production façade was rerun at 31 samples after migrating the real slot
-owners. The direct rows isolate each representation; the production rows add
-the alignment-selected, type-erased façade used by TSS, TSD, nested graph
-storage, and mutable collection storage.
+The production façade was rerun at 31 samples after replacing its closed
+`std::variant` with the project's passive ops-table and explicit
+`ErasedOwner` pattern. The direct rows isolate each representation; the
+production rows add the alignment-selected, type-erased façade used by TSS,
+TSD, nested graph storage, and mutable collection storage.
 
 | Payload | Measurement | Representation B/slot | Allocations | Sequential live read ns | Random live read ns | Remove/resurrect ns per transition | Erase/reinsert ns per transition |
 |---|---|---:|---:|---:|---:|---:|---:|
-| aligned non-trivial, 8 B / align 8 | direct bitmap baseline | 16.251 | 7 | 0.382 | 1.019 | 1.058 | 3.463 |
-| aligned non-trivial, 8 B / align 8 | direct tagged pointer | 16.001 | 5 | 0.336 | 1.016 | 1.320 | 2.711 |
-| aligned non-trivial, 8 B / align 8 | production tagged façade | 16.001 | 5 | 0.377 | 1.023 | 1.129 | 5.049 |
-| packed non-trivial, 9 B / align 1 | direct bitmap baseline | 17.251 | 7 | 0.388 | 1.013 | 1.346 | 3.179 |
-| packed non-trivial, 9 B / align 1 | production bitmap façade | 17.251 | 7 | 0.382 | 1.012 | 1.934 | 5.225 |
+| aligned non-trivial, 8 B / align 8 | direct bitmap baseline | 16.251 | 7 | 0.396 | 1.017 | 1.183 | 3.422 |
+| aligned non-trivial, 8 B / align 8 | direct tagged pointer | 16.001 | 5 | 0.332 | 0.995 | 1.312 | 2.696 |
+| aligned non-trivial, 8 B / align 8 | production tagged façade | 16.002 | 6 | 1.508 | 1.909 | 2.548 | 4.129 |
+| packed non-trivial, 9 B / align 1 | direct bitmap baseline | 17.251 | 7 | 0.382 | 1.005 | 1.190 | 3.331 |
+| packed non-trivial, 9 B / align 1 | production bitmap façade | 17.253 | 8 | 1.520 | 1.984 | 2.587 | 4.602 |
 
 For aligned storage, the production representation removes the two lifecycle
-bitmap allocations and 0.25 B/slot without changing payload stride. Live-read
-cost is effectively unchanged from the bitmap baseline in this run. The raw
-transition microbenchmarks expose façade dispatch overhead: remove/resurrect
-was 6.7% slower and erase/reinsert was 45.8% slower. The weak-alignment façade
-preserves the bitmap footprint and read cost, with the same dispatch overhead
-visible when lifecycle transitions are measured in isolation.
+bitmap allocations but adds one fixed 64-byte strategy allocation. The net
+result is one fewer allocation and a 0.249 B/slot saving at this capacity,
+without changing payload stride. The weak-alignment strategy object is 112
+bytes and one allocation; its per-slot footprint remains effectively the
+bitmap footprint.
 
-These mutation figures are conservative for the actual owners because the
-microbenchmark excludes key hashing, observer publication, destructor work,
-and free/pending queue maintenance. They establish the cost of the reusable
-type-erased boundary itself; an owner-level benchmark is the appropriate
-follow-up if lifecycle transitions become measurable in an application hot
-path.
+The indirect passive-ops call is measurable in these deliberately tiny loops.
+Against the direct bitmap baseline, aligned production sequential/random reads
+were 281%/88% slower, remove/resurrect was 115% slower, and erase/reinsert was
+21% slower. The packed bitmap façade showed the same shape. This is the cost of
+keeping semantic owners independent of the closed set of concrete strategies;
+the type-erased boundary is not a zero-cost abstraction in an isolated slot
+operation benchmark.
+
+These figures isolate the boundary and therefore make it a larger fraction of
+the measured work than it is for owners that also hash keys, publish observers,
+run destructors, and maintain free/pending queues. They establish both the
+fixed memory cost and the per-call dispatch cost of the reusable type-erased
+boundary; an owner-level benchmark remains the appropriate follow-up before
+further hot-path changes.
 
 ## Reproduction
 
@@ -139,18 +148,21 @@ Historical prototype validation:
 
 Production implementation validation after migrating the real owners:
 
-- Fresh macOS native Release suite: 1,343/1,343 passed.
-- Fresh Linux native Release suite under GCC 15: 1,343/1,343 passed.
+- Fresh macOS native Release suite: 1,344/1,344 passed.
+- Fresh Linux native Release suite under GCC 15: 1,344/1,344 passed.
 - Stable-ABI wheel built with Python 3.12 and tested from fresh Python 3.14
   environments on macOS and Linux: 1,760 passed, 10 skipped (`not wip`) on
   each platform.
 - The macOS installed-SDK consumer compiled and passed using the public
   `StableSlotStore` header and both alignment strategies.
-- Focused AppleClang ASan + UBSan lifecycle suite: 200/200 passed. Leak
+- Focused AppleClang ASan + UBSan lifecycle suite: 19/19 passed. Leak
   detection is not supported by the macOS ASan runtime and was disabled.
 - The complete Linux Python compatibility suite passed under GCC 15 ASan +
   UBSan: 1,760 passed, 10 skipped. Leak detection was disabled for the
   process-wide Python run, following the documented sanitizer workflow.
 - Debugger common-layer tests: 12/12 passed; the native debugger fixture also
-  passed as part of the full Release suite.
+  passed as part of the full Release suites, and the LLDB smoke test passed.
+  The GDB smoke navigated the erased stable-slot collections before reaching
+  an unrelated optimized-GCC fixture limitation: complete `TSInput` and
+  `TSOutput` owning types were not emitted in its debug information.
 - Sphinx documentation build with warnings treated as errors: passed.

--- a/docs/source/developer_guide/data_structures/plans_and_ops/time_series.rst
+++ b/docs/source/developer_guide/data_structures/plans_and_ops/time_series.rst
@@ -1287,6 +1287,11 @@ do not use the slot stores.
     contract is declared separately from its concrete strategies under
     ``hgraph/types/utils/impl``.
 
+    The facade owns the selected concrete strategy through
+    ``MemoryUtils::ErasedOwner`` and calls a canonical passive
+    ``StableSlotStoreOps`` table. Semantic owners therefore do not contain a
+    ``std::variant`` or name either representation.
+
     Strategy selection happens once when the immutable ``StorageLayout`` is
     bound. Payloads aligned to at least ``uintptr_t`` use two low pointer bits
     for ``live`` (``00``), pending erase, staged construction, and free. A

--- a/docs/source/developer_guide/data_structures/plans_and_ops/time_series.rst
+++ b/docs/source/developer_guide/data_structures/plans_and_ops/time_series.rst
@@ -1287,10 +1287,12 @@ do not use the slot stores.
     contract is declared separately from its concrete strategies under
     ``hgraph/types/utils/impl``.
 
-    The facade owns the selected concrete strategy through
-    ``MemoryUtils::ErasedOwner`` and calls a canonical passive
-    ``StableSlotStoreOps`` table. Semantic owners therefore do not contain a
-    ``std::variant`` or name either representation.
+    The facade is one tagged implementation pointer. Its private tag selects
+    canonical nop, tagged-pointer, or bitmap behaviour through an inline
+    switch. Semantic owners therefore do not contain a ``std::variant`` or
+    name either representation; concrete classes remain under the ``impl``
+    boundary. The implementation allocation still uses the supplied
+    ``MemoryUtils::AllocatorOps``.
 
     Strategy selection happens once when the immutable ``StorageLayout`` is
     bound. Payloads aligned to at least ``uintptr_t`` use two low pointer bits

--- a/docs/source/developer_guide/data_structures/plans_and_ops/time_series.rst
+++ b/docs/source/developer_guide/data_structures/plans_and_ops/time_series.rst
@@ -1271,7 +1271,7 @@ at the TSS layer first lets TSD's value side reuse them directly.
 The Slot Store Family
 ---------------------
 
-Three primitives in ``hgraph/types/utils/`` express the slot machinery.
+Layered utilities in ``hgraph/types/utils/`` express the slot machinery.
 The ``SlotTSDataStorage`` implementations for collection-shaped
 time-series data build on these primitives so they can support
 per-element insert / remove / replace with stable addresses and the
@@ -1280,16 +1280,31 @@ per-slot bitsets needed to surface deltas. The value-layer
 by design (see *Scalar Plans and Ops > Container Storage Shapes*) and
 do not use the slot stores.
 
+``StableSlotStore<StateModel>``
+    The reusable payload-type-erased contract for non-relocating slots.
+    ``slot_id`` maps through a replaceable pointer table into chained payload
+    blocks, so growth never moves previously published payloads. The public
+    contract is declared separately from its concrete strategies under
+    ``hgraph/types/utils/impl``.
+
+    Strategy selection happens once when the immutable ``StorageLayout`` is
+    bound. Payloads aligned to at least ``uintptr_t`` use two low pointer bits
+    for ``live`` (``00``), pending erase, staged construction, and free. A
+    known-live access can therefore use the encoded word directly. Weaker
+    alignment preserves the payload's compact stride and uses the existing
+    raw pointer table with one constructed bitmap, or constructed and live
+    bitmaps when delayed erase is required. The implementation deliberately
+    does not over-align weak payloads merely to enable tagging.
+
 ``StableSlotStorage``
-    Non-relocating, double-indexed slot storage. ``slots`` is a
-    logical slot-id → payload-pointer table; ``blocks`` owns the
-    chained heap allocations behind those pointers. Growth appends a
-    block; previously issued slot pointers never move.
+    Lower-level allocation-only compatibility utility. It exposes a raw slot
+    pointer table and chained blocks but does not model lifecycle state. New
+    lifecycle-owning structures should use ``StableSlotStore`` instead.
 
 ``KeySlotStore``
     Stable slot-backed key storage with delayed-erase semantics. Owns
     homogeneous keys keyed off a ``StoragePlan`` and a small ops vtable
-    (``hash``, ``equal``). Maintains two parallel bitmaps:
+    (``hash``, ``equal``). Its full lifecycle state model exposes:
 
     - ``constructed[slot]`` — payload object exists in slot memory
     - ``live[slot]`` — payload is currently a member of the set
@@ -1304,12 +1319,12 @@ do not use the slot stores.
 
 ``ValueSlotStore``
     Standalone parallel value memory keyed off externally supplied slot
-    ids. As a reusable utility it owns a per-slot ``constructed`` bit
+    ids. As a reusable utility it owns per-slot constructed state
     so it can be used independently and still destroy its payloads
     correctly. A TSD-specific value side should not treat that bit as a
     second source of truth: TSD key construction and value construction
     happen together, so ``KeySlotStore.constructed`` is authoritative
-    and any reused value-store constructed bit is only a derived mirror.
+    and any reused value-store constructed state is only a derived mirror.
 
 ``KeyMirroredValueSlotStore``
     Wrapper for keyed value storage that enforces the TSD-style
@@ -1349,9 +1364,8 @@ primitives. A TS set data store owns one ``KeySlotStore``. A TS map
 data store owns one ``KeySlotStore`` for keys plus value payload
 storage indexed by the key slots. If the generic ``ValueSlotStore`` is
 reused for that value side, use ``KeyMirroredValueSlotStore`` or the
-same rule internally: its constructed bitmap must be kept as a strict
-mirror of the key store's constructed bitmap rather than a separate
-state surface.
+same rule internally: its constructed state must be kept as a strict mirror
+of the key store's constructed state rather than a separate state surface.
 
 Slot stores are deliberately **not** used for scalar values. The
 delayed-erase, per-slot-bit, and observer machinery exists to support
@@ -1408,7 +1422,7 @@ The value side is itself a recursive time-series layer: each value-
 slot holds a complete time-series value (most often a ``TS``, but
 ``SIGNAL``, ``TSS``, ``TSB``, fixed ``TSL``, ``TSW``, or further nested
 ``TSD`` are all permitted by the schema). Memory stability is preserved by the underlying
-``StableSlotStorage`` so consumers can bind to a specific slot's value
+``StableSlotStore`` so consumers can bind to a specific slot's value
 without worrying about future structural changes.
 
 Slot-backed TSData must be updated in place. Its erased storage plans

--- a/docs/source/developer_guide/data_structures/unified_type_erasure.rst
+++ b/docs/source/developer_guide/data_structures/unified_type_erasure.rst
@@ -538,18 +538,34 @@ records to physical plan offsets. Tuple and bundle descriptors also publish the
 validity-word offset and one bit index per field, so an unset child is displayed
 as typed-null rather than reading uninitialised payload bytes.
 
-The version-two dynamic layout is 88 bytes on supported 64-bit platforms. It
-distinguishes contiguous storage from stable pointer slots and records whether
+The version-three dynamic layout remains 88 bytes on supported 64-bit
+platforms. It distinguishes contiguous storage from stable pointer slots and
+records whether
 size is fixed, data is indirect, a pointer table is used, a ring head is
 present, or keys/elements are embedded erased owners or typed pointers. Version
 two adds independent tagged-data-pointer, tagged-key-pointer, and tagged-slot-
-state flags. For a tagged stable-slot index, ``state_offset`` may identify the
-same pointer table as data or keys: readers accept tag ``00`` as live and mask
-the low two bits before dereferencing other encoded states. Bitmap-backed
-stable slots continue to publish the public ``SlotBitmap`` words and bit count.
-Both strategies are exposed through ``StableSlotDebugView``, so descriptor
-factories do not inspect the selected implementation or a standard-library
-container.
+state flags. Version three also describes an erased stable-slot strategy whose
+index lives behind an implementation pointer. In that form ``data_offset``
+(and ``key_data_offset`` for maps) locates the implementation pointer,
+``auxiliary_offset`` locates the value pointer table within that implementation,
+and ``key_auxiliary_offset`` independently locates a keyed store's pointer
+table. The size/state offsets are interpreted in the key implementation when
+their corresponding flags are set. For a tagged stable-slot index,
+``state_offset`` may identify the same
+pointer table as data or keys: readers accept tag ``00`` as live and mask the
+low two bits before dereferencing other encoded states. Bitmap-backed stable
+slots continue to publish the public ``SlotBitmap`` words and bit count. Both
+strategies are exposed through ``StableSlotDebugView``, so descriptor factories
+do not inspect the selected implementation or a standard-library container.
+
+The semantic ``StableSlotStore`` facade does not contain a closed
+``std::variant`` of those concrete strategies. It owns the selected strategy
+through ``MemoryUtils::ErasedOwner`` and dispatches through one canonical
+passive ``StableSlotStoreOps`` table. The ops table is the public behavioural
+contract; tagged-pointer and bitmap classes stay under the implementation
+boundary. This is the standard boundary for reusable representation policy:
+separate erased behaviour from explicit erased ownership, and reserve
+``std::variant`` for a sum type that is itself part of the semantic contract.
 
 The common embedded-owner field flag describes the three-word
 ``ErasedOwner<InlineStoragePolicy<>, TypeRecord>`` ABI. The record is read

--- a/docs/source/developer_guide/data_structures/unified_type_erasure.rst
+++ b/docs/source/developer_guide/data_structures/unified_type_erasure.rst
@@ -465,7 +465,7 @@ The common record guarantees shallow inspection of every erased pointer:
 * capabilities and whether deeper navigation is available.
 
 Deeper inspection is described by an immutable ``DebugDescriptor`` produced by
-the same factory that resolves the type record. The version-one ABI is:
+the same factory that resolves the type record. The data-only layouts are:
 
 .. code-block:: cpp
 
@@ -538,14 +538,18 @@ records to physical plan offsets. Tuple and bundle descriptors also publish the
 validity-word offset and one bit index per field, so an unset child is displayed
 as typed-null rather than reading uninitialised payload bytes.
 
-The version-one dynamic layout is 88 bytes on supported 64-bit platforms. It
+The version-two dynamic layout is 88 bytes on supported 64-bit platforms. It
 distinguishes contiguous storage from stable pointer slots and records whether
 size is fixed, data is indirect, a pointer table is used, a ring head is
-present, or keys/elements are embedded erased owners or typed pointers. Stable slots use the
-public ``SlotBitmap`` words and bit count, so live and erased entries are read
-without decoding a standard-library container. ``StableSlotStorage`` exposes a
-raw pointer table for the same reason; this representation is smaller than the
-previous ``std::vector`` member and does not add release-mode debug mirrors.
+present, or keys/elements are embedded erased owners or typed pointers. Version
+two adds independent tagged-data-pointer, tagged-key-pointer, and tagged-slot-
+state flags. For a tagged stable-slot index, ``state_offset`` may identify the
+same pointer table as data or keys: readers accept tag ``00`` as live and mask
+the low two bits before dereferencing other encoded states. Bitmap-backed
+stable slots continue to publish the public ``SlotBitmap`` words and bit count.
+Both strategies are exposed through ``StableSlotDebugView``, so descriptor
+factories do not inspect the selected implementation or a standard-library
+container.
 
 The common embedded-owner field flag describes the three-word
 ``ErasedOwner<InlineStoragePolicy<>, TypeRecord>`` ABI. The record is read

--- a/docs/source/developer_guide/data_structures/unified_type_erasure.rst
+++ b/docs/source/developer_guide/data_structures/unified_type_erasure.rst
@@ -549,8 +549,10 @@ index lives behind an implementation pointer. In that form ``data_offset``
 (and ``key_data_offset`` for maps) locates the implementation pointer,
 ``auxiliary_offset`` locates the value pointer table within that implementation,
 and ``key_auxiliary_offset`` independently locates a keyed store's pointer
-table. The size/state offsets are interpreted in the key implementation when
-their corresponding flags are set. For a tagged stable-slot index,
+table. Debugger readers clear the implementation handle's low two private tag
+bits before applying those offsets; this is a no-op for the former raw erased-
+owner pointer. The size/state offsets are interpreted in the key implementation
+when their corresponding flags are set. For a tagged stable-slot index,
 ``state_offset`` may identify the same
 pointer table as data or keys: readers accept tag ``00`` as live and mask the
 low two bits before dereferencing other encoded states. Bitmap-backed stable
@@ -559,16 +561,20 @@ strategies are exposed through ``StableSlotDebugView``, so descriptor factories
 do not inspect the selected implementation or a standard-library container.
 
 The semantic ``StableSlotStore`` facade does not contain a closed
-``std::variant`` of those concrete strategies. It owns the selected strategy
-through ``MemoryUtils::ErasedOwner`` and dispatches through one canonical
-passive ``StableSlotStoreOps`` table. The ops table is the public behavioural
-contract; tagged-pointer and bitmap classes stay under the implementation
-boundary. This is the standard boundary for reusable representation policy:
-separate erased behaviour from explicit erased ownership, and reserve
-``std::variant`` for a sum type that is itself part of the semantic contract.
-The facade's ops pointer is always valid: default and moved-from stores use a
-canonical no-op table, allowing ordinary queries to dispatch without nullable-
-implementation guards.
+``std::variant`` of those concrete strategies. It is one tagged implementation
+pointer whose private tags identify the canonical nop, tagged-pointer, and
+bitmap paths. Default and moved-from stores carry the nop tag rather than a
+nullable implementation. Operations use an inline switch while the concrete
+classes stay under the implementation-file boundary and semantic owners use
+only the erased facade. Allocation and destruction continue to use the bound
+``AllocatorOps``.
+
+This is the measured closed-strategy refinement of the general ops-table
+pattern. Use a passive ops table when independently supplied implementations
+must extend a public behavioural contract. When a small internal strategy set
+is closed, its discriminator is not semantic API, and indirect calls are a
+measured hot-path cost, a private tagged handle plus inline dispatch preserves
+the erased surface without exposing ``std::variant`` ownership to callers.
 
 The common embedded-owner field flag describes the three-word
 ``ErasedOwner<InlineStoragePolicy<>, TypeRecord>`` ABI. The record is read

--- a/docs/source/developer_guide/data_structures/unified_type_erasure.rst
+++ b/docs/source/developer_guide/data_structures/unified_type_erasure.rst
@@ -566,6 +566,9 @@ contract; tagged-pointer and bitmap classes stay under the implementation
 boundary. This is the standard boundary for reusable representation policy:
 separate erased behaviour from explicit erased ownership, and reserve
 ``std::variant`` for a sum type that is itself part of the semantic contract.
+The facade's ops pointer is always valid: default and moved-from stores use a
+canonical no-op table, allowing ordinary queries to dispatch without nullable-
+implementation guards.
 
 The common embedded-owner field flag describes the three-word
 ``ErasedOwner<InlineStoragePolicy<>, TypeRecord>`` ABI. The record is read

--- a/docs/source/developer_guide/memory_utilisation.rst
+++ b/docs/source/developer_guide/memory_utilisation.rst
@@ -170,13 +170,16 @@ store selects its lifecycle representation once from the payload plan:
 pointer-aligned payloads carry state in two low pointer bits, while weaker
 alignment retains one or two compact bitmaps according to the required state
 model. The tagged live state is zero, so dereferencing a known-live pointer
-does not require masking. Reported reserved bytes are approximately:
+does not require masking. A four-word semantic facade owns the selected
+concrete strategy through the common erased-owner protocol and dispatches
+through a passive ops table. Reported reserved bytes are approximately:
 
 .. code-block:: text
 
    capacity * (aligned entry-plus-graph stride + pointer size)
    + block descriptors
    + weak-alignment lifecycle-bitmap word capacity
+   + one fixed erased strategy object
 
 Map and reducers may maintain multiple banks/generations for safe structural
 transition. Ordered reduce deliberately retains a previous chain for one

--- a/docs/source/developer_guide/memory_utilisation.rst
+++ b/docs/source/developer_guide/memory_utilisation.rst
@@ -170,9 +170,10 @@ store selects its lifecycle representation once from the payload plan:
 pointer-aligned payloads carry state in two low pointer bits, while weaker
 alignment retains one or two compact bitmaps according to the required state
 model. The tagged live state is zero, so dereferencing a known-live pointer
-does not require masking. A four-word semantic facade owns the selected
-concrete strategy through the common erased-owner protocol and dispatches
-through a passive ops table. Reported reserved bytes are approximately:
+does not require masking. A one-word semantic facade owns the selected heap
+strategy through a tagged implementation pointer. Its private tag selects the
+canonical nop, aligned, or bitmap path through an inline switch; the common
+aligned path also uses tag zero. Reported reserved bytes are approximately:
 
 .. code-block:: text
 

--- a/docs/source/developer_guide/memory_utilisation.rst
+++ b/docs/source/developer_guide/memory_utilisation.rst
@@ -163,16 +163,20 @@ Python mirrors.
 Stable dynamic slots
 ~~~~~~~~~~~~~~~~~~~~
 
-Keyed nested graphs use ``StableSlotStorage`` and
-``InPlaceGraphSlotStore``. Capacity growth appends a payload block so already
-published graph addresses never move. A separate pointer table is replaced as
-capacity grows; a bitmap tracks constructed slots. Reported reserved bytes are
-approximately:
+Keyed nested graphs use ``StableSlotStore`` and ``InPlaceGraphSlotStore``.
+Capacity growth appends a payload block so already published graph addresses
+never move. A separate pointer table is replaced as capacity grows. The slot
+store selects its lifecycle representation once from the payload plan:
+pointer-aligned payloads carry state in two low pointer bits, while weaker
+alignment retains one or two compact bitmaps according to the required state
+model. The tagged live state is zero, so dereferencing a known-live pointer
+does not require masking. Reported reserved bytes are approximately:
 
 .. code-block:: text
 
    capacity * (aligned entry-plus-graph stride + pointer size)
-   + constructed-bitmap word capacity
+   + block descriptors
+   + weak-alignment lifecycle-bitmap word capacity
 
 Map and reducers may maintain multiple banks/generations for safe structural
 transition. Ordered reduce deliberately retains a previous chain for one
@@ -281,9 +285,10 @@ Allocation and lifecycle risk review
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The audited graph/nested-graph paths use owning RAII types and explicit
-placement lifecycle operations. ``StableSlotStorage`` destroys payloads before
-releasing blocks; its allocator-aware deleter pairs layout/alignment with the
-matching deallocation. Graph deletion follows stop, unsubscribe, then erase.
+placement lifecycle operations. Owners destroy constructed ``StableSlotStore``
+payloads before releasing its blocks; the allocator-aware block deleter pairs
+layout/alignment with the matching deallocation. Graph deletion follows stop,
+unsubscribe, then erase.
 No retired-object side container was found in these paths.
 
 The highest-risk future changes are therefore not simple missing ``delete``

--- a/docs/source/developer_guide/release_readiness.rst
+++ b/docs/source/developer_guide/release_readiness.rst
@@ -36,7 +36,7 @@ Supported platforms
    * - Linux x86_64
      - Official ``manylinux_2_28`` image, GCC 14
      - ``cp312-abi3`` wheel, glibc 2.28+
-     - Official wheel; Ubuntu 24.04/GCC 13 is the native and performance host
+     - Official wheel; Ubuntu 24.04/GCC 14 is the native and performance host
    * - macOS arm64
      - macOS 26 runner, current AppleClang, deployment target 15.0
      - ``cp312-abi3`` wheel, macOS 15+
@@ -81,7 +81,7 @@ requires all of the following from a clean checkout:
 - fresh Release native configure/build and the complete C++ suite on macOS;
 - a Python 3.12 ``cp312-abi3`` wheel, installed into a fresh Python 3.14
   environment, and the complete non-WIP Python suite;
-- the same Release gates on Ubuntu 24.04/GCC 13;
+- the same Release gates on Ubuntu 24.04/GCC 14;
 - Linux Debug/AddressSanitizer native and Python suites for type-erasure,
   ownership, nested-graph, or bridge-lifetime changes;
 - strict ``abi3audit`` for every wheel, install/consumer validation for public

--- a/include/hgraph/runtime/nested_graph_storage.h
+++ b/include/hgraph/runtime/nested_graph_storage.h
@@ -2,8 +2,7 @@
 #define HGRAPH_RUNTIME_NESTED_GRAPH_STORAGE_H
 
 #include <hgraph/types/metadata/debug_descriptor.h>
-#include <hgraph/types/utils/stable_slot_storage.h>
-#include <hgraph/types/utils/slot_bitmap.h>
+#include <hgraph/types/utils/stable_slot_store.h>
 
 #include <algorithm>
 #include <bit>
@@ -33,9 +32,8 @@ namespace hgraph
         explicit InPlaceGraphSlotStore(
             MemoryUtils::StorageLayout graph_layout,
             const MemoryUtils::AllocatorOps &allocator = MemoryUtils::allocator())
-            : storage_(allocator)
         {
-            bind_graph_layout(graph_layout);
+            bind_graph_layout(graph_layout, allocator);
         }
 
         InPlaceGraphSlotStore(const InPlaceGraphSlotStore &) = delete;
@@ -49,7 +47,6 @@ namespace hgraph
         {
             using std::swap;
             swap(storage_, other.storage_);
-            swap(constructed_, other.constructed_);
             swap(graph_layout_, other.graph_layout_);
             swap(slot_layout_, other.slot_layout_);
             swap(graph_offset_, other.graph_offset_);
@@ -57,6 +54,13 @@ namespace hgraph
         }
 
         void bind_graph_layout(MemoryUtils::StorageLayout graph_layout)
+        {
+            bind_graph_layout(graph_layout,
+                              storage_.bound() ? storage_.allocator() : MemoryUtils::allocator());
+        }
+
+        void bind_graph_layout(MemoryUtils::StorageLayout graph_layout,
+                               const MemoryUtils::AllocatorOps &allocator)
         {
             if (!graph_layout.valid() || graph_layout.size == 0) {
                 throw std::logic_error("InPlaceGraphSlotStore requires a non-empty graph layout");
@@ -66,6 +70,7 @@ namespace hgraph
                     graph_layout.alignment != graph_layout_.alignment) {
                     throw std::logic_error("InPlaceGraphSlotStore graph layout must remain constant");
                 }
+                storage_.bind_layout(slot_layout_, allocator);
                 return;
             }
 
@@ -80,19 +85,20 @@ namespace hgraph
                 throw std::overflow_error("InPlaceGraphSlotStore slot size overflow");
             }
             slot_layout_.size = checked_align_to(graph_offset_ + graph_layout.size, slot_layout_.alignment);
+            storage_.bind_layout(slot_layout_, allocator);
             bound_ = true;
         }
 
         [[nodiscard]] bool bound() const noexcept { return bound_; }
         [[nodiscard]] size_t slot_capacity() const noexcept { return storage_.slot_capacity(); }
-        [[nodiscard]] size_t block_count() const noexcept { return storage_.blocks.size(); }
+        [[nodiscard]] size_t block_count() const noexcept { return storage_.block_count(); }
         [[nodiscard]] MemoryUtils::StorageLayout graph_layout() const noexcept { return graph_layout_; }
         [[nodiscard]] MemoryUtils::StorageLayout slot_layout() const noexcept { return slot_layout_; }
         [[nodiscard]] size_t graph_offset() const noexcept { return graph_offset_; }
-        [[nodiscard]] bool has_entries() const noexcept { return constructed_.any(); }
+        [[nodiscard]] bool has_entries() const noexcept { return storage_.constructed_count() != 0; }
         [[nodiscard]] size_t entry_count() const noexcept
         {
-            return constructed_.count();
+            return storage_.constructed_count();
         }
         [[nodiscard]] size_t live_bytes() const noexcept
         {
@@ -100,40 +106,38 @@ namespace hgraph
         }
         [[nodiscard]] size_t reserved_bytes() const noexcept
         {
-            return slot_capacity() * (slot_layout_.size + sizeof(std::byte *)) +
-                   constructed_.word_capacity * sizeof(std::uint64_t);
+            return storage_.dynamic_storage_metrics().reserved_bytes;
         }
 
         void reserve_to(size_t capacity)
         {
             require_bound();
             if (capacity <= storage_.slot_capacity()) { return; }
-            storage_.reserve_to(capacity, slot_layout_.size, slot_layout_.alignment);
-            constructed_.resize(storage_.slot_capacity());
+            storage_.reserve_to(capacity);
         }
 
         [[nodiscard]] bool has_entry(size_t slot) const noexcept
         {
-            return slot < constructed_.size() && constructed_.test(slot);
+            return storage_.constructed(slot);
         }
 
         [[nodiscard]] Entry *entry_at(size_t slot) noexcept
         {
-            return has_entry(slot) ? MemoryUtils::cast<Entry>(storage_.slot_data(slot)) : nullptr;
+            return has_entry(slot) ? MemoryUtils::cast<Entry>(storage_.slot_memory(slot)) : nullptr;
         }
 
         [[nodiscard]] const Entry *entry_at(size_t slot) const noexcept
         {
-            return has_entry(slot) ? MemoryUtils::cast<Entry>(storage_.slot_data(slot)) : nullptr;
+            return has_entry(slot) ? MemoryUtils::cast<Entry>(storage_.slot_memory(slot)) : nullptr;
         }
 
         template <typename... Args>
         Entry &construct_at(size_t slot, Args &&...args)
         {
             require_available_slot(slot);
-            Entry *entry = MemoryUtils::cast<Entry>(storage_.slot_data(slot));
+            Entry *entry = MemoryUtils::cast<Entry>(storage_.slot_memory(slot));
             std::construct_at(entry, std::forward<Args>(args)...);
-            constructed_.set(slot);
+            storage_.mark_constructed(slot);
             return *entry;
         }
 
@@ -142,24 +146,24 @@ namespace hgraph
             Entry *entry = entry_at(slot);
             if (entry == nullptr) { return; }
             std::destroy_at(entry);
-            constructed_.reset(slot);
+            storage_.mark_free(slot);
         }
 
         void destroy_all() noexcept
         {
-            for (size_t slot = 0; slot < constructed_.size(); ++slot) { destroy_at(slot); }
+            for (size_t slot = 0; slot < slot_capacity(); ++slot) { destroy_at(slot); }
         }
 
         [[nodiscard]] void *graph_memory(size_t slot)
         {
             require_slot(slot);
-            return MemoryUtils::advance(storage_.slot_data(slot), graph_offset_);
+            return MemoryUtils::advance(storage_.slot_memory(slot), graph_offset_);
         }
 
         [[nodiscard]] const void *graph_memory(size_t slot) const
         {
             require_slot(slot);
-            return MemoryUtils::advance(storage_.slot_data(slot), graph_offset_);
+            return MemoryUtils::advance(storage_.slot_memory(slot), graph_offset_);
         }
 
         [[nodiscard]] DebugDynamicLayout debug_layout(std::size_t owner_offset,
@@ -175,30 +179,33 @@ namespace hgraph
                                       DebugDynamicFlags::DataIsPointerTable |
                                       DebugDynamicFlags::HasSlotState |
                                       DebugDynamicFlags::ElementsArePointers;
+            const StableSlotDebugView slots = storage_.debug_view();
+            if (slots.pointers_tagged) { flags = flags | DebugDynamicFlags::DataPointersAreTagged; }
+            if (slots.state_tagged) { flags = flags | DebugDynamicFlags::SlotStateIsTaggedPointer; }
             if (keys_are_owners)
             {
                 flags = flags | DebugDynamicFlags::KeyDataIsIndirect |
                         DebugDynamicFlags::KeyDataIsPointerTable |
                         DebugDynamicFlags::KeysAreOwners;
+                if (slots.pointers_tagged) { flags = flags | DebugDynamicFlags::KeyPointersAreTagged; }
             }
             return DebugDynamicLayout{
                 .magic = DEBUG_DYNAMIC_LAYOUT_MAGIC,
                 .abi_version = DEBUG_DYNAMIC_LAYOUT_ABI_VERSION,
                 .kind = DebugDynamicKind::StableSlots,
                 .flags = flags,
-                .size_offset = offset_of(&storage_.slot_count),
-                .data_offset = offset_of(&storage_.slots),
+                .size_offset = offset_of(slots.slot_count),
+                .data_offset = offset_of(slots.pointer_table),
                 .stride = slot_layout_.size,
-                .key_data_offset = keys_are_owners ? offset_of(&storage_.slots) : 0,
+                .key_data_offset = keys_are_owners ? offset_of(slots.pointer_table) : 0,
                 .key_stride = keys_are_owners ? std::size_t{1} : 0,
-                .state_offset = offset_of(&constructed_),
+                .state_offset = offset_of(slots.state),
                 .entry_offset = graph_pointer_offset,
             };
         }
 
       private:
-        StableSlotStorage             storage_{};
-        SlotBitmap                    constructed_{};
+        StableSlotStore<StableSlotStateModel::ConstructedOnly> storage_{};
         MemoryUtils::StorageLayout    graph_layout_{};
         MemoryUtils::StorageLayout    slot_layout_{};
         size_t                        graph_offset_{0};

--- a/include/hgraph/runtime/nested_graph_storage.h
+++ b/include/hgraph/runtime/nested_graph_storage.h
@@ -178,7 +178,9 @@ namespace hgraph
             DebugDynamicFlags flags = DebugDynamicFlags::DataIsIndirect |
                                       DebugDynamicFlags::DataIsPointerTable |
                                       DebugDynamicFlags::HasSlotState |
-                                      DebugDynamicFlags::ElementsArePointers;
+                                      DebugDynamicFlags::ElementsArePointers |
+                                      DebugDynamicFlags::SlotIndexIsIndirect |
+                                      DebugDynamicFlags::SlotSizeIsIndirect;
             const StableSlotDebugView slots = storage_.debug_view();
             if (slots.pointers_tagged) { flags = flags | DebugDynamicFlags::DataPointersAreTagged; }
             if (slots.state_tagged) { flags = flags | DebugDynamicFlags::SlotStateIsTaggedPointer; }
@@ -194,12 +196,15 @@ namespace hgraph
                 .abi_version = DEBUG_DYNAMIC_LAYOUT_ABI_VERSION,
                 .kind = DebugDynamicKind::StableSlots,
                 .flags = flags,
-                .size_offset = offset_of(slots.slot_count),
-                .data_offset = offset_of(slots.pointer_table),
+                .key_auxiliary_offset =
+                    keys_are_owners ? static_cast<std::uint32_t>(slots.pointer_table_offset) : 0,
+                .size_offset = slots.slot_count_offset,
+                .data_offset = offset_of(slots.implementation_pointer),
                 .stride = slot_layout_.size,
-                .key_data_offset = keys_are_owners ? offset_of(slots.pointer_table) : 0,
+                .key_data_offset = keys_are_owners ? offset_of(slots.implementation_pointer) : 0,
                 .key_stride = keys_are_owners ? std::size_t{1} : 0,
-                .state_offset = offset_of(slots.state),
+                .state_offset = slots.state_offset,
+                .auxiliary_offset = slots.pointer_table_offset,
                 .entry_offset = graph_pointer_offset,
             };
         }

--- a/include/hgraph/runtime/nested_graph_storage.h
+++ b/include/hgraph/runtime/nested_graph_storage.h
@@ -55,8 +55,7 @@ namespace hgraph
 
         void bind_graph_layout(MemoryUtils::StorageLayout graph_layout)
         {
-            bind_graph_layout(graph_layout,
-                              storage_.bound() ? storage_.allocator() : MemoryUtils::allocator());
+            bind_graph_layout(graph_layout, storage_.allocator());
         }
 
         void bind_graph_layout(MemoryUtils::StorageLayout graph_layout,

--- a/include/hgraph/types/metadata/debug_descriptor.h
+++ b/include/hgraph/types/metadata/debug_descriptor.h
@@ -21,7 +21,7 @@ namespace hgraph
     inline constexpr std::uint32_t DEBUG_DESCRIPTOR_MAGIC = 0x48474444u;
     inline constexpr std::uint16_t DEBUG_DESCRIPTOR_ABI_VERSION = 3;
     inline constexpr std::uint32_t DEBUG_DYNAMIC_LAYOUT_MAGIC = 0x4847444cu;
-    inline constexpr std::uint16_t DEBUG_DYNAMIC_LAYOUT_ABI_VERSION = 2;
+    inline constexpr std::uint16_t DEBUG_DYNAMIC_LAYOUT_ABI_VERSION = 3;
     inline constexpr std::size_t DEBUG_OWNER_IDENTITY_OFFSET = 0;
     inline constexpr std::size_t DEBUG_OWNER_STATE_OFFSET = sizeof(void *);
     inline constexpr std::size_t DEBUG_OWNER_STORAGE_OFFSET = 2 * sizeof(void *);
@@ -89,6 +89,8 @@ namespace hgraph
         DataPointersAreTagged = 1u << 10u,
         KeyPointersAreTagged = 1u << 11u,
         SlotStateIsTaggedPointer = 1u << 12u,
+        SlotIndexIsIndirect = 1u << 13u,
+        SlotSizeIsIndirect = 1u << 14u,
     };
 
     [[nodiscard]] constexpr DebugDescriptorFlags operator|(DebugDescriptorFlags lhs, DebugDescriptorFlags rhs) noexcept
@@ -141,7 +143,7 @@ namespace hgraph
         DebugDynamicKind kind{DebugDynamicKind::Contiguous};
         std::uint8_t reserved0{0};
         DebugDynamicFlags flags{DebugDynamicFlags::None};
-        std::uint32_t reserved1{0};
+        std::uint32_t key_auxiliary_offset{0};
         std::size_t size_offset{0};
         std::size_t size_constant{0};
         std::size_t data_offset{0};

--- a/include/hgraph/types/metadata/debug_descriptor.h
+++ b/include/hgraph/types/metadata/debug_descriptor.h
@@ -21,7 +21,7 @@ namespace hgraph
     inline constexpr std::uint32_t DEBUG_DESCRIPTOR_MAGIC = 0x48474444u;
     inline constexpr std::uint16_t DEBUG_DESCRIPTOR_ABI_VERSION = 3;
     inline constexpr std::uint32_t DEBUG_DYNAMIC_LAYOUT_MAGIC = 0x4847444cu;
-    inline constexpr std::uint16_t DEBUG_DYNAMIC_LAYOUT_ABI_VERSION = 1;
+    inline constexpr std::uint16_t DEBUG_DYNAMIC_LAYOUT_ABI_VERSION = 2;
     inline constexpr std::size_t DEBUG_OWNER_IDENTITY_OFFSET = 0;
     inline constexpr std::size_t DEBUG_OWNER_STATE_OFFSET = sizeof(void *);
     inline constexpr std::size_t DEBUG_OWNER_STORAGE_OFFSET = 2 * sizeof(void *);
@@ -86,6 +86,9 @@ namespace hgraph
         ElementsAreOwners = 1u << 7u,
         KeysAreOwners = 1u << 8u,
         ElementsArePointers = 1u << 9u,
+        DataPointersAreTagged = 1u << 10u,
+        KeyPointersAreTagged = 1u << 11u,
+        SlotStateIsTaggedPointer = 1u << 12u,
     };
 
     [[nodiscard]] constexpr DebugDescriptorFlags operator|(DebugDescriptorFlags lhs, DebugDescriptorFlags rhs) noexcept

--- a/include/hgraph/types/utils/impl/stable_slot_store_impl.h
+++ b/include/hgraph/types/utils/impl/stable_slot_store_impl.h
@@ -1,0 +1,461 @@
+#ifndef HGRAPH_TYPES_UTILS_IMPL_STABLE_SLOT_STORE_IMPL_H
+#define HGRAPH_TYPES_UTILS_IMPL_STABLE_SLOT_STORE_IMPL_H
+
+#include <hgraph/types/storage_metrics.h>
+#include <hgraph/types/utils/slot_bitmap.h>
+#include <hgraph/types/utils/stable_slot_storage.h>
+#include <hgraph/types/utils/stable_slot_store_fwd.h>
+#include <hgraph/util/tagged_ptr.h>
+
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <stdexcept>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+namespace hgraph::detail
+{
+    /** Common non-relocating payload blocks shared by both slot-index strategies. */
+    class StableSlotBlockStorage
+    {
+      public:
+        StableSlotBlockStorage() noexcept = default;
+
+        StableSlotBlockStorage(MemoryUtils::StorageLayout layout,
+                               const MemoryUtils::AllocatorOps &allocator)
+            : layout_(layout), allocator_(&allocator)
+        {
+            validate_layout(layout_);
+        }
+
+        StableSlotBlockStorage(const StableSlotBlockStorage &) = delete;
+        StableSlotBlockStorage &operator=(const StableSlotBlockStorage &) = delete;
+        StableSlotBlockStorage(StableSlotBlockStorage &&) noexcept = default;
+        StableSlotBlockStorage &operator=(StableSlotBlockStorage &&) noexcept = default;
+
+        void bind(MemoryUtils::StorageLayout layout,
+                  const MemoryUtils::AllocatorOps &allocator)
+        {
+            validate_layout(layout);
+            if (!bound())
+            {
+                layout_ = layout;
+                allocator_ = &allocator;
+                return;
+            }
+            if (layout.size != layout_.size || layout.alignment != layout_.alignment ||
+                allocator_ != &allocator)
+            {
+                throw std::logic_error("StableSlotStore layout and allocator must remain constant");
+            }
+        }
+
+        [[nodiscard]] bool bound() const noexcept { return layout_.valid() && layout_.size != 0; }
+        [[nodiscard]] MemoryUtils::StorageLayout layout() const noexcept { return layout_; }
+        [[nodiscard]] std::size_t stride() const noexcept
+        {
+            return StableSlotBlock::stride_for(layout_.size, layout_.alignment);
+        }
+        [[nodiscard]] const MemoryUtils::AllocatorOps &allocator() const noexcept { return *allocator_; }
+        [[nodiscard]] std::size_t block_count() const noexcept { return blocks_.size(); }
+
+        void prepare_append()
+        {
+            require_bound();
+            blocks_.reserve(blocks_.size() + 1);
+        }
+
+        [[nodiscard]] StableSlotBlock allocate_block(std::size_t first_slot,
+                                                     std::size_t slot_count) const
+        {
+            require_bound();
+            return StableSlotBlock::allocate(
+                first_slot, slot_count, layout_.size, layout_.alignment, allocator());
+        }
+
+        void append(StableSlotBlock block) noexcept
+        {
+            if (block.slot_count != 0) { blocks_.push_back(std::move(block)); }
+        }
+
+        void clear() noexcept { blocks_.clear(); }
+
+        [[nodiscard]] DynamicStorageMetrics dynamic_storage_metrics(
+            std::size_t slot_capacity,
+            std::size_t constructed_count) const noexcept
+        {
+            const std::size_t pointer_bytes = slot_capacity * sizeof(void *);
+            return {
+                .live_bytes = pointer_bytes + blocks_.size() * sizeof(StableSlotBlock) +
+                              constructed_count * stride(),
+                .reserved_bytes = pointer_bytes + blocks_.capacity() * sizeof(StableSlotBlock) +
+                                  slot_capacity * stride(),
+            };
+        }
+
+      private:
+        std::vector<StableSlotBlock> blocks_{};
+        MemoryUtils::StorageLayout layout_{};
+        const MemoryUtils::AllocatorOps *allocator_{&MemoryUtils::allocator()};
+
+        static void validate_layout(MemoryUtils::StorageLayout layout)
+        {
+            if (!layout.valid() || layout.size == 0)
+            {
+                throw std::logic_error("StableSlotStore requires a non-empty power-of-two-aligned layout");
+            }
+        }
+
+        void require_bound() const
+        {
+            if (!bound()) { throw std::logic_error("StableSlotStore has no bound layout"); }
+        }
+    };
+
+    struct EmptyStableSlotBitmap
+    {
+    };
+
+    inline SlotBitmap resized_bitmap_copy(const SlotBitmap &source, std::size_t size)
+    {
+        SlotBitmap result;
+        result.resize(size);
+        if (source.word_count() != 0)
+        {
+            std::copy_n(source.words, source.word_count(), result.words);
+        }
+        return result;
+    }
+
+    /** Existing pointer table plus one or two lifecycle bitmaps. */
+    template <StableSlotStateModel Model>
+    class BitmapStableSlotStoreImpl
+    {
+      public:
+        using LiveBitmap = std::conditional_t<Model == StableSlotStateModel::ConstructedAndLive,
+                                              SlotBitmap,
+                                              EmptyStableSlotBitmap>;
+
+        BitmapStableSlotStoreImpl() noexcept = default;
+
+        BitmapStableSlotStoreImpl(MemoryUtils::StorageLayout layout,
+                                  const MemoryUtils::AllocatorOps &allocator)
+            : blocks_(layout, allocator)
+        {
+        }
+
+        BitmapStableSlotStoreImpl(const BitmapStableSlotStoreImpl &) = delete;
+        BitmapStableSlotStoreImpl &operator=(const BitmapStableSlotStoreImpl &) = delete;
+        BitmapStableSlotStoreImpl(BitmapStableSlotStoreImpl &&other) noexcept
+            : blocks_(std::move(other.blocks_)), slots_(std::exchange(other.slots_, nullptr)),
+              slot_count_(std::exchange(other.slot_count_, 0)),
+              constructed_(std::move(other.constructed_)), live_(std::move(other.live_))
+        {
+        }
+        BitmapStableSlotStoreImpl &operator=(BitmapStableSlotStoreImpl &&other) noexcept
+        {
+            if (this != &other)
+            {
+                delete[] slots_;
+                blocks_ = std::move(other.blocks_);
+                slots_ = std::exchange(other.slots_, nullptr);
+                slot_count_ = std::exchange(other.slot_count_, 0);
+                constructed_ = std::move(other.constructed_);
+                live_ = std::move(other.live_);
+            }
+            return *this;
+        }
+        ~BitmapStableSlotStoreImpl() { delete[] slots_; }
+
+        [[nodiscard]] MemoryUtils::StorageLayout layout() const noexcept { return blocks_.layout(); }
+        [[nodiscard]] const MemoryUtils::AllocatorOps &allocator() const noexcept { return blocks_.allocator(); }
+        [[nodiscard]] std::size_t capacity() const noexcept { return slot_count_; }
+        [[nodiscard]] std::size_t stride() const noexcept { return blocks_.stride(); }
+        [[nodiscard]] std::size_t block_count() const noexcept { return blocks_.block_count(); }
+
+        void reserve_to(std::size_t capacity)
+        {
+            if (capacity <= slot_count_) { return; }
+
+            blocks_.prepare_append();
+            auto replacement = std::make_unique<std::byte *[]>(capacity);
+            if (slot_count_ != 0) { std::copy_n(slots_, slot_count_, replacement.get()); }
+            SlotBitmap next_constructed = resized_bitmap_copy(constructed_, capacity);
+            LiveBitmap next_live = resized_live_bitmap(capacity);
+            StableSlotBlock block = blocks_.allocate_block(slot_count_, capacity - slot_count_);
+            for (std::size_t slot = slot_count_; slot < capacity; ++slot)
+            {
+                replacement[slot] = block.slot_data(slot);
+            }
+
+            blocks_.append(std::move(block));
+            delete[] slots_;
+            slots_ = replacement.release();
+            slot_count_ = capacity;
+            constructed_ = std::move(next_constructed);
+            live_ = std::move(next_live);
+        }
+
+        [[nodiscard]] void *slot_memory(std::size_t slot) const noexcept
+        {
+            return slot < slot_count_ ? slots_[slot] : nullptr;
+        }
+        [[nodiscard]] void *live_slot_memory(std::size_t slot) const noexcept
+        {
+            return live(slot) ? slot_memory(slot) : nullptr;
+        }
+        [[nodiscard]] void *non_live_slot_memory(std::size_t slot) const noexcept
+            requires(Model == StableSlotStateModel::ConstructedAndLive)
+        {
+            return constructed(slot) && !live(slot) ? slot_memory(slot) : nullptr;
+        }
+        [[nodiscard]] bool constructed(std::size_t slot) const noexcept
+        {
+            return constructed_.test(slot);
+        }
+        [[nodiscard]] bool live(std::size_t slot) const noexcept
+        {
+            if constexpr (Model == StableSlotStateModel::ConstructedOnly)
+                return constructed(slot);
+            else
+                return live_.test(slot);
+        }
+
+        void mark_staged(std::size_t slot) noexcept
+        {
+            constructed_.set(slot);
+            if constexpr (Model == StableSlotStateModel::ConstructedAndLive) { live_.reset(slot); }
+        }
+        [[nodiscard]] bool mark_live(std::size_t slot) noexcept
+        {
+            if constexpr (Model == StableSlotStateModel::ConstructedAndLive)
+            {
+                if (!constructed(slot) || live(slot)) { return false; }
+            }
+            else if (constructed(slot))
+            {
+                return false;
+            }
+            constructed_.set(slot);
+            if constexpr (Model == StableSlotStateModel::ConstructedAndLive) { live_.set(slot); }
+            return true;
+        }
+        [[nodiscard]] bool mark_pending(std::size_t slot) noexcept
+        {
+            static_assert(Model == StableSlotStateModel::ConstructedAndLive);
+            if (!live(slot)) { return false; }
+            live_.reset(slot);
+            return true;
+        }
+        void mark_free(std::size_t slot) noexcept
+        {
+            constructed_.reset(slot);
+            if constexpr (Model == StableSlotStateModel::ConstructedAndLive) { live_.reset(slot); }
+        }
+        void reset_states() noexcept
+        {
+            constructed_.reset();
+            if constexpr (Model == StableSlotStateModel::ConstructedAndLive) { live_.reset(); }
+        }
+
+        [[nodiscard]] std::size_t constructed_count() const noexcept { return constructed_.count(); }
+        [[nodiscard]] DynamicStorageMetrics dynamic_storage_metrics() const noexcept
+        {
+            DynamicStorageMetrics result = blocks_.dynamic_storage_metrics(slot_count_, constructed_count());
+            result += constructed_.dynamic_storage_metrics();
+            if constexpr (Model == StableSlotStateModel::ConstructedAndLive)
+            {
+                result += live_.dynamic_storage_metrics();
+            }
+            return result;
+        }
+
+        [[nodiscard]] const void *debug_capacity_address() const noexcept { return &slot_count_; }
+        [[nodiscard]] const void *debug_slots_address() const noexcept { return &slots_; }
+        [[nodiscard]] const void *debug_state_address() const noexcept
+        {
+            if constexpr (Model == StableSlotStateModel::ConstructedAndLive)
+                return &live_;
+            else
+                return &constructed_;
+        }
+
+      private:
+        StableSlotBlockStorage blocks_{};
+        std::byte **slots_{nullptr};
+        std::size_t slot_count_{0};
+        SlotBitmap constructed_{};
+        [[no_unique_address]] LiveBitmap live_{};
+
+        [[nodiscard]] LiveBitmap resized_live_bitmap(std::size_t size) const
+        {
+            if constexpr (Model == StableSlotStateModel::ConstructedAndLive)
+                return resized_bitmap_copy(live_, size);
+            else
+                return {};
+        }
+    };
+
+    enum class TaggedStableSlotState : std::uint8_t
+    {
+        Live = 0,
+        PendingErase = 1,
+        Staged = 2,
+        Free = 3,
+    };
+
+    /** Slot pointer table whose two low alignment bits carry lifecycle state. */
+    template <StableSlotStateModel Model>
+    class TaggedPointerStableSlotStoreImpl
+    {
+      public:
+        using SlotPointer = erased_tagged_ptr<alignof(std::uintptr_t), 2, TaggedStableSlotState>;
+
+        TaggedPointerStableSlotStoreImpl() noexcept = default;
+        TaggedPointerStableSlotStoreImpl(MemoryUtils::StorageLayout layout,
+                                         const MemoryUtils::AllocatorOps &allocator)
+            : blocks_(layout, allocator)
+        {
+            if (layout.alignment < alignof(std::uintptr_t))
+            {
+                throw std::logic_error("Tagged stable slots require pointer-aligned payloads");
+            }
+        }
+
+        TaggedPointerStableSlotStoreImpl(const TaggedPointerStableSlotStoreImpl &) = delete;
+        TaggedPointerStableSlotStoreImpl &operator=(const TaggedPointerStableSlotStoreImpl &) = delete;
+        TaggedPointerStableSlotStoreImpl(TaggedPointerStableSlotStoreImpl &&other) noexcept
+            : blocks_(std::move(other.blocks_)), slots_(std::exchange(other.slots_, nullptr)),
+              slot_count_(std::exchange(other.slot_count_, 0))
+        {
+        }
+        TaggedPointerStableSlotStoreImpl &operator=(TaggedPointerStableSlotStoreImpl &&other) noexcept
+        {
+            if (this != &other)
+            {
+                delete[] slots_;
+                blocks_ = std::move(other.blocks_);
+                slots_ = std::exchange(other.slots_, nullptr);
+                slot_count_ = std::exchange(other.slot_count_, 0);
+            }
+            return *this;
+        }
+        ~TaggedPointerStableSlotStoreImpl() { delete[] slots_; }
+
+        [[nodiscard]] MemoryUtils::StorageLayout layout() const noexcept { return blocks_.layout(); }
+        [[nodiscard]] const MemoryUtils::AllocatorOps &allocator() const noexcept { return blocks_.allocator(); }
+        [[nodiscard]] std::size_t capacity() const noexcept { return slot_count_; }
+        [[nodiscard]] std::size_t stride() const noexcept { return blocks_.stride(); }
+        [[nodiscard]] std::size_t block_count() const noexcept { return blocks_.block_count(); }
+
+        void reserve_to(std::size_t capacity)
+        {
+            if (capacity <= slot_count_) { return; }
+
+            blocks_.prepare_append();
+            auto replacement = std::make_unique<SlotPointer[]>(capacity);
+            if (slot_count_ != 0) { std::copy_n(slots_, slot_count_, replacement.get()); }
+            StableSlotBlock block = blocks_.allocate_block(slot_count_, capacity - slot_count_);
+            for (std::size_t slot = slot_count_; slot < capacity; ++slot)
+            {
+                replacement[slot].set(block.slot_data(slot), TaggedStableSlotState::Free);
+            }
+
+            blocks_.append(std::move(block));
+            delete[] slots_;
+            slots_ = replacement.release();
+            slot_count_ = capacity;
+        }
+
+        [[nodiscard]] void *slot_memory(std::size_t slot) const noexcept
+        {
+            return slot < slot_count_ ? slots_[slot].ptr() : nullptr;
+        }
+        [[nodiscard]] void *live_slot_memory(std::size_t slot) const noexcept
+        {
+            if (!live(slot)) { return nullptr; }
+            return reinterpret_cast<void *>(slots_[slot].raw_bits());
+        }
+        [[nodiscard]] void *non_live_slot_memory(std::size_t slot) const noexcept
+            requires(Model == StableSlotStateModel::ConstructedAndLive)
+        {
+            return constructed(slot) && !live(slot) ? slot_memory(slot) : nullptr;
+        }
+        [[nodiscard]] bool constructed(std::size_t slot) const noexcept
+        {
+            return slot < slot_count_ && !slots_[slot].has_enum(TaggedStableSlotState::Free);
+        }
+        [[nodiscard]] bool live(std::size_t slot) const noexcept
+        {
+            return slot < slot_count_ && slots_[slot].has_enum(TaggedStableSlotState::Live);
+        }
+
+        void mark_staged(std::size_t slot) noexcept
+        {
+            slots_[slot].set_tag(TaggedStableSlotState::Staged);
+        }
+        [[nodiscard]] bool mark_live(std::size_t slot) noexcept
+        {
+            if constexpr (Model == StableSlotStateModel::ConstructedAndLive)
+            {
+                if (!constructed(slot) || live(slot)) { return false; }
+            }
+            else if (constructed(slot))
+            {
+                return false;
+            }
+            slots_[slot].set_tag(TaggedStableSlotState::Live);
+            return true;
+        }
+        [[nodiscard]] bool mark_pending(std::size_t slot) noexcept
+        {
+            static_assert(Model == StableSlotStateModel::ConstructedAndLive);
+            if (!live(slot)) { return false; }
+            slots_[slot].set_tag(TaggedStableSlotState::PendingErase);
+            return true;
+        }
+        void mark_free(std::size_t slot) noexcept
+        {
+            slots_[slot].set_tag(TaggedStableSlotState::Free);
+        }
+        void reset_states() noexcept
+        {
+            for (std::size_t slot = 0; slot < slot_count_; ++slot) { mark_free(slot); }
+        }
+
+        [[nodiscard]] std::size_t constructed_count() const noexcept
+        {
+            std::size_t result = 0;
+            for (std::size_t slot = 0; slot < slot_count_; ++slot)
+            {
+                result += constructed(slot) ? 1U : 0U;
+            }
+            return result;
+        }
+        [[nodiscard]] DynamicStorageMetrics dynamic_storage_metrics() const noexcept
+        {
+            return blocks_.dynamic_storage_metrics(slot_count_, constructed_count());
+        }
+
+        [[nodiscard]] const void *debug_capacity_address() const noexcept { return &slot_count_; }
+        [[nodiscard]] const void *debug_slots_address() const noexcept { return &slots_; }
+        [[nodiscard]] const void *debug_state_address() const noexcept { return &slots_; }
+
+      private:
+        StableSlotBlockStorage blocks_{};
+        SlotPointer *slots_{nullptr};
+        std::size_t slot_count_{0};
+    };
+
+    static_assert(sizeof(TaggedPointerStableSlotStoreImpl<StableSlotStateModel::ConstructedOnly>) <=
+                  8 * sizeof(void *));
+    static_assert(sizeof(BitmapStableSlotStoreImpl<StableSlotStateModel::ConstructedOnly>) <=
+                  11 * sizeof(void *));
+    static_assert(sizeof(BitmapStableSlotStoreImpl<StableSlotStateModel::ConstructedAndLive>) <=
+                  14 * sizeof(void *));
+}  // namespace hgraph::detail
+
+#endif  // HGRAPH_TYPES_UTILS_IMPL_STABLE_SLOT_STORE_IMPL_H

--- a/include/hgraph/types/utils/impl/stable_slot_store_impl.h
+++ b/include/hgraph/types/utils/impl/stable_slot_store_impl.h
@@ -1,10 +1,9 @@
 #ifndef HGRAPH_TYPES_UTILS_IMPL_STABLE_SLOT_STORE_IMPL_H
 #define HGRAPH_TYPES_UTILS_IMPL_STABLE_SLOT_STORE_IMPL_H
 
-#include <hgraph/types/storage_metrics.h>
 #include <hgraph/types/utils/slot_bitmap.h>
 #include <hgraph/types/utils/stable_slot_storage.h>
-#include <hgraph/types/utils/stable_slot_store_fwd.h>
+#include <hgraph/types/utils/stable_slot_store.h>
 #include <hgraph/util/tagged_ptr.h>
 
 #include <algorithm>
@@ -145,6 +144,12 @@ namespace hgraph::detail
                                   const MemoryUtils::AllocatorOps &allocator)
             : blocks_(layout, allocator)
         {
+        }
+
+        void bind(MemoryUtils::StorageLayout layout,
+                  const MemoryUtils::AllocatorOps &allocator)
+        {
+            blocks_.bind(layout, allocator);
         }
 
         BitmapStableSlotStoreImpl(const BitmapStableSlotStoreImpl &) = delete;
@@ -323,6 +328,16 @@ namespace hgraph::detail
             {
                 throw std::logic_error("Tagged stable slots require pointer-aligned payloads");
             }
+        }
+
+        void bind(MemoryUtils::StorageLayout layout,
+                  const MemoryUtils::AllocatorOps &allocator)
+        {
+            if (layout.alignment < alignof(std::uintptr_t))
+            {
+                throw std::logic_error("Tagged stable slots require pointer-aligned payloads");
+            }
+            blocks_.bind(layout, allocator);
         }
 
         TaggedPointerStableSlotStoreImpl(const TaggedPointerStableSlotStoreImpl &) = delete;

--- a/include/hgraph/types/utils/impl/stable_slot_store_impl.h
+++ b/include/hgraph/types/utils/impl/stable_slot_store_impl.h
@@ -3,7 +3,7 @@
 
 #include <hgraph/types/utils/slot_bitmap.h>
 #include <hgraph/types/utils/stable_slot_storage.h>
-#include <hgraph/types/utils/stable_slot_store.h>
+#include <hgraph/types/utils/stable_slot_store_fwd.h>
 #include <hgraph/util/tagged_ptr.h>
 
 #include <algorithm>

--- a/include/hgraph/types/utils/impl/stable_slot_store_impl.h
+++ b/include/hgraph/types/utils/impl/stable_slot_store_impl.h
@@ -122,9 +122,10 @@ namespace hgraph::detail
     {
         SlotBitmap result;
         result.resize(size);
-        if (source.word_count() != 0)
+        const std::size_t preserved_words = std::min(source.word_count(), result.word_count());
+        for (std::size_t index = 0; index < preserved_words; ++index)
         {
-            std::copy_n(source.words, source.word_count(), result.words);
+            result.words[index] = source.words[index];
         }
         return result;
     }
@@ -293,7 +294,12 @@ namespace hgraph::detail
         std::byte **slots_{nullptr};
         std::size_t slot_count_{0};
         SlotBitmap constructed_{};
-        [[no_unique_address]] LiveBitmap live_{};
+#if defined(_MSC_VER)
+        [[msvc::no_unique_address]]
+#else
+        [[no_unique_address]]
+#endif
+        LiveBitmap live_{};
 
         [[nodiscard]] LiveBitmap resized_live_bitmap(std::size_t size) const
         {

--- a/include/hgraph/types/utils/key_slot_store.h
+++ b/include/hgraph/types/utils/key_slot_store.h
@@ -3,8 +3,7 @@
 
 #include <hgraph/util/scope.h>
 #include <hgraph/types/utils/slot_observer.h>
-#include <hgraph/types/utils/slot_bitmap.h>
-#include <hgraph/types/utils/stable_slot_storage.h>
+#include <hgraph/types/utils/stable_slot_store.h>
 #include <hgraph/types/value/value_view.h>
 
 #include <ankerl/unordered_dense.h>
@@ -98,9 +97,13 @@ namespace hgraph
      * key-to-slot lookup through an internal hash index. Logical removal is
      * split from physical erase:
      *
-     * - `constructed[slot]` means a key object still exists in slot memory
-     * - `live[slot]` means that constructed key is currently present
-     * - `constructed && !live` means the key is pending physical erase
+     * - ``constructed(slot)`` means a key object still exists in slot memory
+     * - ``live(slot)`` means that constructed key is currently present
+     * - constructed and not live means the key is pending physical erase
+     *
+     * The lifecycle representation is selected from the payload alignment:
+     * pointer-aligned keys use tagged slot pointers, while weaker alignments
+     * use the compact bitmap implementation.
      *
      * Pending removals remain addressable by slot and key until the owner
      * explicitly flushes them with `erase_pending()`. The store deliberately
@@ -139,20 +142,11 @@ namespace hgraph
             bool   constructed{false};
         };
 
-        /**
-         * Non-moving slot memory for the key payloads.
-         */
-        StableSlotStorage key_storage{};
-        /**
-         * Physical ownership bitset. If set, a key object exists in slot
-         * memory and may still be inspected even when no longer live.
-         */
-        SlotBitmap constructed{};
-        /**
-         * Logical membership bitset. If set, the constructed key currently
-         * participates in lookup and iteration.
-         */
-        SlotBitmap live{};
+      private:
+        using StableStorage = StableSlotStore<StableSlotStateModel::ConstructedAndLive>;
+        StableStorage key_storage{};
+
+      public:
         /**
          * Structural observers kept in sync with insert, remove, erase, clear,
          * and capacity events.
@@ -162,11 +156,11 @@ namespace hgraph
         /**
          * Bind the store to ``plan`` and ``ops``. ``plan`` must remain valid
          * for the store's lifetime; the optional ``allocator`` is held by
-         * the underlying ``StableSlotStorage``.
+         * the underlying ``StableSlotStore``.
          */
         KeySlotStore(const MemoryUtils::StoragePlan &plan, KeySlotStoreOps ops,
                      const MemoryUtils::AllocatorOps &allocator = MemoryUtils::allocator())
-            : key_storage(allocator), m_key_plan(&plan), m_ops(ops) {
+            : key_storage(plan.layout, allocator), m_key_plan(&plan), m_ops(ops) {
             validate_plan();
             validate_ops();
             rebuild_index();
@@ -199,8 +193,8 @@ namespace hgraph
          * index and must only be destroyed or assigned into.
          */
         KeySlotStore(KeySlotStore &&other) noexcept
-            : key_storage(std::move(other.key_storage)), constructed(std::move(other.constructed)), live(std::move(other.live)),
-              observers(std::move(other.observers)), m_size(std::exchange(other.m_size, 0)),
+            : key_storage(std::move(other.key_storage)), observers(std::move(other.observers)),
+              m_size(std::exchange(other.m_size, 0)),
               m_pending_erase_count(std::exchange(other.m_pending_erase_count, 0)),
               m_key_plan(std::exchange(other.m_key_plan, nullptr)), m_ops(other.m_ops),
               m_value_binding(std::exchange(other.m_value_binding, {})),
@@ -209,8 +203,6 @@ namespace hgraph
               m_index_owner(std::move(other.m_index_owner)),
               m_index(std::move(other.m_index)) {
             if (m_index_owner != nullptr) { m_index_owner->store = this; }
-            other.constructed.clear();
-            other.live.clear();
             other.m_free_slots.clear();
         }
 
@@ -219,8 +211,6 @@ namespace hgraph
             if (this != &other) {
                 hard_clear();
                 key_storage           = std::move(other.key_storage);
-                constructed           = std::move(other.constructed);
-                live                  = std::move(other.live);
                 observers             = std::move(other.observers);
                 m_size                = std::exchange(other.m_size, 0);
                 m_pending_erase_count = std::exchange(other.m_pending_erase_count, 0);
@@ -233,8 +223,6 @@ namespace hgraph
                 m_index               = std::move(other.m_index);
                 m_index_owner         = std::move(other.m_index_owner);
                 if (m_index_owner != nullptr) { m_index_owner->store = this; }
-                other.constructed.clear();
-                other.live.clear();
                 other.m_free_slots.clear();
             }
             return *this;
@@ -251,22 +239,27 @@ namespace hgraph
         [[nodiscard]] size_t                           pending_erase_count() const noexcept { return m_pending_erase_count; }
         /** Bound storage plan; never null after successful construction. */
         [[nodiscard]] const MemoryUtils::StoragePlan  *plan() const noexcept { return m_key_plan; }
-        /** Allocator carried through to the underlying ``StableSlotStorage``. */
+        /** Allocator carried through to the underlying ``StableSlotStore``. */
         [[nodiscard]] const MemoryUtils::AllocatorOps &allocator() const noexcept { return key_storage.allocator(); }
         /** True when at least one slot is awaiting physical erase. */
         [[nodiscard]] bool                             has_pending_erase() const noexcept { return m_pending_erase_count != 0; }
+        /** Selected stable-slot index representation. */
+        [[nodiscard]] StableSlotRepresentation slot_representation() const noexcept
+        {
+            return key_storage.representation();
+        }
+        /** Data-only addresses used when publishing debugger offsets. */
+        [[nodiscard]] StableSlotDebugView debug_slot_view() const noexcept { return key_storage.debug_view(); }
         /** Slots logically removed in the current batch. Stale resurrected entries may be present. */
         [[nodiscard]] std::span<const size_t> pending_erase_slots() const noexcept
         {
             return m_pending_erase_slots;
         }
 
-        /** Exact occupied/retained heap bytes owned by keys, indices, bitmaps, and bookkeeping. */
+        /** Exact occupied/retained heap bytes owned by keys, indices, state, and bookkeeping. */
         [[nodiscard]] DynamicStorageMetrics dynamic_storage_metrics() const noexcept
         {
-            DynamicStorageMetrics result = key_storage.dynamic_storage_metrics(constructed.count());
-            result += constructed.dynamic_storage_metrics();
-            result += live.dynamic_storage_metrics();
+            DynamicStorageMetrics result = key_storage.dynamic_storage_metrics();
             result += observers.dynamic_storage_metrics();
             result += vector_metrics(m_free_slots);
             result += vector_metrics(m_pending_erase_slots);
@@ -291,18 +284,20 @@ namespace hgraph
          * Return whether slot memory still contains a constructed key object.
          */
         [[nodiscard]] bool slot_constructed(size_t slot) const noexcept {
-            return slot < constructed.size() && constructed.test(slot);
+            return key_storage.constructed(slot);
         }
 
         /**
          * Return whether the constructed key at `slot` is logically present.
          */
-        [[nodiscard]] bool slot_live(size_t slot) const noexcept { return slot < live.size() && live.test(slot); }
+        [[nodiscard]] bool slot_live(size_t slot) const noexcept { return key_storage.live(slot); }
 
         /**
          * Return whether a removed key is awaiting physical erase.
          */
-        [[nodiscard]] bool slot_pending_erase(size_t slot) const noexcept { return slot_constructed(slot) && !slot_live(slot); }
+        [[nodiscard]] bool slot_pending_erase(size_t slot) const noexcept {
+            return key_storage.non_live_slot_memory(slot) != nullptr;
+        }
 
         /**
          * Return the key payload stored at `slot`.
@@ -316,7 +311,7 @@ namespace hgraph
          */
         [[nodiscard]] void *operator[](size_t slot) {
             require_constructed_slot(slot);
-            return key_storage.slot_data(slot);
+            return key_storage.slot_memory(slot);
         }
 
         /**
@@ -324,17 +319,19 @@ namespace hgraph
          */
         [[nodiscard]] const void *operator[](size_t slot) const {
             require_constructed_slot(slot);
-            return key_storage.slot_data(slot);
+            return key_storage.slot_memory(slot);
         }
 
         /** Pointer to ``slot``'s payload if constructed; ``nullptr`` otherwise. */
         [[nodiscard]] void *key_memory(size_t slot) noexcept {
-            return slot_constructed(slot) ? key_storage.slot_data(slot) : nullptr;
+            if (void *memory = key_storage.live_slot_memory(slot); memory != nullptr) { return memory; }
+            return slot_constructed(slot) ? key_storage.slot_memory(slot) : nullptr;
         }
 
         /** Const overload of ``key_memory``. */
         [[nodiscard]] const void *key_memory(size_t slot) const noexcept {
-            return slot_constructed(slot) ? key_storage.slot_data(slot) : nullptr;
+            if (const void *memory = key_storage.live_slot_memory(slot); memory != nullptr) { return memory; }
+            return slot_constructed(slot) ? key_storage.slot_memory(slot) : nullptr;
         }
 
         /**
@@ -385,14 +382,14 @@ namespace hgraph
         template <typename T> [[nodiscard]] T *try_key(size_t slot) {
             if (!slot_constructed(slot)) { return nullptr; }
             require_type<T>();
-            return MemoryUtils::cast<T>(key_storage.slot_data(slot));
+            return MemoryUtils::cast<T>(key_storage.slot_memory(slot));
         }
 
         /** Const overload of ``try_key``. */
         template <typename T> [[nodiscard]] const T *try_key(size_t slot) const {
             if (!slot_constructed(slot)) { return nullptr; }
             require_type<T>();
-            return MemoryUtils::cast<T>(key_storage.slot_data(slot));
+            return MemoryUtils::cast<T>(key_storage.slot_memory(slot));
         }
 
         /**
@@ -404,9 +401,7 @@ namespace hgraph
             if (capacity <= slot_capacity()) { return; }
 
             const size_t old_capacity = slot_capacity();
-            key_storage.reserve_to(capacity, m_key_plan->layout.size, m_key_plan->layout.alignment);
-            constructed.resize(capacity);
-            live.resize(capacity);
+            key_storage.reserve_to(capacity);
             m_free_slots.reserve(m_free_slots.size() + capacity - old_capacity);
             m_index->reserve(capacity);
             for (size_t slot = capacity; slot > old_capacity; --slot) { m_free_slots.push_back(slot - 1); }
@@ -422,8 +417,8 @@ namespace hgraph
       private:
         [[nodiscard]] auto rollback_new_slot(size_t slot) {
             return ::hgraph::make_scope_exit([this, slot]() noexcept {
-                m_key_plan->destroy(key_storage.slot_data(slot));
-                constructed.reset(slot);
+                m_key_plan->destroy(key_storage.slot_memory(slot));
+                key_storage.mark_free(slot);
                 m_free_slots.push_back(slot);
             });
         }
@@ -463,12 +458,12 @@ namespace hgraph
 
             const size_t slot = acquire_free_slot();
             auto rollback_free = ::hgraph::make_scope_exit([&]() noexcept { m_free_slots.push_back(slot); });
-            m_key_plan->copy_construct(key_storage.slot_data(slot), key);
-            constructed.set(slot);
+            m_key_plan->copy_construct(key_storage.slot_memory(slot), key);
+            key_storage.mark_staged(slot);
             auto rollback = rollback_new_slot(slot);
             rollback_free.release();
             m_index->insert(slot);
-            live.set(slot);
+            static_cast<void>(key_storage.mark_live(slot));
             ++m_size;
             rollback.release();
             observers.notify_insert(slot);
@@ -483,19 +478,19 @@ namespace hgraph
             }
 
             const size_t slot = acquire_free_slot();
-            void *destination = key_storage.slot_data(slot);
+            void *destination = key_storage.slot_memory(slot);
             auto rollback_free = ::hgraph::make_scope_exit([&]() noexcept { m_free_slots.push_back(slot); });
             m_value_binding.default_construct_at(destination);
             auto rollback_value = ::hgraph::make_scope_exit([&]() noexcept { m_value_binding.destroy_at(destination); });
             m_value_binding.ops_ref().copy_assign_from(
                 m_value_binding, destination, key.binding(), key.data());
 
-            constructed.set(slot);
+            key_storage.mark_staged(slot);
             auto rollback = rollback_new_slot(slot);
             rollback_value.release();
             rollback_free.release();
             m_index->insert(slot);
-            live.set(slot);
+            static_cast<void>(key_storage.mark_live(slot));
             ++m_size;
             rollback.release();
             observers.notify_insert(slot);
@@ -521,12 +516,12 @@ namespace hgraph
             }
             const size_t slot = acquire_free_slot();
             auto rollback_free = ::hgraph::make_scope_exit([&]() noexcept { m_free_slots.push_back(slot); });
-            m_key_plan->move_construct(key_storage.slot_data(slot), key);
-            constructed.set(slot);
+            m_key_plan->move_construct(key_storage.slot_memory(slot), key);
+            key_storage.mark_staged(slot);
             auto rollback = rollback_new_slot(slot);
             rollback_free.release();
             m_index->insert(slot);
-            live.set(slot);
+            static_cast<void>(key_storage.mark_live(slot));
             ++m_size;
             rollback.release();
             observers.notify_insert(slot);
@@ -541,7 +536,7 @@ namespace hgraph
 
         /** Logically remove ``key``. Returns ``true`` if a live key was removed. */
         [[nodiscard]] bool remove(const void *key) {
-            const size_t slot = find_slot(key);
+            const size_t slot = find_stored_slot(key);
             return slot != npos && remove_slot(slot);
         }
 
@@ -558,10 +553,9 @@ namespace hgraph
          * pending erase set is flushed.
          */
         [[nodiscard]] bool remove_slot(size_t slot) {
-            if (!slot_live(slot)) { return false; }
+            if (!key_storage.mark_pending_erase(slot)) { return false; }
 
             observers.notify_remove(slot);
-            live.reset(slot);
             m_pending_erase_slots.push_back(slot);
             ++m_pending_erase_count;
             --m_size;
@@ -578,12 +572,13 @@ namespace hgraph
             if (m_key_plan == nullptr || m_pending_erase_count == 0) { return; }
 
             for (const size_t slot : m_pending_erase_slots) {
-                if (!slot_pending_erase(slot)) { continue; }
+                void *memory = key_storage.non_live_slot_memory(slot);
+                if (memory == nullptr) { continue; }
 
                 observers.notify_erase(slot);
                 m_index->erase(slot);
-                m_key_plan->destroy(key_storage.slot_data(slot));
-                constructed.reset(slot);
+                m_key_plan->destroy(memory);
+                key_storage.mark_free(slot);
                 m_free_slots.push_back(slot);
             }
 
@@ -732,7 +727,7 @@ namespace hgraph
         }
 
         void require_constructed_slot(size_t slot) const {
-            if (slot >= constructed.size()) { throw std::out_of_range("KeySlotStore slot out of range"); }
+            if (slot >= slot_capacity()) { throw std::out_of_range("KeySlotStore slot out of range"); }
             if (!slot_constructed(slot)) { throw std::logic_error("KeySlotStore slot is not constructed"); }
         }
 
@@ -762,8 +757,7 @@ namespace hgraph
         }
 
         [[nodiscard]] InsertResult reuse_existing_slot(size_t slot) {
-            if (slot_live(slot)) { return {.slot = slot, .inserted = false, .constructed = false}; }
-            live.set(slot);
+            if (!key_storage.mark_live(slot)) { return {.slot = slot, .inserted = false, .constructed = false}; }
             --m_pending_erase_count;
             if (m_pending_erase_count == 0) { m_pending_erase_slots.clear(); }
             ++m_size;
@@ -798,7 +792,7 @@ namespace hgraph
         void hard_clear() noexcept {
             if (m_key_plan != nullptr) {
                 for (size_t slot = 0; slot < slot_capacity(); ++slot) {
-                    if (slot_constructed(slot)) { m_key_plan->destroy(key_storage.slot_data(slot)); }
+                    if (slot_constructed(slot)) { m_key_plan->destroy(key_storage.slot_memory(slot)); }
                 }
             }
 
@@ -807,8 +801,7 @@ namespace hgraph
             m_size                = 0;
             m_pending_erase_count = 0;
             m_pending_erase_slots.clear();
-            constructed.reset();
-            live.reset();
+            key_storage.reset_states();
             m_free_slots.clear();
             for (size_t slot = slot_capacity(); slot > 0; --slot) { m_free_slots.push_back(slot - 1); }
         }

--- a/include/hgraph/types/utils/slot_bitmap.h
+++ b/include/hgraph/types/utils/slot_bitmap.h
@@ -71,9 +71,9 @@ namespace hgraph
             {
                 auto replacement = std::make_unique<std::uint64_t[]>(required_words);
                 const std::size_t preserved_words = std::min(old_word_count, word_capacity);
-                if (preserved_words != 0)
+                for (std::size_t index = 0; index < preserved_words; ++index)
                 {
-                    std::copy_n(words, preserved_words, replacement.get());
+                    replacement[index] = words[index];
                 }
                 delete[] words;
                 words = replacement.release();

--- a/include/hgraph/types/utils/stable_slot_store.h
+++ b/include/hgraph/types/utils/stable_slot_store.h
@@ -63,11 +63,14 @@ namespace hgraph
     {
         using StableSlotStoreImplementationOwner = MemoryUtils::ErasedOwner<>;
 
+        /** Canonical no-op table used by default and moved-from stores. */
+        [[nodiscard]] HGRAPH_EXPORT const StableSlotStoreOps &noop_stable_slot_store_ops() noexcept;
+
         /** Owning result returned by the implementation-only strategy factory. */
         struct StableSlotStoreImplementation
         {
             StableSlotStoreImplementationOwner owner{};
-            const StableSlotStoreOps *ops{nullptr};
+            const StableSlotStoreOps *ops{&noop_stable_slot_store_ops()};
 
             StableSlotStoreImplementation() noexcept = default;
             StableSlotStoreImplementation(const StableSlotStoreImplementation &) = delete;
@@ -112,7 +115,7 @@ namespace hgraph
 
         StableSlotStore(StableSlotStore &&other) noexcept
             : implementation_(std::move(other.implementation_)),
-              ops_(std::exchange(other.ops_, nullptr))
+              ops_(std::exchange(other.ops_, &detail::noop_stable_slot_store_ops()))
         {
         }
 
@@ -121,7 +124,7 @@ namespace hgraph
             if (this != &other)
             {
                 implementation_ = std::move(other.implementation_);
-                ops_ = std::exchange(other.ops_, nullptr);
+                ops_ = std::exchange(other.ops_, &detail::noop_stable_slot_store_ops());
             }
             return *this;
         }
@@ -151,27 +154,27 @@ namespace hgraph
 
         [[nodiscard]] StableSlotRepresentation representation() const noexcept
         {
-            return bound() ? ops_->representation : StableSlotRepresentation::Unbound;
+            return ops_->representation;
         }
         [[nodiscard]] bool bound() const noexcept
         {
-            return ops_ != nullptr && implementation_.has_value();
+            return ops_ != &detail::noop_stable_slot_store_ops();
         }
         [[nodiscard]] std::size_t slot_capacity() const noexcept
         {
-            return bound() ? ops_->capacity_impl(implementation()) : 0;
+            return ops_->capacity_impl(implementation());
         }
         [[nodiscard]] std::size_t stride() const noexcept
         {
-            return bound() ? ops_->stride_impl(implementation()) : 0;
+            return ops_->stride_impl(implementation());
         }
         [[nodiscard]] std::size_t block_count() const noexcept
         {
-            return bound() ? ops_->block_count_impl(implementation()) : 0;
+            return ops_->block_count_impl(implementation());
         }
         [[nodiscard]] const MemoryUtils::AllocatorOps &allocator() const noexcept
         {
-            return bound() ? *ops_->allocator_impl(implementation()) : MemoryUtils::allocator();
+            return *ops_->allocator_impl(implementation());
         }
 
         void reserve_to(std::size_t capacity)
@@ -186,7 +189,7 @@ namespace hgraph
         }
         [[nodiscard]] const void *slot_memory(std::size_t slot) const noexcept
         {
-            return bound() ? ops_->slot_memory_impl(implementation(), slot) : nullptr;
+            return ops_->slot_memory_impl(implementation(), slot);
         }
         [[nodiscard]] void *live_slot_memory(std::size_t slot) noexcept
         {
@@ -194,7 +197,7 @@ namespace hgraph
         }
         [[nodiscard]] const void *live_slot_memory(std::size_t slot) const noexcept
         {
-            return bound() ? ops_->live_slot_memory_impl(implementation(), slot) : nullptr;
+            return ops_->live_slot_memory_impl(implementation(), slot);
         }
         /** Constructed, non-live slot memory (pending erase or transiently staged). */
         [[nodiscard]] void *non_live_slot_memory(std::size_t slot) noexcept
@@ -205,15 +208,15 @@ namespace hgraph
         [[nodiscard]] const void *non_live_slot_memory(std::size_t slot) const noexcept
             requires(Model == StableSlotStateModel::ConstructedAndLive)
         {
-            return bound() ? ops_->non_live_slot_memory_impl(implementation(), slot) : nullptr;
+            return ops_->non_live_slot_memory_impl(implementation(), slot);
         }
         [[nodiscard]] bool constructed(std::size_t slot) const noexcept
         {
-            return bound() && ops_->constructed_impl(implementation(), slot);
+            return ops_->constructed_impl(implementation(), slot);
         }
         [[nodiscard]] bool live(std::size_t slot) const noexcept
         {
-            return bound() && ops_->live_impl(implementation(), slot);
+            return ops_->live_impl(implementation(), slot);
         }
 
         void mark_staged(std::size_t slot) noexcept
@@ -242,16 +245,15 @@ namespace hgraph
         }
         void reset_states() noexcept
         {
-            if (bound()) { ops_->reset_states_impl(implementation()); }
+            ops_->reset_states_impl(implementation());
         }
 
         [[nodiscard]] std::size_t constructed_count() const noexcept
         {
-            return bound() ? ops_->constructed_count_impl(implementation()) : 0;
+            return ops_->constructed_count_impl(implementation());
         }
         [[nodiscard]] DynamicStorageMetrics dynamic_storage_metrics() const noexcept
         {
-            if (!bound()) { return {}; }
             DynamicStorageMetrics result = ops_->dynamic_storage_metrics_impl(implementation());
             const auto *plan = implementation_.plan();
             if (plan != nullptr)
@@ -264,11 +266,13 @@ namespace hgraph
 
         [[nodiscard]] StableSlotDebugView debug_view() const noexcept
         {
-            if (!bound() || !implementation_.stores_heap()) { return {}; }
             StableSlotDebugView result = ops_->debug_view_impl(implementation());
-            result.implementation_pointer = MemoryUtils::advance(
-                static_cast<const void *>(&implementation_),
-                detail::StableSlotStoreImplementationOwner::debug_storage_offset());
+            if (implementation_.stores_heap())
+            {
+                result.implementation_pointer = MemoryUtils::advance(
+                    static_cast<const void *>(&implementation_),
+                    detail::StableSlotStoreImplementationOwner::debug_storage_offset());
+            }
             return result;
         }
 
@@ -281,14 +285,17 @@ namespace hgraph
 
       private:
         detail::StableSlotStoreImplementationOwner implementation_{};
-        const StableSlotStoreOps *ops_{nullptr};
+        const StableSlotStoreOps *ops_{&detail::noop_stable_slot_store_ops()};
 
         [[nodiscard]] void *implementation() noexcept { return implementation_.data(); }
         [[nodiscard]] const void *implementation() const noexcept { return implementation_.data(); }
 
         void require_bound() const
         {
-            if (!bound()) { throw std::logic_error("StableSlotStore has no bound layout"); }
+            if (ops_ == &detail::noop_stable_slot_store_ops())
+            {
+                throw std::logic_error("StableSlotStore has no bound layout");
+            }
         }
     };
 

--- a/include/hgraph/types/utils/stable_slot_store.h
+++ b/include/hgraph/types/utils/stable_slot_store.h
@@ -1,25 +1,87 @@
 #ifndef HGRAPH_TYPES_UTILS_STABLE_SLOT_STORE_H
 #define HGRAPH_TYPES_UTILS_STABLE_SLOT_STORE_H
 
-#include <hgraph/types/utils/impl/stable_slot_store_impl.h>
+#include <hgraph/hgraph_export.h>
+#include <hgraph/types/storage_metrics.h>
+#include <hgraph/types/utils/memory_utils.h>
+#include <hgraph/types/utils/stable_slot_store_fwd.h>
 
 #include <cstddef>
 #include <stdexcept>
-#include <type_traits>
 #include <utility>
-#include <variant>
 
 namespace hgraph
 {
-    /** Data-only addresses used to publish stable-slot debugger offsets. */
+    /** Data-only erased implementation offsets used by debugger descriptors. */
     struct StableSlotDebugView
     {
-        const void *slot_count{nullptr};
-        const void *pointer_table{nullptr};
-        const void *state{nullptr};
+        const void *implementation_pointer{nullptr};
+        std::size_t slot_count_offset{0};
+        std::size_t pointer_table_offset{0};
+        std::size_t state_offset{0};
         bool pointers_tagged{false};
         bool state_tagged{false};
     };
+
+    /**
+     * Passive behaviour table for one stable-slot representation.
+     *
+     * The first argument of every hook is the erased implementation memory,
+     * matching the runtime's established ops-table pattern. Concrete tagged
+     * and bitmap types populate canonical tables behind the implementation
+     * boundary; semantic owners call only through this contract.
+     */
+    struct StableSlotStoreOps
+    {
+        StableSlotRepresentation representation{StableSlotRepresentation::Unbound};
+
+        MemoryUtils::StorageLayout (*layout_impl)(const void *implementation) noexcept{nullptr};
+        const MemoryUtils::AllocatorOps *(*allocator_impl)(const void *implementation) noexcept{nullptr};
+        std::size_t (*capacity_impl)(const void *implementation) noexcept{nullptr};
+        std::size_t (*stride_impl)(const void *implementation) noexcept{nullptr};
+        std::size_t (*block_count_impl)(const void *implementation) noexcept{nullptr};
+
+        void (*reserve_to_impl)(void *implementation, std::size_t capacity){nullptr};
+        const void *(*slot_memory_impl)(const void *implementation, std::size_t slot) noexcept{nullptr};
+        const void *(*live_slot_memory_impl)(const void *implementation, std::size_t slot) noexcept{nullptr};
+        const void *(*non_live_slot_memory_impl)(const void *implementation, std::size_t slot) noexcept{nullptr};
+        bool (*constructed_impl)(const void *implementation, std::size_t slot) noexcept{nullptr};
+        bool (*live_impl)(const void *implementation, std::size_t slot) noexcept{nullptr};
+
+        void (*mark_staged_impl)(void *implementation, std::size_t slot) noexcept{nullptr};
+        bool (*mark_live_impl)(void *implementation, std::size_t slot) noexcept{nullptr};
+        bool (*mark_pending_impl)(void *implementation, std::size_t slot) noexcept{nullptr};
+        void (*mark_free_impl)(void *implementation, std::size_t slot) noexcept{nullptr};
+        void (*reset_states_impl)(void *implementation) noexcept{nullptr};
+
+        std::size_t (*constructed_count_impl)(const void *implementation) noexcept{nullptr};
+        DynamicStorageMetrics (*dynamic_storage_metrics_impl)(const void *implementation) noexcept{nullptr};
+        StableSlotDebugView (*debug_view_impl)(const void *implementation) noexcept{nullptr};
+    };
+
+    namespace detail
+    {
+        using StableSlotStoreImplementationOwner = MemoryUtils::ErasedOwner<>;
+
+        /** Owning result returned by the implementation-only strategy factory. */
+        struct StableSlotStoreImplementation
+        {
+            StableSlotStoreImplementationOwner owner{};
+            const StableSlotStoreOps *ops{nullptr};
+
+            StableSlotStoreImplementation() noexcept = default;
+            StableSlotStoreImplementation(const StableSlotStoreImplementation &) = delete;
+            StableSlotStoreImplementation &operator=(const StableSlotStoreImplementation &) = delete;
+            StableSlotStoreImplementation(StableSlotStoreImplementation &&) noexcept = default;
+            StableSlotStoreImplementation &operator=(StableSlotStoreImplementation &&) noexcept = default;
+        };
+
+        /** Select and construct the concrete strategy from immutable layout metadata. */
+        HGRAPH_EXPORT StableSlotStoreImplementation make_stable_slot_store_implementation(
+            StableSlotStateModel model,
+            MemoryUtils::StorageLayout layout,
+            const MemoryUtils::AllocatorOps &allocator);
+    }  // namespace detail
 
     /**
      * Payload-type-erased stable slot storage with an alignment-selected index.
@@ -28,6 +90,10 @@ namespace hgraph
      * Weaker alignments retain the existing raw pointer table plus the bitmap
      * planes required by ``Model``. Selection happens once when the layout is
      * bound and never changes for the lifetime of the store.
+     *
+     * Behaviour and ownership are independent: ``StableSlotStoreOps`` erases
+     * representation behaviour while ``ErasedOwner`` owns the selected
+     * implementation according to its storage plan.
      */
     template <StableSlotStateModel Model>
     class StableSlotStore
@@ -43,8 +109,22 @@ namespace hgraph
 
         StableSlotStore(const StableSlotStore &) = delete;
         StableSlotStore &operator=(const StableSlotStore &) = delete;
-        StableSlotStore(StableSlotStore &&) noexcept = default;
-        StableSlotStore &operator=(StableSlotStore &&) noexcept = default;
+
+        StableSlotStore(StableSlotStore &&other) noexcept
+            : implementation_(std::move(other.implementation_)),
+              ops_(std::exchange(other.ops_, nullptr))
+        {
+        }
+
+        StableSlotStore &operator=(StableSlotStore &&other) noexcept
+        {
+            if (this != &other)
+            {
+                implementation_ = std::move(other.implementation_);
+                ops_ = std::exchange(other.ops_, nullptr);
+            }
+            return *this;
+        }
 
         void bind_layout(MemoryUtils::StorageLayout layout,
                          const MemoryUtils::AllocatorOps &allocator = MemoryUtils::allocator())
@@ -53,180 +133,158 @@ namespace hgraph
             {
                 throw std::logic_error("StableSlotStore requires a non-empty valid layout");
             }
-            if (representation() != StableSlotRepresentation::Unbound)
+            if (bound())
             {
-                visit([&](const auto &impl) {
-                    const auto existing = impl.layout();
-                    if (existing.size != layout.size || existing.alignment != layout.alignment ||
-                        &impl.allocator() != &allocator)
-                    {
-                        throw std::logic_error("StableSlotStore layout and allocator must remain constant");
-                    }
-                });
+                const auto existing = ops_->layout_impl(implementation());
+                if (existing.size != layout.size || existing.alignment != layout.alignment ||
+                    ops_->allocator_impl(implementation()) != &allocator)
+                {
+                    throw std::logic_error("StableSlotStore layout and allocator must remain constant");
+                }
                 return;
             }
 
-            if (layout.alignment >= alignof(std::uintptr_t))
-                implementation_.template emplace<TaggedImpl>(layout, allocator);
-            else
-                implementation_.template emplace<BitmapImpl>(layout, allocator);
+            auto selected = detail::make_stable_slot_store_implementation(Model, layout, allocator);
+            implementation_ = std::move(selected.owner);
+            ops_ = selected.ops;
         }
 
         [[nodiscard]] StableSlotRepresentation representation() const noexcept
         {
-            if (std::holds_alternative<TaggedImpl>(implementation_))
-                return StableSlotRepresentation::TaggedPointer;
-            if (std::holds_alternative<BitmapImpl>(implementation_))
-                return StableSlotRepresentation::Bitmap;
-            return StableSlotRepresentation::Unbound;
+            return bound() ? ops_->representation : StableSlotRepresentation::Unbound;
         }
         [[nodiscard]] bool bound() const noexcept
         {
-            return representation() != StableSlotRepresentation::Unbound;
+            return ops_ != nullptr && implementation_.has_value();
         }
         [[nodiscard]] std::size_t slot_capacity() const noexcept
         {
-            return bound() ? visit([](const auto &impl) { return impl.capacity(); }) : 0;
+            return bound() ? ops_->capacity_impl(implementation()) : 0;
         }
         [[nodiscard]] std::size_t stride() const noexcept
         {
-            return bound() ? visit([](const auto &impl) { return impl.stride(); }) : 0;
+            return bound() ? ops_->stride_impl(implementation()) : 0;
         }
         [[nodiscard]] std::size_t block_count() const noexcept
         {
-            return bound() ? visit([](const auto &impl) { return impl.block_count(); }) : 0;
+            return bound() ? ops_->block_count_impl(implementation()) : 0;
         }
         [[nodiscard]] const MemoryUtils::AllocatorOps &allocator() const noexcept
         {
-            return bound() ? visit([](const auto &impl) -> const MemoryUtils::AllocatorOps & {
-                return impl.allocator();
-            }) : MemoryUtils::allocator();
+            return bound() ? *ops_->allocator_impl(implementation()) : MemoryUtils::allocator();
         }
 
         void reserve_to(std::size_t capacity)
         {
             require_bound();
-            visit([&](auto &impl) { impl.reserve_to(capacity); });
+            ops_->reserve_to_impl(implementation(), capacity);
         }
 
         [[nodiscard]] void *slot_memory(std::size_t slot) noexcept
         {
-            return bound() ? visit([&](auto &impl) { return impl.slot_memory(slot); }) : nullptr;
+            return const_cast<void *>(static_cast<const StableSlotStore &>(*this).slot_memory(slot));
         }
         [[nodiscard]] const void *slot_memory(std::size_t slot) const noexcept
         {
-            return bound() ? visit([&](const auto &impl) { return impl.slot_memory(slot); }) : nullptr;
+            return bound() ? ops_->slot_memory_impl(implementation(), slot) : nullptr;
         }
         [[nodiscard]] void *live_slot_memory(std::size_t slot) noexcept
         {
-            return bound() ? visit([&](auto &impl) { return impl.live_slot_memory(slot); }) : nullptr;
+            return const_cast<void *>(static_cast<const StableSlotStore &>(*this).live_slot_memory(slot));
         }
         [[nodiscard]] const void *live_slot_memory(std::size_t slot) const noexcept
         {
-            return bound() ? visit([&](const auto &impl) { return impl.live_slot_memory(slot); }) : nullptr;
+            return bound() ? ops_->live_slot_memory_impl(implementation(), slot) : nullptr;
         }
         /** Constructed, non-live slot memory (pending erase or transiently staged). */
         [[nodiscard]] void *non_live_slot_memory(std::size_t slot) noexcept
             requires(Model == StableSlotStateModel::ConstructedAndLive)
         {
-            return bound() ? visit([&](auto &impl) { return impl.non_live_slot_memory(slot); }) : nullptr;
+            return const_cast<void *>(static_cast<const StableSlotStore &>(*this).non_live_slot_memory(slot));
         }
         [[nodiscard]] const void *non_live_slot_memory(std::size_t slot) const noexcept
             requires(Model == StableSlotStateModel::ConstructedAndLive)
         {
-            return bound() ? visit([&](const auto &impl) { return impl.non_live_slot_memory(slot); }) : nullptr;
+            return bound() ? ops_->non_live_slot_memory_impl(implementation(), slot) : nullptr;
         }
         [[nodiscard]] bool constructed(std::size_t slot) const noexcept
         {
-            return bound() && visit([&](const auto &impl) { return impl.constructed(slot); });
+            return bound() && ops_->constructed_impl(implementation(), slot);
         }
         [[nodiscard]] bool live(std::size_t slot) const noexcept
         {
-            return bound() && visit([&](const auto &impl) { return impl.live(slot); });
+            return bound() && ops_->live_impl(implementation(), slot);
         }
 
         void mark_staged(std::size_t slot) noexcept
             requires(Model == StableSlotStateModel::ConstructedAndLive)
         {
-            visit([&](auto &impl) { impl.mark_staged(slot); });
+            ops_->mark_staged_impl(implementation(), slot);
         }
         void mark_constructed(std::size_t slot) noexcept
             requires(Model == StableSlotStateModel::ConstructedOnly)
         {
-            static_cast<void>(visit([&](auto &impl) { return impl.mark_live(slot); }));
+            static_cast<void>(ops_->mark_live_impl(implementation(), slot));
         }
         [[nodiscard]] bool mark_live(std::size_t slot) noexcept
             requires(Model == StableSlotStateModel::ConstructedAndLive)
         {
-            return visit([&](auto &impl) { return impl.mark_live(slot); });
+            return ops_->mark_live_impl(implementation(), slot);
         }
         [[nodiscard]] bool mark_pending_erase(std::size_t slot) noexcept
             requires(Model == StableSlotStateModel::ConstructedAndLive)
         {
-            return visit([&](auto &impl) { return impl.mark_pending(slot); });
+            return ops_->mark_pending_impl(implementation(), slot);
         }
         void mark_free(std::size_t slot) noexcept
         {
-            visit([&](auto &impl) { impl.mark_free(slot); });
+            ops_->mark_free_impl(implementation(), slot);
         }
         void reset_states() noexcept
         {
-            if (bound()) { visit([](auto &impl) { impl.reset_states(); }); }
+            if (bound()) { ops_->reset_states_impl(implementation()); }
         }
 
         [[nodiscard]] std::size_t constructed_count() const noexcept
         {
-            return bound() ? visit([](const auto &impl) { return impl.constructed_count(); }) : 0;
+            return bound() ? ops_->constructed_count_impl(implementation()) : 0;
         }
         [[nodiscard]] DynamicStorageMetrics dynamic_storage_metrics() const noexcept
         {
-            return bound() ? visit([](const auto &impl) { return impl.dynamic_storage_metrics(); })
-                           : DynamicStorageMetrics{};
+            if (!bound()) { return {}; }
+            DynamicStorageMetrics result = ops_->dynamic_storage_metrics_impl(implementation());
+            const auto *plan = implementation_.plan();
+            if (plan != nullptr)
+            {
+                result.live_bytes += plan->layout.size;
+                result.reserved_bytes += plan->layout.size;
+            }
+            return result;
         }
 
         [[nodiscard]] StableSlotDebugView debug_view() const noexcept
         {
-            if (!bound()) { return {}; }
-            return visit([&](const auto &impl) {
-                constexpr bool tagged = std::is_same_v<std::remove_cvref_t<decltype(impl)>, TaggedImpl>;
-                return StableSlotDebugView{
-                    .slot_count = impl.debug_capacity_address(),
-                    .pointer_table = impl.debug_slots_address(),
-                    .state = impl.debug_state_address(),
-                    .pointers_tagged = tagged,
-                    .state_tagged = tagged,
-                };
-            });
+            if (!bound() || !implementation_.stores_heap()) { return {}; }
+            StableSlotDebugView result = ops_->debug_view_impl(implementation());
+            result.implementation_pointer = MemoryUtils::advance(
+                static_cast<const void *>(&implementation_),
+                detail::StableSlotStoreImplementationOwner::debug_storage_offset());
+            return result;
         }
 
-        void swap(StableSlotStore &other) noexcept { implementation_.swap(other.implementation_); }
+        void swap(StableSlotStore &other) noexcept
+        {
+            using std::swap;
+            swap(implementation_, other.implementation_);
+            swap(ops_, other.ops_);
+        }
 
       private:
-        using TaggedImpl = detail::TaggedPointerStableSlotStoreImpl<Model>;
-        using BitmapImpl = detail::BitmapStableSlotStoreImpl<Model>;
-        using Implementation = std::variant<std::monostate, TaggedImpl, BitmapImpl>;
+        detail::StableSlotStoreImplementationOwner implementation_{};
+        const StableSlotStoreOps *ops_{nullptr};
 
-        Implementation implementation_{};
-
-        template <typename Visitor>
-        decltype(auto) visit(Visitor &&visitor)
-        {
-            if (auto *tagged = std::get_if<TaggedImpl>(&implementation_); tagged != nullptr)
-                return std::forward<Visitor>(visitor)(*tagged);
-            if (auto *bitmap = std::get_if<BitmapImpl>(&implementation_); bitmap != nullptr)
-                return std::forward<Visitor>(visitor)(*bitmap);
-            throw std::logic_error("StableSlotStore has no bound layout");
-        }
-
-        template <typename Visitor>
-        decltype(auto) visit(Visitor &&visitor) const
-        {
-            if (const auto *tagged = std::get_if<TaggedImpl>(&implementation_); tagged != nullptr)
-                return std::forward<Visitor>(visitor)(*tagged);
-            if (const auto *bitmap = std::get_if<BitmapImpl>(&implementation_); bitmap != nullptr)
-                return std::forward<Visitor>(visitor)(*bitmap);
-            throw std::logic_error("StableSlotStore has no bound layout");
-        }
+        [[nodiscard]] void *implementation() noexcept { return implementation_.data(); }
+        [[nodiscard]] const void *implementation() const noexcept { return implementation_.data(); }
 
         void require_bound() const
         {
@@ -234,8 +292,8 @@ namespace hgraph
         }
     };
 
-    static_assert(sizeof(StableSlotStore<StableSlotStateModel::ConstructedOnly>) <= 12 * sizeof(void *));
-    static_assert(sizeof(StableSlotStore<StableSlotStateModel::ConstructedAndLive>) <= 15 * sizeof(void *));
+    static_assert(sizeof(StableSlotStore<StableSlotStateModel::ConstructedOnly>) <= 4 * sizeof(void *));
+    static_assert(sizeof(StableSlotStore<StableSlotStateModel::ConstructedAndLive>) <= 4 * sizeof(void *));
 }  // namespace hgraph
 
 #endif  // HGRAPH_TYPES_UTILS_STABLE_SLOT_STORE_H

--- a/include/hgraph/types/utils/stable_slot_store.h
+++ b/include/hgraph/types/utils/stable_slot_store.h
@@ -3,10 +3,12 @@
 
 #include <hgraph/hgraph_export.h>
 #include <hgraph/types/storage_metrics.h>
+#include <hgraph/types/utils/impl/stable_slot_store_impl.h>
 #include <hgraph/types/utils/memory_utils.h>
 #include <hgraph/types/utils/stable_slot_store_fwd.h>
 
 #include <cstddef>
+#include <cstdint>
 #include <stdexcept>
 #include <utility>
 
@@ -23,84 +25,56 @@ namespace hgraph
         bool state_tagged{false};
     };
 
-    /**
-     * Passive behaviour table for one stable-slot representation.
-     *
-     * The first argument of every hook is the erased implementation memory,
-     * matching the runtime's established ops-table pattern. Concrete tagged
-     * and bitmap types populate canonical tables behind the implementation
-     * boundary; semantic owners call only through this contract.
-     */
-    struct StableSlotStoreOps
-    {
-        StableSlotRepresentation representation{StableSlotRepresentation::Unbound};
-
-        MemoryUtils::StorageLayout (*layout_impl)(const void *implementation) noexcept{nullptr};
-        const MemoryUtils::AllocatorOps *(*allocator_impl)(const void *implementation) noexcept{nullptr};
-        std::size_t (*capacity_impl)(const void *implementation) noexcept{nullptr};
-        std::size_t (*stride_impl)(const void *implementation) noexcept{nullptr};
-        std::size_t (*block_count_impl)(const void *implementation) noexcept{nullptr};
-
-        void (*reserve_to_impl)(void *implementation, std::size_t capacity){nullptr};
-        const void *(*slot_memory_impl)(const void *implementation, std::size_t slot) noexcept{nullptr};
-        const void *(*live_slot_memory_impl)(const void *implementation, std::size_t slot) noexcept{nullptr};
-        const void *(*non_live_slot_memory_impl)(const void *implementation, std::size_t slot) noexcept{nullptr};
-        bool (*constructed_impl)(const void *implementation, std::size_t slot) noexcept{nullptr};
-        bool (*live_impl)(const void *implementation, std::size_t slot) noexcept{nullptr};
-
-        void (*mark_staged_impl)(void *implementation, std::size_t slot) noexcept{nullptr};
-        bool (*mark_live_impl)(void *implementation, std::size_t slot) noexcept{nullptr};
-        bool (*mark_pending_impl)(void *implementation, std::size_t slot) noexcept{nullptr};
-        void (*mark_free_impl)(void *implementation, std::size_t slot) noexcept{nullptr};
-        void (*reset_states_impl)(void *implementation) noexcept{nullptr};
-
-        std::size_t (*constructed_count_impl)(const void *implementation) noexcept{nullptr};
-        DynamicStorageMetrics (*dynamic_storage_metrics_impl)(const void *implementation) noexcept{nullptr};
-        StableSlotDebugView (*debug_view_impl)(const void *implementation) noexcept{nullptr};
-    };
-
     namespace detail
     {
-        using StableSlotStoreImplementationOwner = MemoryUtils::ErasedOwner<>;
-
-        /** Canonical no-op table used by default and moved-from stores. */
-        [[nodiscard]] HGRAPH_EXPORT const StableSlotStoreOps &noop_stable_slot_store_ops() noexcept;
-
-        /** Owning result returned by the implementation-only strategy factory. */
-        struct StableSlotStoreImplementation
+        /**
+         * Private representation tag carried by the erased implementation pointer.
+         *
+         * The aligned implementation deliberately uses tag zero so its pointer can
+         * be consumed without masking on the common live-slot path.  The nop tag is
+         * a non-null logical state even though it has no implementation allocation.
+         */
+        enum class StableSlotStoreImplementationTag : std::uintptr_t
         {
-            StableSlotStoreImplementationOwner owner{};
-            const StableSlotStoreOps *ops{&noop_stable_slot_store_ops()};
-
-            StableSlotStoreImplementation() noexcept = default;
-            StableSlotStoreImplementation(const StableSlotStoreImplementation &) = delete;
-            StableSlotStoreImplementation &operator=(const StableSlotStoreImplementation &) = delete;
-            StableSlotStoreImplementation(StableSlotStoreImplementation &&) noexcept = default;
-            StableSlotStoreImplementation &operator=(StableSlotStoreImplementation &&) noexcept = default;
+            TaggedPointer = 0,
+            Bitmap = 1,
+            Nop = 2,
         };
 
-        /** Select and construct the concrete strategy from immutable layout metadata. */
-        HGRAPH_EXPORT StableSlotStoreImplementation make_stable_slot_store_implementation(
-            StableSlotStateModel model,
-            MemoryUtils::StorageLayout layout,
-            const MemoryUtils::AllocatorOps &allocator);
-    }  // namespace detail
+        inline constexpr std::uintptr_t STABLE_SLOT_STORE_IMPLEMENTATION_TAG_MASK{0x3};
+        inline constexpr std::uintptr_t NOP_STABLE_SLOT_STORE_HANDLE{
+            static_cast<std::uintptr_t>(StableSlotStoreImplementationTag::Nop)};
+
+        /** Select, allocate, and construct a concrete strategy. */
+        [[nodiscard]] HGRAPH_EXPORT std::uintptr_t
+        make_stable_slot_store_implementation(StableSlotStateModel model, MemoryUtils::StorageLayout layout,
+                                              const MemoryUtils::AllocatorOps &allocator);
+
+        /** Destroy and deallocate a concrete strategy selected by its handle tag. */
+        HGRAPH_EXPORT void destroy_stable_slot_store_implementation(StableSlotStateModel model,
+                                                                    std::uintptr_t handle) noexcept;
+    } // namespace detail
 
     /**
      * Payload-type-erased stable slot storage with an alignment-selected index.
      *
-     * Pointer-aligned payloads carry lifecycle state in two low pointer bits.
-     * Weaker alignments retain the existing raw pointer table plus the bitmap
-     * planes required by ``Model``. Selection happens once when the layout is
-     * bound and never changes for the lifetime of the store.
+     * Pointer-aligned payloads carry lifecycle state in two low slot-pointer
+     * bits. Weaker alignments retain a raw pointer table plus the bitmap planes
+     * required by ``Model``. Selection happens once when the layout is bound and
+     * never changes for the lifetime of the store.
      *
-     * Behaviour and ownership are independent: ``StableSlotStoreOps`` erases
-     * representation behaviour while ``ErasedOwner`` owns the selected
-     * implementation according to its storage plan.
+     * The facade owns one tagged implementation pointer. Its low bits select the
+     * canonical nop, tagged-pointer, or bitmap strategy; each public operation
+     * uses an inline representation switch so the compiler can optimize the
+     * concrete hot path. Concrete storage types remain in the implementation
+     * header and semantic owners interact only with this erased surface.
      */
-    template <StableSlotStateModel Model>
-    class StableSlotStore
+    template <StableSlotStateModel Model> class StableSlotStore
     {
+        using TaggedImplementation = detail::TaggedPointerStableSlotStoreImpl<Model>;
+        using BitmapImplementation = detail::BitmapStableSlotStoreImpl<Model>;
+        using ImplementationTag = detail::StableSlotStoreImplementationTag;
+
       public:
         StableSlotStore() noexcept = default;
 
@@ -114,193 +88,380 @@ namespace hgraph
         StableSlotStore &operator=(const StableSlotStore &) = delete;
 
         StableSlotStore(StableSlotStore &&other) noexcept
-            : implementation_(std::move(other.implementation_)),
-              ops_(std::exchange(other.ops_, &detail::noop_stable_slot_store_ops()))
+            : implementation_(std::exchange(other.implementation_, detail::NOP_STABLE_SLOT_STORE_HANDLE))
         {
         }
 
         StableSlotStore &operator=(StableSlotStore &&other) noexcept
         {
-            if (this != &other)
-            {
-                implementation_ = std::move(other.implementation_);
-                ops_ = std::exchange(other.ops_, &detail::noop_stable_slot_store_ops());
+            if (this != &other) {
+                detail::destroy_stable_slot_store_implementation(Model, implementation_);
+                implementation_ = std::exchange(other.implementation_, detail::NOP_STABLE_SLOT_STORE_HANDLE);
             }
             return *this;
         }
 
+        ~StableSlotStore() { detail::destroy_stable_slot_store_implementation(Model, implementation_); }
+
         void bind_layout(MemoryUtils::StorageLayout layout,
                          const MemoryUtils::AllocatorOps &allocator = MemoryUtils::allocator())
         {
-            if (!layout.valid() || layout.size == 0)
-            {
+            if (!layout.valid() || layout.size == 0) {
                 throw std::logic_error("StableSlotStore requires a non-empty valid layout");
             }
-            if (bound())
-            {
-                const auto existing = ops_->layout_impl(implementation());
+            if (bound()) {
+                const auto existing = bound_layout();
                 if (existing.size != layout.size || existing.alignment != layout.alignment ||
-                    ops_->allocator_impl(implementation()) != &allocator)
-                {
+                    &this->allocator() != &allocator) {
                     throw std::logic_error("StableSlotStore layout and allocator must remain constant");
                 }
                 return;
             }
 
-            auto selected = detail::make_stable_slot_store_implementation(Model, layout, allocator);
-            implementation_ = std::move(selected.owner);
-            ops_ = selected.ops;
+            implementation_ = detail::make_stable_slot_store_implementation(Model, layout, allocator);
         }
 
         [[nodiscard]] StableSlotRepresentation representation() const noexcept
         {
-            return ops_->representation;
+            switch (implementation_tag()) {
+            case ImplementationTag::TaggedPointer:
+                return StableSlotRepresentation::TaggedPointer;
+            case ImplementationTag::Bitmap:
+                return StableSlotRepresentation::Bitmap;
+            case ImplementationTag::Nop:
+                return StableSlotRepresentation::Unbound;
+            }
+            return StableSlotRepresentation::Unbound;
         }
-        [[nodiscard]] bool bound() const noexcept
-        {
-            return ops_ != &detail::noop_stable_slot_store_ops();
-        }
+
+        [[nodiscard]] bool bound() const noexcept { return implementation_tag() != ImplementationTag::Nop; }
+
         [[nodiscard]] std::size_t slot_capacity() const noexcept
         {
-            return ops_->capacity_impl(implementation());
+            switch (implementation_tag()) {
+            case ImplementationTag::TaggedPointer:
+                return tagged_implementation()->capacity();
+            case ImplementationTag::Bitmap:
+                return bitmap_implementation()->capacity();
+            case ImplementationTag::Nop:
+                return 0;
+            }
+            return 0;
         }
+
         [[nodiscard]] std::size_t stride() const noexcept
         {
-            return ops_->stride_impl(implementation());
+            switch (implementation_tag()) {
+            case ImplementationTag::TaggedPointer:
+                return tagged_implementation()->stride();
+            case ImplementationTag::Bitmap:
+                return bitmap_implementation()->stride();
+            case ImplementationTag::Nop:
+                return 0;
+            }
+            return 0;
         }
+
         [[nodiscard]] std::size_t block_count() const noexcept
         {
-            return ops_->block_count_impl(implementation());
+            switch (implementation_tag()) {
+            case ImplementationTag::TaggedPointer:
+                return tagged_implementation()->block_count();
+            case ImplementationTag::Bitmap:
+                return bitmap_implementation()->block_count();
+            case ImplementationTag::Nop:
+                return 0;
+            }
+            return 0;
         }
+
         [[nodiscard]] const MemoryUtils::AllocatorOps &allocator() const noexcept
         {
-            return *ops_->allocator_impl(implementation());
+            switch (implementation_tag()) {
+            case ImplementationTag::TaggedPointer:
+                return tagged_implementation()->allocator();
+            case ImplementationTag::Bitmap:
+                return bitmap_implementation()->allocator();
+            case ImplementationTag::Nop:
+                return MemoryUtils::allocator();
+            }
+            return MemoryUtils::allocator();
         }
 
         void reserve_to(std::size_t capacity)
         {
             require_bound();
-            ops_->reserve_to_impl(implementation(), capacity);
+            if (implementation_tag() == ImplementationTag::TaggedPointer)
+                tagged_implementation()->reserve_to(capacity);
+            else
+                bitmap_implementation()->reserve_to(capacity);
         }
 
         [[nodiscard]] void *slot_memory(std::size_t slot) noexcept
         {
             return const_cast<void *>(static_cast<const StableSlotStore &>(*this).slot_memory(slot));
         }
+
         [[nodiscard]] const void *slot_memory(std::size_t slot) const noexcept
         {
-            return ops_->slot_memory_impl(implementation(), slot);
+            switch (implementation_tag()) {
+            case ImplementationTag::TaggedPointer:
+                return tagged_implementation()->slot_memory(slot);
+            case ImplementationTag::Bitmap:
+                return bitmap_implementation()->slot_memory(slot);
+            case ImplementationTag::Nop:
+                return nullptr;
+            }
+            return nullptr;
         }
+
         [[nodiscard]] void *live_slot_memory(std::size_t slot) noexcept
         {
             return const_cast<void *>(static_cast<const StableSlotStore &>(*this).live_slot_memory(slot));
         }
+
         [[nodiscard]] const void *live_slot_memory(std::size_t slot) const noexcept
         {
-            return ops_->live_slot_memory_impl(implementation(), slot);
+            switch (implementation_tag()) {
+            case ImplementationTag::TaggedPointer:
+                return tagged_implementation()->live_slot_memory(slot);
+            case ImplementationTag::Bitmap:
+                return bitmap_implementation()->live_slot_memory(slot);
+            case ImplementationTag::Nop:
+                return nullptr;
+            }
+            return nullptr;
         }
-        /** Constructed, non-live slot memory (pending erase or transiently staged). */
+
+        /** Constructed, non-live slot memory (pending erase or transiently staged).
+         */
         [[nodiscard]] void *non_live_slot_memory(std::size_t slot) noexcept
             requires(Model == StableSlotStateModel::ConstructedAndLive)
         {
             return const_cast<void *>(static_cast<const StableSlotStore &>(*this).non_live_slot_memory(slot));
         }
+
         [[nodiscard]] const void *non_live_slot_memory(std::size_t slot) const noexcept
             requires(Model == StableSlotStateModel::ConstructedAndLive)
         {
-            return ops_->non_live_slot_memory_impl(implementation(), slot);
+            switch (implementation_tag()) {
+            case ImplementationTag::TaggedPointer:
+                return tagged_implementation()->non_live_slot_memory(slot);
+            case ImplementationTag::Bitmap:
+                return bitmap_implementation()->non_live_slot_memory(slot);
+            case ImplementationTag::Nop:
+                return nullptr;
+            }
+            return nullptr;
         }
+
         [[nodiscard]] bool constructed(std::size_t slot) const noexcept
         {
-            return ops_->constructed_impl(implementation(), slot);
+            switch (implementation_tag()) {
+            case ImplementationTag::TaggedPointer:
+                return tagged_implementation()->constructed(slot);
+            case ImplementationTag::Bitmap:
+                return bitmap_implementation()->constructed(slot);
+            case ImplementationTag::Nop:
+                return false;
+            }
+            return false;
         }
+
         [[nodiscard]] bool live(std::size_t slot) const noexcept
         {
-            return ops_->live_impl(implementation(), slot);
+            switch (implementation_tag()) {
+            case ImplementationTag::TaggedPointer:
+                return tagged_implementation()->live(slot);
+            case ImplementationTag::Bitmap:
+                return bitmap_implementation()->live(slot);
+            case ImplementationTag::Nop:
+                return false;
+            }
+            return false;
         }
 
         void mark_staged(std::size_t slot) noexcept
             requires(Model == StableSlotStateModel::ConstructedAndLive)
         {
-            ops_->mark_staged_impl(implementation(), slot);
+            if (implementation_tag() == ImplementationTag::TaggedPointer)
+                tagged_implementation()->mark_staged(slot);
+            else if (implementation_tag() == ImplementationTag::Bitmap)
+                bitmap_implementation()->mark_staged(slot);
         }
+
         void mark_constructed(std::size_t slot) noexcept
             requires(Model == StableSlotStateModel::ConstructedOnly)
         {
-            static_cast<void>(ops_->mark_live_impl(implementation(), slot));
+            static_cast<void>(mark_live_impl(slot));
         }
+
         [[nodiscard]] bool mark_live(std::size_t slot) noexcept
             requires(Model == StableSlotStateModel::ConstructedAndLive)
         {
-            return ops_->mark_live_impl(implementation(), slot);
+            return mark_live_impl(slot);
         }
+
         [[nodiscard]] bool mark_pending_erase(std::size_t slot) noexcept
             requires(Model == StableSlotStateModel::ConstructedAndLive)
         {
-            return ops_->mark_pending_impl(implementation(), slot);
+            switch (implementation_tag()) {
+            case ImplementationTag::TaggedPointer:
+                return tagged_implementation()->mark_pending(slot);
+            case ImplementationTag::Bitmap:
+                return bitmap_implementation()->mark_pending(slot);
+            case ImplementationTag::Nop:
+                return false;
+            }
+            return false;
         }
+
         void mark_free(std::size_t slot) noexcept
         {
-            ops_->mark_free_impl(implementation(), slot);
+            if (implementation_tag() == ImplementationTag::TaggedPointer)
+                tagged_implementation()->mark_free(slot);
+            else if (implementation_tag() == ImplementationTag::Bitmap)
+                bitmap_implementation()->mark_free(slot);
         }
+
         void reset_states() noexcept
         {
-            ops_->reset_states_impl(implementation());
+            if (implementation_tag() == ImplementationTag::TaggedPointer)
+                tagged_implementation()->reset_states();
+            else if (implementation_tag() == ImplementationTag::Bitmap)
+                bitmap_implementation()->reset_states();
         }
 
         [[nodiscard]] std::size_t constructed_count() const noexcept
         {
-            return ops_->constructed_count_impl(implementation());
+            switch (implementation_tag()) {
+            case ImplementationTag::TaggedPointer:
+                return tagged_implementation()->constructed_count();
+            case ImplementationTag::Bitmap:
+                return bitmap_implementation()->constructed_count();
+            case ImplementationTag::Nop:
+                return 0;
+            }
+            return 0;
         }
+
         [[nodiscard]] DynamicStorageMetrics dynamic_storage_metrics() const noexcept
         {
-            DynamicStorageMetrics result = ops_->dynamic_storage_metrics_impl(implementation());
-            const auto *plan = implementation_.plan();
-            if (plan != nullptr)
-            {
-                result.live_bytes += plan->layout.size;
-                result.reserved_bytes += plan->layout.size;
+            switch (implementation_tag()) {
+            case ImplementationTag::TaggedPointer: {
+                auto result = tagged_implementation()->dynamic_storage_metrics();
+                result.live_bytes += sizeof(TaggedImplementation);
+                result.reserved_bytes += sizeof(TaggedImplementation);
+                return result;
             }
-            return result;
+            case ImplementationTag::Bitmap: {
+                auto result = bitmap_implementation()->dynamic_storage_metrics();
+                result.live_bytes += sizeof(BitmapImplementation);
+                result.reserved_bytes += sizeof(BitmapImplementation);
+                return result;
+            }
+            case ImplementationTag::Nop:
+                return {};
+            }
+            return {};
         }
 
         [[nodiscard]] StableSlotDebugView debug_view() const noexcept
         {
-            StableSlotDebugView result = ops_->debug_view_impl(implementation());
-            if (implementation_.stores_heap())
-            {
-                result.implementation_pointer = MemoryUtils::advance(
-                    static_cast<const void *>(&implementation_),
-                    detail::StableSlotStoreImplementationOwner::debug_storage_offset());
+            switch (implementation_tag()) {
+            case ImplementationTag::TaggedPointer:
+                return implementation_debug_view(tagged_implementation(), true);
+            case ImplementationTag::Bitmap:
+                return implementation_debug_view(bitmap_implementation(), false);
+            case ImplementationTag::Nop:
+                return {};
             }
-            return result;
+            return {};
         }
 
         void swap(StableSlotStore &other) noexcept
         {
             using std::swap;
             swap(implementation_, other.implementation_);
-            swap(ops_, other.ops_);
         }
 
       private:
-        detail::StableSlotStoreImplementationOwner implementation_{};
-        const StableSlotStoreOps *ops_{&detail::noop_stable_slot_store_ops()};
+        std::uintptr_t implementation_{detail::NOP_STABLE_SLOT_STORE_HANDLE};
 
-        [[nodiscard]] void *implementation() noexcept { return implementation_.data(); }
-        [[nodiscard]] const void *implementation() const noexcept { return implementation_.data(); }
+        [[nodiscard]] ImplementationTag implementation_tag() const noexcept
+        {
+            return static_cast<ImplementationTag>(implementation_ & detail::STABLE_SLOT_STORE_IMPLEMENTATION_TAG_MASK);
+        }
+
+        [[nodiscard]] TaggedImplementation *tagged_implementation() noexcept
+        {
+            return reinterpret_cast<TaggedImplementation *>(implementation_);
+        }
+
+        [[nodiscard]] const TaggedImplementation *tagged_implementation() const noexcept
+        {
+            return reinterpret_cast<const TaggedImplementation *>(implementation_);
+        }
+
+        [[nodiscard]] BitmapImplementation *bitmap_implementation() noexcept
+        {
+            return reinterpret_cast<BitmapImplementation *>(implementation_ &
+                                                            ~detail::STABLE_SLOT_STORE_IMPLEMENTATION_TAG_MASK);
+        }
+
+        [[nodiscard]] const BitmapImplementation *bitmap_implementation() const noexcept
+        {
+            return reinterpret_cast<const BitmapImplementation *>(implementation_ &
+                                                                  ~detail::STABLE_SLOT_STORE_IMPLEMENTATION_TAG_MASK);
+        }
+
+        [[nodiscard]] MemoryUtils::StorageLayout bound_layout() const noexcept
+        {
+            return implementation_tag() == ImplementationTag::TaggedPointer ? tagged_implementation()->layout()
+                                                                            : bitmap_implementation()->layout();
+        }
+
+        [[nodiscard]] bool mark_live_impl(std::size_t slot) noexcept
+        {
+            switch (implementation_tag()) {
+            case ImplementationTag::TaggedPointer:
+                return tagged_implementation()->mark_live(slot);
+            case ImplementationTag::Bitmap:
+                return bitmap_implementation()->mark_live(slot);
+            case ImplementationTag::Nop:
+                return false;
+            }
+            return false;
+        }
+
+        template <typename Implementation>
+        [[nodiscard]] StableSlotDebugView implementation_debug_view(const Implementation *typed,
+                                                                    bool tagged) const noexcept
+        {
+            const auto *base = reinterpret_cast<const std::byte *>(typed);
+            const auto offset_of = [base](const void *address) {
+                return static_cast<std::size_t>(static_cast<const std::byte *>(address) - base);
+            };
+            return {
+                .implementation_pointer = &implementation_,
+                .slot_count_offset = offset_of(typed->debug_capacity_address()),
+                .pointer_table_offset = offset_of(typed->debug_slots_address()),
+                .state_offset = offset_of(typed->debug_state_address()),
+                .pointers_tagged = tagged,
+                .state_tagged = tagged,
+            };
+        }
 
         void require_bound() const
         {
-            if (ops_ == &detail::noop_stable_slot_store_ops())
-            {
+            if (implementation_tag() == ImplementationTag::Nop) {
                 throw std::logic_error("StableSlotStore has no bound layout");
             }
         }
     };
 
-    static_assert(sizeof(StableSlotStore<StableSlotStateModel::ConstructedOnly>) <= 4 * sizeof(void *));
-    static_assert(sizeof(StableSlotStore<StableSlotStateModel::ConstructedAndLive>) <= 4 * sizeof(void *));
-}  // namespace hgraph
+    static_assert(sizeof(StableSlotStore<StableSlotStateModel::ConstructedOnly>) == sizeof(void *));
+    static_assert(sizeof(StableSlotStore<StableSlotStateModel::ConstructedAndLive>) == sizeof(void *));
+} // namespace hgraph
 
-#endif  // HGRAPH_TYPES_UTILS_STABLE_SLOT_STORE_H
+#endif // HGRAPH_TYPES_UTILS_STABLE_SLOT_STORE_H

--- a/include/hgraph/types/utils/stable_slot_store.h
+++ b/include/hgraph/types/utils/stable_slot_store.h
@@ -1,0 +1,241 @@
+#ifndef HGRAPH_TYPES_UTILS_STABLE_SLOT_STORE_H
+#define HGRAPH_TYPES_UTILS_STABLE_SLOT_STORE_H
+
+#include <hgraph/types/utils/impl/stable_slot_store_impl.h>
+
+#include <cstddef>
+#include <stdexcept>
+#include <type_traits>
+#include <utility>
+#include <variant>
+
+namespace hgraph
+{
+    /** Data-only addresses used to publish stable-slot debugger offsets. */
+    struct StableSlotDebugView
+    {
+        const void *slot_count{nullptr};
+        const void *pointer_table{nullptr};
+        const void *state{nullptr};
+        bool pointers_tagged{false};
+        bool state_tagged{false};
+    };
+
+    /**
+     * Payload-type-erased stable slot storage with an alignment-selected index.
+     *
+     * Pointer-aligned payloads carry lifecycle state in two low pointer bits.
+     * Weaker alignments retain the existing raw pointer table plus the bitmap
+     * planes required by ``Model``. Selection happens once when the layout is
+     * bound and never changes for the lifetime of the store.
+     */
+    template <StableSlotStateModel Model>
+    class StableSlotStore
+    {
+      public:
+        StableSlotStore() noexcept = default;
+
+        StableSlotStore(MemoryUtils::StorageLayout layout,
+                        const MemoryUtils::AllocatorOps &allocator = MemoryUtils::allocator())
+        {
+            bind_layout(layout, allocator);
+        }
+
+        StableSlotStore(const StableSlotStore &) = delete;
+        StableSlotStore &operator=(const StableSlotStore &) = delete;
+        StableSlotStore(StableSlotStore &&) noexcept = default;
+        StableSlotStore &operator=(StableSlotStore &&) noexcept = default;
+
+        void bind_layout(MemoryUtils::StorageLayout layout,
+                         const MemoryUtils::AllocatorOps &allocator = MemoryUtils::allocator())
+        {
+            if (!layout.valid() || layout.size == 0)
+            {
+                throw std::logic_error("StableSlotStore requires a non-empty valid layout");
+            }
+            if (representation() != StableSlotRepresentation::Unbound)
+            {
+                visit([&](const auto &impl) {
+                    const auto existing = impl.layout();
+                    if (existing.size != layout.size || existing.alignment != layout.alignment ||
+                        &impl.allocator() != &allocator)
+                    {
+                        throw std::logic_error("StableSlotStore layout and allocator must remain constant");
+                    }
+                });
+                return;
+            }
+
+            if (layout.alignment >= alignof(std::uintptr_t))
+                implementation_.template emplace<TaggedImpl>(layout, allocator);
+            else
+                implementation_.template emplace<BitmapImpl>(layout, allocator);
+        }
+
+        [[nodiscard]] StableSlotRepresentation representation() const noexcept
+        {
+            if (std::holds_alternative<TaggedImpl>(implementation_))
+                return StableSlotRepresentation::TaggedPointer;
+            if (std::holds_alternative<BitmapImpl>(implementation_))
+                return StableSlotRepresentation::Bitmap;
+            return StableSlotRepresentation::Unbound;
+        }
+        [[nodiscard]] bool bound() const noexcept
+        {
+            return representation() != StableSlotRepresentation::Unbound;
+        }
+        [[nodiscard]] std::size_t slot_capacity() const noexcept
+        {
+            return bound() ? visit([](const auto &impl) { return impl.capacity(); }) : 0;
+        }
+        [[nodiscard]] std::size_t stride() const noexcept
+        {
+            return bound() ? visit([](const auto &impl) { return impl.stride(); }) : 0;
+        }
+        [[nodiscard]] std::size_t block_count() const noexcept
+        {
+            return bound() ? visit([](const auto &impl) { return impl.block_count(); }) : 0;
+        }
+        [[nodiscard]] const MemoryUtils::AllocatorOps &allocator() const noexcept
+        {
+            return bound() ? visit([](const auto &impl) -> const MemoryUtils::AllocatorOps & {
+                return impl.allocator();
+            }) : MemoryUtils::allocator();
+        }
+
+        void reserve_to(std::size_t capacity)
+        {
+            require_bound();
+            visit([&](auto &impl) { impl.reserve_to(capacity); });
+        }
+
+        [[nodiscard]] void *slot_memory(std::size_t slot) noexcept
+        {
+            return bound() ? visit([&](auto &impl) { return impl.slot_memory(slot); }) : nullptr;
+        }
+        [[nodiscard]] const void *slot_memory(std::size_t slot) const noexcept
+        {
+            return bound() ? visit([&](const auto &impl) { return impl.slot_memory(slot); }) : nullptr;
+        }
+        [[nodiscard]] void *live_slot_memory(std::size_t slot) noexcept
+        {
+            return bound() ? visit([&](auto &impl) { return impl.live_slot_memory(slot); }) : nullptr;
+        }
+        [[nodiscard]] const void *live_slot_memory(std::size_t slot) const noexcept
+        {
+            return bound() ? visit([&](const auto &impl) { return impl.live_slot_memory(slot); }) : nullptr;
+        }
+        /** Constructed, non-live slot memory (pending erase or transiently staged). */
+        [[nodiscard]] void *non_live_slot_memory(std::size_t slot) noexcept
+            requires(Model == StableSlotStateModel::ConstructedAndLive)
+        {
+            return bound() ? visit([&](auto &impl) { return impl.non_live_slot_memory(slot); }) : nullptr;
+        }
+        [[nodiscard]] const void *non_live_slot_memory(std::size_t slot) const noexcept
+            requires(Model == StableSlotStateModel::ConstructedAndLive)
+        {
+            return bound() ? visit([&](const auto &impl) { return impl.non_live_slot_memory(slot); }) : nullptr;
+        }
+        [[nodiscard]] bool constructed(std::size_t slot) const noexcept
+        {
+            return bound() && visit([&](const auto &impl) { return impl.constructed(slot); });
+        }
+        [[nodiscard]] bool live(std::size_t slot) const noexcept
+        {
+            return bound() && visit([&](const auto &impl) { return impl.live(slot); });
+        }
+
+        void mark_staged(std::size_t slot) noexcept
+            requires(Model == StableSlotStateModel::ConstructedAndLive)
+        {
+            visit([&](auto &impl) { impl.mark_staged(slot); });
+        }
+        void mark_constructed(std::size_t slot) noexcept
+            requires(Model == StableSlotStateModel::ConstructedOnly)
+        {
+            static_cast<void>(visit([&](auto &impl) { return impl.mark_live(slot); }));
+        }
+        [[nodiscard]] bool mark_live(std::size_t slot) noexcept
+            requires(Model == StableSlotStateModel::ConstructedAndLive)
+        {
+            return visit([&](auto &impl) { return impl.mark_live(slot); });
+        }
+        [[nodiscard]] bool mark_pending_erase(std::size_t slot) noexcept
+            requires(Model == StableSlotStateModel::ConstructedAndLive)
+        {
+            return visit([&](auto &impl) { return impl.mark_pending(slot); });
+        }
+        void mark_free(std::size_t slot) noexcept
+        {
+            visit([&](auto &impl) { impl.mark_free(slot); });
+        }
+        void reset_states() noexcept
+        {
+            if (bound()) { visit([](auto &impl) { impl.reset_states(); }); }
+        }
+
+        [[nodiscard]] std::size_t constructed_count() const noexcept
+        {
+            return bound() ? visit([](const auto &impl) { return impl.constructed_count(); }) : 0;
+        }
+        [[nodiscard]] DynamicStorageMetrics dynamic_storage_metrics() const noexcept
+        {
+            return bound() ? visit([](const auto &impl) { return impl.dynamic_storage_metrics(); })
+                           : DynamicStorageMetrics{};
+        }
+
+        [[nodiscard]] StableSlotDebugView debug_view() const noexcept
+        {
+            if (!bound()) { return {}; }
+            return visit([&](const auto &impl) {
+                constexpr bool tagged = std::is_same_v<std::remove_cvref_t<decltype(impl)>, TaggedImpl>;
+                return StableSlotDebugView{
+                    .slot_count = impl.debug_capacity_address(),
+                    .pointer_table = impl.debug_slots_address(),
+                    .state = impl.debug_state_address(),
+                    .pointers_tagged = tagged,
+                    .state_tagged = tagged,
+                };
+            });
+        }
+
+        void swap(StableSlotStore &other) noexcept { implementation_.swap(other.implementation_); }
+
+      private:
+        using TaggedImpl = detail::TaggedPointerStableSlotStoreImpl<Model>;
+        using BitmapImpl = detail::BitmapStableSlotStoreImpl<Model>;
+        using Implementation = std::variant<std::monostate, TaggedImpl, BitmapImpl>;
+
+        Implementation implementation_{};
+
+        template <typename Visitor>
+        decltype(auto) visit(Visitor &&visitor)
+        {
+            if (auto *tagged = std::get_if<TaggedImpl>(&implementation_); tagged != nullptr)
+                return std::forward<Visitor>(visitor)(*tagged);
+            if (auto *bitmap = std::get_if<BitmapImpl>(&implementation_); bitmap != nullptr)
+                return std::forward<Visitor>(visitor)(*bitmap);
+            throw std::logic_error("StableSlotStore has no bound layout");
+        }
+
+        template <typename Visitor>
+        decltype(auto) visit(Visitor &&visitor) const
+        {
+            if (const auto *tagged = std::get_if<TaggedImpl>(&implementation_); tagged != nullptr)
+                return std::forward<Visitor>(visitor)(*tagged);
+            if (const auto *bitmap = std::get_if<BitmapImpl>(&implementation_); bitmap != nullptr)
+                return std::forward<Visitor>(visitor)(*bitmap);
+            throw std::logic_error("StableSlotStore has no bound layout");
+        }
+
+        void require_bound() const
+        {
+            if (!bound()) { throw std::logic_error("StableSlotStore has no bound layout"); }
+        }
+    };
+
+    static_assert(sizeof(StableSlotStore<StableSlotStateModel::ConstructedOnly>) <= 12 * sizeof(void *));
+    static_assert(sizeof(StableSlotStore<StableSlotStateModel::ConstructedAndLive>) <= 15 * sizeof(void *));
+}  // namespace hgraph
+
+#endif  // HGRAPH_TYPES_UTILS_STABLE_SLOT_STORE_H

--- a/include/hgraph/types/utils/stable_slot_store_fwd.h
+++ b/include/hgraph/types/utils/stable_slot_store_fwd.h
@@ -20,6 +20,8 @@ namespace hgraph
         Bitmap,
     };
 
+    struct StableSlotStoreOps;
+
     template <StableSlotStateModel Model>
     class StableSlotStore;
 }  // namespace hgraph

--- a/include/hgraph/types/utils/stable_slot_store_fwd.h
+++ b/include/hgraph/types/utils/stable_slot_store_fwd.h
@@ -1,0 +1,27 @@
+#ifndef HGRAPH_TYPES_UTILS_STABLE_SLOT_STORE_FWD_H
+#define HGRAPH_TYPES_UTILS_STABLE_SLOT_STORE_FWD_H
+
+#include <cstdint>
+
+namespace hgraph
+{
+    /** Durable lifecycle information required by a stable-slot owner. */
+    enum class StableSlotStateModel : std::uint8_t
+    {
+        ConstructedOnly,
+        ConstructedAndLive,
+    };
+
+    /** Physical representation selected when a stable-slot layout is bound. */
+    enum class StableSlotRepresentation : std::uint8_t
+    {
+        Unbound,
+        TaggedPointer,
+        Bitmap,
+    };
+
+    template <StableSlotStateModel Model>
+    class StableSlotStore;
+}  // namespace hgraph
+
+#endif  // HGRAPH_TYPES_UTILS_STABLE_SLOT_STORE_FWD_H

--- a/include/hgraph/types/utils/stable_slot_store_fwd.h
+++ b/include/hgraph/types/utils/stable_slot_store_fwd.h
@@ -20,8 +20,6 @@ namespace hgraph
         Bitmap,
     };
 
-    struct StableSlotStoreOps;
-
     template <StableSlotStateModel Model>
     class StableSlotStore;
 }  // namespace hgraph

--- a/include/hgraph/types/utils/value_slot_store.h
+++ b/include/hgraph/types/utils/value_slot_store.h
@@ -4,7 +4,7 @@
 #include <hgraph/types/utils/key_slot_store.h>
 #include <hgraph/types/utils/slot_observer.h>
 #include <hgraph/types/utils/slot_bitmap.h>
-#include <hgraph/types/utils/stable_slot_storage.h>
+#include <hgraph/types/utils/stable_slot_store.h>
 
 #include <algorithm>
 #include <cstddef>
@@ -25,7 +25,7 @@ namespace hgraph
      * - non-moving slot-backed value memory
      * - one stable bound storage plan
      * - per-slot ``updated`` flags owned and reset by the caller
-     * - per-slot ``constructed`` flags for live payload ownership
+     * - per-slot constructed state for live payload ownership
      * - structural observers mirroring capacity / insert / remove / erase /
      *   clear events
      *
@@ -44,7 +44,7 @@ namespace hgraph
          */
         ValueSlotStore(const MemoryUtils::StoragePlan &plan,
                        const MemoryUtils::AllocatorOps &allocator = MemoryUtils::allocator())
-            : value_storage(allocator)
+            : value_storage(plan.layout, allocator)
         {
             bind_plan(plan);
         }
@@ -56,12 +56,10 @@ namespace hgraph
         ValueSlotStore(ValueSlotStore &&other) noexcept
             : value_storage(std::move(other.value_storage))
             , updated(std::move(other.updated))
-            , constructed(std::move(other.constructed))
             , observers(std::move(other.observers))
             , m_value_plan(std::exchange(other.m_value_plan, nullptr))
         {
             other.updated.clear();
-            other.constructed.clear();
         }
 
         /** Move assignment destroys the existing payloads and adopts ``other``. */
@@ -71,11 +69,9 @@ namespace hgraph
                 destroy_all();
                 value_storage = std::move(other.value_storage);
                 updated = std::move(other.updated);
-                constructed = std::move(other.constructed);
                 observers = std::move(other.observers);
                 m_value_plan = std::exchange(other.m_value_plan, nullptr);
                 other.updated.clear();
-                other.constructed.clear();
             }
             return *this;
         }
@@ -86,12 +82,13 @@ namespace hgraph
             destroy_all();
         }
 
-        /** Stable per-slot byte storage for the bound plan. */
-        StableSlotStorage value_storage{};
+      private:
+        using StableStorage = StableSlotStore<StableSlotStateModel::ConstructedOnly>;
+        StableStorage value_storage{};
+
+      public:
         /** Per-slot caller-managed ``updated`` bit. */
         SlotBitmap updated{};
-        /** Per-slot ``constructed`` bit indicating live payload ownership. */
-        SlotBitmap constructed{};
         /** Structural observer list mirrored against slot lifecycle events. */
         SlotObserverList observers{};
 
@@ -101,13 +98,24 @@ namespace hgraph
         [[nodiscard]] size_t stride() const noexcept { return value_storage.stride(); }
         /** Bound storage plan for the held value type, or ``nullptr`` if unbound. */
         [[nodiscard]] const MemoryUtils::StoragePlan *plan() const noexcept { return m_value_plan; }
+        /** Selected stable-slot index representation. */
+        [[nodiscard]] StableSlotRepresentation slot_representation() const noexcept
+        {
+            return value_storage.representation();
+        }
+        /** Allocator used for stable payload blocks. */
+        [[nodiscard]] const MemoryUtils::AllocatorOps &allocator() const noexcept
+        {
+            return value_storage.allocator();
+        }
+        /** Data-only addresses used when publishing debugger offsets. */
+        [[nodiscard]] StableSlotDebugView debug_slot_view() const noexcept { return value_storage.debug_view(); }
 
         /** Exact occupied/retained heap bytes owned by the value slots. */
         [[nodiscard]] DynamicStorageMetrics dynamic_storage_metrics() const noexcept
         {
-            DynamicStorageMetrics result = value_storage.dynamic_storage_metrics(constructed.count());
+            DynamicStorageMetrics result = value_storage.dynamic_storage_metrics();
             result += updated.dynamic_storage_metrics();
-            result += constructed.dynamic_storage_metrics();
             result += observers.dynamic_storage_metrics();
             return result;
         }
@@ -127,6 +135,10 @@ namespace hgraph
             }
             if (m_value_plan == nullptr) {
                 m_value_plan = &plan;
+                if (!value_storage.bound())
+                    value_storage.bind_layout(plan.layout);
+                else
+                    value_storage.bind_layout(plan.layout, value_storage.allocator());
                 return;
             }
             if (m_value_plan != &plan) {
@@ -135,22 +147,21 @@ namespace hgraph
         }
 
         /** Mutable byte pointer for ``slot``; not bounds-checked. */
-        [[nodiscard]] void *value_memory(size_t slot) noexcept { return value_storage.slot_data(slot); }
+        [[nodiscard]] void *value_memory(size_t slot) noexcept { return value_storage.slot_memory(slot); }
 
         /** Const byte pointer for ``slot``; not bounds-checked. */
-        [[nodiscard]] const void *value_memory(size_t slot) const noexcept { return value_storage.slot_data(slot); }
+        [[nodiscard]] const void *value_memory(size_t slot) const noexcept { return value_storage.slot_memory(slot); }
 
         /**
          * Grow capacity to at least ``capacity`` slots. Leaves existing
-         * payloads in place; new bits in ``updated`` and ``constructed``
+         * payloads in place; new ``updated`` bits and constructed states
          * default to ``false``.
          */
         void reserve_to(size_t capacity)
         {
-            const auto &plan = require_bound_plan();
-            value_storage.reserve_to(capacity, plan.layout.size, plan.layout.alignment);
+            (void) require_bound_plan();
+            value_storage.reserve_to(capacity);
             updated.resize(capacity);
-            constructed.resize(capacity);
         }
 
         /** Typed overload that asserts the bound plan is the canonical plan for ``T``. */
@@ -170,7 +181,7 @@ namespace hgraph
         /** True if ``slot`` currently holds a constructed payload. */
         [[nodiscard]] bool has_slot(size_t slot) const noexcept
         {
-            return slot < constructed.size() && constructed.test(slot);
+            return value_storage.constructed(slot);
         }
 
         /** Mark ``slot`` as updated. */
@@ -223,7 +234,7 @@ namespace hgraph
             const auto &plan = require_bound_plan();
             require_unconstructed_slot(slot);
             plan.default_construct(value_memory(slot));
-            constructed.set(slot);
+            value_storage.mark_constructed(slot);
         }
 
         /**
@@ -235,7 +246,7 @@ namespace hgraph
             const auto &plan = require_bound_plan();
             require_unconstructed_slot(slot);
             plan.copy_construct(value_memory(slot), src);
-            constructed.set(slot);
+            value_storage.mark_constructed(slot);
         }
 
         /**
@@ -251,7 +262,7 @@ namespace hgraph
 
             T *value = MemoryUtils::cast<T>(value_memory(slot));
             std::construct_at(value, std::forward<Args>(args)...);
-            constructed.set(slot);
+            value_storage.mark_constructed(slot);
             return *value;
         }
 
@@ -267,7 +278,7 @@ namespace hgraph
             }
 
             m_value_plan->destroy(value_memory(slot));
-            constructed.reset(slot);
+            value_storage.mark_free(slot);
             clear_updated(slot);
         }
 
@@ -275,11 +286,11 @@ namespace hgraph
         void destroy_all() noexcept
         {
             if (m_value_plan != nullptr) {
-                for (size_t slot = 0; slot < constructed.size(); ++slot) {
+                for (size_t slot = 0; slot < slot_capacity(); ++slot) {
                     destroy_at(slot);
                 }
             } else {
-                constructed.reset();
+                value_storage.reset_states();
             }
             clear_all_updated();
         }
@@ -329,7 +340,7 @@ namespace hgraph
 
         void require_unconstructed_slot(size_t slot) const
         {
-            if (slot >= constructed.size()) {
+            if (slot >= slot_capacity()) {
                 throw std::out_of_range("ValueSlotStore slot out of range");
             }
             if (has_slot(slot)) {
@@ -341,8 +352,8 @@ namespace hgraph
     /**
      * Value-side storage whose payload lifetime mirrors a ``KeySlotStore``.
      *
-     * ``ValueSlotStore`` is intentionally reusable and owns an internal
-     * constructed bitmap. TSD-style storage should not expose that bitmap as a
+     * ``ValueSlotStore`` is intentionally reusable and owns internal
+     * constructed state. TSD-style storage should not expose that state as a
      * second source of truth. This wrapper registers as a key-store observer
      * and keeps the value payload constructed exactly when the key slot is
      * constructed, including pending-erase slots. The referenced key store
@@ -371,7 +382,7 @@ namespace hgraph
             m_keys.remove_slot_observer(this);
         }
 
-        /** Key store whose constructed bitmap owns value payload lifetime. */
+        /** Key store whose constructed state owns value payload lifetime. */
         [[nodiscard]] const KeySlotStore &key_store() const noexcept { return m_keys; }
         /** Number of value slots currently addressable. */
         [[nodiscard]] size_t slot_capacity() const noexcept { return m_values.slot_capacity(); }
@@ -389,7 +400,7 @@ namespace hgraph
 
         /**
          * True when the key slot is constructed. This is the public lifetime
-         * answer for mirrored storage; the wrapped ``ValueSlotStore`` bitmap is
+         * answer for mirrored storage; the wrapped ``ValueSlotStore`` state is
          * only an internal mirror.
          */
         [[nodiscard]] bool has_slot(size_t slot) const noexcept

--- a/include/hgraph/types/value/mutable_container_ops.h
+++ b/include/hgraph/types/value/mutable_container_ops.h
@@ -192,7 +192,8 @@ namespace hgraph
             };
             const StableSlotDebugView slots = slots_.debug_slot_view();
             DebugDynamicFlags flags = DebugDynamicFlags::DataIsIndirect |
-                                      DebugDynamicFlags::DataIsPointerTable;
+                                      DebugDynamicFlags::DataIsPointerTable |
+                                      DebugDynamicFlags::SlotIndexIsIndirect;
             if (slots.pointers_tagged) { flags = flags | DebugDynamicFlags::DataPointersAreTagged; }
             return DebugDynamicLayout{
                 .magic = DEBUG_DYNAMIC_LAYOUT_MAGIC,
@@ -200,8 +201,9 @@ namespace hgraph
                 .kind = DebugDynamicKind::StableSlots,
                 .flags = flags,
                 .size_offset = offset_of(&size_),
-                .data_offset = offset_of(slots.pointer_table),
+                .data_offset = offset_of(slots.implementation_pointer),
                 .stride = element_binding_.checked_plan().layout.size,
+                .auxiliary_offset = slots.pointer_table_offset,
             };
         }
 
@@ -658,7 +660,9 @@ namespace hgraph
                                       DebugDynamicFlags::KeyDataIsIndirect |
                                       DebugDynamicFlags::DataIsPointerTable |
                                       DebugDynamicFlags::KeyDataIsPointerTable |
-                                      DebugDynamicFlags::HasSlotState;
+                                      DebugDynamicFlags::HasSlotState |
+                                      DebugDynamicFlags::SlotIndexIsIndirect |
+                                      DebugDynamicFlags::SlotSizeIsIndirect;
             if (value_slots.pointers_tagged) { flags = flags | DebugDynamicFlags::DataPointersAreTagged; }
             if (key_slots.pointers_tagged) { flags = flags | DebugDynamicFlags::KeyPointersAreTagged; }
             if (key_slots.state_tagged) { flags = flags | DebugDynamicFlags::SlotStateIsTaggedPointer; }
@@ -667,12 +671,15 @@ namespace hgraph
                 .abi_version = DEBUG_DYNAMIC_LAYOUT_ABI_VERSION,
                 .kind = DebugDynamicKind::StableSlots,
                 .flags = flags,
-                .size_offset = offset_of(key_slots.slot_count),
-                .data_offset = offset_of(value_slots.pointer_table),
+                .key_auxiliary_offset =
+                    static_cast<std::uint32_t>(key_slots.pointer_table_offset),
+                .size_offset = key_slots.slot_count_offset,
+                .data_offset = offset_of(value_slots.implementation_pointer),
                 .stride = value_binding_.checked_plan().layout.size,
-                .key_data_offset = offset_of(key_slots.pointer_table),
+                .key_data_offset = offset_of(key_slots.implementation_pointer),
                 .key_stride = key_binding_.checked_plan().layout.size,
-                .state_offset = offset_of(key_slots.state),
+                .state_offset = key_slots.state_offset,
+                .auxiliary_offset = value_slots.pointer_table_offset,
             };
         }
 
@@ -1193,7 +1200,9 @@ namespace hgraph
             const StableSlotDebugView slots = keys_.debug_slot_view();
             DebugDynamicFlags flags = DebugDynamicFlags::DataIsIndirect |
                                       DebugDynamicFlags::DataIsPointerTable |
-                                      DebugDynamicFlags::HasSlotState;
+                                      DebugDynamicFlags::HasSlotState |
+                                      DebugDynamicFlags::SlotIndexIsIndirect |
+                                      DebugDynamicFlags::SlotSizeIsIndirect;
             if (slots.pointers_tagged) { flags = flags | DebugDynamicFlags::DataPointersAreTagged; }
             if (slots.state_tagged) { flags = flags | DebugDynamicFlags::SlotStateIsTaggedPointer; }
             return DebugDynamicLayout{
@@ -1201,10 +1210,11 @@ namespace hgraph
                 .abi_version = DEBUG_DYNAMIC_LAYOUT_ABI_VERSION,
                 .kind = DebugDynamicKind::StableSlots,
                 .flags = flags,
-                .size_offset = offset_of(slots.slot_count),
-                .data_offset = offset_of(slots.pointer_table),
+                .size_offset = slots.slot_count_offset,
+                .data_offset = offset_of(slots.implementation_pointer),
                 .stride = element_binding_.checked_plan().layout.size,
-                .state_offset = offset_of(slots.state),
+                .state_offset = slots.state_offset,
+                .auxiliary_offset = slots.pointer_table_offset,
             };
         }
 

--- a/include/hgraph/types/value/mutable_container_ops.h
+++ b/include/hgraph/types/value/mutable_container_ops.h
@@ -190,13 +190,17 @@ namespace hgraph
             const auto offset_of = [base](const auto *member) {
                 return static_cast<std::size_t>(reinterpret_cast<const std::byte *>(member) - base);
             };
+            const StableSlotDebugView slots = slots_.debug_slot_view();
+            DebugDynamicFlags flags = DebugDynamicFlags::DataIsIndirect |
+                                      DebugDynamicFlags::DataIsPointerTable;
+            if (slots.pointers_tagged) { flags = flags | DebugDynamicFlags::DataPointersAreTagged; }
             return DebugDynamicLayout{
                 .magic = DEBUG_DYNAMIC_LAYOUT_MAGIC,
                 .abi_version = DEBUG_DYNAMIC_LAYOUT_ABI_VERSION,
                 .kind = DebugDynamicKind::StableSlots,
-                .flags = DebugDynamicFlags::DataIsIndirect | DebugDynamicFlags::DataIsPointerTable,
+                .flags = flags,
                 .size_offset = offset_of(&size_),
-                .data_offset = offset_of(&slots_.value_storage.slots),
+                .data_offset = offset_of(slots.pointer_table),
                 .stride = element_binding_.checked_plan().layout.size,
             };
         }
@@ -648,19 +652,27 @@ namespace hgraph
             const auto offset_of = [base](const auto *member) {
                 return static_cast<std::size_t>(reinterpret_cast<const std::byte *>(member) - base);
             };
+            const StableSlotDebugView key_slots = keys_.debug_slot_view();
+            const StableSlotDebugView value_slots = values_.debug_slot_view();
+            DebugDynamicFlags flags = DebugDynamicFlags::DataIsIndirect |
+                                      DebugDynamicFlags::KeyDataIsIndirect |
+                                      DebugDynamicFlags::DataIsPointerTable |
+                                      DebugDynamicFlags::KeyDataIsPointerTable |
+                                      DebugDynamicFlags::HasSlotState;
+            if (value_slots.pointers_tagged) { flags = flags | DebugDynamicFlags::DataPointersAreTagged; }
+            if (key_slots.pointers_tagged) { flags = flags | DebugDynamicFlags::KeyPointersAreTagged; }
+            if (key_slots.state_tagged) { flags = flags | DebugDynamicFlags::SlotStateIsTaggedPointer; }
             return DebugDynamicLayout{
                 .magic = DEBUG_DYNAMIC_LAYOUT_MAGIC,
                 .abi_version = DEBUG_DYNAMIC_LAYOUT_ABI_VERSION,
                 .kind = DebugDynamicKind::StableSlots,
-                .flags = DebugDynamicFlags::DataIsIndirect | DebugDynamicFlags::KeyDataIsIndirect |
-                         DebugDynamicFlags::DataIsPointerTable | DebugDynamicFlags::KeyDataIsPointerTable |
-                         DebugDynamicFlags::HasSlotState,
-                .size_offset = offset_of(&keys_.key_storage.slot_count),
-                .data_offset = offset_of(&values_.value_storage.slots),
+                .flags = flags,
+                .size_offset = offset_of(key_slots.slot_count),
+                .data_offset = offset_of(value_slots.pointer_table),
                 .stride = value_binding_.checked_plan().layout.size,
-                .key_data_offset = offset_of(&keys_.key_storage.slots),
+                .key_data_offset = offset_of(key_slots.pointer_table),
                 .key_stride = key_binding_.checked_plan().layout.size,
-                .state_offset = offset_of(&keys_.live),
+                .state_offset = offset_of(key_slots.state),
             };
         }
 
@@ -685,7 +697,7 @@ namespace hgraph
             const auto &ops = value_binding_.ops_ref();
             for (std::size_t slot = 0; slot < values_.slot_capacity(); ++slot)
             {
-                if (values_.constructed.test(slot))
+                if (values_.has_slot(slot))
                 {
                     result += ops.dynamic_storage_metrics(values_.value_memory(slot));
                 }
@@ -1178,16 +1190,21 @@ namespace hgraph
             const auto offset_of = [base](const auto *member) {
                 return static_cast<std::size_t>(reinterpret_cast<const std::byte *>(member) - base);
             };
+            const StableSlotDebugView slots = keys_.debug_slot_view();
+            DebugDynamicFlags flags = DebugDynamicFlags::DataIsIndirect |
+                                      DebugDynamicFlags::DataIsPointerTable |
+                                      DebugDynamicFlags::HasSlotState;
+            if (slots.pointers_tagged) { flags = flags | DebugDynamicFlags::DataPointersAreTagged; }
+            if (slots.state_tagged) { flags = flags | DebugDynamicFlags::SlotStateIsTaggedPointer; }
             return DebugDynamicLayout{
                 .magic = DEBUG_DYNAMIC_LAYOUT_MAGIC,
                 .abi_version = DEBUG_DYNAMIC_LAYOUT_ABI_VERSION,
                 .kind = DebugDynamicKind::StableSlots,
-                .flags = DebugDynamicFlags::DataIsIndirect | DebugDynamicFlags::DataIsPointerTable |
-                         DebugDynamicFlags::HasSlotState,
-                .size_offset = offset_of(&keys_.key_storage.slot_count),
-                .data_offset = offset_of(&keys_.key_storage.slots),
+                .flags = flags,
+                .size_offset = offset_of(slots.slot_count),
+                .data_offset = offset_of(slots.pointer_table),
                 .stride = element_binding_.checked_plan().layout.size,
-                .state_offset = offset_of(&keys_.live),
+                .state_offset = offset_of(slots.state),
             };
         }
 

--- a/python/tests/test_packaging.py
+++ b/python/tests/test_packaging.py
@@ -146,6 +146,9 @@ def test_full_suite_gate_installs_the_wheel_test_extra():
 
 def test_release_workflow_targets_supported_platforms():
     workflow = (ROOT / ".github/workflows/build.yml").read_text()
+    nightly_workflow = (
+        ROOT / ".github/workflows/parity-nightly.yml"
+    ).read_text()
 
     assert "macos-15-intel" not in workflow
     assert "          - os: macos-26" in workflow
@@ -163,7 +166,13 @@ def test_release_workflow_targets_supported_platforms():
     assert "--exclude libnanobind-abi3.so" in workflow
     assert "tests/python_extension_consumer/check.py" in workflow
     assert "libarrow-acero=24" in workflow
-    assert "g++-13 --version" in workflow
+    for linux_workflow in (workflow, nightly_workflow):
+        assert 'GCC_VERSION: "14"' in linux_workflow
+        assert 'command -v "gcc-$GCC_VERSION"' in linux_workflow
+        assert 'command -v "g++-$GCC_VERSION"' in linux_workflow
+        assert '-eq "$GCC_VERSION"' in linux_workflow
+        assert "gcc-13" not in linux_workflow
+        assert "g++-13" not in linux_workflow
     assert "runs-on: ubuntu-24.04" in workflow
     # Windows builds with Ninja over cl (vcvars via msvc-dev-cmd): the
     # Visual Studio generator ignores CMAKE_CXX_COMPILER_LAUNCHER, so the

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -31,6 +31,7 @@ set(HGRAPH_RUNTIME_SOURCES
     hgraph/types/temporal.cpp
     hgraph/types/time_zone_provider.cpp
     hgraph/types/type_pointer.cpp
+    hgraph/types/utils/stable_slot_store.cpp
     hgraph/types/metadata/debug_descriptor.cpp
     hgraph/types/metadata/ts_data_atomic_ops.cpp
     hgraph/types/metadata/ts_data_dynamic_list_ops.cpp

--- a/src/hgraph/types/metadata/debug_descriptor.cpp
+++ b/src/hgraph/types/metadata/debug_descriptor.cpp
@@ -26,7 +26,7 @@ namespace hgraph
         static_assert(CommonErasedOwner::debug_storage_offset() == DEBUG_OWNER_STORAGE_OFFSET);
         inline constexpr std::uint32_t KNOWN_DESCRIPTOR_FLAGS = 1u;
         inline constexpr std::uint32_t KNOWN_FIELD_FLAGS = (1u << 4u) - 1u;
-        inline constexpr std::uint32_t KNOWN_DYNAMIC_FLAGS = (1u << 13u) - 1u;
+        inline constexpr std::uint32_t KNOWN_DYNAMIC_FLAGS = (1u << 15u) - 1u;
         inline constexpr std::uint32_t VALIDITY_WORD_SIZE = sizeof(std::uint64_t);
 
         struct DescriptorKey
@@ -375,7 +375,7 @@ namespace hgraph
         const auto kind_value = static_cast<std::uint8_t>(kind);
         if (magic != DEBUG_DYNAMIC_LAYOUT_MAGIC || abi_version != DEBUG_DYNAMIC_LAYOUT_ABI_VERSION ||
             kind_value < static_cast<std::uint8_t>(DebugDynamicKind::Contiguous) ||
-            kind_value > static_cast<std::uint8_t>(DebugDynamicKind::StableSlots) || reserved0 != 0 || reserved1 != 0 ||
+            kind_value > static_cast<std::uint8_t>(DebugDynamicKind::StableSlots) || reserved0 != 0 ||
             (static_cast<std::uint32_t>(flags) & ~KNOWN_DYNAMIC_FLAGS) != 0 || stride == 0)
             return false;
         if (has_flag(flags, DebugDynamicFlags::SizeIsConstant) == (size_offset != 0)) return false;
@@ -400,6 +400,22 @@ namespace hgraph
             (!has_flag(flags, DebugDynamicFlags::HasSlotState) || state_offset == 0 ||
              (!has_flag(flags, DebugDynamicFlags::DataPointersAreTagged) &&
               !has_flag(flags, DebugDynamicFlags::KeyPointersAreTagged))))
+            return false;
+        if (has_flag(flags, DebugDynamicFlags::SlotIndexIsIndirect) &&
+            (kind != DebugDynamicKind::StableSlots ||
+             !has_flag(flags, DebugDynamicFlags::DataIsIndirect) ||
+             !has_flag(flags, DebugDynamicFlags::DataIsPointerTable) ||
+             has_flag(flags, DebugDynamicFlags::HasHead) ||
+             (key_stride != 0 &&
+              (!has_flag(flags, DebugDynamicFlags::KeyDataIsIndirect) ||
+               !has_flag(flags, DebugDynamicFlags::KeyDataIsPointerTable)))))
+            return false;
+        if (has_flag(flags, DebugDynamicFlags::SlotSizeIsIndirect) &&
+            (!has_flag(flags, DebugDynamicFlags::SlotIndexIsIndirect) ||
+             has_flag(flags, DebugDynamicFlags::SizeIsConstant)))
+            return false;
+        if (key_auxiliary_offset != 0 &&
+            (!has_flag(flags, DebugDynamicFlags::SlotIndexIsIndirect) || key_stride == 0))
             return false;
         return true;
     }

--- a/src/hgraph/types/metadata/debug_descriptor.cpp
+++ b/src/hgraph/types/metadata/debug_descriptor.cpp
@@ -26,7 +26,7 @@ namespace hgraph
         static_assert(CommonErasedOwner::debug_storage_offset() == DEBUG_OWNER_STORAGE_OFFSET);
         inline constexpr std::uint32_t KNOWN_DESCRIPTOR_FLAGS = 1u;
         inline constexpr std::uint32_t KNOWN_FIELD_FLAGS = (1u << 4u) - 1u;
-        inline constexpr std::uint32_t KNOWN_DYNAMIC_FLAGS = (1u << 10u) - 1u;
+        inline constexpr std::uint32_t KNOWN_DYNAMIC_FLAGS = (1u << 13u) - 1u;
         inline constexpr std::uint32_t VALIDITY_WORD_SIZE = sizeof(std::uint64_t);
 
         struct DescriptorKey
@@ -389,6 +389,17 @@ namespace hgraph
              !has_flag(flags, DebugDynamicFlags::DataIsIndirect)))
             return false;
         if (has_flag(flags, DebugDynamicFlags::HasSlotState) && kind != DebugDynamicKind::StableSlots)
+            return false;
+        if (has_flag(flags, DebugDynamicFlags::DataPointersAreTagged) &&
+            !has_flag(flags, DebugDynamicFlags::DataIsPointerTable))
+            return false;
+        if (has_flag(flags, DebugDynamicFlags::KeyPointersAreTagged) &&
+            !has_flag(flags, DebugDynamicFlags::KeyDataIsPointerTable))
+            return false;
+        if (has_flag(flags, DebugDynamicFlags::SlotStateIsTaggedPointer) &&
+            (!has_flag(flags, DebugDynamicFlags::HasSlotState) || state_offset == 0 ||
+             (!has_flag(flags, DebugDynamicFlags::DataPointersAreTagged) &&
+              !has_flag(flags, DebugDynamicFlags::KeyPointersAreTagged))))
             return false;
         return true;
     }

--- a/src/hgraph/types/metadata/ts_data_slot_ops.cpp
+++ b/src/hgraph/types/metadata/ts_data_slot_ops.cpp
@@ -119,7 +119,9 @@ namespace hgraph::ts_data_plan_factory_detail
             const StableSlotDebugView slots = keys.debug_slot_view();
             DebugDynamicFlags flags = DebugDynamicFlags::DataIsIndirect |
                                       DebugDynamicFlags::DataIsPointerTable |
-                                      DebugDynamicFlags::HasSlotState;
+                                      DebugDynamicFlags::HasSlotState |
+                                      DebugDynamicFlags::SlotIndexIsIndirect |
+                                      DebugDynamicFlags::SlotSizeIsIndirect;
             if (slots.pointers_tagged) { flags = flags | DebugDynamicFlags::DataPointersAreTagged; }
             if (slots.state_tagged) { flags = flags | DebugDynamicFlags::SlotStateIsTaggedPointer; }
             return DebugDynamicLayout{
@@ -127,10 +129,11 @@ namespace hgraph::ts_data_plan_factory_detail
                 .abi_version = DEBUG_DYNAMIC_LAYOUT_ABI_VERSION,
                 .kind = DebugDynamicKind::StableSlots,
                 .flags = flags,
-                .size_offset = debug_address_offset(sample, slots.slot_count),
-                .data_offset = debug_address_offset(sample, slots.pointer_table),
+                .size_offset = slots.slot_count_offset,
+                .data_offset = debug_address_offset(sample, slots.implementation_pointer),
                 .stride = key_binding.checked_plan().layout.size,
-                .state_offset = debug_address_offset(sample, slots.state),
+                .state_offset = slots.state_offset,
+                .auxiliary_offset = slots.pointer_table_offset,
             };
         }
 
@@ -2166,17 +2169,22 @@ namespace hgraph::ts_data_plan_factory_detail
                                           DebugDynamicFlags::KeyDataIsIndirect |
                                           DebugDynamicFlags::DataIsPointerTable |
                                           DebugDynamicFlags::KeyDataIsPointerTable |
-                                          DebugDynamicFlags::HasSlotState;
+                                          DebugDynamicFlags::HasSlotState |
+                                          DebugDynamicFlags::SlotIndexIsIndirect |
+                                          DebugDynamicFlags::SlotSizeIsIndirect;
                 if (value_slots.pointers_tagged) { flags = flags | DebugDynamicFlags::DataPointersAreTagged; }
                 if (key_slots.pointers_tagged) { flags = flags | DebugDynamicFlags::KeyPointersAreTagged; }
                 if (key_slots.state_tagged) { flags = flags | DebugDynamicFlags::SlotStateIsTaggedPointer; }
                 debug_layout.flags = flags;
-                debug_layout.size_offset = debug_address_offset(sample, key_slots.slot_count);
-                debug_layout.data_offset = debug_address_offset(sample, value_slots.pointer_table);
+                debug_layout.key_auxiliary_offset =
+                    static_cast<std::uint32_t>(key_slots.pointer_table_offset);
+                debug_layout.size_offset = key_slots.slot_count_offset;
+                debug_layout.data_offset = debug_address_offset(sample, value_slots.implementation_pointer);
                 debug_layout.stride = element_type.checked_plan().layout.size;
-                debug_layout.key_data_offset = debug_address_offset(sample, key_slots.pointer_table);
+                debug_layout.key_data_offset = debug_address_offset(sample, key_slots.implementation_pointer);
                 debug_layout.key_stride = key_binding.checked_plan().layout.size;
-                debug_layout.state_offset = debug_address_offset(sample, key_slots.state);
+                debug_layout.state_offset = key_slots.state_offset;
+                debug_layout.auxiliary_offset = value_slots.pointer_table_offset;
                 const auto &debug = intern_dynamic_debug_descriptor(
                     value_schema->header, plan_, DebugLayoutKind::KeyedSlots,
                     key_binding.record(), dict_layout.element_value_binding.record(), debug_layout,

--- a/src/hgraph/types/metadata/ts_data_slot_ops.cpp
+++ b/src/hgraph/types/metadata/ts_data_slot_ops.cpp
@@ -105,20 +105,32 @@ namespace hgraph::ts_data_plan_factory_detail
         }
 
         template <typename Storage>
+        [[nodiscard]] std::size_t debug_address_offset(const Storage &storage, const void *address) noexcept
+        {
+            return static_cast<std::size_t>(static_cast<const std::byte *>(address) -
+                                            reinterpret_cast<const std::byte *>(&storage));
+        }
+
+        template <typename Storage>
         [[nodiscard]] DebugDynamicLayout tss_value_debug_layout(const Storage &sample,
                                                                  const ValueTypeRef &key_binding)
         {
             const auto &keys = sample.keys();
+            const StableSlotDebugView slots = keys.debug_slot_view();
+            DebugDynamicFlags flags = DebugDynamicFlags::DataIsIndirect |
+                                      DebugDynamicFlags::DataIsPointerTable |
+                                      DebugDynamicFlags::HasSlotState;
+            if (slots.pointers_tagged) { flags = flags | DebugDynamicFlags::DataPointersAreTagged; }
+            if (slots.state_tagged) { flags = flags | DebugDynamicFlags::SlotStateIsTaggedPointer; }
             return DebugDynamicLayout{
                 .magic = DEBUG_DYNAMIC_LAYOUT_MAGIC,
                 .abi_version = DEBUG_DYNAMIC_LAYOUT_ABI_VERSION,
                 .kind = DebugDynamicKind::StableSlots,
-                .flags = DebugDynamicFlags::DataIsIndirect | DebugDynamicFlags::DataIsPointerTable |
-                         DebugDynamicFlags::HasSlotState,
-                .size_offset = debug_offset(sample, keys.live.bit_count),
-                .data_offset = debug_offset(sample, keys.key_storage.slots),
+                .flags = flags,
+                .size_offset = debug_address_offset(sample, slots.slot_count),
+                .data_offset = debug_address_offset(sample, slots.pointer_table),
                 .stride = key_binding.checked_plan().layout.size,
-                .state_offset = debug_offset(sample, keys.live.words),
+                .state_offset = debug_address_offset(sample, slots.state),
             };
         }
 
@@ -2147,13 +2159,24 @@ namespace hgraph::ts_data_plan_factory_detail
                 const TSDSlotStorage sample{key_binding, element_type};
                 const auto &keys = sample.keys();
                 const auto &values = sample.debug_values();
+                const StableSlotDebugView key_slots = keys.debug_slot_view();
+                const StableSlotDebugView value_slots = values.debug_slot_view();
                 auto debug_layout = tss_value_debug_layout(sample, key_binding);
-                debug_layout.flags = debug_layout.flags | DebugDynamicFlags::KeyDataIsIndirect |
-                                     DebugDynamicFlags::KeyDataIsPointerTable;
-                debug_layout.data_offset = debug_offset(sample, values.value_storage.slots);
+                DebugDynamicFlags flags = DebugDynamicFlags::DataIsIndirect |
+                                          DebugDynamicFlags::KeyDataIsIndirect |
+                                          DebugDynamicFlags::DataIsPointerTable |
+                                          DebugDynamicFlags::KeyDataIsPointerTable |
+                                          DebugDynamicFlags::HasSlotState;
+                if (value_slots.pointers_tagged) { flags = flags | DebugDynamicFlags::DataPointersAreTagged; }
+                if (key_slots.pointers_tagged) { flags = flags | DebugDynamicFlags::KeyPointersAreTagged; }
+                if (key_slots.state_tagged) { flags = flags | DebugDynamicFlags::SlotStateIsTaggedPointer; }
+                debug_layout.flags = flags;
+                debug_layout.size_offset = debug_address_offset(sample, key_slots.slot_count);
+                debug_layout.data_offset = debug_address_offset(sample, value_slots.pointer_table);
                 debug_layout.stride = element_type.checked_plan().layout.size;
-                debug_layout.key_data_offset = debug_offset(sample, keys.key_storage.slots);
+                debug_layout.key_data_offset = debug_address_offset(sample, key_slots.pointer_table);
                 debug_layout.key_stride = key_binding.checked_plan().layout.size;
+                debug_layout.state_offset = debug_address_offset(sample, key_slots.state);
                 const auto &debug = intern_dynamic_debug_descriptor(
                     value_schema->header, plan_, DebugLayoutKind::KeyedSlots,
                     key_binding.record(), dict_layout.element_value_binding.record(), debug_layout,

--- a/src/hgraph/types/utils/stable_slot_store.cpp
+++ b/src/hgraph/types/utils/stable_slot_store.cpp
@@ -1,172 +1,91 @@
-#include <hgraph/types/utils/impl/stable_slot_store_impl.h>
+#include <hgraph/types/utils/stable_slot_store.h>
 
-#include <utility>
+#include <cassert>
+#include <memory>
+#include <stdexcept>
 
 namespace hgraph
 {
     namespace
     {
-        template <StableSlotStateModel Model, typename Implementation, bool Tagged>
-        [[nodiscard]] const StableSlotStoreOps &stable_slot_store_ops_for() noexcept
+        using Tag = detail::StableSlotStoreImplementationTag;
+
+        template <typename Implementation>
+        [[nodiscard]] std::uintptr_t make_implementation(MemoryUtils::StorageLayout layout,
+                                                         const MemoryUtils::AllocatorOps &allocator, Tag tag)
         {
-            static const StableSlotStoreOps ops{
-                .representation = Tagged ? StableSlotRepresentation::TaggedPointer
-                                         : StableSlotRepresentation::Bitmap,
-                .layout_impl = [](const void *implementation) noexcept {
-                    return MemoryUtils::cast<Implementation>(implementation)->layout();
-                },
-                .allocator_impl = [](const void *implementation) noexcept {
-                    return &MemoryUtils::cast<Implementation>(implementation)->allocator();
-                },
-                .capacity_impl = [](const void *implementation) noexcept {
-                    return MemoryUtils::cast<Implementation>(implementation)->capacity();
-                },
-                .stride_impl = [](const void *implementation) noexcept {
-                    return MemoryUtils::cast<Implementation>(implementation)->stride();
-                },
-                .block_count_impl = [](const void *implementation) noexcept {
-                    return MemoryUtils::cast<Implementation>(implementation)->block_count();
-                },
-                .reserve_to_impl = [](void *implementation, std::size_t capacity) {
-                    MemoryUtils::cast<Implementation>(implementation)->reserve_to(capacity);
-                },
-                .slot_memory_impl = [](const void *implementation, std::size_t slot) noexcept -> const void * {
-                    return MemoryUtils::cast<Implementation>(implementation)->slot_memory(slot);
-                },
-                .live_slot_memory_impl = [](const void *implementation, std::size_t slot) noexcept -> const void * {
-                    return MemoryUtils::cast<Implementation>(implementation)->live_slot_memory(slot);
-                },
-                .non_live_slot_memory_impl = [](const void *implementation, std::size_t slot) noexcept -> const void * {
-                    if constexpr (Model == StableSlotStateModel::ConstructedAndLive)
-                        return MemoryUtils::cast<Implementation>(implementation)->non_live_slot_memory(slot);
-                    else
-                        return nullptr;
-                },
-                .constructed_impl = [](const void *implementation, std::size_t slot) noexcept {
-                    return MemoryUtils::cast<Implementation>(implementation)->constructed(slot);
-                },
-                .live_impl = [](const void *implementation, std::size_t slot) noexcept {
-                    return MemoryUtils::cast<Implementation>(implementation)->live(slot);
-                },
-                .mark_staged_impl = [](void *implementation, std::size_t slot) noexcept {
-                    MemoryUtils::cast<Implementation>(implementation)->mark_staged(slot);
-                },
-                .mark_live_impl = [](void *implementation, std::size_t slot) noexcept {
-                    return MemoryUtils::cast<Implementation>(implementation)->mark_live(slot);
-                },
-                .mark_pending_impl = [](void *implementation, std::size_t slot) noexcept {
-                    if constexpr (Model == StableSlotStateModel::ConstructedAndLive)
-                        return MemoryUtils::cast<Implementation>(implementation)->mark_pending(slot);
-                    else
-                        return false;
-                },
-                .mark_free_impl = [](void *implementation, std::size_t slot) noexcept {
-                    MemoryUtils::cast<Implementation>(implementation)->mark_free(slot);
-                },
-                .reset_states_impl = [](void *implementation) noexcept {
-                    MemoryUtils::cast<Implementation>(implementation)->reset_states();
-                },
-                .constructed_count_impl = [](const void *implementation) noexcept {
-                    return MemoryUtils::cast<Implementation>(implementation)->constructed_count();
-                },
-                .dynamic_storage_metrics_impl = [](const void *implementation) noexcept {
-                    return MemoryUtils::cast<Implementation>(implementation)->dynamic_storage_metrics();
-                },
-                .debug_view_impl = [](const void *implementation) noexcept {
-                    const auto *typed = MemoryUtils::cast<Implementation>(implementation);
-                    const auto *base = static_cast<const std::byte *>(implementation);
-                    const auto offset_of = [base](const void *address) {
-                        return static_cast<std::size_t>(
-                            static_cast<const std::byte *>(address) - base);
-                    };
-                    return StableSlotDebugView{
-                        .slot_count_offset = offset_of(typed->debug_capacity_address()),
-                        .pointer_table_offset = offset_of(typed->debug_slots_address()),
-                        .state_offset = offset_of(typed->debug_state_address()),
-                        .pointers_tagged = Tagged,
-                        .state_tagged = Tagged,
-                    };
-                },
-            };
-            return ops;
+            static_assert(alignof(Implementation) > detail::STABLE_SLOT_STORE_IMPLEMENTATION_TAG_MASK);
+            const auto &plan = MemoryUtils::plan_for<Implementation>();
+            void *storage = allocator.allocate_storage(plan.layout);
+            try {
+                std::construct_at(static_cast<Implementation *>(storage), layout, allocator);
+            } catch (...) {
+                allocator.deallocate_storage(storage, plan.layout);
+                throw;
+            }
+
+            const auto address = reinterpret_cast<std::uintptr_t>(storage);
+            assert((address & detail::STABLE_SLOT_STORE_IMPLEMENTATION_TAG_MASK) == 0);
+            return address | static_cast<std::uintptr_t>(tag);
         }
 
-        template <StableSlotStateModel Model, typename Implementation, bool Tagged>
-        [[nodiscard]] detail::StableSlotStoreImplementation make_implementation(
-            MemoryUtils::StorageLayout layout,
-            const MemoryUtils::AllocatorOps &allocator)
+        template <typename Implementation> void destroy_implementation(std::uintptr_t handle) noexcept
         {
-            detail::StableSlotStoreImplementation result;
-            result.owner = detail::StableSlotStoreImplementationOwner{
-                MemoryUtils::plan_for<Implementation>(), allocator};
-            result.owner.as<Implementation>()->bind(layout, allocator);
-            result.ops = &stable_slot_store_ops_for<Model, Implementation, Tagged>();
-            return result;
+            auto *implementation =
+                reinterpret_cast<Implementation *>(handle & ~detail::STABLE_SLOT_STORE_IMPLEMENTATION_TAG_MASK);
+            const MemoryUtils::AllocatorOps *allocator = &implementation->allocator();
+            const auto layout = MemoryUtils::plan_for<Implementation>().layout;
+            std::destroy_at(implementation);
+            allocator->deallocate_storage(implementation, layout);
         }
-    }  // namespace
 
-    const StableSlotStoreOps &detail::noop_stable_slot_store_ops() noexcept
-    {
-        static const StableSlotStoreOps ops{
-            .representation = StableSlotRepresentation::Unbound,
-            .layout_impl = [](const void *) noexcept { return MemoryUtils::StorageLayout{}; },
-            .allocator_impl = [](const void *) noexcept { return &MemoryUtils::allocator(); },
-            .capacity_impl = [](const void *) noexcept { return std::size_t{0}; },
-            .stride_impl = [](const void *) noexcept { return std::size_t{0}; },
-            .block_count_impl = [](const void *) noexcept { return std::size_t{0}; },
-            .reserve_to_impl = [](void *, std::size_t) {},
-            .slot_memory_impl = [](const void *, std::size_t) noexcept -> const void * {
-                return nullptr;
-            },
-            .live_slot_memory_impl = [](const void *, std::size_t) noexcept -> const void * {
-                return nullptr;
-            },
-            .non_live_slot_memory_impl = [](const void *, std::size_t) noexcept -> const void * {
-                return nullptr;
-            },
-            .constructed_impl = [](const void *, std::size_t) noexcept { return false; },
-            .live_impl = [](const void *, std::size_t) noexcept { return false; },
-            .mark_staged_impl = [](void *, std::size_t) noexcept {},
-            .mark_live_impl = [](void *, std::size_t) noexcept { return false; },
-            .mark_pending_impl = [](void *, std::size_t) noexcept { return false; },
-            .mark_free_impl = [](void *, std::size_t) noexcept {},
-            .reset_states_impl = [](void *) noexcept {},
-            .constructed_count_impl = [](const void *) noexcept { return std::size_t{0}; },
-            .dynamic_storage_metrics_impl = [](const void *) noexcept {
-                return DynamicStorageMetrics{};
-            },
-            .debug_view_impl = [](const void *) noexcept { return StableSlotDebugView{}; },
-        };
-        return ops;
-    }
-
-    detail::StableSlotStoreImplementation detail::make_stable_slot_store_implementation(
-        StableSlotStateModel model,
-        MemoryUtils::StorageLayout layout,
-        const MemoryUtils::AllocatorOps &allocator)
-    {
-        if (!layout.valid() || layout.size == 0)
+        template <StableSlotStateModel Model>
+        [[nodiscard]] std::uintptr_t make_for_model(MemoryUtils::StorageLayout layout,
+                                                    const MemoryUtils::AllocatorOps &allocator)
         {
+            if (layout.alignment >= alignof(std::uintptr_t)) {
+                using Implementation = detail::TaggedPointerStableSlotStoreImpl<Model>;
+                return make_implementation<Implementation>(layout, allocator, Tag::TaggedPointer);
+            }
+
+            using Implementation = detail::BitmapStableSlotStoreImpl<Model>;
+            return make_implementation<Implementation>(layout, allocator, Tag::Bitmap);
+        }
+
+        template <StableSlotStateModel Model> void destroy_for_model(std::uintptr_t handle) noexcept
+        {
+            const auto tag = static_cast<Tag>(handle & detail::STABLE_SLOT_STORE_IMPLEMENTATION_TAG_MASK);
+            switch (tag) {
+            case Tag::TaggedPointer:
+                destroy_implementation<detail::TaggedPointerStableSlotStoreImpl<Model>>(handle);
+                return;
+            case Tag::Bitmap:
+                destroy_implementation<detail::BitmapStableSlotStoreImpl<Model>>(handle);
+                return;
+            case Tag::Nop:
+                return;
+            }
+        }
+    } // namespace
+
+    std::uintptr_t detail::make_stable_slot_store_implementation(StableSlotStateModel model,
+                                                                 MemoryUtils::StorageLayout layout,
+                                                                 const MemoryUtils::AllocatorOps &allocator)
+    {
+        if (!layout.valid() || layout.size == 0) {
             throw std::logic_error("StableSlotStore requires a non-empty valid layout");
         }
 
-        if (layout.alignment >= alignof(std::uintptr_t))
-        {
-            if (model == StableSlotStateModel::ConstructedOnly)
-            {
-                using Implementation = TaggedPointerStableSlotStoreImpl<StableSlotStateModel::ConstructedOnly>;
-                return make_implementation<StableSlotStateModel::ConstructedOnly, Implementation, true>(layout, allocator);
-            }
-            using Implementation = TaggedPointerStableSlotStoreImpl<StableSlotStateModel::ConstructedAndLive>;
-            return make_implementation<StableSlotStateModel::ConstructedAndLive, Implementation, true>(layout, allocator);
-        }
-
         if (model == StableSlotStateModel::ConstructedOnly)
-        {
-            using Implementation = BitmapStableSlotStoreImpl<StableSlotStateModel::ConstructedOnly>;
-            return make_implementation<StableSlotStateModel::ConstructedOnly, Implementation, false>(layout, allocator);
-        }
-        using Implementation = BitmapStableSlotStoreImpl<StableSlotStateModel::ConstructedAndLive>;
-        return make_implementation<StableSlotStateModel::ConstructedAndLive, Implementation, false>(layout, allocator);
+            return make_for_model<StableSlotStateModel::ConstructedOnly>(layout, allocator);
+        return make_for_model<StableSlotStateModel::ConstructedAndLive>(layout, allocator);
     }
-}  // namespace hgraph
+
+    void detail::destroy_stable_slot_store_implementation(StableSlotStateModel model, std::uintptr_t handle) noexcept
+    {
+        if (model == StableSlotStateModel::ConstructedOnly)
+            destroy_for_model<StableSlotStateModel::ConstructedOnly>(handle);
+        else
+            destroy_for_model<StableSlotStateModel::ConstructedAndLive>(handle);
+    }
+} // namespace hgraph

--- a/src/hgraph/types/utils/stable_slot_store.cpp
+++ b/src/hgraph/types/utils/stable_slot_store.cpp
@@ -1,0 +1,137 @@
+#include <hgraph/types/utils/impl/stable_slot_store_impl.h>
+
+#include <utility>
+
+namespace hgraph
+{
+    namespace
+    {
+        template <StableSlotStateModel Model, typename Implementation, bool Tagged>
+        [[nodiscard]] const StableSlotStoreOps &stable_slot_store_ops_for() noexcept
+        {
+            static const StableSlotStoreOps ops{
+                .representation = Tagged ? StableSlotRepresentation::TaggedPointer
+                                         : StableSlotRepresentation::Bitmap,
+                .layout_impl = [](const void *implementation) noexcept {
+                    return MemoryUtils::cast<Implementation>(implementation)->layout();
+                },
+                .allocator_impl = [](const void *implementation) noexcept {
+                    return &MemoryUtils::cast<Implementation>(implementation)->allocator();
+                },
+                .capacity_impl = [](const void *implementation) noexcept {
+                    return MemoryUtils::cast<Implementation>(implementation)->capacity();
+                },
+                .stride_impl = [](const void *implementation) noexcept {
+                    return MemoryUtils::cast<Implementation>(implementation)->stride();
+                },
+                .block_count_impl = [](const void *implementation) noexcept {
+                    return MemoryUtils::cast<Implementation>(implementation)->block_count();
+                },
+                .reserve_to_impl = [](void *implementation, std::size_t capacity) {
+                    MemoryUtils::cast<Implementation>(implementation)->reserve_to(capacity);
+                },
+                .slot_memory_impl = [](const void *implementation, std::size_t slot) noexcept -> const void * {
+                    return MemoryUtils::cast<Implementation>(implementation)->slot_memory(slot);
+                },
+                .live_slot_memory_impl = [](const void *implementation, std::size_t slot) noexcept -> const void * {
+                    return MemoryUtils::cast<Implementation>(implementation)->live_slot_memory(slot);
+                },
+                .non_live_slot_memory_impl = [](const void *implementation, std::size_t slot) noexcept -> const void * {
+                    if constexpr (Model == StableSlotStateModel::ConstructedAndLive)
+                        return MemoryUtils::cast<Implementation>(implementation)->non_live_slot_memory(slot);
+                    else
+                        return nullptr;
+                },
+                .constructed_impl = [](const void *implementation, std::size_t slot) noexcept {
+                    return MemoryUtils::cast<Implementation>(implementation)->constructed(slot);
+                },
+                .live_impl = [](const void *implementation, std::size_t slot) noexcept {
+                    return MemoryUtils::cast<Implementation>(implementation)->live(slot);
+                },
+                .mark_staged_impl = [](void *implementation, std::size_t slot) noexcept {
+                    MemoryUtils::cast<Implementation>(implementation)->mark_staged(slot);
+                },
+                .mark_live_impl = [](void *implementation, std::size_t slot) noexcept {
+                    return MemoryUtils::cast<Implementation>(implementation)->mark_live(slot);
+                },
+                .mark_pending_impl = [](void *implementation, std::size_t slot) noexcept {
+                    if constexpr (Model == StableSlotStateModel::ConstructedAndLive)
+                        return MemoryUtils::cast<Implementation>(implementation)->mark_pending(slot);
+                    else
+                        return false;
+                },
+                .mark_free_impl = [](void *implementation, std::size_t slot) noexcept {
+                    MemoryUtils::cast<Implementation>(implementation)->mark_free(slot);
+                },
+                .reset_states_impl = [](void *implementation) noexcept {
+                    MemoryUtils::cast<Implementation>(implementation)->reset_states();
+                },
+                .constructed_count_impl = [](const void *implementation) noexcept {
+                    return MemoryUtils::cast<Implementation>(implementation)->constructed_count();
+                },
+                .dynamic_storage_metrics_impl = [](const void *implementation) noexcept {
+                    return MemoryUtils::cast<Implementation>(implementation)->dynamic_storage_metrics();
+                },
+                .debug_view_impl = [](const void *implementation) noexcept {
+                    const auto *typed = MemoryUtils::cast<Implementation>(implementation);
+                    const auto *base = static_cast<const std::byte *>(implementation);
+                    const auto offset_of = [base](const void *address) {
+                        return static_cast<std::size_t>(
+                            static_cast<const std::byte *>(address) - base);
+                    };
+                    return StableSlotDebugView{
+                        .slot_count_offset = offset_of(typed->debug_capacity_address()),
+                        .pointer_table_offset = offset_of(typed->debug_slots_address()),
+                        .state_offset = offset_of(typed->debug_state_address()),
+                        .pointers_tagged = Tagged,
+                        .state_tagged = Tagged,
+                    };
+                },
+            };
+            return ops;
+        }
+
+        template <StableSlotStateModel Model, typename Implementation, bool Tagged>
+        [[nodiscard]] detail::StableSlotStoreImplementation make_implementation(
+            MemoryUtils::StorageLayout layout,
+            const MemoryUtils::AllocatorOps &allocator)
+        {
+            detail::StableSlotStoreImplementation result;
+            result.owner = detail::StableSlotStoreImplementationOwner{
+                MemoryUtils::plan_for<Implementation>(), allocator};
+            result.owner.as<Implementation>()->bind(layout, allocator);
+            result.ops = &stable_slot_store_ops_for<Model, Implementation, Tagged>();
+            return result;
+        }
+    }  // namespace
+
+    detail::StableSlotStoreImplementation detail::make_stable_slot_store_implementation(
+        StableSlotStateModel model,
+        MemoryUtils::StorageLayout layout,
+        const MemoryUtils::AllocatorOps &allocator)
+    {
+        if (!layout.valid() || layout.size == 0)
+        {
+            throw std::logic_error("StableSlotStore requires a non-empty valid layout");
+        }
+
+        if (layout.alignment >= alignof(std::uintptr_t))
+        {
+            if (model == StableSlotStateModel::ConstructedOnly)
+            {
+                using Implementation = TaggedPointerStableSlotStoreImpl<StableSlotStateModel::ConstructedOnly>;
+                return make_implementation<StableSlotStateModel::ConstructedOnly, Implementation, true>(layout, allocator);
+            }
+            using Implementation = TaggedPointerStableSlotStoreImpl<StableSlotStateModel::ConstructedAndLive>;
+            return make_implementation<StableSlotStateModel::ConstructedAndLive, Implementation, true>(layout, allocator);
+        }
+
+        if (model == StableSlotStateModel::ConstructedOnly)
+        {
+            using Implementation = BitmapStableSlotStoreImpl<StableSlotStateModel::ConstructedOnly>;
+            return make_implementation<StableSlotStateModel::ConstructedOnly, Implementation, false>(layout, allocator);
+        }
+        using Implementation = BitmapStableSlotStoreImpl<StableSlotStateModel::ConstructedAndLive>;
+        return make_implementation<StableSlotStateModel::ConstructedAndLive, Implementation, false>(layout, allocator);
+    }
+}  // namespace hgraph

--- a/src/hgraph/types/utils/stable_slot_store.cpp
+++ b/src/hgraph/types/utils/stable_slot_store.cpp
@@ -105,6 +105,41 @@ namespace hgraph
         }
     }  // namespace
 
+    const StableSlotStoreOps &detail::noop_stable_slot_store_ops() noexcept
+    {
+        static const StableSlotStoreOps ops{
+            .representation = StableSlotRepresentation::Unbound,
+            .layout_impl = [](const void *) noexcept { return MemoryUtils::StorageLayout{}; },
+            .allocator_impl = [](const void *) noexcept { return &MemoryUtils::allocator(); },
+            .capacity_impl = [](const void *) noexcept { return std::size_t{0}; },
+            .stride_impl = [](const void *) noexcept { return std::size_t{0}; },
+            .block_count_impl = [](const void *) noexcept { return std::size_t{0}; },
+            .reserve_to_impl = [](void *, std::size_t) {},
+            .slot_memory_impl = [](const void *, std::size_t) noexcept -> const void * {
+                return nullptr;
+            },
+            .live_slot_memory_impl = [](const void *, std::size_t) noexcept -> const void * {
+                return nullptr;
+            },
+            .non_live_slot_memory_impl = [](const void *, std::size_t) noexcept -> const void * {
+                return nullptr;
+            },
+            .constructed_impl = [](const void *, std::size_t) noexcept { return false; },
+            .live_impl = [](const void *, std::size_t) noexcept { return false; },
+            .mark_staged_impl = [](void *, std::size_t) noexcept {},
+            .mark_live_impl = [](void *, std::size_t) noexcept { return false; },
+            .mark_pending_impl = [](void *, std::size_t) noexcept { return false; },
+            .mark_free_impl = [](void *, std::size_t) noexcept {},
+            .reset_states_impl = [](void *) noexcept {},
+            .constructed_count_impl = [](const void *) noexcept { return std::size_t{0}; },
+            .dynamic_storage_metrics_impl = [](const void *) noexcept {
+                return DynamicStorageMetrics{};
+            },
+            .debug_view_impl = [](const void *) noexcept { return StableSlotDebugView{}; },
+        };
+        return ops;
+    }
+
     detail::StableSlotStoreImplementation detail::make_stable_slot_store_implementation(
         StableSlotStateModel model,
         MemoryUtils::StorageLayout layout,

--- a/tests/cpp/CMakeLists.txt
+++ b/tests/cpp/CMakeLists.txt
@@ -212,6 +212,7 @@ hgraph_add_test_objects(hgraph_value_test_objects
     test_schema_examples.cpp
     test_scope.cpp
     test_slot_utils.cpp
+    test_stable_slot_representation_prototype.cpp
     test_specialized_views.cpp
     test_static_schema.cpp
     test_temporal.cpp
@@ -305,6 +306,17 @@ target_link_libraries(hgraph_type_erasure_perf
 )
 
 hgraph_enable_private_pch(hgraph_type_erasure_perf)
+
+add_executable(hgraph_stable_slot_representation_perf
+    stable_slot_representation_perf.cpp
+)
+
+target_link_libraries(hgraph_stable_slot_representation_perf
+    PRIVATE
+        hgraph::core
+)
+
+hgraph_enable_private_pch(hgraph_stable_slot_representation_perf)
 
 include(Catch)
 catch_discover_tests(hgraph_unit_tests)

--- a/tests/cpp/header_compile_check.cpp
+++ b/tests/cpp/header_compile_check.cpp
@@ -15,6 +15,7 @@
 #include <hgraph/types/utils/memory_utils.h>
 #include <hgraph/types/utils/slot_observer.h>
 #include <hgraph/types/utils/stable_slot_storage.h>
+#include <hgraph/types/utils/stable_slot_store.h>
 #include <hgraph/types/utils/value_slot_store.h>
 #include <hgraph/types/time_series/ts_data.h>
 #include <hgraph/types/time_series/ts_data/base_view.h>
@@ -82,6 +83,11 @@ void instantiate_slot_stores() {
     using hgraph::KeySlotStore;
     using hgraph::KeyMirroredValueSlotStore;
     using hgraph::ValueSlotStore;
+
+    hgraph::StableSlotStore<hgraph::StableSlotStateModel::ConstructedAndLive> stable_slots(
+        MemoryUtils::layout_for<std::int64_t>());
+    stable_slots.reserve_to(8);
+    assert(stable_slots.representation() == hgraph::StableSlotRepresentation::TaggedPointer);
 
     KeySlotStore keys(MemoryUtils::plan_for<std::int32_t>(), hgraph::key_slot_store_ops_for<std::int32_t>());
     KeyMirroredValueSlotStore mirrored_values(keys, MemoryUtils::plan_for<std::int32_t>());

--- a/tests/cpp/stable_slot_representation_perf.cpp
+++ b/tests/cpp/stable_slot_representation_perf.cpp
@@ -284,14 +284,26 @@ public:
                    hgraph::SlotBitmap::bits_per_word) *
                   sizeof(std::uint64_t)
             : 0;
+    const std::size_t payload_bytes = capacity() * store_.stride();
+    const std::size_t slot_index_bytes =
+        capacity() * sizeof(void *) + bitmap_bytes;
+    const std::size_t block_descriptor_bytes =
+        store_.block_count() * sizeof(hgraph::StableSlotBlock);
+    const std::size_t described_store_bytes =
+        payload_bytes + slot_index_bytes + block_descriptor_bytes;
+    const std::size_t reserved_store_bytes =
+        store_.dynamic_storage_metrics().reserved_bytes;
     return PrototypeMemoryReport{
-        .payload_bytes = capacity() * store_.stride(),
-        .slot_index_bytes = capacity() * sizeof(void *) + bitmap_bytes,
+        .payload_bytes = payload_bytes,
+        .slot_index_bytes = slot_index_bytes,
         .lifecycle_index_bytes =
             free_slots_.capacity() * sizeof(std::size_t) +
             pending_slots_.capacity() * sizeof(std::size_t),
-        .block_descriptor_bytes =
-            store_.block_count() * sizeof(hgraph::StableSlotBlock),
+        .block_descriptor_bytes = block_descriptor_bytes,
+        .implementation_bytes =
+            reserved_store_bytes >= described_store_bytes
+                ? reserved_store_bytes - described_store_bytes
+                : 0,
         .payload_allocations = store_.block_count(),
         .slot_index_allocations =
             capacity() == 0
@@ -304,6 +316,8 @@ public:
                                             : std::size_t{1}),
         .block_descriptor_allocations =
             store_.block_count() == 0 ? std::size_t{0} : std::size_t{1},
+        .implementation_allocations = store_.bound() ? std::size_t{1}
+                                                     : std::size_t{0},
     };
   }
 
@@ -350,7 +364,8 @@ void run_store_suite_impl(std::string_view representation_name,
   const PrototypeMemoryReport report = store.memory_report();
   const std::size_t representation_bytes = report.payload_bytes +
                                            report.slot_index_bytes +
-                                           report.block_descriptor_bytes;
+                                           report.block_descriptor_bytes +
+                                           report.implementation_bytes;
   std::cout << "memory"
             << " representation=" << representation_name
             << " payload_size=" << sizeof(Value)
@@ -361,6 +376,7 @@ void run_store_suite_impl(std::string_view representation_name,
             << " slot_index_bytes=" << report.slot_index_bytes
             << " slot_management_bytes=" << report.lifecycle_index_bytes
             << " block_descriptor_bytes=" << report.block_descriptor_bytes
+            << " implementation_bytes=" << report.implementation_bytes
             << " representation_bytes=" << representation_bytes
             << " representation_bytes_per_slot="
             << static_cast<double>(representation_bytes) /
@@ -375,6 +391,8 @@ void run_store_suite_impl(std::string_view representation_name,
             << report.slot_management_allocations
             << " block_descriptor_allocations="
             << report.block_descriptor_allocations
+            << " implementation_allocations="
+            << report.implementation_allocations
             << " total_allocations=" << report.total_allocations() << '\n';
 
   const std::string prefix{representation_name};

--- a/tests/cpp/stable_slot_representation_perf.cpp
+++ b/tests/cpp/stable_slot_representation_perf.cpp
@@ -1,0 +1,485 @@
+#include "stable_slot_representation_prototype.h"
+
+#include <hgraph/types/utils/stable_slot_store.h>
+
+#include <algorithm>
+#include <atomic>
+#include <chrono>
+#include <cstddef>
+#include <cstdint>
+#include <cstdlib>
+#include <iomanip>
+#include <iostream>
+#include <limits>
+#include <memory>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace {
+using namespace hgraph::experimental;
+
+volatile std::uint64_t retained_value{0};
+
+struct alignas(8) AlignedTracked8 {
+  std::uint64_t stored{0};
+
+  explicit AlignedTracked8(std::uint64_t value) : stored(value) {}
+  ~AlignedTracked8() {}
+
+  [[nodiscard]] std::uint64_t value() const noexcept { return stored; }
+};
+
+struct PackedTrivial9 {
+  std::byte bytes[9]{};
+
+  explicit PackedTrivial9(std::uint64_t value) {
+    bytes[0] = static_cast<std::byte>(value & 0xffU);
+  }
+
+  [[nodiscard]] std::uint64_t value() const noexcept {
+    return std::to_integer<std::uint8_t>(bytes[0]);
+  }
+};
+
+struct PackedTracked9 {
+  std::byte bytes[9]{};
+
+  explicit PackedTracked9(std::uint64_t value) {
+    bytes[0] = static_cast<std::byte>(value & 0xffU);
+  }
+  ~PackedTracked9() {}
+
+  [[nodiscard]] std::uint64_t value() const noexcept {
+    return std::to_integer<std::uint8_t>(bytes[0]);
+  }
+};
+
+static_assert(sizeof(AlignedTracked8) == 8);
+static_assert(alignof(AlignedTracked8) == 8);
+static_assert(sizeof(PackedTrivial9) == 9);
+static_assert(alignof(PackedTrivial9) == 1);
+static_assert(std::is_trivially_destructible_v<PackedTrivial9>);
+static_assert(sizeof(PackedTracked9) == 9);
+static_assert(alignof(PackedTracked9) == 1);
+static_assert(!std::is_trivially_destructible_v<PackedTracked9>);
+
+[[nodiscard]] std::size_t env_size(const char *name, std::size_t fallback,
+                                   std::size_t minimum = 1) {
+  const char *value = std::getenv(name);
+  if (value == nullptr || *value == '\0') {
+    return fallback;
+  }
+
+  char *end = nullptr;
+  const auto parsed = std::strtoull(value, &end, 10);
+  if (end == value || *end != '\0' ||
+      parsed > std::numeric_limits<std::size_t>::max()) {
+    throw std::invalid_argument(std::string{name} +
+                                " must be a non-negative integer");
+  }
+  return std::max<std::size_t>(static_cast<std::size_t>(parsed), minimum);
+}
+
+[[nodiscard]] bool selected(std::string_view name) noexcept {
+  const char *filter = std::getenv("HGRAPH_STABLE_SLOT_PERF_FILTER");
+  return filter == nullptr || *filter == '\0' || name.contains(filter);
+}
+
+template <typename T> [[nodiscard]] T median(std::vector<T> values) {
+  std::ranges::sort(values);
+  return values[values.size() / 2];
+}
+
+[[nodiscard]] double percentile(std::vector<double> values, double quantile) {
+  std::ranges::sort(values);
+  const double position = quantile * static_cast<double>(values.size() - 1);
+  const auto lower = static_cast<std::size_t>(position);
+  const auto upper = std::min(lower + 1, values.size() - 1);
+  const double fraction = position - static_cast<double>(lower);
+  return values[lower] + (values[upper] - values[lower]) * fraction;
+}
+
+void retain(std::uint64_t value) noexcept {
+  retained_value = value;
+  std::atomic_signal_fence(std::memory_order_seq_cst);
+}
+
+template <typename Operation>
+void run_benchmark(std::string_view name, std::size_t default_iterations,
+                   std::size_t work_items_per_iteration, std::size_t samples,
+                   Operation &&operation) {
+  if (!selected(name)) {
+    return;
+  }
+
+  const std::size_t override_iterations =
+      env_size("HGRAPH_STABLE_SLOT_PERF_ITERATIONS", 0, 0);
+  const std::size_t iterations =
+      override_iterations == 0 ? default_iterations : override_iterations;
+  for (std::size_t warmup = 0; warmup < 3; ++warmup) {
+    retain(operation());
+  }
+
+  std::vector<double> elapsed_per_item;
+  std::vector<std::uint64_t> checksums;
+  elapsed_per_item.reserve(samples);
+  checksums.reserve(samples);
+  for (std::size_t sample = 0; sample < samples; ++sample) {
+    std::uint64_t checksum = 0;
+    const auto start = std::chrono::steady_clock::now();
+    for (std::size_t iteration = 0; iteration < iterations; ++iteration) {
+      checksum += operation();
+    }
+    const auto elapsed = std::chrono::duration<double, std::nano>(
+                             std::chrono::steady_clock::now() - start)
+                             .count();
+    retain(checksum);
+    elapsed_per_item.push_back(
+        elapsed / static_cast<double>(iterations * work_items_per_iteration));
+    checksums.push_back(checksum);
+  }
+
+  if (!std::ranges::all_of(checksums, [&](std::uint64_t value) {
+        return value == checksums.front();
+      })) {
+    throw std::runtime_error(std::string{name} +
+                             " produced an unstable checksum");
+  }
+
+  std::cout << "benchmark"
+            << " name=" << name << " samples=" << samples
+            << " iterations=" << iterations
+            << " work_items_per_iteration=" << work_items_per_iteration
+            << " median_ns_per_item=" << median(elapsed_per_item)
+            << " p10_ns_per_item=" << percentile(elapsed_per_item, 0.10)
+            << " p90_ns_per_item=" << percentile(elapsed_per_item, 0.90)
+            << " checksum=" << checksums.front() << '\n';
+}
+
+template <typename Store> void fill(Store &store, std::size_t capacity) {
+  for (std::size_t slot = 0; slot < capacity; ++slot) {
+    const std::size_t inserted = store.emplace((slot % 251U) + 1U);
+    if (inserted != slot) {
+      throw std::runtime_error("prototype assigned an unexpected slot");
+    }
+  }
+}
+
+template <typename T> class ProductionStableSlotStore {
+public:
+  using value_type = T;
+
+  explicit ProductionStableSlotStore(std::size_t initial_capacity = 0)
+      : store_(hgraph::MemoryUtils::StorageLayout{sizeof(T), alignof(T)}) {
+    if (initial_capacity != 0) {
+      reserve_to(initial_capacity);
+    }
+  }
+
+  ProductionStableSlotStore(const ProductionStableSlotStore &) = delete;
+  ProductionStableSlotStore &
+  operator=(const ProductionStableSlotStore &) = delete;
+
+  ~ProductionStableSlotStore() { destroy_all(); }
+
+  [[nodiscard]] std::size_t capacity() const noexcept {
+    return store_.slot_capacity();
+  }
+  [[nodiscard]] std::size_t payload_stride() const noexcept {
+    return store_.stride();
+  }
+
+  void reserve_to(std::size_t capacity) {
+    if (capacity <= store_.slot_capacity()) {
+      return;
+    }
+    const std::size_t old_capacity = store_.slot_capacity();
+    free_slots_.reserve(capacity);
+    pending_slots_.reserve(capacity);
+    store_.reserve_to(capacity);
+    for (std::size_t slot = capacity; slot > old_capacity; --slot) {
+      free_slots_.push_back(slot - 1);
+    }
+  }
+
+  template <typename... Args> std::size_t emplace(Args &&...args) {
+    if (free_slots_.empty()) {
+      reserve_to(std::max<std::size_t>(
+          live_count_ + pending_count_ + 1,
+          std::max<std::size_t>(8, capacity() * 2)));
+    }
+    const std::size_t slot = free_slots_.back();
+    free_slots_.pop_back();
+    T *memory = hgraph::MemoryUtils::cast<T>(store_.slot_memory(slot));
+    try {
+      std::construct_at(memory, std::forward<Args>(args)...);
+    } catch (...) {
+      free_slots_.push_back(slot);
+      throw;
+    }
+    store_.mark_staged(slot);
+    static_cast<void>(store_.mark_live(slot));
+    ++live_count_;
+    return slot;
+  }
+
+  bool remove(std::size_t slot) {
+    if (!store_.mark_pending_erase(slot)) {
+      return false;
+    }
+    pending_slots_.push_back(slot);
+    --live_count_;
+    ++pending_count_;
+    return true;
+  }
+
+  bool resurrect(std::size_t slot) {
+    if (!store_.mark_live(slot)) {
+      return false;
+    }
+    ++live_count_;
+    --pending_count_;
+    if (pending_count_ == 0) {
+      pending_slots_.clear();
+    }
+    return true;
+  }
+
+  void erase_pending() noexcept {
+    for (const std::size_t slot : pending_slots_) {
+      void *memory = store_.non_live_slot_memory(slot);
+      if (memory == nullptr) {
+        continue;
+      }
+      std::destroy_at(hgraph::MemoryUtils::cast<T>(memory));
+      store_.mark_free(slot);
+      free_slots_.push_back(slot);
+    }
+    pending_slots_.clear();
+    pending_count_ = 0;
+  }
+
+  [[nodiscard]] bool live(std::size_t slot) const noexcept {
+    return store_.live(slot);
+  }
+  [[nodiscard]] T *memory_unchecked(std::size_t slot) noexcept {
+    if (void *memory = store_.live_slot_memory(slot); memory != nullptr) {
+      return hgraph::MemoryUtils::cast<T>(memory);
+    }
+    return hgraph::MemoryUtils::cast<T>(store_.slot_memory(slot));
+  }
+  [[nodiscard]] const T *memory_unchecked(std::size_t slot) const noexcept {
+    if (const void *memory = store_.live_slot_memory(slot); memory != nullptr) {
+      return hgraph::MemoryUtils::cast<T>(memory);
+    }
+    return hgraph::MemoryUtils::cast<T>(store_.slot_memory(slot));
+  }
+
+  [[nodiscard]] PrototypeMemoryReport memory_report() const noexcept {
+    const std::size_t bitmap_bytes =
+        store_.representation() == hgraph::StableSlotRepresentation::Bitmap
+            ? 2 * ((capacity() + hgraph::SlotBitmap::bits_per_word - 1) /
+                   hgraph::SlotBitmap::bits_per_word) *
+                  sizeof(std::uint64_t)
+            : 0;
+    return PrototypeMemoryReport{
+        .payload_bytes = capacity() * store_.stride(),
+        .slot_index_bytes = capacity() * sizeof(void *) + bitmap_bytes,
+        .lifecycle_index_bytes =
+            free_slots_.capacity() * sizeof(std::size_t) +
+            pending_slots_.capacity() * sizeof(std::size_t),
+        .block_descriptor_bytes =
+            store_.block_count() * sizeof(hgraph::StableSlotBlock),
+        .payload_allocations = store_.block_count(),
+        .slot_index_allocations =
+            capacity() == 0
+                ? std::size_t{0}
+                : std::size_t{1} +
+                      (bitmap_bytes == 0 ? std::size_t{0} : std::size_t{2}),
+        .slot_management_allocations =
+            (free_slots_.capacity() == 0 ? std::size_t{0} : std::size_t{1}) +
+            (pending_slots_.capacity() == 0 ? std::size_t{0}
+                                            : std::size_t{1}),
+        .block_descriptor_allocations =
+            store_.block_count() == 0 ? std::size_t{0} : std::size_t{1},
+    };
+  }
+
+private:
+  using Store = hgraph::StableSlotStore<
+      hgraph::StableSlotStateModel::ConstructedAndLive>;
+
+  Store store_;
+  std::vector<std::size_t> free_slots_{};
+  std::vector<std::size_t> pending_slots_{};
+  std::size_t live_count_{0};
+  std::size_t pending_count_{0};
+
+  void destroy_all() noexcept {
+    for (std::size_t slot = 0; slot < capacity(); ++slot) {
+      if (store_.constructed(slot)) {
+        std::destroy_at(hgraph::MemoryUtils::cast<T>(store_.slot_memory(slot)));
+        store_.mark_free(slot);
+      }
+    }
+  }
+};
+
+[[nodiscard]] std::vector<std::size_t> random_slots(std::size_t capacity) {
+  std::vector<std::size_t> slots(capacity);
+  std::uint64_t state = 0x9e3779b97f4a7c15ULL;
+  for (std::size_t &slot : slots) {
+    state ^= state >> 12U;
+    state ^= state << 25U;
+    state ^= state >> 27U;
+    slot = static_cast<std::size_t>((state * 0x2545f4914f6cdd1dULL) % capacity);
+  }
+  return slots;
+}
+
+template <typename Store>
+void run_store_suite_impl(std::string_view representation_name,
+                          std::size_t capacity, std::size_t samples,
+                          const std::vector<std::size_t> &random_order) {
+  using Value = typename Store::value_type;
+  Store store(capacity);
+  fill(store, capacity);
+
+  const PrototypeMemoryReport report = store.memory_report();
+  const std::size_t representation_bytes = report.payload_bytes +
+                                           report.slot_index_bytes +
+                                           report.block_descriptor_bytes;
+  std::cout << "memory"
+            << " representation=" << representation_name
+            << " payload_size=" << sizeof(Value)
+            << " payload_alignment=" << alignof(Value)
+            << " capacity=" << capacity
+            << " payload_stride=" << store.payload_stride()
+            << " payload_bytes=" << report.payload_bytes
+            << " slot_index_bytes=" << report.slot_index_bytes
+            << " slot_management_bytes=" << report.lifecycle_index_bytes
+            << " block_descriptor_bytes=" << report.block_descriptor_bytes
+            << " representation_bytes=" << representation_bytes
+            << " representation_bytes_per_slot="
+            << static_cast<double>(representation_bytes) /
+                   static_cast<double>(capacity)
+            << " total_bytes=" << report.total_bytes()
+            << " total_bytes_per_slot="
+            << static_cast<double>(report.total_bytes()) /
+                   static_cast<double>(capacity)
+            << " payload_allocations=" << report.payload_allocations
+            << " slot_index_allocations=" << report.slot_index_allocations
+            << " slot_management_allocations="
+            << report.slot_management_allocations
+            << " block_descriptor_allocations="
+            << report.block_descriptor_allocations
+            << " total_allocations=" << report.total_allocations() << '\n';
+
+  const std::string prefix{representation_name};
+  const std::size_t scan_iterations =
+      std::max<std::size_t>(1, 4'000'000 / capacity);
+
+  run_benchmark(prefix + ".sequential_live_read", scan_iterations, capacity,
+                samples, [&] {
+                  std::uint64_t checksum = 0;
+                  for (std::size_t slot = 0; slot < capacity; ++slot) {
+                    if (store.live(slot)) {
+                      checksum += store.memory_unchecked(slot)->value();
+                    }
+                  }
+                  return checksum;
+                });
+
+  run_benchmark(prefix + ".random_live_read", scan_iterations, capacity,
+                samples, [&] {
+                  std::uint64_t checksum = 0;
+                  for (const std::size_t slot : random_order) {
+                    if (store.live(slot)) {
+                      checksum += store.memory_unchecked(slot)->value();
+                    }
+                  }
+                  return checksum;
+                });
+
+  std::size_t toggle_slot = capacity / 2;
+  run_benchmark(prefix + ".remove_resurrect", 500'000, 2, samples, [&] {
+    if (!store.remove(toggle_slot) || !store.resurrect(toggle_slot)) {
+      throw std::runtime_error("remove/resurrect lifecycle failed");
+    }
+    return store.memory_unchecked(toggle_slot)->value();
+  });
+
+  run_benchmark(prefix + ".erase_reinsert", 100'000, 2, samples, [&] {
+    if (!store.remove(toggle_slot)) {
+      throw std::runtime_error("remove before erase failed");
+    }
+    store.erase_pending();
+    const std::size_t inserted = store.emplace(73);
+    if (inserted != toggle_slot) {
+      throw std::runtime_error("erase did not recycle the same slot");
+    }
+    return store.memory_unchecked(toggle_slot)->value();
+  });
+}
+
+template <typename Value, typename Representation>
+void run_store_suite(std::string_view representation_name, std::size_t capacity,
+                     std::size_t samples,
+                     const std::vector<std::size_t> &random_order) {
+  run_store_suite_impl<PrototypeStableSlotStore<Value, Representation>>(
+      representation_name, capacity, samples, random_order);
+}
+} // namespace
+
+int main() {
+  try {
+    const std::size_t capacity =
+        env_size("HGRAPH_STABLE_SLOT_PERF_CAPACITY", 65'536);
+    const std::size_t samples = env_size("HGRAPH_STABLE_SLOT_PERF_SAMPLES", 15);
+    const auto random_order = random_slots(capacity);
+
+    std::cout << std::fixed << std::setprecision(3);
+    std::cout << "config capacity=" << capacity << " samples=" << samples
+              << '\n';
+
+    run_store_suite<AlignedTracked8,
+                    BitmapPointerRepresentation<AlignedTracked8>>(
+        "aligned8.bitmap", capacity, samples, random_order);
+    run_store_suite<AlignedTracked8,
+                    TaggedPointerRepresentation<AlignedTracked8, 8>>(
+        "aligned8.tagged8", capacity, samples, random_order);
+    run_store_suite_impl<ProductionStableSlotStore<AlignedTracked8>>(
+        "aligned8.production", capacity, samples, random_order);
+
+    run_store_suite<PackedTrivial9,
+                    BitmapPointerRepresentation<PackedTrivial9>>(
+        "packed_trivial9.bitmap", capacity, samples, random_order);
+    run_store_suite<PackedTrivial9,
+                    ParentTrackedTrivialRepresentation<PackedTrivial9>>(
+        "packed_trivial9.parent", capacity, samples, random_order);
+    run_store_suite<PackedTrivial9,
+                    TaggedPointerRepresentation<PackedTrivial9, 8>>(
+        "packed_trivial9.tagged8", capacity, samples, random_order);
+
+    run_store_suite<PackedTracked9,
+                    BitmapPointerRepresentation<PackedTracked9>>(
+        "packed_tracked9.bitmap", capacity, samples, random_order);
+    run_store_suite_impl<ProductionStableSlotStore<PackedTracked9>>(
+        "packed_tracked9.production", capacity, samples, random_order);
+    run_store_suite<PackedTracked9, StateByteRepresentation<PackedTracked9>>(
+        "packed_tracked9.state_byte", capacity, samples, random_order);
+    run_store_suite<PackedTracked9,
+                    TaggedPointerRepresentation<PackedTracked9, 4>>(
+        "packed_tracked9.tagged4", capacity, samples, random_order);
+    run_store_suite<PackedTracked9,
+                    TaggedPointerRepresentation<PackedTracked9, 8>>(
+        "packed_tracked9.tagged8", capacity, samples, random_order);
+  } catch (const std::exception &error) {
+    std::cerr << "stable-slot representation benchmark failed: " << error.what()
+              << '\n';
+    return 1;
+  }
+  return 0;
+}

--- a/tests/cpp/stable_slot_representation_prototype.h
+++ b/tests/cpp/stable_slot_representation_prototype.h
@@ -89,19 +89,22 @@ struct PrototypeMemoryReport {
   std::size_t slot_index_bytes{0};
   std::size_t lifecycle_index_bytes{0};
   std::size_t block_descriptor_bytes{0};
+  std::size_t implementation_bytes{0};
   std::size_t payload_allocations{0};
   std::size_t slot_index_allocations{0};
   std::size_t slot_management_allocations{0};
   std::size_t block_descriptor_allocations{0};
+  std::size_t implementation_allocations{0};
 
   [[nodiscard]] constexpr std::size_t total_bytes() const noexcept {
     return payload_bytes + slot_index_bytes + lifecycle_index_bytes +
-           block_descriptor_bytes;
+           block_descriptor_bytes + implementation_bytes;
   }
 
   [[nodiscard]] constexpr std::size_t total_allocations() const noexcept {
     return payload_allocations + slot_index_allocations +
-           slot_management_allocations + block_descriptor_allocations;
+           slot_management_allocations + block_descriptor_allocations +
+           implementation_allocations;
   }
 };
 

--- a/tests/cpp/stable_slot_representation_prototype.h
+++ b/tests/cpp/stable_slot_representation_prototype.h
@@ -1,0 +1,644 @@
+#ifndef HGRAPH_TESTS_STABLE_SLOT_REPRESENTATION_PROTOTYPE_H
+#define HGRAPH_TESTS_STABLE_SLOT_REPRESENTATION_PROTOTYPE_H
+
+#include <hgraph/types/utils/slot_bitmap.h>
+#include <hgraph/types/utils/stable_slot_storage.h>
+#include <hgraph/util/tagged_ptr.h>
+
+#include <algorithm>
+#include <bit>
+#include <cstddef>
+#include <cstdint>
+#include <iterator>
+#include <memory>
+#include <new>
+#include <stdexcept>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+namespace hgraph::experimental {
+enum class SlotState : std::uintptr_t {
+  Live = 0b00,
+  PendingErase = 0b01,
+  Staged = 0b10,
+  Free = 0b11,
+};
+
+enum class SlotRepresentationKind : std::uint8_t {
+  BitmapPointer,
+  TaggedPointer,
+  ParentTrackedTrivial,
+  ExplicitStateByte,
+};
+
+struct SlotRepresentationChoice {
+  SlotRepresentationKind kind{SlotRepresentationKind::TaggedPointer};
+  std::size_t payload_stride{0};
+  std::size_t lifecycle_bits_per_slot{0};
+};
+
+[[nodiscard]] constexpr std::size_t
+aligned_size(std::size_t size, std::size_t alignment) noexcept {
+  if (alignment <= 1) {
+    return size;
+  }
+  const std::size_t mask = alignment - 1;
+  return (size + mask) & ~mask;
+}
+
+[[nodiscard]] constexpr SlotRepresentationChoice choose_slot_representation(
+    std::size_t payload_size, std::size_t payload_alignment,
+    bool trivially_destructible,
+    std::size_t tag_alignment = alignof(std::uintptr_t)) noexcept {
+  // Pointer-table bytes are common to all four candidates. Compare the
+  // differing payload stride and lifecycle bits using eighths of a byte so
+  // the compact bitmap baseline is not accidentally rounded up to a byte.
+  SlotRepresentationChoice best{
+      SlotRepresentationKind::BitmapPointer,
+      aligned_size(payload_size, payload_alignment),
+      2,
+  };
+  const auto consider = [&best](SlotRepresentationChoice candidate) constexpr {
+    const std::size_t best_bits =
+        best.payload_stride * 8 + best.lifecycle_bits_per_slot;
+    const std::size_t candidate_bits =
+        candidate.payload_stride * 8 + candidate.lifecycle_bits_per_slot;
+    if (candidate_bits < best_bits) {
+      best = candidate;
+    }
+  };
+
+  const std::size_t tagged_alignment =
+      std::max(payload_alignment, tag_alignment);
+  const std::size_t tagged_stride =
+      aligned_size(payload_size, tagged_alignment);
+  consider({SlotRepresentationKind::TaggedPointer, tagged_stride, 0});
+  if (trivially_destructible) {
+    consider({SlotRepresentationKind::ParentTrackedTrivial,
+              aligned_size(payload_size, payload_alignment), 1});
+  } else {
+    consider({SlotRepresentationKind::ExplicitStateByte,
+              aligned_size(payload_size + 1, payload_alignment), 0});
+  }
+  return best;
+}
+
+struct PrototypeMemoryReport {
+  std::size_t payload_bytes{0};
+  std::size_t slot_index_bytes{0};
+  std::size_t lifecycle_index_bytes{0};
+  std::size_t block_descriptor_bytes{0};
+  std::size_t payload_allocations{0};
+  std::size_t slot_index_allocations{0};
+  std::size_t slot_management_allocations{0};
+  std::size_t block_descriptor_allocations{0};
+
+  [[nodiscard]] constexpr std::size_t total_bytes() const noexcept {
+    return payload_bytes + slot_index_bytes + lifecycle_index_bytes +
+           block_descriptor_bytes;
+  }
+
+  [[nodiscard]] constexpr std::size_t total_allocations() const noexcept {
+    return payload_allocations + slot_index_allocations +
+           slot_management_allocations + block_descriptor_allocations;
+  }
+};
+
+class PrototypePayloadBlocks {
+public:
+  PrototypePayloadBlocks(
+      std::size_t slot_size, std::size_t slot_alignment,
+      const MemoryUtils::AllocatorOps &allocator = MemoryUtils::allocator())
+      : slot_size_(slot_size), slot_alignment_(slot_alignment),
+        allocator_(&allocator) {
+    if (slot_size_ == 0) {
+      throw std::logic_error("prototype slot size must be positive");
+    }
+  }
+
+  PrototypePayloadBlocks(const PrototypePayloadBlocks &) = delete;
+  PrototypePayloadBlocks &operator=(const PrototypePayloadBlocks &) = delete;
+  PrototypePayloadBlocks(PrototypePayloadBlocks &&) = delete;
+  PrototypePayloadBlocks &operator=(PrototypePayloadBlocks &&) = delete;
+
+  [[nodiscard]] std::size_t capacity() const noexcept { return capacity_; }
+  [[nodiscard]] std::size_t stride() const noexcept {
+    return StableSlotBlock::stride_for(slot_size_, slot_alignment_);
+  }
+
+  template <typename Initializer>
+  void reserve_to(std::size_t capacity, Initializer &&initializer) {
+    if (capacity <= capacity_) {
+      return;
+    }
+    blocks_.reserve(blocks_.size() + 1);
+    StableSlotBlock block =
+        StableSlotBlock::allocate(capacity_, capacity - capacity_, slot_size_,
+                                  slot_alignment_, *allocator_);
+    std::forward<Initializer>(initializer)(block);
+    blocks_.push_back(std::move(block));
+    capacity_ = capacity;
+  }
+
+  [[nodiscard]] std::byte *raw_slot(std::size_t slot) const {
+    if (slot >= capacity_) {
+      throw std::out_of_range("prototype slot out of range");
+    }
+    const auto it =
+        std::upper_bound(blocks_.begin(), blocks_.end(), slot,
+                         [](std::size_t value, const StableSlotBlock &block) {
+                           return value < block.first_slot;
+                         });
+    if (it == blocks_.begin()) {
+      throw std::logic_error("prototype slot block lookup failed");
+    }
+    return std::prev(it)->slot_data(slot);
+  }
+
+  [[nodiscard]] std::size_t payload_bytes() const noexcept {
+    std::size_t result = 0;
+    for (const auto &block : blocks_) {
+      result += block.slot_count * block.stride;
+    }
+    return result;
+  }
+
+  [[nodiscard]] std::size_t descriptor_bytes() const noexcept {
+    return blocks_.capacity() * sizeof(StableSlotBlock);
+  }
+  [[nodiscard]] std::size_t block_count() const noexcept {
+    return blocks_.size();
+  }
+  [[nodiscard]] std::size_t descriptor_allocations() const noexcept {
+    return blocks_.capacity() == 0 ? 0 : 1;
+  }
+
+private:
+  std::vector<StableSlotBlock> blocks_{};
+  std::size_t capacity_{0};
+  std::size_t slot_size_{0};
+  std::size_t slot_alignment_{0};
+  const MemoryUtils::AllocatorOps *allocator_{nullptr};
+};
+
+template <typename T> class BitmapPointerRepresentation {
+public:
+  [[nodiscard]] static constexpr std::size_t storage_slot_size() noexcept {
+    return sizeof(T);
+  }
+  [[nodiscard]] static constexpr std::size_t storage_alignment() noexcept {
+    return alignof(T);
+  }
+
+  void reserve_entries(std::size_t old_capacity, std::size_t new_capacity,
+                       const StableSlotBlock &block) {
+    pointers_.resize(new_capacity);
+    constructed_.resize(new_capacity);
+    live_.resize(new_capacity);
+    for (std::size_t slot = old_capacity; slot < new_capacity; ++slot) {
+      pointers_[slot] = MemoryUtils::cast<T>(block.slot_data(slot));
+    }
+  }
+
+  [[nodiscard]] T *free_memory(std::size_t slot,
+                               const PrototypePayloadBlocks &) const noexcept {
+    return pointers_[slot];
+  }
+  [[nodiscard]] T *memory(std::size_t slot) const noexcept {
+    return pointers_[slot];
+  }
+  [[nodiscard]] SlotState state(std::size_t slot) const noexcept {
+    if (!constructed_.test(slot)) {
+      return SlotState::Free;
+    }
+    return live_.test(slot) ? SlotState::Live : SlotState::PendingErase;
+  }
+  [[nodiscard]] bool constructed(std::size_t slot) const noexcept {
+    return constructed_.test(slot);
+  }
+  [[nodiscard]] bool live(std::size_t slot) const noexcept {
+    return live_.test(slot);
+  }
+  [[nodiscard]] bool pending(std::size_t slot) const noexcept {
+    return constructed_.test(slot) && !live_.test(slot);
+  }
+
+  void mark_staged(std::size_t slot, T *) noexcept { constructed_.set(slot); }
+  void mark_live(std::size_t slot) noexcept { live_.set(slot); }
+  void mark_pending(std::size_t slot) noexcept { live_.reset(slot); }
+  void mark_free(std::size_t slot) noexcept {
+    live_.reset(slot);
+    constructed_.reset(slot);
+  }
+
+  [[nodiscard]] std::size_t index_bytes() const noexcept {
+    return pointers_.capacity() * sizeof(T *) +
+           constructed_.word_capacity * sizeof(std::uint64_t) +
+           live_.word_capacity * sizeof(std::uint64_t);
+  }
+  [[nodiscard]] std::size_t index_allocations() const noexcept {
+    return (pointers_.capacity() == 0 ? 0 : 1) +
+           (constructed_.word_capacity == 0 ? 0 : 1) +
+           (live_.word_capacity == 0 ? 0 : 1);
+  }
+
+private:
+  std::vector<T *> pointers_{};
+  SlotBitmap constructed_{};
+  SlotBitmap live_{};
+};
+
+template <typename T, std::size_t TagAlignment = alignof(std::uintptr_t)>
+class TaggedPointerRepresentation {
+public:
+  static_assert(TagAlignment >= 4 && std::has_single_bit(TagAlignment));
+  using SlotPointer = erased_tagged_ptr<TagAlignment, 2, SlotState>;
+
+  [[nodiscard]] static constexpr std::size_t storage_slot_size() noexcept {
+    return sizeof(T);
+  }
+  [[nodiscard]] static constexpr std::size_t storage_alignment() noexcept {
+    return std::max(alignof(T), TagAlignment);
+  }
+
+  void reserve_entries(std::size_t old_capacity, std::size_t new_capacity,
+                       const StableSlotBlock &block) {
+    pointers_.resize(new_capacity);
+    for (std::size_t slot = old_capacity; slot < new_capacity; ++slot) {
+      pointers_[slot].set(MemoryUtils::cast<T>(block.slot_data(slot)),
+                          SlotState::Free);
+    }
+  }
+
+  [[nodiscard]] T *free_memory(std::size_t slot,
+                               const PrototypePayloadBlocks &) const noexcept {
+    return pointers_[slot].template as<T>();
+  }
+  [[nodiscard]] T *memory(std::size_t slot) const noexcept {
+    const auto &pointer = pointers_[slot];
+    if (pointer.has_enum(SlotState::Live)) {
+      return reinterpret_cast<T *>(pointer.raw_bits());
+    }
+    return pointer.template as<T>();
+  }
+  [[nodiscard]] SlotState state(std::size_t slot) const noexcept {
+    return pointers_[slot].enum_value();
+  }
+  [[nodiscard]] bool constructed(std::size_t slot) const noexcept {
+    const auto value = state(slot);
+    return value != SlotState::Free;
+  }
+  [[nodiscard]] bool live(std::size_t slot) const noexcept {
+    return state(slot) == SlotState::Live;
+  }
+  [[nodiscard]] bool pending(std::size_t slot) const noexcept {
+    return state(slot) == SlotState::PendingErase;
+  }
+
+  void mark_staged(std::size_t slot, T *) noexcept {
+    pointers_[slot].set_tag(SlotState::Staged);
+  }
+  void mark_live(std::size_t slot) noexcept {
+    pointers_[slot].set_tag(SlotState::Live);
+  }
+  void mark_pending(std::size_t slot) noexcept {
+    pointers_[slot].set_tag(SlotState::PendingErase);
+  }
+  void mark_free(std::size_t slot) noexcept {
+    pointers_[slot].set_tag(SlotState::Free);
+  }
+
+  [[nodiscard]] std::size_t index_bytes() const noexcept {
+    return pointers_.capacity() * sizeof(SlotPointer);
+  }
+  [[nodiscard]] std::size_t index_allocations() const noexcept {
+    return pointers_.capacity() == 0 ? 0 : 1;
+  }
+
+private:
+  std::vector<SlotPointer> pointers_{};
+};
+
+template <typename T> class ParentTrackedTrivialRepresentation {
+public:
+  static_assert(std::is_trivially_destructible_v<T>);
+
+  [[nodiscard]] static constexpr std::size_t storage_slot_size() noexcept {
+    return sizeof(T);
+  }
+  [[nodiscard]] static constexpr std::size_t storage_alignment() noexcept {
+    return alignof(T);
+  }
+
+  void reserve_entries(std::size_t, std::size_t new_capacity,
+                       const StableSlotBlock &) {
+    pointers_.resize(new_capacity, nullptr);
+    live_.resize(new_capacity);
+  }
+
+  [[nodiscard]] T *free_memory(std::size_t slot,
+                               const PrototypePayloadBlocks &blocks) const {
+    return MemoryUtils::cast<T>(blocks.raw_slot(slot));
+  }
+  [[nodiscard]] T *memory(std::size_t slot) const noexcept {
+    return pointers_[slot];
+  }
+  [[nodiscard]] SlotState state(std::size_t slot) const noexcept {
+    if (pointers_[slot] == nullptr) {
+      return SlotState::Free;
+    }
+    return live_.test(slot) ? SlotState::Live : SlotState::PendingErase;
+  }
+  [[nodiscard]] bool constructed(std::size_t slot) const noexcept {
+    return pointers_[slot] != nullptr;
+  }
+  [[nodiscard]] bool live(std::size_t slot) const noexcept {
+    return live_.test(slot);
+  }
+  [[nodiscard]] bool pending(std::size_t slot) const noexcept {
+    return pointers_[slot] != nullptr && !live_.test(slot);
+  }
+
+  void mark_staged(std::size_t slot, T *memory) noexcept {
+    pointers_[slot] = memory;
+  }
+  void mark_live(std::size_t slot) noexcept { live_.set(slot); }
+  void mark_pending(std::size_t slot) noexcept { live_.reset(slot); }
+  void mark_free(std::size_t slot) noexcept {
+    live_.reset(slot);
+    pointers_[slot] = nullptr;
+  }
+
+  [[nodiscard]] std::size_t index_bytes() const noexcept {
+    return pointers_.capacity() * sizeof(T *) +
+           live_.word_capacity * sizeof(std::uint64_t);
+  }
+  [[nodiscard]] std::size_t index_allocations() const noexcept {
+    return (pointers_.capacity() == 0 ? 0 : 1) +
+           (live_.word_capacity == 0 ? 0 : 1);
+  }
+
+private:
+  std::vector<T *> pointers_{};
+  SlotBitmap live_{};
+};
+
+template <typename T> class StateByteRepresentation {
+public:
+  [[nodiscard]] static constexpr std::size_t storage_slot_size() noexcept {
+    return sizeof(T) + 1;
+  }
+  [[nodiscard]] static constexpr std::size_t storage_alignment() noexcept {
+    return alignof(T);
+  }
+
+  void reserve_entries(std::size_t old_capacity, std::size_t new_capacity,
+                       const StableSlotBlock &block) {
+    pointers_.resize(new_capacity);
+    for (std::size_t slot = old_capacity; slot < new_capacity; ++slot) {
+      pointers_[slot] = MemoryUtils::cast<T>(block.slot_data(slot));
+      write_state(slot, SlotState::Free);
+    }
+  }
+
+  [[nodiscard]] T *free_memory(std::size_t slot,
+                               const PrototypePayloadBlocks &) const noexcept {
+    return pointers_[slot];
+  }
+  [[nodiscard]] T *memory(std::size_t slot) const noexcept {
+    return pointers_[slot];
+  }
+  [[nodiscard]] SlotState state(std::size_t slot) const noexcept {
+    return static_cast<SlotState>(
+        std::to_integer<std::uint8_t>(*state_memory(slot)));
+  }
+  [[nodiscard]] bool constructed(std::size_t slot) const noexcept {
+    return state(slot) != SlotState::Free;
+  }
+  [[nodiscard]] bool live(std::size_t slot) const noexcept {
+    return state(slot) == SlotState::Live;
+  }
+  [[nodiscard]] bool pending(std::size_t slot) const noexcept {
+    return state(slot) == SlotState::PendingErase;
+  }
+
+  void mark_staged(std::size_t slot, T *) noexcept {
+    write_state(slot, SlotState::Staged);
+  }
+  void mark_live(std::size_t slot) noexcept {
+    write_state(slot, SlotState::Live);
+  }
+  void mark_pending(std::size_t slot) noexcept {
+    write_state(slot, SlotState::PendingErase);
+  }
+  void mark_free(std::size_t slot) noexcept {
+    write_state(slot, SlotState::Free);
+  }
+
+  [[nodiscard]] std::size_t index_bytes() const noexcept {
+    return pointers_.capacity() * sizeof(T *);
+  }
+  [[nodiscard]] std::size_t index_allocations() const noexcept {
+    return pointers_.capacity() == 0 ? 0 : 1;
+  }
+
+private:
+  [[nodiscard]] std::byte *state_memory(std::size_t slot) const noexcept {
+    return reinterpret_cast<std::byte *>(pointers_[slot]) + sizeof(T);
+  }
+
+  void write_state(std::size_t slot, SlotState state) noexcept {
+    *state_memory(slot) =
+        static_cast<std::byte>(static_cast<std::uint8_t>(state));
+  }
+
+  std::vector<T *> pointers_{};
+};
+
+template <typename T, typename Representation> class PrototypeStableSlotStore {
+public:
+  using value_type = T;
+
+  explicit PrototypeStableSlotStore(std::size_t initial_capacity = 0)
+      : blocks_(Representation::storage_slot_size(),
+                Representation::storage_alignment()) {
+    if (initial_capacity != 0) {
+      reserve_to(initial_capacity);
+    }
+  }
+
+  PrototypeStableSlotStore(const PrototypeStableSlotStore &) = delete;
+  PrototypeStableSlotStore &
+  operator=(const PrototypeStableSlotStore &) = delete;
+  PrototypeStableSlotStore(PrototypeStableSlotStore &&) = delete;
+  PrototypeStableSlotStore &operator=(PrototypeStableSlotStore &&) = delete;
+
+  ~PrototypeStableSlotStore() { destroy_all(); }
+
+  [[nodiscard]] std::size_t capacity() const noexcept {
+    return blocks_.capacity();
+  }
+  [[nodiscard]] std::size_t size() const noexcept { return live_count_; }
+  [[nodiscard]] std::size_t pending_erase_count() const noexcept {
+    return pending_count_;
+  }
+  [[nodiscard]] std::size_t payload_stride() const noexcept {
+    return blocks_.stride();
+  }
+
+  void reserve_to(std::size_t capacity) {
+    if (capacity <= blocks_.capacity()) {
+      return;
+    }
+    const std::size_t old_capacity = blocks_.capacity();
+    free_slots_.reserve(capacity);
+    pending_slots_.reserve(capacity);
+    blocks_.reserve_to(capacity, [&](const StableSlotBlock &block) {
+      representation_.reserve_entries(old_capacity, capacity, block);
+    });
+    for (std::size_t slot = capacity; slot > old_capacity; --slot) {
+      free_slots_.push_back(slot - 1);
+    }
+  }
+
+  template <typename Publish, typename... Args>
+  std::size_t emplace_with_publish(Publish &&publish, Args &&...args) {
+    if (free_slots_.empty()) {
+      reserve_to(
+          std::max<std::size_t>(live_count_ + pending_count_ + 1,
+                                std::max<std::size_t>(8, capacity() * 2)));
+    }
+    const std::size_t slot = free_slots_.back();
+    free_slots_.pop_back();
+    T *memory = representation_.free_memory(slot, blocks_);
+    try {
+      std::construct_at(memory, std::forward<Args>(args)...);
+    } catch (...) {
+      free_slots_.push_back(slot);
+      throw;
+    }
+    representation_.mark_staged(slot, memory);
+    try {
+      std::forward<Publish>(publish)(slot, memory);
+    } catch (...) {
+      std::destroy_at(memory);
+      representation_.mark_free(slot);
+      free_slots_.push_back(slot);
+      throw;
+    }
+    representation_.mark_live(slot);
+    ++live_count_;
+    return slot;
+  }
+
+  template <typename... Args> std::size_t emplace(Args &&...args) {
+    return emplace_with_publish([](std::size_t, T *) {},
+                                std::forward<Args>(args)...);
+  }
+
+  bool remove(std::size_t slot) {
+    if (slot >= capacity() || !representation_.live(slot)) {
+      return false;
+    }
+    pending_slots_.push_back(slot);
+    representation_.mark_pending(slot);
+    --live_count_;
+    ++pending_count_;
+    return true;
+  }
+
+  bool resurrect(std::size_t slot) {
+    if (slot >= capacity() || !representation_.pending(slot)) {
+      return false;
+    }
+    representation_.mark_live(slot);
+    ++live_count_;
+    --pending_count_;
+    if (pending_count_ == 0) {
+      pending_slots_.clear();
+    }
+    return true;
+  }
+
+  void erase_pending() noexcept {
+    for (const std::size_t slot : pending_slots_) {
+      if (!representation_.pending(slot)) {
+        continue;
+      }
+      std::destroy_at(representation_.memory(slot));
+      representation_.mark_free(slot);
+      free_slots_.push_back(slot);
+    }
+    pending_slots_.clear();
+    pending_count_ = 0;
+  }
+
+  [[nodiscard]] SlotState state(std::size_t slot) const {
+    require_slot(slot);
+    return representation_.state(slot);
+  }
+  [[nodiscard]] bool live(std::size_t slot) const noexcept {
+    return slot < capacity() && representation_.live(slot);
+  }
+  [[nodiscard]] bool constructed(std::size_t slot) const noexcept {
+    return slot < capacity() && representation_.constructed(slot);
+  }
+  [[nodiscard]] T *memory(std::size_t slot) noexcept {
+    return constructed(slot) ? representation_.memory(slot) : nullptr;
+  }
+  [[nodiscard]] const T *memory(std::size_t slot) const noexcept {
+    return constructed(slot) ? representation_.memory(slot) : nullptr;
+  }
+  [[nodiscard]] T *memory_unchecked(std::size_t slot) noexcept {
+    return representation_.memory(slot);
+  }
+  [[nodiscard]] const T *memory_unchecked(std::size_t slot) const noexcept {
+    return representation_.memory(slot);
+  }
+
+  [[nodiscard]] PrototypeMemoryReport memory_report() const noexcept {
+    return PrototypeMemoryReport{
+        .payload_bytes = blocks_.payload_bytes(),
+        .slot_index_bytes = representation_.index_bytes(),
+        .lifecycle_index_bytes =
+            free_slots_.capacity() * sizeof(std::size_t) +
+            pending_slots_.capacity() * sizeof(std::size_t),
+        .block_descriptor_bytes = blocks_.descriptor_bytes(),
+        .payload_allocations = blocks_.block_count(),
+        .slot_index_allocations = representation_.index_allocations(),
+        .slot_management_allocations =
+            (free_slots_.capacity() == 0 ? std::size_t{0} : std::size_t{1}) +
+            (pending_slots_.capacity() == 0 ? std::size_t{0} : std::size_t{1}),
+        .block_descriptor_allocations = blocks_.descriptor_allocations(),
+    };
+  }
+
+private:
+  Representation representation_{};
+  PrototypePayloadBlocks blocks_;
+  std::vector<std::size_t> free_slots_{};
+  std::vector<std::size_t> pending_slots_{};
+  std::size_t live_count_{0};
+  std::size_t pending_count_{0};
+
+  void require_slot(std::size_t slot) const {
+    if (slot >= capacity()) {
+      throw std::out_of_range("prototype slot out of range");
+    }
+  }
+
+  void destroy_all() noexcept {
+    for (std::size_t slot = 0; slot < capacity(); ++slot) {
+      if (representation_.constructed(slot)) {
+        std::destroy_at(representation_.memory(slot));
+        representation_.mark_free(slot);
+      }
+    }
+    live_count_ = 0;
+    pending_count_ = 0;
+  }
+};
+} // namespace hgraph::experimental
+
+#endif // HGRAPH_TESTS_STABLE_SLOT_REPRESENTATION_PROTOTYPE_H

--- a/tests/cpp/test_slot_utils.cpp
+++ b/tests/cpp/test_slot_utils.cpp
@@ -200,8 +200,8 @@ namespace
     };
 }  // namespace
 
-static_assert(sizeof(StableSlotStore<StableSlotStateModel::ConstructedOnly>) <= 4 * sizeof(void *));
-static_assert(sizeof(StableSlotStore<StableSlotStateModel::ConstructedAndLive>) <= 4 * sizeof(void *));
+static_assert(sizeof(StableSlotStore<StableSlotStateModel::ConstructedOnly>) == sizeof(void *));
+static_assert(sizeof(StableSlotStore<StableSlotStateModel::ConstructedAndLive>) == sizeof(void *));
 static_assert(std::is_nothrow_move_constructible_v<
               StableSlotStore<StableSlotStateModel::ConstructedAndLive>>);
 static_assert(std::is_nothrow_move_assignable_v<
@@ -239,6 +239,9 @@ TEST_CASE("stable slot store selects tagged pointers for pointer-aligned layouts
     CHECK(debug.pointers_tagged);
     CHECK(debug.state_tagged);
     CHECK(debug.pointer_table_offset == debug.state_offset);
+    CHECK((*static_cast<const std::uintptr_t *>(debug.implementation_pointer) &
+           detail::STABLE_SLOT_STORE_IMPLEMENTATION_TAG_MASK) ==
+          static_cast<std::uintptr_t>(detail::StableSlotStoreImplementationTag::TaggedPointer));
 
     storage.mark_free(0);
     CHECK_FALSE(storage.constructed(0));
@@ -301,6 +304,9 @@ TEST_CASE("stable slot store preserves bitmap fallback for weak alignment", "[v2
     CHECK_FALSE(debug.pointers_tagged);
     CHECK_FALSE(debug.state_tagged);
     CHECK(debug.pointer_table_offset != debug.state_offset);
+    CHECK((*static_cast<const std::uintptr_t *>(debug.implementation_pointer) &
+           detail::STABLE_SLOT_STORE_IMPLEMENTATION_TAG_MASK) ==
+          static_cast<std::uintptr_t>(detail::StableSlotStoreImplementationTag::Bitmap));
 }
 
 TEST_CASE("constructed-only stable slot stores use one lifecycle plane", "[v2 slot utils][stable-slot-store]")

--- a/tests/cpp/test_slot_utils.cpp
+++ b/tests/cpp/test_slot_utils.cpp
@@ -3,12 +3,14 @@
 #include <hgraph/runtime/nested_graph_storage.h>
 #include <hgraph/types/utils/key_slot_store.h>
 #include <hgraph/types/utils/slot_bitmap.h>
+#include <hgraph/types/utils/stable_slot_storage.h>
 #include <hgraph/types/utils/value_slot_store.h>
 
 #include <array>
 #include <cstdint>
 #include <stdexcept>
 #include <string>
+#include <type_traits>
 #include <utility>
 #include <vector>
 
@@ -198,10 +200,12 @@ namespace
     };
 }  // namespace
 
-static_assert(sizeof(StableSlotStore<StableSlotStateModel::ConstructedOnly>) <=
-              sizeof(StableSlotStorage) + sizeof(SlotBitmap));
-static_assert(sizeof(StableSlotStore<StableSlotStateModel::ConstructedAndLive>) <=
-              sizeof(StableSlotStorage) + 2 * sizeof(SlotBitmap));
+static_assert(sizeof(StableSlotStore<StableSlotStateModel::ConstructedOnly>) <= 4 * sizeof(void *));
+static_assert(sizeof(StableSlotStore<StableSlotStateModel::ConstructedAndLive>) <= 4 * sizeof(void *));
+static_assert(std::is_nothrow_move_constructible_v<
+              StableSlotStore<StableSlotStateModel::ConstructedAndLive>>);
+static_assert(std::is_nothrow_move_assignable_v<
+              StableSlotStore<StableSlotStateModel::ConstructedAndLive>>);
 
 TEST_CASE("stable slot store selects tagged pointers for pointer-aligned layouts", "[v2 slot utils][stable-slot-store]")
 {
@@ -231,9 +235,10 @@ TEST_CASE("stable slot store selects tagged pointers for pointer-aligned layouts
     storage.reserve_to(8);
     CHECK(storage.slot_memory(0) == first);
     const auto debug = storage.debug_view();
+    CHECK(debug.implementation_pointer != nullptr);
     CHECK(debug.pointers_tagged);
     CHECK(debug.state_tagged);
-    CHECK(debug.pointer_table == debug.state);
+    CHECK(debug.pointer_table_offset == debug.state_offset);
 
     storage.mark_free(0);
     CHECK_FALSE(storage.constructed(0));
@@ -264,9 +269,10 @@ TEST_CASE("stable slot store preserves bitmap fallback for weak alignment", "[v2
     CHECK(storage.constructed(0));
     CHECK(storage.constructed(65));
     const auto debug = storage.debug_view();
+    CHECK(debug.implementation_pointer != nullptr);
     CHECK_FALSE(debug.pointers_tagged);
     CHECK_FALSE(debug.state_tagged);
-    CHECK(debug.pointer_table != debug.state);
+    CHECK(debug.pointer_table_offset != debug.state_offset);
 }
 
 TEST_CASE("constructed-only stable slot stores use one lifecycle plane", "[v2 slot utils][stable-slot-store]")
@@ -293,6 +299,35 @@ TEST_CASE("constructed-only stable slot stores use one lifecycle plane", "[v2 sl
     bitmap.mark_free(3);
     CHECK_FALSE(tagged.constructed(3));
     CHECK_FALSE(bitmap.constructed(3));
+}
+
+TEST_CASE("stable slot store moves erased strategies without moving payloads", "[v2 slot utils][stable-slot-store]")
+{
+    using Store = StableSlotStore<StableSlotStateModel::ConstructedAndLive>;
+
+    Store source(MemoryUtils::layout_for<PointerAlignedSlot>());
+    source.reserve_to(4);
+    void *first = source.slot_memory(0);
+    source.mark_staged(0);
+    REQUIRE(source.mark_live(0));
+
+    Store moved(std::move(source));
+    CHECK_FALSE(source.bound());
+    CHECK(source.representation() == StableSlotRepresentation::Unbound);
+    CHECK(source.slot_capacity() == 0);
+    CHECK(moved.representation() == StableSlotRepresentation::TaggedPointer);
+    CHECK(moved.slot_memory(0) == first);
+    CHECK(moved.live(0));
+
+    Store destination(MemoryUtils::layout_for<WeaklyAlignedSlot>());
+    destination.reserve_to(2);
+    REQUIRE(destination.representation() == StableSlotRepresentation::Bitmap);
+    destination = std::move(moved);
+
+    CHECK_FALSE(moved.bound());
+    CHECK(destination.representation() == StableSlotRepresentation::TaggedPointer);
+    CHECK(destination.slot_memory(0) == first);
+    CHECK(destination.live(0));
 }
 
 TEST_CASE("stable slot storage preserves existing slot addresses across chained growth", "[v2 slot utils]") {
@@ -389,7 +424,7 @@ TEST_CASE("in-place graph slots co-locate stable entries and aligned graph paylo
         auto &second = store.construct_at(1, 22);
 
         REQUIRE(store.block_count() == 1);
-        REQUIRE(AllocationProbe::allocations == 1);
+        REQUIRE(AllocationProbe::allocations == 2);  // erased strategy object + payload block
         CHECK(store.entry_at(0) == &first);
         CHECK(store.entry_at(1) == &second);
         CHECK(first.value == 11);
@@ -403,7 +438,7 @@ TEST_CASE("in-place graph slots co-locate stable entries and aligned graph paylo
         store.reserve_to(5);
 
         CHECK(store.block_count() == 2);
-        CHECK(AllocationProbe::allocations == 2);
+        CHECK(AllocationProbe::allocations == 3);
         CHECK(store.entry_at(0) == first_address);
         CHECK(store.graph_memory(0) == first_graph_address);
         CHECK(store.slot_capacity() == 5);
@@ -420,7 +455,7 @@ TEST_CASE("in-place graph slots co-locate stable entries and aligned graph paylo
     }
 
     CHECK(InPlaceEntry::destroyed == 2);
-    CHECK(AllocationProbe::deallocations == 2);
+    CHECK(AllocationProbe::deallocations == 3);
 }
 
 TEST_CASE("in-place graph slots reject layout changes and occupied construction", "[v2 slot utils]") {
@@ -446,11 +481,11 @@ TEST_CASE("in-place graph slots leave a throwing construction reusable", "[v2 sl
 
     REQUIRE_THROWS_AS(store.construct_at(0, true), std::runtime_error);
     CHECK_FALSE(store.has_entry(0));
-    CHECK(AllocationProbe::allocations == 1);
+    CHECK(AllocationProbe::allocations == 2);  // erased strategy object + payload block
 
     store.construct_at(0, false);
     REQUIRE(store.has_entry(0));
-    CHECK(AllocationProbe::allocations == 1);
+    CHECK(AllocationProbe::allocations == 2);
 
     store.destroy_at(0);
     CHECK_FALSE(store.has_entry(0));
@@ -633,10 +668,10 @@ TEST_CASE("value slot stores can share a custom allocator", "[v2 slot utils]") {
         store.reserve_to(3);
         store.construct_at<TrackedPayload>(1, 17);
         REQUIRE(&store.allocator() == &allocator);
-        REQUIRE(AllocationProbe::allocations == 1);
+        REQUIRE(AllocationProbe::allocations == 2);  // erased strategy object + payload block
     }
 
-    REQUIRE(AllocationProbe::deallocations == 1);
+    REQUIRE(AllocationProbe::deallocations == 2);
 }
 
 TEST_CASE("key mirrored value slot store derives lifetime from key construction", "[v2 slot utils]") {
@@ -908,7 +943,7 @@ TEST_CASE("key slot store supports custom allocators with explicit pending erase
         REQUIRE(reused.slot == inserted.slot);
         REQUIRE(TrackedKey::copied == 2);
         REQUIRE(&store.allocator() == &allocator);
-        REQUIRE(AllocationProbe::allocations == 1);
+        REQUIRE(AllocationProbe::allocations == 2);  // erased strategy object + payload block
 
         store.clear();
         REQUIRE(TrackedKey::live_instances == 2);
@@ -917,7 +952,7 @@ TEST_CASE("key slot store supports custom allocators with explicit pending erase
     }
 
     REQUIRE(TrackedKey::live_instances == 0);
-    REQUIRE(AllocationProbe::deallocations == 1);
+    REQUIRE(AllocationProbe::deallocations == 2);
 }
 
 TEST_CASE("key slot store survives deterministic adversarial lifecycle transitions", "[v2 slot utils][lifetime]")

--- a/tests/cpp/test_slot_utils.cpp
+++ b/tests/cpp/test_slot_utils.cpp
@@ -186,7 +186,114 @@ namespace
 
         ~ThrowingInPlaceEntry() { ++destroyed; }
     };
+
+    struct alignas(std::uintptr_t) PointerAlignedSlot
+    {
+        std::array<std::byte, sizeof(std::uintptr_t)> bytes{};
+    };
+
+    struct WeaklyAlignedSlot
+    {
+        std::array<std::byte, 3> bytes{};
+    };
 }  // namespace
+
+static_assert(sizeof(StableSlotStore<StableSlotStateModel::ConstructedOnly>) <=
+              sizeof(StableSlotStorage) + sizeof(SlotBitmap));
+static_assert(sizeof(StableSlotStore<StableSlotStateModel::ConstructedAndLive>) <=
+              sizeof(StableSlotStorage) + 2 * sizeof(SlotBitmap));
+
+TEST_CASE("stable slot store selects tagged pointers for pointer-aligned layouts", "[v2 slot utils][stable-slot-store]")
+{
+    StableSlotStore<StableSlotStateModel::ConstructedAndLive> storage(
+        MemoryUtils::layout_for<PointerAlignedSlot>());
+    REQUIRE(storage.representation() == StableSlotRepresentation::TaggedPointer);
+
+    storage.reserve_to(2);
+    void *first = storage.slot_memory(0);
+    REQUIRE(first != nullptr);
+    CHECK_FALSE(storage.constructed(0));
+    CHECK_FALSE(storage.live(0));
+
+    storage.mark_staged(0);
+    CHECK(storage.constructed(0));
+    CHECK_FALSE(storage.live(0));
+    REQUIRE(storage.mark_live(0));
+    CHECK(storage.live(0));
+    CHECK(storage.live_slot_memory(0) == first);
+    REQUIRE(storage.mark_pending_erase(0));
+    CHECK(storage.constructed(0));
+    CHECK_FALSE(storage.live(0));
+    CHECK(storage.slot_memory(0) == first);
+    CHECK(storage.non_live_slot_memory(0) == first);
+    CHECK_FALSE(storage.mark_pending_erase(0));
+
+    storage.reserve_to(8);
+    CHECK(storage.slot_memory(0) == first);
+    const auto debug = storage.debug_view();
+    CHECK(debug.pointers_tagged);
+    CHECK(debug.state_tagged);
+    CHECK(debug.pointer_table == debug.state);
+
+    storage.mark_free(0);
+    CHECK_FALSE(storage.constructed(0));
+}
+
+TEST_CASE("stable slot store preserves bitmap fallback for weak alignment", "[v2 slot utils][stable-slot-store]")
+{
+    StableSlotStore<StableSlotStateModel::ConstructedAndLive> storage(
+        MemoryUtils::layout_for<WeaklyAlignedSlot>());
+    REQUIRE(storage.representation() == StableSlotRepresentation::Bitmap);
+
+    storage.reserve_to(130);
+    void *first = storage.slot_memory(0);
+    storage.mark_staged(0);
+    REQUIRE(storage.mark_live(0));
+    storage.mark_staged(65);
+    REQUIRE(storage.mark_pending_erase(0));
+    CHECK(storage.constructed(0));
+    CHECK(storage.constructed(65));
+    CHECK_FALSE(storage.live(0));
+    CHECK_FALSE(storage.live(65));
+    CHECK(storage.non_live_slot_memory(0) == first);
+    CHECK(storage.non_live_slot_memory(65) == storage.slot_memory(65));
+    CHECK(storage.constructed_count() == 2);
+
+    storage.reserve_to(260);
+    CHECK(storage.slot_memory(0) == first);
+    CHECK(storage.constructed(0));
+    CHECK(storage.constructed(65));
+    const auto debug = storage.debug_view();
+    CHECK_FALSE(debug.pointers_tagged);
+    CHECK_FALSE(debug.state_tagged);
+    CHECK(debug.pointer_table != debug.state);
+}
+
+TEST_CASE("constructed-only stable slot stores use one lifecycle plane", "[v2 slot utils][stable-slot-store]")
+{
+    StableSlotStore<StableSlotStateModel::ConstructedOnly> tagged(
+        MemoryUtils::layout_for<PointerAlignedSlot>());
+    StableSlotStore<StableSlotStateModel::ConstructedOnly> bitmap(
+        MemoryUtils::layout_for<WeaklyAlignedSlot>());
+    tagged.reserve_to(8);
+    bitmap.reserve_to(8);
+
+    tagged.mark_constructed(3);
+    bitmap.mark_constructed(3);
+    CHECK(tagged.constructed(3));
+    CHECK(bitmap.constructed(3));
+    CHECK(tagged.live(3));
+    CHECK(bitmap.live(3));
+    CHECK(tagged.dynamic_storage_metrics().reserved_bytes >=
+          tagged.dynamic_storage_metrics().live_bytes);
+    CHECK(bitmap.dynamic_storage_metrics().reserved_bytes >=
+          bitmap.dynamic_storage_metrics().live_bytes);
+
+    tagged.mark_free(3);
+    bitmap.mark_free(3);
+    CHECK_FALSE(tagged.constructed(3));
+    CHECK_FALSE(bitmap.constructed(3));
+}
 
 TEST_CASE("stable slot storage preserves existing slot addresses across chained growth", "[v2 slot utils]") {
     StableSlotStorage storage;
@@ -276,6 +383,7 @@ TEST_CASE("in-place graph slots co-locate stable entries and aligned graph paylo
 
     {
         InPlaceGraphSlotStore<InPlaceEntry> store(graph_layout, allocator);
+        store.bind_graph_layout(graph_layout);
         store.reserve_to(2);
         auto &first  = store.construct_at(0, 11);
         auto &second = store.construct_at(1, 22);
@@ -524,7 +632,7 @@ TEST_CASE("value slot stores can share a custom allocator", "[v2 slot utils]") {
         ValueSlotStore store(MemoryUtils::plan_for<TrackedPayload>(), allocator);
         store.reserve_to(3);
         store.construct_at<TrackedPayload>(1, 17);
-        REQUIRE(&store.value_storage.allocator() == &allocator);
+        REQUIRE(&store.allocator() == &allocator);
         REQUIRE(AllocationProbe::allocations == 1);
     }
 

--- a/tests/cpp/test_slot_utils.cpp
+++ b/tests/cpp/test_slot_utils.cpp
@@ -244,6 +244,34 @@ TEST_CASE("stable slot store selects tagged pointers for pointer-aligned layouts
     CHECK_FALSE(storage.constructed(0));
 }
 
+TEST_CASE("stable slot store defaults to canonical no-op operations", "[v2 slot utils][stable-slot-store]")
+{
+    StableSlotStore<StableSlotStateModel::ConstructedAndLive> storage;
+
+    CHECK_FALSE(storage.bound());
+    CHECK(storage.representation() == StableSlotRepresentation::Unbound);
+    CHECK(storage.slot_capacity() == 0);
+    CHECK(storage.stride() == 0);
+    CHECK(storage.block_count() == 0);
+    CHECK(&storage.allocator() == &MemoryUtils::allocator());
+    CHECK(storage.slot_memory(3) == nullptr);
+    CHECK(storage.live_slot_memory(3) == nullptr);
+    CHECK(storage.non_live_slot_memory(3) == nullptr);
+    CHECK_FALSE(storage.constructed(3));
+    CHECK_FALSE(storage.live(3));
+    CHECK(storage.constructed_count() == 0);
+    CHECK(storage.dynamic_storage_metrics().live_bytes == 0);
+    CHECK(storage.dynamic_storage_metrics().reserved_bytes == 0);
+    CHECK(storage.debug_view().implementation_pointer == nullptr);
+
+    storage.mark_staged(3);
+    CHECK_FALSE(storage.mark_live(3));
+    CHECK_FALSE(storage.mark_pending_erase(3));
+    storage.mark_free(3);
+    storage.reset_states();
+    CHECK_THROWS_AS(storage.reserve_to(4), std::logic_error);
+}
+
 TEST_CASE("stable slot store preserves bitmap fallback for weak alignment", "[v2 slot utils][stable-slot-store]")
 {
     StableSlotStore<StableSlotStateModel::ConstructedAndLive> storage(
@@ -315,6 +343,9 @@ TEST_CASE("stable slot store moves erased strategies without moving payloads", "
     CHECK_FALSE(source.bound());
     CHECK(source.representation() == StableSlotRepresentation::Unbound);
     CHECK(source.slot_capacity() == 0);
+    CHECK(&source.allocator() == &MemoryUtils::allocator());
+    source.reset_states();
+    CHECK_FALSE(source.mark_live(0));
     CHECK(moved.representation() == StableSlotRepresentation::TaggedPointer);
     CHECK(moved.slot_memory(0) == first);
     CHECK(moved.live(0));

--- a/tests/cpp/test_stable_slot_representation_prototype.cpp
+++ b/tests/cpp/test_stable_slot_representation_prototype.cpp
@@ -1,0 +1,243 @@
+#include <catch2/catch_test_macros.hpp>
+
+#include "stable_slot_representation_prototype.h"
+
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <stdexcept>
+#include <type_traits>
+
+namespace {
+using namespace hgraph::experimental;
+
+struct alignas(8) TrackedValue {
+  static inline int constructed_count{0};
+  static inline int destroyed_count{0};
+
+  std::uint64_t value{0};
+
+  explicit TrackedValue(std::uint64_t value_) : value(value_) {
+    ++constructed_count;
+  }
+  ~TrackedValue() { ++destroyed_count; }
+
+  static void reset() noexcept {
+    constructed_count = 0;
+    destroyed_count = 0;
+  }
+};
+
+struct PackedTrivial9 {
+  std::array<std::byte, 9> bytes{};
+};
+
+struct PackedTracked9 {
+  std::array<std::byte, 9> bytes{};
+
+  ~PackedTracked9() {}
+};
+
+struct alignas(4) WeaklyAlignedTracked12 {
+  std::array<std::byte, 12> bytes{};
+
+  ~WeaklyAlignedTracked12() {}
+};
+
+static_assert(sizeof(PackedTrivial9) == 9);
+static_assert(alignof(PackedTrivial9) == 1);
+static_assert(std::is_trivially_destructible_v<PackedTrivial9>);
+static_assert(sizeof(PackedTracked9) == 9);
+static_assert(alignof(PackedTracked9) == 1);
+static_assert(!std::is_trivially_destructible_v<PackedTracked9>);
+static_assert(sizeof(WeaklyAlignedTracked12) == 12);
+static_assert(alignof(WeaklyAlignedTracked12) == 4);
+
+template <typename Representation> void check_non_trivial_lifecycle() {
+  TrackedValue::reset();
+  {
+    PrototypeStableSlotStore<TrackedValue, Representation> store(2);
+    const std::size_t slot0 = store.emplace(41);
+    const std::size_t slot1 = store.emplace(42);
+    REQUIRE(slot0 == 0);
+    REQUIRE(slot1 == 1);
+    REQUIRE(store.size() == 2);
+    REQUIRE(store.state(slot0) == SlotState::Live);
+
+    TrackedValue *const stable_address = store.memory(slot0);
+    REQUIRE(stable_address != nullptr);
+    CHECK(stable_address->value == 41);
+
+    store.reserve_to(16);
+    CHECK(store.memory(slot0) == stable_address);
+    CHECK(store.memory(slot1)->value == 42);
+
+    REQUIRE(store.remove(slot0));
+    CHECK(store.state(slot0) == SlotState::PendingErase);
+    CHECK(store.constructed(slot0));
+    CHECK(store.memory(slot0) == stable_address);
+    CHECK(store.pending_erase_count() == 1);
+
+    REQUIRE(store.resurrect(slot0));
+    CHECK(store.state(slot0) == SlotState::Live);
+    CHECK(store.memory(slot0) == stable_address);
+    CHECK(store.pending_erase_count() == 0);
+
+    REQUIRE(store.remove(slot0));
+    store.erase_pending();
+    CHECK(store.state(slot0) == SlotState::Free);
+    CHECK_FALSE(store.constructed(slot0));
+    CHECK(store.memory(slot0) == nullptr);
+    CHECK(TrackedValue::destroyed_count == 1);
+
+    const std::size_t reused_slot = store.emplace(43);
+    CHECK(reused_slot == slot0);
+    CHECK(store.memory(reused_slot) == stable_address);
+    CHECK(store.memory(reused_slot)->value == 43);
+  }
+  CHECK(TrackedValue::constructed_count == 3);
+  CHECK(TrackedValue::destroyed_count == 3);
+}
+} // namespace
+
+TEST_CASE("compact stable-slot chooser selects the smallest valid lifecycle "
+          "representation",
+          "[stable-slot-prototype][memory]") {
+  using namespace hgraph::experimental;
+
+  constexpr auto aligned = choose_slot_representation(
+      sizeof(TrackedValue), alignof(TrackedValue), false, 8);
+  static_assert(aligned.kind == SlotRepresentationKind::TaggedPointer);
+  static_assert(aligned.payload_stride == 8);
+  static_assert(aligned.lifecycle_bits_per_slot == 0);
+
+  constexpr auto trivial = choose_slot_representation(
+      sizeof(PackedTrivial9), alignof(PackedTrivial9), true, 8);
+  static_assert(trivial.kind == SlotRepresentationKind::ParentTrackedTrivial);
+  static_assert(trivial.payload_stride == 9);
+  static_assert(trivial.lifecycle_bits_per_slot == 1);
+
+  constexpr auto state_byte = choose_slot_representation(
+      sizeof(PackedTracked9), alignof(PackedTracked9), false, 8);
+  static_assert(state_byte.kind == SlotRepresentationKind::BitmapPointer);
+  static_assert(state_byte.payload_stride == 9);
+  static_assert(state_byte.lifecycle_bits_per_slot == 2);
+
+  constexpr auto padded =
+      choose_slot_representation(sizeof(WeaklyAlignedTracked12),
+                                 alignof(WeaklyAlignedTracked12), false, 8);
+  static_assert(padded.kind == SlotRepresentationKind::BitmapPointer);
+  static_assert(padded.payload_stride == 12);
+}
+
+TEST_CASE("bitmap stable-slot prototype preserves lifecycle and addresses",
+          "[stable-slot-prototype]") {
+  check_non_trivial_lifecycle<BitmapPointerRepresentation<TrackedValue>>();
+}
+
+TEST_CASE(
+    "tagged-pointer stable-slot prototype preserves lifecycle and addresses",
+    "[stable-slot-prototype]") {
+  using Representation = TaggedPointerRepresentation<TrackedValue>;
+  static_assert(sizeof(typename Representation::SlotPointer) == sizeof(void *));
+  check_non_trivial_lifecycle<Representation>();
+}
+
+TEST_CASE("state-byte stable-slot prototype preserves lifecycle and addresses",
+          "[stable-slot-prototype]") {
+  check_non_trivial_lifecycle<StateByteRepresentation<TrackedValue>>();
+}
+
+TEST_CASE("parent-tracked trivial prototype needs no constructed bitmap",
+          "[stable-slot-prototype][memory]") {
+  using namespace hgraph::experimental;
+  using Representation = ParentTrackedTrivialRepresentation<PackedTrivial9>;
+
+  PrototypeStableSlotStore<PackedTrivial9, Representation> store(4);
+  const std::size_t slot = store.emplace(PackedTrivial9{});
+  PackedTrivial9 *const stable_address = store.memory(slot);
+  REQUIRE(stable_address != nullptr);
+
+  store.reserve_to(32);
+  CHECK(store.memory(slot) == stable_address);
+  REQUIRE(store.remove(slot));
+  CHECK(store.state(slot) == SlotState::PendingErase);
+  REQUIRE(store.resurrect(slot));
+  CHECK(store.memory(slot) == stable_address);
+
+  const PrototypeMemoryReport report = store.memory_report();
+  CHECK(store.payload_stride() == sizeof(PackedTrivial9));
+  CHECK(report.slot_index_bytes >= store.capacity() * sizeof(void *));
+}
+
+TEST_CASE("compact stable-slot publication failure destroys staged values and "
+          "reuses the slot",
+          "[stable-slot-prototype][lifecycle]") {
+  using namespace hgraph::experimental;
+  using Store =
+      PrototypeStableSlotStore<TrackedValue,
+                               TaggedPointerRepresentation<TrackedValue>>;
+
+  TrackedValue::reset();
+  Store store(1);
+  REQUIRE_THROWS_AS(store.emplace_with_publish(
+                        [&store](std::size_t slot, TrackedValue *memory) {
+                          CHECK(memory->value == 7);
+                          CHECK(store.state(slot) == SlotState::Staged);
+                          throw std::runtime_error("publish failed");
+                        },
+                        7),
+                    std::runtime_error);
+
+  CHECK(store.size() == 0);
+  CHECK(store.state(0) == SlotState::Free);
+  CHECK_FALSE(store.constructed(0));
+  CHECK(TrackedValue::constructed_count == 1);
+  CHECK(TrackedValue::destroyed_count == 1);
+
+  const std::size_t slot = store.emplace(8);
+  CHECK(slot == 0);
+  CHECK(store.memory(slot)->value == 8);
+}
+
+TEST_CASE(
+    "state byte trades one payload byte for weakly aligned non-trivial values",
+    "[stable-slot-prototype][memory]") {
+  using namespace hgraph::experimental;
+  using ByteStore =
+      PrototypeStableSlotStore<PackedTracked9,
+                               StateByteRepresentation<PackedTracked9>>;
+  using TaggedStore =
+      PrototypeStableSlotStore<PackedTracked9,
+                               TaggedPointerRepresentation<PackedTracked9, 8>>;
+
+  ByteStore byte_store(64);
+  TaggedStore tagged_store(64);
+
+  CHECK(byte_store.payload_stride() == 10);
+  CHECK(tagged_store.payload_stride() == 16);
+  CHECK(byte_store.memory_report().payload_bytes == 64 * 10);
+  CHECK(tagged_store.memory_report().payload_bytes == 64 * 16);
+  CHECK(byte_store.memory_report().slot_index_bytes ==
+        tagged_store.memory_report().slot_index_bytes);
+}
+
+TEST_CASE("tagged pointer removes both standalone lifecycle bitmaps",
+          "[stable-slot-prototype][memory]") {
+  using namespace hgraph::experimental;
+  using Baseline =
+      PrototypeStableSlotStore<TrackedValue,
+                               BitmapPointerRepresentation<TrackedValue>>;
+  using Tagged =
+      PrototypeStableSlotStore<TrackedValue,
+                               TaggedPointerRepresentation<TrackedValue>>;
+
+  Baseline baseline(128);
+  Tagged tagged(128);
+
+  CHECK(tagged.memory_report().slot_index_bytes == 128 * sizeof(void *));
+  CHECK(baseline.memory_report().slot_index_bytes ==
+        tagged.memory_report().slot_index_bytes + 4 * sizeof(std::uint64_t));
+  CHECK(tagged.memory_report().slot_index_allocations == 1);
+  CHECK(baseline.memory_report().slot_index_allocations == 3);
+}

--- a/tests/cpp/test_type_record.cpp
+++ b/tests/cpp/test_type_record.cpp
@@ -122,7 +122,7 @@ TEST_CASE("debug descriptor common enums and layouts are fixed", "[type-erasure]
     STATIC_REQUIRE(DEBUG_DESCRIPTOR_MAGIC == 0x48474444u);
     STATIC_REQUIRE(DEBUG_DESCRIPTOR_ABI_VERSION == 3);
     STATIC_REQUIRE(DEBUG_DYNAMIC_LAYOUT_MAGIC == 0x4847444cu);
-    STATIC_REQUIRE(DEBUG_DYNAMIC_LAYOUT_ABI_VERSION == 1);
+    STATIC_REQUIRE(DEBUG_DYNAMIC_LAYOUT_ABI_VERSION == 2);
     STATIC_REQUIRE(sizeof(DebugLayoutKind) == sizeof(std::uint8_t));
     STATIC_REQUIRE(sizeof(DebugAtomicKind) == sizeof(std::uint8_t));
     STATIC_REQUIRE(sizeof(DebugDescriptorFlags) == sizeof(std::uint32_t));
@@ -143,6 +143,9 @@ TEST_CASE("debug descriptor common enums and layouts are fixed", "[type-erasure]
     STATIC_REQUIRE(static_cast<std::uint8_t>(DebugAtomicKind::FloatingPoint) == 4);
     STATIC_REQUIRE(static_cast<std::uint32_t>(DebugFieldFlags::EmbeddedPointer) == (1u << 2u));
     STATIC_REQUIRE(static_cast<std::uint32_t>(DebugDynamicFlags::ElementsArePointers) == (1u << 9u));
+    STATIC_REQUIRE(static_cast<std::uint32_t>(DebugDynamicFlags::DataPointersAreTagged) == (1u << 10u));
+    STATIC_REQUIRE(static_cast<std::uint32_t>(DebugDynamicFlags::KeyPointersAreTagged) == (1u << 11u));
+    STATIC_REQUIRE(static_cast<std::uint32_t>(DebugDynamicFlags::SlotStateIsTaggedPointer) == (1u << 12u));
 
     DebugDescriptor descriptor{
         .magic = DEBUG_DESCRIPTOR_MAGIC,
@@ -186,6 +189,28 @@ TEST_CASE("debug descriptor common enums and layouts are fixed", "[type-erasure]
                     DebugDynamicFlags::ElementsAreOwners;
     dynamic.size_offset = sizeof(std::size_t);
     REQUIRE(dynamic.valid());
+
+    dynamic.flags = dynamic.flags | DebugDynamicFlags::DataPointersAreTagged;
+    REQUIRE(dynamic.valid());
+    dynamic.flags = dynamic.flags | DebugDynamicFlags::HasSlotState |
+                    DebugDynamicFlags::SlotStateIsTaggedPointer;
+    dynamic.state_offset = 2 * sizeof(std::size_t);
+    REQUIRE(dynamic.valid());
+    dynamic.flags = static_cast<DebugDynamicFlags>(
+        static_cast<std::uint32_t>(dynamic.flags) &
+        ~static_cast<std::uint32_t>(DebugDynamicFlags::DataPointersAreTagged));
+    REQUIRE_FALSE(dynamic.valid());
+
+    dynamic.flags = DebugDynamicFlags::DataIsIndirect | DebugDynamicFlags::DataIsPointerTable |
+                    DebugDynamicFlags::HasSlotState | DebugDynamicFlags::SlotStateIsTaggedPointer;
+    REQUIRE_FALSE(dynamic.valid());
+    dynamic.flags = DebugDynamicFlags::DataIsIndirect | DebugDynamicFlags::DataIsPointerTable |
+                    DebugDynamicFlags::DataPointersAreTagged | DebugDynamicFlags::SlotStateIsTaggedPointer;
+    REQUIRE_FALSE(dynamic.valid());
+
+    dynamic.flags = DebugDynamicFlags::DataIsIndirect | DebugDynamicFlags::DataIsPointerTable |
+                    DebugDynamicFlags::ElementsAreOwners;
+    dynamic.state_offset = 0;
     dynamic.flags = dynamic.flags | DebugDynamicFlags::ElementsArePointers;
     REQUIRE_FALSE(dynamic.valid());
 }

--- a/tests/cpp/test_type_record.cpp
+++ b/tests/cpp/test_type_record.cpp
@@ -122,11 +122,13 @@ TEST_CASE("debug descriptor common enums and layouts are fixed", "[type-erasure]
     STATIC_REQUIRE(DEBUG_DESCRIPTOR_MAGIC == 0x48474444u);
     STATIC_REQUIRE(DEBUG_DESCRIPTOR_ABI_VERSION == 3);
     STATIC_REQUIRE(DEBUG_DYNAMIC_LAYOUT_MAGIC == 0x4847444cu);
-    STATIC_REQUIRE(DEBUG_DYNAMIC_LAYOUT_ABI_VERSION == 2);
+    STATIC_REQUIRE(DEBUG_DYNAMIC_LAYOUT_ABI_VERSION == 3);
     STATIC_REQUIRE(sizeof(DebugLayoutKind) == sizeof(std::uint8_t));
     STATIC_REQUIRE(sizeof(DebugAtomicKind) == sizeof(std::uint8_t));
     STATIC_REQUIRE(sizeof(DebugDescriptorFlags) == sizeof(std::uint32_t));
     STATIC_REQUIRE(sizeof(DebugFieldFlags) == sizeof(std::uint32_t));
+    STATIC_REQUIRE(sizeof(DebugDynamicLayout) == 88);
+    STATIC_REQUIRE(offsetof(DebugDynamicLayout, key_auxiliary_offset) == 12);
     STATIC_REQUIRE(static_cast<std::uint8_t>(DebugLayoutKind::Opaque) == 0);
     STATIC_REQUIRE(static_cast<std::uint8_t>(DebugLayoutKind::Atomic) == 1);
     STATIC_REQUIRE(static_cast<std::uint8_t>(DebugLayoutKind::FixedComposite) == 2);
@@ -146,6 +148,8 @@ TEST_CASE("debug descriptor common enums and layouts are fixed", "[type-erasure]
     STATIC_REQUIRE(static_cast<std::uint32_t>(DebugDynamicFlags::DataPointersAreTagged) == (1u << 10u));
     STATIC_REQUIRE(static_cast<std::uint32_t>(DebugDynamicFlags::KeyPointersAreTagged) == (1u << 11u));
     STATIC_REQUIRE(static_cast<std::uint32_t>(DebugDynamicFlags::SlotStateIsTaggedPointer) == (1u << 12u));
+    STATIC_REQUIRE(static_cast<std::uint32_t>(DebugDynamicFlags::SlotIndexIsIndirect) == (1u << 13u));
+    STATIC_REQUIRE(static_cast<std::uint32_t>(DebugDynamicFlags::SlotSizeIsIndirect) == (1u << 14u));
 
     DebugDescriptor descriptor{
         .magic = DEBUG_DESCRIPTOR_MAGIC,
@@ -212,6 +216,18 @@ TEST_CASE("debug descriptor common enums and layouts are fixed", "[type-erasure]
                     DebugDynamicFlags::ElementsAreOwners;
     dynamic.state_offset = 0;
     dynamic.flags = dynamic.flags | DebugDynamicFlags::ElementsArePointers;
+    REQUIRE_FALSE(dynamic.valid());
+
+    dynamic.flags = DebugDynamicFlags::DataIsIndirect | DebugDynamicFlags::KeyDataIsIndirect |
+                    DebugDynamicFlags::DataIsPointerTable | DebugDynamicFlags::KeyDataIsPointerTable |
+                    DebugDynamicFlags::SlotIndexIsIndirect | DebugDynamicFlags::SlotSizeIsIndirect;
+    dynamic.size_offset = sizeof(std::size_t);
+    dynamic.auxiliary_offset = 2 * sizeof(std::size_t);
+    REQUIRE(dynamic.valid());
+    dynamic.key_stride = sizeof(std::uint32_t);
+    dynamic.key_auxiliary_offset = 3 * sizeof(std::uint32_t);
+    REQUIRE(dynamic.valid());
+    dynamic.flags = dynamic.flags | DebugDynamicFlags::HasHead;
     REQUIRE_FALSE(dynamic.valid());
 }
 

--- a/tests/debugger/test_debugger_common.py
+++ b/tests/debugger/test_debugger_common.py
@@ -206,7 +206,7 @@ class CommonDebuggerFormattingTest(unittest.TestCase):
         snapshot = dynamic_layout()
         self.assertTrue(common.debug_dynamic_layout_valid(snapshot))
         self.assertIn("valid kind=StableSlots", common.debug_dynamic_layout_summary(snapshot))
-        self.assertFalse(common.debug_dynamic_layout_valid(dynamic_layout(abi_version=2)))
+        self.assertFalse(common.debug_dynamic_layout_valid(dynamic_layout(abi_version=1)))
         self.assertFalse(common.debug_dynamic_layout_valid(dynamic_layout(flags=1 << 20)))
         self.assertFalse(
             common.debug_dynamic_layout_valid(
@@ -227,6 +227,28 @@ class CommonDebuggerFormattingTest(unittest.TestCase):
                     flags=dynamic_layout()["flags"]
                     | common.DEBUG_DYNAMIC_ELEMENTS_ARE_OWNERS
                     | common.DEBUG_DYNAMIC_ELEMENTS_ARE_POINTERS
+                )
+            )
+        )
+        tagged_flags = (
+            dynamic_layout()["flags"]
+            | common.DEBUG_DYNAMIC_DATA_POINTERS_TAGGED
+            | common.DEBUG_DYNAMIC_SLOT_STATE_TAGGED
+        )
+        self.assertTrue(
+            common.debug_dynamic_layout_valid(dynamic_layout(flags=tagged_flags))
+        )
+        self.assertFalse(
+            common.debug_dynamic_layout_valid(
+                dynamic_layout(
+                    flags=tagged_flags & ~common.DEBUG_DYNAMIC_DATA_POINTERS_TAGGED
+                )
+            )
+        )
+        self.assertFalse(
+            common.debug_dynamic_layout_valid(
+                dynamic_layout(
+                    flags=tagged_flags & ~common.DEBUG_DYNAMIC_HAS_SLOT_STATE
                 )
             )
         )

--- a/tests/debugger/test_debugger_common.py
+++ b/tests/debugger/test_debugger_common.py
@@ -71,7 +71,7 @@ def dynamic_layout(**overrides):
         "flags": common.DEBUG_DYNAMIC_DATA_INDIRECT
         | common.DEBUG_DYNAMIC_DATA_POINTER_TABLE
         | common.DEBUG_DYNAMIC_HAS_SLOT_STATE,
-        "reserved1": 0,
+        "key_auxiliary_offset": 0,
         "size_offset": 16,
         "size_constant": 0,
         "data_offset": 8,
@@ -237,6 +237,38 @@ class CommonDebuggerFormattingTest(unittest.TestCase):
         )
         self.assertTrue(
             common.debug_dynamic_layout_valid(dynamic_layout(flags=tagged_flags))
+        )
+        erased_flags = (
+            dynamic_layout()["flags"]
+            | common.DEBUG_DYNAMIC_SLOT_INDEX_INDIRECT
+            | common.DEBUG_DYNAMIC_SLOT_SIZE_INDIRECT
+        )
+        self.assertTrue(
+            common.debug_dynamic_layout_valid(
+                dynamic_layout(flags=erased_flags, auxiliary_offset=32)
+            )
+        )
+        keyed_erased_flags = (
+            erased_flags
+            | common.DEBUG_DYNAMIC_KEY_DATA_INDIRECT
+            | common.DEBUG_DYNAMIC_KEY_DATA_POINTER_TABLE
+        )
+        self.assertTrue(
+            common.debug_dynamic_layout_valid(
+                dynamic_layout(
+                    flags=keyed_erased_flags,
+                    key_stride=8,
+                    key_auxiliary_offset=48,
+                )
+            )
+        )
+        self.assertFalse(
+            common.debug_dynamic_layout_valid(
+                dynamic_layout(
+                    flags=dynamic_layout()["flags"]
+                    | common.DEBUG_DYNAMIC_SLOT_SIZE_INDIRECT
+                )
+            )
         )
         self.assertFalse(
             common.debug_dynamic_layout_valid(

--- a/tests/install_consumer/main.cpp
+++ b/tests/install_consumer/main.cpp
@@ -10,6 +10,7 @@
 #include <hgraph/types/time_series/visitor.h>
 #include <hgraph/types/type_pointer.h>
 #include <hgraph/types/type_resolution.h>
+#include <hgraph/types/utils/stable_slot_store.h>
 #include <hgraph/types/value/any_ops.h>
 #include <hgraph/types/value/value.h>
 #include <hgraph/types/value/value_builder.h>
@@ -19,6 +20,7 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <memory>
 #include <stdexcept>
 #include <type_traits>
 
@@ -41,6 +43,31 @@ int main()
     static_assert(std::is_standard_layout_v<AnyPtr>);
     static_assert(std::is_trivially_copyable_v<AnyPtr>);
     static_assert(TS_DATA_OPS_ABI_VERSION == 5);
+
+    StableSlotStore<StableSlotStateModel::ConstructedAndLive> stable_slots{
+        MemoryUtils::StorageLayout{sizeof(std::uintptr_t), alignof(std::uintptr_t)}};
+    stable_slots.reserve_to(4);
+    auto *stable_value = std::construct_at(
+        MemoryUtils::cast<std::uintptr_t>(stable_slots.slot_memory(0)),
+        std::uintptr_t{41});
+    stable_slots.mark_staged(0);
+    if (!stable_slots.mark_live(0) ||
+        stable_slots.representation() != StableSlotRepresentation::TaggedPointer ||
+        stable_slots.live_slot_memory(0) != stable_value)
+    {
+        throw std::runtime_error("installed stable-slot tagged strategy is unusable");
+    }
+    std::destroy_at(stable_value);
+    stable_slots.mark_free(0);
+
+    StableSlotStore<StableSlotStateModel::ConstructedOnly> weak_stable_slots{
+        MemoryUtils::StorageLayout{3, 1}};
+    weak_stable_slots.reserve_to(4);
+    if (weak_stable_slots.representation() != StableSlotRepresentation::Bitmap)
+    {
+        throw std::runtime_error("installed stable-slot bitmap strategy is unusable");
+    }
+
     using ConsumerScalar =
         Bundle<"consumer::Scalar", Field<"number", Int>, Field<"label", Str>>;
     using ConsumerBundle = TSBFromScalar<ConsumerScalar>;

--- a/tools/debugger/hgraph_debug_common.py
+++ b/tools/debugger/hgraph_debug_common.py
@@ -10,7 +10,7 @@ TYPE_KIND_NONE = 0xFF
 DEBUG_DESCRIPTOR_MAGIC = 0x48474444
 DEBUG_DESCRIPTOR_ABI_VERSION = 3
 DEBUG_DYNAMIC_LAYOUT_MAGIC = 0x4847444C
-DEBUG_DYNAMIC_LAYOUT_ABI_VERSION = 2
+DEBUG_DYNAMIC_LAYOUT_ABI_VERSION = 3
 
 FAMILY_NAMES = {
     0: "Invalid",
@@ -133,7 +133,9 @@ DEBUG_DYNAMIC_ELEMENTS_ARE_POINTERS = 1 << 9
 DEBUG_DYNAMIC_DATA_POINTERS_TAGGED = 1 << 10
 DEBUG_DYNAMIC_KEY_POINTERS_TAGGED = 1 << 11
 DEBUG_DYNAMIC_SLOT_STATE_TAGGED = 1 << 12
-KNOWN_DEBUG_DYNAMIC_FLAGS = (1 << 13) - 1
+DEBUG_DYNAMIC_SLOT_INDEX_INDIRECT = 1 << 13
+DEBUG_DYNAMIC_SLOT_SIZE_INDIRECT = 1 << 14
+KNOWN_DEBUG_DYNAMIC_FLAGS = (1 << 15) - 1
 DEBUG_OWNER_STATE_MASK = 0x3
 DEBUG_OWNER_INLINE_STATE = 1
 DEBUG_OWNER_HEAP_STATE = 2
@@ -308,7 +310,6 @@ def debug_dynamic_layout_valid(snapshot):
         and snapshot.get("abi_version") == DEBUG_DYNAMIC_LAYOUT_ABI_VERSION
         and kind in DEBUG_DYNAMIC_KIND_NAMES
         and snapshot.get("reserved0", 0) == 0
-        and snapshot.get("reserved1", 0) == 0
         and (flags & ~KNOWN_DEBUG_DYNAMIC_FLAGS) == 0
         and snapshot.get("stride", 0) > 0
         and bool(flags & DEBUG_DYNAMIC_SIZE_CONSTANT)
@@ -343,6 +344,36 @@ def debug_dynamic_layout_valid(snapshot):
             )
         )
         and not (
+            flags & DEBUG_DYNAMIC_SLOT_INDEX_INDIRECT
+            and (
+                kind != 2
+                or not flags & DEBUG_DYNAMIC_DATA_INDIRECT
+                or not flags & DEBUG_DYNAMIC_DATA_POINTER_TABLE
+                or flags & DEBUG_DYNAMIC_HAS_HEAD
+                or (
+                    snapshot.get("key_stride", 0)
+                    and (
+                        not flags & DEBUG_DYNAMIC_KEY_DATA_INDIRECT
+                        or not flags & DEBUG_DYNAMIC_KEY_DATA_POINTER_TABLE
+                    )
+                )
+            )
+        )
+        and not (
+            flags & DEBUG_DYNAMIC_SLOT_SIZE_INDIRECT
+            and (
+                not flags & DEBUG_DYNAMIC_SLOT_INDEX_INDIRECT
+                or flags & DEBUG_DYNAMIC_SIZE_CONSTANT
+            )
+        )
+        and not (
+            snapshot.get("key_auxiliary_offset", 0)
+            and (
+                not flags & DEBUG_DYNAMIC_SLOT_INDEX_INDIRECT
+                or not snapshot.get("key_stride", 0)
+            )
+        )
+        and not (
             flags & DEBUG_DYNAMIC_ELEMENTS_ARE_OWNERS
             and flags & DEBUG_DYNAMIC_ELEMENTS_ARE_POINTERS
         )
@@ -355,7 +386,7 @@ def debug_dynamic_layout_summary(snapshot):
     return (
         "DebugDynamicLayout{{{} kind={} flags=0x{:x} size_offset={} size_constant={} "
         "data_offset={} stride={} key_data_offset={} key_stride={} state_offset={} "
-        "auxiliary_offset={} entry_offset={}}}"
+        "auxiliary_offset={} key_auxiliary_offset={} entry_offset={}}}"
     ).format(
         state,
         kind,
@@ -368,6 +399,7 @@ def debug_dynamic_layout_summary(snapshot):
         snapshot.get("key_stride", 0),
         snapshot.get("state_offset", 0),
         snapshot.get("auxiliary_offset", 0),
+        snapshot.get("key_auxiliary_offset", 0),
         snapshot.get("entry_offset", 0),
     )
 

--- a/tools/debugger/hgraph_debug_common.py
+++ b/tools/debugger/hgraph_debug_common.py
@@ -10,7 +10,7 @@ TYPE_KIND_NONE = 0xFF
 DEBUG_DESCRIPTOR_MAGIC = 0x48474444
 DEBUG_DESCRIPTOR_ABI_VERSION = 3
 DEBUG_DYNAMIC_LAYOUT_MAGIC = 0x4847444C
-DEBUG_DYNAMIC_LAYOUT_ABI_VERSION = 1
+DEBUG_DYNAMIC_LAYOUT_ABI_VERSION = 2
 
 FAMILY_NAMES = {
     0: "Invalid",
@@ -130,7 +130,10 @@ DEBUG_DYNAMIC_HAS_HEAD = 1 << 6
 DEBUG_DYNAMIC_ELEMENTS_ARE_OWNERS = 1 << 7
 DEBUG_DYNAMIC_KEYS_ARE_OWNERS = 1 << 8
 DEBUG_DYNAMIC_ELEMENTS_ARE_POINTERS = 1 << 9
-KNOWN_DEBUG_DYNAMIC_FLAGS = (1 << 10) - 1
+DEBUG_DYNAMIC_DATA_POINTERS_TAGGED = 1 << 10
+DEBUG_DYNAMIC_KEY_POINTERS_TAGGED = 1 << 11
+DEBUG_DYNAMIC_SLOT_STATE_TAGGED = 1 << 12
+KNOWN_DEBUG_DYNAMIC_FLAGS = (1 << 13) - 1
 DEBUG_OWNER_STATE_MASK = 0x3
 DEBUG_OWNER_INLINE_STATE = 1
 DEBUG_OWNER_HEAP_STATE = 2
@@ -319,6 +322,26 @@ def debug_dynamic_layout_valid(snapshot):
             )
         )
         and not (flags & DEBUG_DYNAMIC_HAS_SLOT_STATE and kind != 2)
+        and not (
+            flags & DEBUG_DYNAMIC_DATA_POINTERS_TAGGED
+            and not flags & DEBUG_DYNAMIC_DATA_POINTER_TABLE
+        )
+        and not (
+            flags & DEBUG_DYNAMIC_KEY_POINTERS_TAGGED
+            and not flags & DEBUG_DYNAMIC_KEY_DATA_POINTER_TABLE
+        )
+        and not (
+            flags & DEBUG_DYNAMIC_SLOT_STATE_TAGGED
+            and (
+                not flags & DEBUG_DYNAMIC_HAS_SLOT_STATE
+                or snapshot.get("state_offset", 0) == 0
+                or not flags
+                & (
+                    DEBUG_DYNAMIC_DATA_POINTERS_TAGGED
+                    | DEBUG_DYNAMIC_KEY_POINTERS_TAGGED
+                )
+            )
+        )
         and not (
             flags & DEBUG_DYNAMIC_ELEMENTS_ARE_OWNERS
             and flags & DEBUG_DYNAMIC_ELEMENTS_ARE_POINTERS

--- a/tools/debugger/hgraph_gdb.py
+++ b/tools/debugger/hgraph_gdb.py
@@ -405,7 +405,11 @@ def dynamic_child_addresses(data_address, layout):
     state_bits = 0
     if flags & common.DEBUG_DYNAMIC_HAS_SLOT_STATE:
         state_words = read_unsigned(data_address + layout["state_offset"])
-        state_bits = read_unsigned(data_address + layout["state_offset"] + target_pointer_size())
+        state_bits = (
+            size
+            if flags & common.DEBUG_DYNAMIC_SLOT_STATE_TAGGED
+            else read_unsigned(data_address + layout["state_offset"] + target_pointer_size())
+        )
         if state_words is None or state_bits is None:
             return
     for logical_index in range(visible_size):
@@ -413,16 +417,25 @@ def dynamic_child_addresses(data_address, layout):
         if flags & common.DEBUG_DYNAMIC_HAS_SLOT_STATE:
             if physical_index >= state_bits:
                 continue
-            word = read_unsigned(state_words + (physical_index // 64) * 8, 8)
-            if word is None or not (word & (1 << (physical_index % 64))):
-                continue
+            if flags & common.DEBUG_DYNAMIC_SLOT_STATE_TAGGED:
+                state = read_unsigned(state_words + physical_index * target_pointer_size())
+                if state is None or state & 0x3:
+                    continue
+            else:
+                word = read_unsigned(state_words + (physical_index // 64) * 8, 8)
+                if word is None or not (word & (1 << (physical_index % 64))):
+                    continue
         if flags & common.DEBUG_DYNAMIC_DATA_POINTER_TABLE:
             element = read_unsigned(data_base + physical_index * target_pointer_size())
+            if element is not None and flags & common.DEBUG_DYNAMIC_DATA_POINTERS_TAGGED:
+                element &= ~0x3
         else:
             element = data_base + physical_index * layout["stride"]
         if key_base:
             if flags & common.DEBUG_DYNAMIC_KEY_DATA_POINTER_TABLE:
                 key = read_unsigned(key_base + physical_index * target_pointer_size())
+                if key is not None and flags & common.DEBUG_DYNAMIC_KEY_POINTERS_TAGGED:
+                    key &= ~0x3
             else:
                 key = key_base + physical_index * layout["key_stride"]
         else:

--- a/tools/debugger/hgraph_gdb.py
+++ b/tools/debugger/hgraph_gdb.py
@@ -169,7 +169,7 @@ def dynamic_layout_snapshot(value):
         "kind": integer(field(value, "kind")),
         "reserved0": integer(field(value, "reserved0")),
         "flags": integer(field(value, "flags")),
-        "reserved1": integer(field(value, "reserved1")),
+        "key_auxiliary_offset": integer(field(value, "key_auxiliary_offset")),
         "size_offset": integer(field(value, "size_offset")),
         "size_constant": integer(field(value, "size_constant")),
         "data_offset": integer(field(value, "data_offset")),
@@ -374,10 +374,28 @@ def dynamic_pointer(value):
 
 def dynamic_child_addresses(data_address, layout):
     flags = layout["flags"]
+    slot_index_indirect = bool(flags & common.DEBUG_DYNAMIC_SLOT_INDEX_INDIRECT)
+    data_implementation = 0
+    key_implementation = 0
+    if slot_index_indirect:
+        data_implementation = read_unsigned(data_address + layout["data_offset"])
+        if not data_implementation:
+            return
+        if layout["key_stride"]:
+            key_implementation = read_unsigned(data_address + layout["key_data_offset"])
+            if not key_implementation:
+                return
+        else:
+            key_implementation = data_implementation
+    size_base = (
+        key_implementation
+        if flags & common.DEBUG_DYNAMIC_SLOT_SIZE_INDIRECT
+        else data_address
+    )
     size = (
         layout["size_constant"]
         if flags & common.DEBUG_DYNAMIC_SIZE_CONSTANT
-        else read_unsigned(data_address + layout["size_offset"])
+        else read_unsigned(size_base + layout["size_offset"])
     )
     if size is None or size > (1 << 30):
         return
@@ -389,14 +407,22 @@ def dynamic_child_addresses(data_address, layout):
     )
     if head is None:
         return
-    data_base = data_address + layout["data_offset"]
+    data_base = (
+        data_implementation + layout["auxiliary_offset"]
+        if slot_index_indirect
+        else data_address + layout["data_offset"]
+    )
     if flags & common.DEBUG_DYNAMIC_DATA_INDIRECT:
         data_base = read_unsigned(data_base)
     if data_base is None:
         return
     key_base = 0
     if layout["key_stride"]:
-        key_base = data_address + layout["key_data_offset"]
+        key_base = (
+            key_implementation + layout["key_auxiliary_offset"]
+            if slot_index_indirect
+            else data_address + layout["key_data_offset"]
+        )
         if flags & common.DEBUG_DYNAMIC_KEY_DATA_INDIRECT:
             key_base = read_unsigned(key_base)
         if key_base is None:
@@ -404,11 +430,12 @@ def dynamic_child_addresses(data_address, layout):
     state_words = 0
     state_bits = 0
     if flags & common.DEBUG_DYNAMIC_HAS_SLOT_STATE:
-        state_words = read_unsigned(data_address + layout["state_offset"])
+        state_base = key_implementation if slot_index_indirect else data_address
+        state_words = read_unsigned(state_base + layout["state_offset"])
         state_bits = (
             size
             if flags & common.DEBUG_DYNAMIC_SLOT_STATE_TAGGED
-            else read_unsigned(data_address + layout["state_offset"] + target_pointer_size())
+            else read_unsigned(state_base + layout["state_offset"] + target_pointer_size())
         )
         if state_words is None or state_bits is None:
             return

--- a/tools/debugger/hgraph_gdb.py
+++ b/tools/debugger/hgraph_gdb.py
@@ -379,10 +379,16 @@ def dynamic_child_addresses(data_address, layout):
     key_implementation = 0
     if slot_index_indirect:
         data_implementation = read_unsigned(data_address + layout["data_offset"])
+        if data_implementation is None:
+            return
+        data_implementation &= ~0x3
         if not data_implementation:
             return
         if layout["key_stride"]:
             key_implementation = read_unsigned(data_address + layout["key_data_offset"])
+            if key_implementation is None:
+                return
+            key_implementation &= ~0x3
             if not key_implementation:
                 return
         else:

--- a/tools/debugger/hgraph_lldb.py
+++ b/tools/debugger/hgraph_lldb.py
@@ -182,7 +182,7 @@ def dynamic_layout_snapshot(value):
         "kind": integer(child(value, "kind")),
         "reserved0": integer(child(value, "reserved0")),
         "flags": integer(child(value, "flags")),
-        "reserved1": integer(child(value, "reserved1")),
+        "key_auxiliary_offset": integer(child(value, "key_auxiliary_offset")),
         "size_offset": integer(child(value, "size_offset")),
         "size_constant": integer(child(value, "size_constant")),
         "data_offset": integer(child(value, "data_offset")),
@@ -347,10 +347,28 @@ def make_ts_parent_pointer(value, data_address, layout, name):
 
 def dynamic_child_addresses(value, data_address, layout):
     flags = layout["flags"]
+    slot_index_indirect = bool(flags & common.DEBUG_DYNAMIC_SLOT_INDEX_INDIRECT)
+    data_implementation = 0
+    key_implementation = 0
+    if slot_index_indirect:
+        data_implementation = read_unsigned(value, data_address + layout["data_offset"])
+        if not data_implementation:
+            return
+        if layout["key_stride"]:
+            key_implementation = read_unsigned(value, data_address + layout["key_data_offset"])
+            if not key_implementation:
+                return
+        else:
+            key_implementation = data_implementation
+    size_base = (
+        key_implementation
+        if flags & common.DEBUG_DYNAMIC_SLOT_SIZE_INDIRECT
+        else data_address
+    )
     size = (
         layout["size_constant"]
         if flags & common.DEBUG_DYNAMIC_SIZE_CONSTANT
-        else read_unsigned(value, data_address + layout["size_offset"])
+        else read_unsigned(value, size_base + layout["size_offset"])
     )
     if size is None or size > (1 << 30):
         return
@@ -362,14 +380,22 @@ def dynamic_child_addresses(value, data_address, layout):
     )
     if head is None:
         return
-    data_base = data_address + layout["data_offset"]
+    data_base = (
+        data_implementation + layout["auxiliary_offset"]
+        if slot_index_indirect
+        else data_address + layout["data_offset"]
+    )
     if flags & common.DEBUG_DYNAMIC_DATA_INDIRECT:
         data_base = read_unsigned(value, data_base)
     if data_base is None:
         return
     key_base = 0
     if layout["key_stride"]:
-        key_base = data_address + layout["key_data_offset"]
+        key_base = (
+            key_implementation + layout["key_auxiliary_offset"]
+            if slot_index_indirect
+            else data_address + layout["key_data_offset"]
+        )
         if flags & common.DEBUG_DYNAMIC_KEY_DATA_INDIRECT:
             key_base = read_unsigned(value, key_base)
         if key_base is None:
@@ -377,13 +403,14 @@ def dynamic_child_addresses(value, data_address, layout):
     state_words = 0
     state_bits = 0
     if flags & common.DEBUG_DYNAMIC_HAS_SLOT_STATE:
-        state_words = read_unsigned(value, data_address + layout["state_offset"])
+        state_base = key_implementation if slot_index_indirect else data_address
+        state_words = read_unsigned(value, state_base + layout["state_offset"])
         state_bits = (
             size
             if flags & common.DEBUG_DYNAMIC_SLOT_STATE_TAGGED
             else read_unsigned(
                 value,
-                data_address + layout["state_offset"] + value.GetTarget().GetAddressByteSize(),
+                state_base + layout["state_offset"] + value.GetTarget().GetAddressByteSize(),
             )
         )
         if state_words is None or state_bits is None:

--- a/tools/debugger/hgraph_lldb.py
+++ b/tools/debugger/hgraph_lldb.py
@@ -352,10 +352,16 @@ def dynamic_child_addresses(value, data_address, layout):
     key_implementation = 0
     if slot_index_indirect:
         data_implementation = read_unsigned(value, data_address + layout["data_offset"])
+        if data_implementation is None:
+            return
+        data_implementation &= ~0x3
         if not data_implementation:
             return
         if layout["key_stride"]:
             key_implementation = read_unsigned(value, data_address + layout["key_data_offset"])
+            if key_implementation is None:
+                return
+            key_implementation &= ~0x3
             if not key_implementation:
                 return
         else:

--- a/tools/debugger/hgraph_lldb.py
+++ b/tools/debugger/hgraph_lldb.py
@@ -378,9 +378,13 @@ def dynamic_child_addresses(value, data_address, layout):
     state_bits = 0
     if flags & common.DEBUG_DYNAMIC_HAS_SLOT_STATE:
         state_words = read_unsigned(value, data_address + layout["state_offset"])
-        state_bits = read_unsigned(
-            value,
-            data_address + layout["state_offset"] + value.GetTarget().GetAddressByteSize(),
+        state_bits = (
+            size
+            if flags & common.DEBUG_DYNAMIC_SLOT_STATE_TAGGED
+            else read_unsigned(
+                value,
+                data_address + layout["state_offset"] + value.GetTarget().GetAddressByteSize(),
+            )
         )
         if state_words is None or state_bits is None:
             return
@@ -394,16 +398,25 @@ def dynamic_child_addresses(value, data_address, layout):
         if flags & common.DEBUG_DYNAMIC_HAS_SLOT_STATE:
             if physical_index >= state_bits:
                 continue
-            word = read_unsigned(value, state_words + (physical_index // 64) * 8, 8)
-            if word is None or not (word & (1 << (physical_index % 64))):
-                continue
+            if flags & common.DEBUG_DYNAMIC_SLOT_STATE_TAGGED:
+                state = read_unsigned(value, state_words + physical_index * pointer_size)
+                if state is None or state & 0x3:
+                    continue
+            else:
+                word = read_unsigned(value, state_words + (physical_index // 64) * 8, 8)
+                if word is None or not (word & (1 << (physical_index % 64))):
+                    continue
         if flags & common.DEBUG_DYNAMIC_DATA_POINTER_TABLE:
             element = read_unsigned(value, data_base + physical_index * pointer_size)
+            if element is not None and flags & common.DEBUG_DYNAMIC_DATA_POINTERS_TAGGED:
+                element &= ~0x3
         else:
             element = data_base + physical_index * layout["stride"]
         if key_base:
             if flags & common.DEBUG_DYNAMIC_KEY_DATA_POINTER_TABLE:
                 key = read_unsigned(value, key_base + physical_index * pointer_size)
+                if key is not None and flags & common.DEBUG_DYNAMIC_KEY_POINTERS_TAGGED:
+                    key &= ~0x3
             else:
                 key = key_base + physical_index * layout["key_stride"]
         else:


### PR DESCRIPTION
## Summary

- provide one reusable `StableSlotStore` facade for value slots, key slots, TSS/TSD storage, dynamic TSL storage, mutable containers, and nested-graph slots
- select two-bit tagged slot pointers for payloads aligned to at least `uintptr_t`; live is `00`, so the common live dereference needs no pointer masking
- retain the existing compact bitmap representation for weaker payload alignment without padding
- replace the rejected passive-ops dispatch with one tagged implementation handle: `00` aligned, `01` bitmap, and `10` canonical nop
- dispatch the closed internal strategy set through inline switches while keeping the erased semantic facade and concrete implementation classes separate; there is no `std::variant` in semantic owners
- keep allocation and destruction under the supplied `MemoryUtils::AllocatorOps`, including move, rollback, metrics, and debugger handling
- shrink the facade from four words to one word and preserve the non-null canonical nop invariant for default and moved-from stores
- extend debugger ABI v3 for heap-indirect tagged slot indices, including independent key/value pointer-table offsets
- document when the project should use extensible passive ops tables versus a measured private tagged-dispatch refinement

## Performance

GCC 14.3 on physical `hg-linux`, seven reverse-order process runs:

| Payload/dispatch | Sequential read | Random read | Remove/resurrect | Erase/reinsert |
|---|---:|---:|---:|---:|
| aligned ops table | 1.904 ns | 2.671 ns | 2.315 ns | 5.747 ns |
| aligned tagged dispatch | 0.393 ns | 0.733 ns | 1.313 ns | 4.005 ns |
| packed ops table | 2.735 ns | 2.974 ns | 2.878 ns | 6.800 ns |
| packed tagged dispatch | 0.989 ns | 1.078 ns | 1.995 ns | 5.189 ns |

The inline tagged handle improves isolated aligned operations by 30–79% and bitmap-backed operations by 24–64%.

Owner-level GCC 14.3 A/B results:

| Runtime workload | Ops table | Tagged dispatch | Delta |
|---|---:|---:|---:|
| dynamic TSL construct/grow four | 386.225 ns | 356.361 ns | -7.7% |
| sparse TSD source cycle | 608.021 ns | 576.374 ns | -5.2% |
| alternating switch nested-graph lifecycle | 114,363.330 ns | 111,652.110 ns | -2.4% |
| dense 1,000-key TSD source cycle | 80,107.790 ns | 78,606.856 ns | -1.9% |
| sparse dynamic TSL source cycle | 419.734 ns | 418.110 ns | -0.4% |

At 65,536 aligned slots, the representation still removes two lifecycle bitmap allocations, adds one fixed strategy allocation, and saves approximately 0.249 B/slot without changing payload stride. Full methodology and earlier alternatives are recorded in `benchmarks/results/stable-slot-representation-20260801-mac-issue228.md`.

## Validation

- macOS native Release, fresh configure and clean build: 1,358/1,358 passed
- physical `hg-linux` native Release, GCC 14.3 with warnings-as-errors: 1,358/1,358 passed
- stable-ABI wheel built with Python 3.12 and installed into fresh Python 3.14 environments: 1,770 passed, 10 skipped on macOS and Linux
- physical `hg-linux` GCC 14.3 AddressSanitizer native suite: 1,358/1,358 passed with the documented `detect_leaks=0` setting
- macOS installed-SDK consumer compiling and exercising both alignment strategies: 1/1 passed
- debugger common layer: 12/12 passed; LLDB end-to-end type-erasure smoke passed
- GDB successfully traversed the changed TSS/TSD stable-slot path, then stopped at the pre-existing GCC 14 omission of the complete `hgraph::TSInput` debug type in the later NodeView check
- Sphinx HTML build with warnings as errors: passed
- final formatted facade/header recompiled and its focused store suite passed on macOS and GCC 14 Linux: 80 assertions across 5 tests

Closes #228

Follow-up: #232
