### PR TITLE
Optimize keyed slot access

### DIFF
--- a/include/hgraph/types/utils/key_slot_store.h
+++ b/include/hgraph/types/utils/key_slot_store.h
@@ -310,6 +310,7 @@ namespace hgraph
          * erased.
          */
         [[nodiscard]] void *operator[](size_t slot) {
+            if (void *memory = key_memory(slot); memory != nullptr) { return memory; }
             require_constructed_slot(slot);
             return key_storage.slot_memory(slot);
         }
@@ -318,6 +319,7 @@ namespace hgraph
          * Const overload of the constructed-slot accessor.
          */
         [[nodiscard]] const void *operator[](size_t slot) const {
+            if (const void *memory = key_memory(slot); memory != nullptr) { return memory; }
             require_constructed_slot(slot);
             return key_storage.slot_memory(slot);
         }

--- a/include/hgraph/types/utils/value_slot_store.h
+++ b/include/hgraph/types/utils/value_slot_store.h
@@ -152,6 +152,18 @@ namespace hgraph
         /** Const byte pointer for ``slot``; not bounds-checked. */
         [[nodiscard]] const void *value_memory(size_t slot) const noexcept { return value_storage.slot_memory(slot); }
 
+        /** Mutable payload pointer when ``slot`` is constructed; ``nullptr`` otherwise. */
+        [[nodiscard]] void *try_value_memory(size_t slot) noexcept
+        {
+            return value_storage.live_slot_memory(slot);
+        }
+
+        /** Const overload of ``try_value_memory``. */
+        [[nodiscard]] const void *try_value_memory(size_t slot) const noexcept
+        {
+            return value_storage.live_slot_memory(slot);
+        }
+
         /**
          * Grow capacity to at least ``capacity`` slots. Leaves existing
          * payloads in place; new ``updated`` bits and constructed states
@@ -421,6 +433,7 @@ namespace hgraph
         /** Mutable payload memory for a constructed key slot. */
         [[nodiscard]] void *value_memory(size_t slot)
         {
+            if (void *memory = m_values.try_value_memory(slot); memory != nullptr) { return memory; }
             require_mirrored_slot(slot);
             return m_values.value_memory(slot);
         }
@@ -428,6 +441,7 @@ namespace hgraph
         /** Const payload memory for a constructed key slot. */
         [[nodiscard]] const void *value_memory(size_t slot) const
         {
+            if (const void *memory = m_values.try_value_memory(slot); memory != nullptr) { return memory; }
             require_mirrored_slot(slot);
             return m_values.value_memory(slot);
         }

--- a/tests/cpp/test_slot_utils.cpp
+++ b/tests/cpp/test_slot_utils.cpp
@@ -677,9 +677,12 @@ TEST_CASE("value slot store uses its bound plan for lifecycle operations", "[v2 
     store.reserve_to(2);
 
     REQUIRE(store.plan() == &MemoryUtils::plan_for<std::string>());
+    REQUIRE(store.try_value_memory(0) == nullptr);
+    REQUIRE(store.try_value_memory(store.slot_capacity()) == nullptr);
 
     store.construct_at(0);
     REQUIRE(store.has_slot(0));
+    REQUIRE(store.try_value_memory(0) == store.value_memory(0));
     REQUIRE(*store.try_value<std::string>(0) == "");
 
     const std::string source = "copied";
@@ -690,6 +693,7 @@ TEST_CASE("value slot store uses its bound plan for lifecycle operations", "[v2 
     store.destroy_all();
     REQUIRE_FALSE(store.has_slot(0));
     REQUIRE_FALSE(store.has_slot(1));
+    REQUIRE(store.try_value_memory(0) == nullptr);
 }
 
 TEST_CASE("value slot stores can share a custom allocator", "[v2 slot utils]") {
@@ -734,12 +738,15 @@ TEST_CASE("key mirrored value slot store derives lifetime from key construction"
     REQUIRE(values.has_slot(first.slot));
     REQUIRE(values.try_value<std::string>(first.slot) != nullptr);
     REQUIRE(*values.try_value<std::string>(first.slot) == "eleven");
+    REQUIRE(*MemoryUtils::cast<std::string>(values.value_memory(first.slot)) == "eleven");
     REQUIRE(values.mirrors_key_construction());
 
     keys.erase_pending();
     REQUIRE_FALSE(keys.slot_constructed(first.slot));
     REQUIRE_FALSE(values.has_slot(first.slot));
     REQUIRE(values.try_value<std::string>(first.slot) == nullptr);
+    REQUIRE_THROWS_AS(static_cast<void>(values.value_memory(first.slot)), std::logic_error);
+    REQUIRE_THROWS_AS(static_cast<void>(values.value_memory(values.slot_capacity())), std::out_of_range);
     REQUIRE(values.mirrors_key_construction());
 }
 


### PR DESCRIPTION
## Summary

- add a constructed-value memory fast path to `ValueSlotStore`
- use the mirrored key/value lifetime invariant to avoid repeated stable-slot validation on the common live-slot path
- make `KeySlotStore::operator[]` reuse its existing single-dispatch key lookup before falling back to detailed validation
- preserve pending-erase, erased-slot, and out-of-range behavior through the existing cold validation paths
- extend native lifecycle and error-path coverage

## Root cause

Sparse TSD child value access revalidated the same key/value construction invariant through multiple stable-slot state dispatches. The stable-slot transition made that redundant validation visible in the per-tick hot path.

## Performance

Measured on the physical `hg-linux` host, pinned to CPU 2:

- end-to-end `tsd_sparse_reduce_std` (15 fresh processes): **27.382 ms → 25.519 ms** (**6.8% faster**)
- the patched result is within **0.4%** of the 25.427 ms pre-regression reference
- native source path median: 607.541 ns/op → 562.464 ns/op (**7.4% faster**)
- native reducer path median: 6104.967 ns/op → 6036.714 ns/op (**1.1% faster**)

## Validation

macOS:

- fresh native CMake build and full C++ suite: **1365/1365 passed**
- stable-ABI wheel built with Python 3.12 and installed/tested with Python 3.14: **1770 passed, 10 skipped**

Physical `hg-linux`:

- fresh native CMake build and full C++ suite: **1365/1365 passed**
- stable-ABI wheel built with Python 3.12 and installed/tested with Python 3.14 using `polars[rtcompat]`: **1770 passed, 10 skipped**
