### PR TITLE
Stop service adaptor registry growth

### DIFF
--- a/python/hgraph/_wiring/_graph.py
+++ b/python/hgraph/_wiring/_graph.py
@@ -168,12 +168,30 @@ def _prepare_higher_order_call(func, args, kwargs, *, default_key_arg):
         name: value for name, value in kwargs.items()
         if name.startswith("__")
     }
-    return (
-        _wrap_graph_fn(
-            func, input_names=input_names, scalar_bindings=scalar_bindings),
-        tuple(prepared_args),
-        special_kwargs,
-    )
+    wrapped = None
+    cache = getattr(func, "_wired_fn_cache", None)
+    if cache is not None:
+        candidate = (
+            tuple(input_names),
+            tuple(sorted(scalar_bindings.items())),
+        )
+        try:
+            hash(candidate)
+        except TypeError:
+            pass
+        else:
+            wrapped = cache.get(candidate)
+            if wrapped is None:
+                wrapped = _wrap_graph_fn(
+                    func,
+                    input_names=input_names,
+                    scalar_bindings=scalar_bindings,
+                )
+                cache[candidate] = wrapped
+    if wrapped is None:
+        wrapped = _wrap_graph_fn(
+            func, input_names=input_names, scalar_bindings=scalar_bindings)
+    return wrapped, tuple(prepared_args), special_kwargs
 
 
 def _as_wired(func):
@@ -354,6 +372,7 @@ class _GraphFn:
         self._requires = requires
         self._label = label
         self._deprecated = deprecated
+        self._wired_fn_cache = {}
         out = self._signature.return_annotation
         if isinstance(out, type):
             from .._types import TimeSeriesSchema
@@ -426,6 +445,7 @@ class _GraphFn:
 
         resolved = copy.copy(self)
         resolved._seed_bindings = dict(bindings)
+        resolved._wired_fn_cache = {}
         return resolved
 
     def __call__(self, *args, **kwargs):

--- a/python/hgraph/_wiring/_node.py
+++ b/python/hgraph/_wiring/_node.py
@@ -104,6 +104,7 @@ class _PyNode:
         self._node_type = node_type
         self._label = label
         self._deprecated = deprecated
+        self._wired_fn_cache = {}
         self._start_fn = None
         self._stop_fn = None
         self.__name__ = fn.__name__
@@ -245,6 +246,7 @@ class _PyNode:
 
         pinned = copy.copy(self)
         pinned._pins = dict(self._pins)
+        pinned._wired_fn_cache = {}
         items = item if isinstance(item, tuple) else (item,)
         for entry in items:
             if isinstance(entry, slice) and isinstance(entry.start, _TypeVarSentinel):
@@ -265,6 +267,7 @@ class _PyNode:
         resolved = copy.copy(self)
         resolved._pins = dict(self._pins)
         resolved._pins.update(bindings)
+        resolved._wired_fn_cache = {}
         return resolved
 
     @staticmethod

--- a/python/hgraph/_wiring/_services.py
+++ b/python/hgraph/_wiring/_services.py
@@ -1069,6 +1069,7 @@ class _ServiceImpl:
         self.resolvers = dict(resolvers) if resolvers else None
         self.label = label
         self.deprecated = deprecated
+        self._bound_impl_cache = {}
         if interfaces is None:
             raise TypeError(f"@service_impl '{self.__name__}' requires interfaces=")
         self.manual_adaptor = isinstance(interfaces, (tuple, list))
@@ -1233,6 +1234,23 @@ def _bind_registered_impl(implementation, path, config):
         if ts_type is not None:
             resolved_config[param.name] = _TsExpr(ts_type, f"resolved[{name}]")
 
+    cache_key = None
+    if not registration_contexts:
+        candidate = (
+            implementation.interfaces,
+            path,
+            tuple(sorted(resolved_config.items())),
+        )
+        try:
+            hash(candidate)
+        except TypeError:
+            pass
+        else:
+            cached = implementation._bound_impl_cache.get(candidate)
+            if cached is not None:
+                return cached
+            cache_key = candidate
+
     def bound(*ports):
         if len(ports) != native_ports:
             raise WiringError(
@@ -1297,13 +1315,17 @@ def _bind_registered_impl(implementation, path, config):
     if implementation.resolvers or implementation.deprecated or implementation.label:
         from ._graph import _GraphFn
 
-        return _GraphFn(
+        result = _GraphFn(
             bound,
             resolvers=implementation.resolvers,
             label=implementation.label,
             deprecated=implementation.deprecated,
         )
-    return bound
+    else:
+        result = bound
+    if cache_key is not None:
+        implementation._bound_impl_cache[cache_key] = result
+    return result
 
 
 def _resolve_registered_implementation(implementation, resolution_dict, operation):

--- a/python/tests/test_registry_snapshot.py
+++ b/python/tests/test_registry_snapshot.py
@@ -1,10 +1,45 @@
-from hgraph import TS, eval_node, graph
+from hgraph import (
+    TS,
+    TSD,
+    eval_node,
+    graph,
+    map_,
+    register_adaptor,
+    service_adaptor,
+    service_adaptor_impl,
+)
 from hgraph.debug import RuntimeRegistrySnapshot, runtime_registry_snapshot
 
 
 @graph
 def _registry_reuse_graph(ts: TS[int]) -> TS[int]:
     return ts + 1
+
+
+@service_adaptor
+def _registry_reuse_adaptor(
+    request: TS[int], path: str = "registry_reuse"
+) -> TS[int]: ...
+
+
+@service_adaptor_impl(interfaces=_registry_reuse_adaptor)
+def _registry_reuse_adaptor_impl(
+    request: TSD[int, TS[int]], path: str
+) -> TSD[int, TS[int]]:
+    return map_(_registry_reuse_graph, request)
+
+
+@graph
+def _registry_reuse_adaptor_graph(ts: TS[int]) -> TS[int]:
+    register_adaptor("registry_reuse", _registry_reuse_adaptor_impl)
+    return _registry_reuse_adaptor(ts, path="registry_reuse")
+
+
+@graph
+def _registry_reuse_map_graph(
+    ts: TSD[int, TS[int]],
+) -> TSD[int, TS[int]]:
+    return map_(_registry_reuse_graph, ts)
 
 
 def test_runtime_registry_snapshot_exposes_cold_path_cardinalities():
@@ -27,6 +62,40 @@ def test_repeated_equivalent_graph_construction_reuses_runtime_types():
     after_first = runtime_registry_snapshot()
 
     assert eval_node(_registry_reuse_graph, [1, 2]) == [2, 3]
+    after_repeated = runtime_registry_snapshot()
+
+    assert after_repeated.node_runtime_types == after_first.node_runtime_types
+    assert after_repeated.graph_programs == after_first.graph_programs
+    assert after_repeated.graph_runtime_types == after_first.graph_runtime_types
+    assert (
+        after_repeated.executor_runtime_types
+        == after_first.executor_runtime_types
+    )
+    assert after_repeated.type_records == after_first.type_records
+
+
+def test_repeated_service_adaptor_wiring_reuses_runtime_types():
+    eval_node(_registry_reuse_adaptor_graph, [1, 2])
+    after_first = runtime_registry_snapshot()
+
+    eval_node(_registry_reuse_adaptor_graph, [1, 2])
+    after_repeated = runtime_registry_snapshot()
+
+    assert after_repeated.node_runtime_types == after_first.node_runtime_types
+    assert after_repeated.graph_programs == after_first.graph_programs
+    assert after_repeated.graph_runtime_types == after_first.graph_runtime_types
+    assert (
+        after_repeated.executor_runtime_types
+        == after_first.executor_runtime_types
+    )
+    assert after_repeated.type_records == after_first.type_records
+
+
+def test_repeated_higher_order_wiring_reuses_runtime_types():
+    eval_node(_registry_reuse_map_graph, [{1: 1}, {1: 2}])
+    after_first = runtime_registry_snapshot()
+
+    eval_node(_registry_reuse_map_graph, [{1: 1}, {1: 2}])
     after_repeated = runtime_registry_snapshot()
 
     assert after_repeated.node_runtime_types == after_first.node_runtime_types

--- a/src/hgraph/runtime/map_node.cpp
+++ b/src/hgraph/runtime/map_node.cpp
@@ -279,6 +279,8 @@ namespace hgraph
             MemoryUtils::StorageLayout graph_layout{};
         };
 
+        using MapNodeContextPtr = std::shared_ptr<const MapNodeContext>;
+
         struct SourceRepointStatus
         {
             bool mux_repointed{false};    ///< any MULTIPLEXED source re-pointed
@@ -286,34 +288,42 @@ namespace hgraph
             bool broadcast_repointed{false};
         };
 
-        // Program-lifetime, intentionally-leaked context storage — same rationale
-        // as single_nested_graph_contexts (see nested_graph_node.cpp).
-        [[nodiscard]] std::vector<std::unique_ptr<MapNodeContext>> &map_node_contexts() noexcept
+        [[nodiscard]] MapNodeContextPtr make_map_node_context(
+            MapNodeSpec spec,
+            std::size_t storage_offset,
+            MemoryUtils::StorageLayout graph_layout)
         {
-            static auto *contexts = new std::vector<std::unique_ptr<MapNodeContext>>;
-            return *contexts;
-        }
-
-        [[nodiscard]] const MapNodeContext &register_map_node_context(MapNodeSpec spec,
-                                                                      std::size_t storage_offset,
-                                                                      MemoryUtils::StorageLayout graph_layout)
-        {
-            auto context = std::make_unique<MapNodeContext>(MapNodeContext{
+            return std::make_shared<MapNodeContext>(MapNodeContext{
                 .spec           = std::move(spec),
                 .storage_offset = storage_offset,
                 .graph_layout   = graph_layout,
             });
-            const auto *result = context.get();
-            map_node_contexts().push_back(std::move(context));
-            return *result;
+        }
+
+        [[nodiscard]] const ValueTypeMetaData *map_node_context_schema()
+        {
+            return TypeRegistry::instance().register_scalar<MapNodeContextPtr>(
+                "hgraph.runtime.map_node_context");
+        }
+
+        [[nodiscard]] const MapNodeContext &map_node_context(const NodeView &view)
+        {
+            const ValueView scalar_context = view.scalars();
+            const auto &context = scalar_context.checked_as<MapNodeContextPtr>();
+            if (!context)
+            {
+                throw std::logic_error("map node has no runtime context");
+            }
+            return *context;
         }
 
         [[nodiscard]] NodeStorageMetrics map_storage_metrics(
             const void *raw_context, const void *memory) noexcept
         {
-            const auto &context = *static_cast<const MapNodeContext *>(raw_context);
+            const auto &plan = *static_cast<const MemoryUtils::StoragePlan *>(raw_context);
             const auto &storage = *MemoryUtils::cast<const MapNodeStorage>(
-                MemoryUtils::advance(memory, context.storage_offset));
+                MemoryUtils::advance(
+                    memory, plan.component(map_storage_field_name).offset));
             NodeStorageMetrics result{};
             for (const auto *bank : {&storage.entries, &storage.previous_entries})
             {
@@ -1287,10 +1297,10 @@ namespace hgraph
 
     MapNodeView MapNodeView::from_node(NodeView view, const void *context)
     {
-        if (context == nullptr) { throw std::logic_error("MapNodeView requires a typed view context"); }
-        const auto &typed_context = *static_cast<const MapNodeContext *>(context);
+        static_cast<void>(context);
+        const auto &typed_context = map_node_context(view);
         void       *storage = MemoryUtils::advance(view.data(), typed_context.storage_offset);
-        return MapNodeView{std::move(view), context, storage};
+        return MapNodeView{std::move(view), &typed_context, storage};
     }
 
     const NodeView &MapNodeView::node() const noexcept { return view_; }
@@ -1332,9 +1342,16 @@ namespace hgraph
     {
         validate_map_node_spec(meta, spec);
 
+        if (meta.scalar_schema != nullptr)
+        {
+            throw std::invalid_argument(
+                "map_node reserves scalar configuration for its runtime context");
+        }
+
         meta.requires_phase_runner =
             meta.requires_phase_runner || spec.child.graph_builder.requires_phase_runner();
         meta.node_kind = NodeKind::Nested;
+        meta.scalar_schema = map_node_context_schema();
         meta.valid_inputs = std::vector<std::size_t>{};
         if (meta.output_schema != nullptr &&
             spec.output_binding_mode != MapOutputBindingMode::ChildTerminalWritesElement)
@@ -1390,12 +1407,17 @@ namespace hgraph
                 descriptor.storage_plan->component(map_storage_field_name).offset + entries_offset,
                 graph_pointer_offset, true),
         };
-        descriptor.ops.extended_view_context = &register_map_node_context(
+        MapNodeContextPtr context = make_map_node_context(
             std::move(spec),
             descriptor.storage_plan->component(map_storage_field_name).offset,
             graph_layout);
+        descriptor.ops.extended_view_context = descriptor.storage_plan;
 
-        return NodeBuilder::from_descriptor(std::move(descriptor));
+        static const std::byte runtime_type_id{};
+        NodeBuilder builder = NodeBuilder::from_canonical_descriptor(
+            std::move(descriptor), &runtime_type_id);
+        builder.scalars(Value{std::move(context)});
+        return builder;
     }
 
     NodeBuilder map_node_with_error_capture(const NodeBuilder &builder,
@@ -1415,8 +1437,15 @@ namespace hgraph
             throw std::invalid_argument("map_node_with_error_capture requires a TSD map node");
         }
 
-        const auto &context = *static_cast<const MapNodeContext *>(ops.extended_view_context);
+        const ValueView scalar_context = builder.scalars().view();
+        const auto &context = scalar_context.checked_as<MapNodeContextPtr>();
+        if (!context)
+        {
+            throw std::logic_error(
+                "map_node_with_error_capture requires a runtime context");
+        }
         NodeTypeMetaData meta = *type.schema();
+        meta.scalar_schema = nullptr;
         if (meta.output_schema == nullptr || meta.output_schema->kind != TSTypeKind::TSD)
         {
             throw std::invalid_argument("map_node_with_error_capture requires a TSD map output");
@@ -1432,7 +1461,7 @@ namespace hgraph
         meta.captures_errors = true;
         meta.error_capture = options;
 
-        NodeBuilder result = map_node(std::move(meta), context.spec);
+        NodeBuilder result = map_node(std::move(meta), context->spec);
         result.input_endpoint(builder.input_endpoint());
         if (!builder.output_endpoint().empty()) { result.output_endpoint(builder.output_endpoint()); }
         result.label(std::string{builder.label()});

--- a/src/hgraph/runtime/node.cpp
+++ b/src/hgraph/runtime/node.cpp
@@ -953,11 +953,10 @@ namespace hgraph
                          const std::vector<DebugField> &debug_fields,
                          const std::optional<NodeTypeDescriptor::DynamicDebug>
                              &dynamic_debug) const {
-            // Supplied debug descriptors are uncommon and may carry
-            // caller-owned names.  Keep them on the conservative path
-            // until their complete value contract is part of this key.
-            if (runtime_type_id == nullptr || !debug_fields.empty() ||
-                dynamic_debug.has_value()) {
+            // Named debug fields may carry caller-owned names. Keep them on
+            // the conservative path until their ownership is part of this
+            // key. Dynamic layouts are data-only and can be compared in full.
+            if (runtime_type_id == nullptr || !debug_fields.empty()) {
               return {};
             }
             const auto found = canonical_types.find(runtime_type_id);
@@ -968,7 +967,8 @@ namespace hgraph
               if (candidate.plan() == &plan &&
                   candidate.record()->implementation_name() ==
                       implementation_label &&
-                  schema_equivalent(*candidate.schema(), schema)) {
+                  schema_equivalent(*candidate.schema(), schema) &&
+                  dynamic_debug_equivalent(candidate, dynamic_debug)) {
                 return candidate;
               }
             }
@@ -1021,10 +1021,24 @@ namespace hgraph
                                           : nullptr,
                 dynamic_debug.has_value() ? &dynamic_debug->layout : nullptr);
             if (runtime_type_id != nullptr && debug_fields.empty() &&
-                !dynamic_debug.has_value()) {
+                (!dynamic_debug.has_value() || dynamic_debug->layout.valid())) {
               canonical_types[runtime_type_id].push_back(type);
             }
             return type;
+          }
+
+          [[nodiscard]] static bool dynamic_debug_equivalent(
+              NodeTypeRef candidate,
+              const std::optional<NodeTypeDescriptor::DynamicDebug>
+                  &requested) noexcept {
+            const DebugDescriptor *debug = candidate.record()->debug;
+            if (!requested.has_value()) {
+              return debug == nullptr || debug->dynamic_layout == nullptr;
+            }
+            return debug != nullptr && debug->dynamic_layout != nullptr &&
+                   debug->key_type == requested->key_type &&
+                   debug->element_type == requested->element_type &&
+                   *debug->dynamic_layout == requested->layout;
           }
 
             static void fill_default_ops(NodeOps &ops)

--- a/src/hgraph/runtime/service_node.cpp
+++ b/src/hgraph/runtime/service_node.cpp
@@ -133,12 +133,19 @@ namespace hgraph
             std::string path,
             std::size_t storage_offset)
         {
+            auto &contexts = subscription_key_source_contexts();
+            const auto existing = std::ranges::find_if(
+                contexts,
+                [&](const auto &context) {
+                    return context->path == path && context->storage_offset == storage_offset;
+                });
+            if (existing != contexts.end()) { return **existing; }
             auto context = std::make_unique<SubscriptionKeySourceContext>(SubscriptionKeySourceContext{
                 .path           = std::move(path),
                 .storage_offset = storage_offset,
             });
             const auto *result = context.get();
-            subscription_key_source_contexts().push_back(std::move(context));
+            contexts.push_back(std::move(context));
             return *result;
         }
 
@@ -153,12 +160,19 @@ namespace hgraph
             std::string path,
             std::size_t storage_offset)
         {
+            auto &contexts = subscription_key_capture_contexts();
+            const auto existing = std::ranges::find_if(
+                contexts,
+                [&](const auto &context) {
+                    return context->path == path && context->storage_offset == storage_offset;
+                });
+            if (existing != contexts.end()) { return **existing; }
             auto context = std::make_unique<SubscriptionKeyCaptureContext>(SubscriptionKeyCaptureContext{
                 .path           = std::move(path),
                 .storage_offset = storage_offset,
             });
             const auto *result = context.get();
-            subscription_key_capture_contexts().push_back(std::move(context));
+            contexts.push_back(std::move(context));
             return *result;
         }
 
@@ -189,12 +203,19 @@ namespace hgraph
             std::string path,
             std::size_t storage_offset)
         {
+            auto &contexts = request_input_source_contexts();
+            const auto existing = std::ranges::find_if(
+                contexts,
+                [&](const auto &context) {
+                    return context->path == path && context->storage_offset == storage_offset;
+                });
+            if (existing != contexts.end()) { return **existing; }
             auto context = std::make_unique<RequestInputSourceContext>(RequestInputSourceContext{
                 .path           = std::move(path),
                 .storage_offset = storage_offset,
             });
             const auto *result = context.get();
-            request_input_source_contexts().push_back(std::move(context));
+            contexts.push_back(std::move(context));
             return *result;
         }
 
@@ -217,12 +238,19 @@ namespace hgraph
             std::string path,
             std::size_t storage_offset)
         {
+            auto &contexts = request_input_capture_contexts();
+            const auto existing = std::ranges::find_if(
+                contexts,
+                [&](const auto &context) {
+                    return context->path == path && context->storage_offset == storage_offset;
+                });
+            if (existing != contexts.end()) { return **existing; }
             auto context = std::make_unique<RequestInputCaptureContext>(RequestInputCaptureContext{
                 .path           = std::move(path),
                 .storage_offset = storage_offset,
             });
             const auto *result = context.get();
-            request_input_capture_contexts().push_back(std::move(context));
+            contexts.push_back(std::move(context));
             return *result;
         }
 
@@ -717,7 +745,12 @@ namespace hgraph
                 throw std::logic_error("request id source failed to publish its id");
             }
         };
-        NodeBuilder builder = NodeBuilder::native(std::move(schema), std::move(callbacks));
+        static const std::byte runtime_type_id{};
+        NodeTypeDescriptor descriptor;
+        descriptor.schema = std::move(schema);
+        descriptor.callbacks = std::move(callbacks);
+        NodeBuilder builder = NodeBuilder::from_canonical_descriptor(
+            std::move(descriptor), &runtime_type_id);
         builder.label("request_id_source");
         return builder;
     }
@@ -748,7 +781,8 @@ namespace hgraph
         descriptor.ops.extended_view_type_id = SubscriptionKeySourceView::node_view_type_id();
         descriptor.ops.extended_view_context = context;
 
-        NodeBuilder builder = NodeBuilder::from_descriptor(std::move(descriptor));
+        NodeBuilder builder = NodeBuilder::from_canonical_descriptor(
+            std::move(descriptor), context);
         builder.label(std::string{"subscription_key_source:"} + context->path);
         return builder;
     }
@@ -787,7 +821,8 @@ namespace hgraph
         descriptor.ops.evaluate_impl          = &subscription_key_capture_evaluate_impl;
         descriptor.ops.extended_view_context  = context;
 
-        NodeBuilder builder = NodeBuilder::from_descriptor(std::move(descriptor));
+        NodeBuilder builder = NodeBuilder::from_canonical_descriptor(
+            std::move(descriptor), context);
         builder.label(std::string{"subscription_key_capture:"} + context->path);
         return builder;
     }
@@ -819,7 +854,8 @@ namespace hgraph
         descriptor.ops.extended_view_type_id = RequestInputSourceView::node_view_type_id();
         descriptor.ops.extended_view_context = context;
 
-        NodeBuilder builder = NodeBuilder::from_descriptor(std::move(descriptor));
+        NodeBuilder builder = NodeBuilder::from_canonical_descriptor(
+            std::move(descriptor), context);
         builder.label(std::string{"request_input_source:"} + context->path);
         return builder;
     }
@@ -869,7 +905,8 @@ namespace hgraph
         descriptor.ops.evaluate_impl         = &request_input_capture_evaluate_impl;
         descriptor.ops.extended_view_context = context;
 
-        NodeBuilder builder = NodeBuilder::from_descriptor(std::move(descriptor));
+        NodeBuilder builder = NodeBuilder::from_canonical_descriptor(
+            std::move(descriptor), context);
         builder.label(std::string{"request_input_capture:"} + context->path);
         return builder;
     }

--- a/src/hgraph/runtime/shared_output_node.cpp
+++ b/src/hgraph/runtime/shared_output_node.cpp
@@ -10,6 +10,7 @@
 #include <hgraph/types/time_series/ts_output/base_view.h>
 #include <hgraph/types/time_series_reference.h>
 
+#include <algorithm>
 #include <array>
 #include <deque>
 #include <stdexcept>
@@ -45,9 +46,18 @@ namespace hgraph
             std::size_t storage_offset = 0)
         {
             if (key.empty()) { throw std::invalid_argument("shared output key must not be empty"); }
+            static auto *configs = new std::deque<SharedOutputConfig>;
+            const auto existing = std::ranges::find_if(
+                *configs,
+                [&](const SharedOutputConfig &config) {
+                    return config.key == key &&
+                           config.target_schema == &target_schema &&
+                           config.storage_offset == storage_offset &&
+                           config.strict == strict;
+                });
+            if (existing != configs->end()) { return *existing; }
             // Node callback tables are interned, so builder config storage must
             // outlive every graph instance created from the builder.
-            static auto *configs = new std::deque<SharedOutputConfig>;
             configs->push_back(SharedOutputConfig{
                 .key = std::move(key),
                 .target_schema = &target_schema,
@@ -232,15 +242,14 @@ namespace hgraph
         auto       &registry = TypeRegistry::instance();
         const auto *output_schema = registry.ref(&target_schema);
 
-        NodeTypeMetaData schema;
-        schema.display_name      = "shared_output_source";
-        schema.output_schema     = output_schema;
-        schema.state_schema      = output_schema->value_schema;
-        schema.node_kind         = NodeKind::PullSource;
-        schema.schedule_on_start = true;
+        NodeTypeDescriptor descriptor;
+        descriptor.schema.display_name      = "shared_output_source";
+        descriptor.schema.output_schema     = output_schema;
+        descriptor.schema.state_schema      = output_schema->value_schema;
+        descriptor.schema.node_kind         = NodeKind::PullSource;
+        descriptor.schema.schedule_on_start = true;
 
-        NodeCallbacks callbacks;
-        callbacks.evaluate = [config](const NodeView &view, DateTime evaluation_time) {
+        descriptor.callbacks.evaluate = [config](const NodeView &view, DateTime evaluation_time) {
             const auto  state = view.state();
             const auto &reference = state.checked_as<TimeSeriesReference>();
             if (reference.is_empty() && reference.target_schema() == nullptr)
@@ -256,11 +265,12 @@ namespace hgraph
                 throw std::logic_error("shared output source failed to publish the captured reference");
             }
         };
-        callbacks.stop = [](const NodeView &view, DateTime) {
+        descriptor.callbacks.stop = [](const NodeView &view, DateTime) {
             view.replace_state(Value{TimeSeriesReference{}});
         };
 
-        NodeBuilder builder = NodeBuilder::native(std::move(schema), std::move(callbacks));
+        NodeBuilder builder = NodeBuilder::from_canonical_descriptor(
+            std::move(descriptor), config);
         builder.label(std::string{"shared_output_source:"} + config->key);
         return builder;
     }
@@ -297,7 +307,8 @@ namespace hgraph
         descriptor.ops.evaluate_impl         = &shared_output_capture_evaluate_impl;
         descriptor.ops.extended_view_context = config;
 
-        NodeBuilder builder = NodeBuilder::from_descriptor(std::move(descriptor));
+        NodeBuilder builder = NodeBuilder::from_canonical_descriptor(
+            std::move(descriptor), config);
         builder.label(std::string{"shared_output_capture:"} + config->key);
         return builder;
     }

--- a/src/hgraph/types/graph_wiring.cpp
+++ b/src/hgraph/types/graph_wiring.cpp
@@ -2223,7 +2223,12 @@ WiringPortRef Wiring::add_node(std::type_index def,
 
     NodeBuilder builder = make_builder(); // intern miss: only now pay for (and
                                           // register) the builder
-    builder.scalars(std::move(scalars));
+    // The supplied scalar participates in wiring interning. A specialised
+    // builder may carry a different runtime-only value (for example a nested
+    // graph context); preserve that explicit per-instance configuration.
+    if (!builder.scalars().has_value()) {
+      builder.scalars(std::move(scalars));
+    }
 
     WiringInstance &instance = impl_->instances.emplace_back();
     instance.definition = def;

--- a/tests/cpp/test_registry_snapshot.cpp
+++ b/tests/cpp/test_registry_snapshot.cpp
@@ -1,5 +1,7 @@
+#include <hgraph/lib/std/std_operators.h>
 #include <hgraph/runtime/registry_snapshot.h>
 #include <hgraph/runtime/runtime.h>
+#include <hgraph/types/service_wiring.h>
 #include <hgraph/types/static_node.h>
 
 #include <catch2/catch_test_macros.hpp>
@@ -31,6 +33,67 @@ GraphBuilder canonical_graph(std::string label = "registry_canonical_graph") {
   graph.label(std::move(label)).add_node(std::move(node));
   return graph;
 }
+
+struct RegistryServiceAdaptor : service_adaptor::interface {
+  static constexpr std::string_view name{"registry_service_adaptor"};
+  using input_schema = TS<Int>;
+  using output_schema = TS<Int>;
+};
+
+struct RegistryServiceAdaptorSource {
+  static constexpr auto name = "registry_service_adaptor_source";
+  static constexpr bool schedule_on_start = true;
+
+  static void eval(Out<TS<Int>> out) { out.set(Int{1}); }
+};
+
+struct RegistryServiceAdaptorImpl {
+  static constexpr auto name = "registry_service_adaptor_impl";
+
+  static void eval(
+      In<"requests", TSD<Int, TS<Int>>, InputValidity::Unchecked> requests,
+      Out<TSD<Int, TS<Int>>> out) {
+    (void)requests;
+    (void)out;
+  }
+};
+
+struct RegistryServiceAdaptorGraph {
+  static constexpr auto name = "registry_service_adaptor_graph";
+
+  static void compose(Wiring &w) {
+    const auto custom = service_adaptor::path("registry_reuse");
+    service_adaptor::register_service_adaptor_impl<
+        RegistryServiceAdaptor, RegistryServiceAdaptorImpl>(w, custom);
+    const auto request = wire<RegistryServiceAdaptorSource>(w);
+    static_cast<void>(wire<RegistryServiceAdaptor>(w, custom, request));
+  }
+};
+
+struct RegistryMapSource {
+  static constexpr auto name = "registry_map_source";
+  static constexpr bool schedule_on_start = true;
+
+  static void eval(Out<TSD<Int, TS<Int>>>) {}
+};
+
+struct RegistryMappedGraph {
+  static constexpr auto name = "registry_mapped_graph";
+
+  static Port<TS<Int>> compose(Wiring &, Port<TS<Int>> value) {
+    using namespace hgraph::stdlib::syntax;
+    return (value + Int{1}).as<TS<Int>>();
+  }
+};
+
+struct RegistryMapGraph {
+  static constexpr auto name = "registry_map_graph";
+
+  static void compose(Wiring &w) {
+    const auto values = wire<RegistryMapSource>(w);
+    static_cast<void>(wire<stdlib::map_>(w, fn<RegistryMappedGraph>(), values));
+  }
+};
 } // namespace
 
 TEST_CASE("runtime registry snapshot reports retained type cardinalities")
@@ -180,4 +243,48 @@ TEST_CASE("equivalent graph and executor runtime types are reused") {
       .mode(GraphExecutorMode::RealTime)
       .graph_builder(canonical_graph());
   CHECK(realtime_executor.type() != first_executor_type);
+}
+
+TEST_CASE("native service adaptor wiring reuses runtime types") {
+  using namespace hgraph;
+
+  stdlib::register_standard_operators();
+
+  GraphBuilder first = build_graph<RegistryServiceAdaptorGraph>();
+  static_cast<void>(first.root_type());
+  const RuntimeRegistrySnapshot after_first = runtime_registry_snapshot();
+
+  GraphBuilder repeated = build_graph<RegistryServiceAdaptorGraph>();
+  static_cast<void>(repeated.root_type());
+  const RuntimeRegistrySnapshot after_repeated = runtime_registry_snapshot();
+
+  CHECK(after_repeated.node_runtime_types == after_first.node_runtime_types);
+  CHECK(after_repeated.graph_programs == after_first.graph_programs);
+  CHECK(after_repeated.graph_runtime_types ==
+        after_first.graph_runtime_types);
+  CHECK(after_repeated.executor_runtime_types ==
+        after_first.executor_runtime_types);
+  CHECK(after_repeated.type_records == after_first.type_records);
+}
+
+TEST_CASE("native map wiring reuses runtime types") {
+  using namespace hgraph;
+
+  stdlib::register_standard_operators();
+
+  GraphBuilder first = build_graph<RegistryMapGraph>();
+  static_cast<void>(first.root_type());
+  const RuntimeRegistrySnapshot after_first = runtime_registry_snapshot();
+
+  GraphBuilder repeated = build_graph<RegistryMapGraph>();
+  static_cast<void>(repeated.root_type());
+  const RuntimeRegistrySnapshot after_repeated = runtime_registry_snapshot();
+
+  CHECK(after_repeated.node_runtime_types == after_first.node_runtime_types);
+  CHECK(after_repeated.graph_programs == after_first.graph_programs);
+  CHECK(after_repeated.graph_runtime_types ==
+        after_first.graph_runtime_types);
+  CHECK(after_repeated.executor_runtime_types ==
+        after_first.executor_runtime_types);
+  CHECK(after_repeated.type_records == after_first.type_records);
 }


### PR DESCRIPTION
## Summary

- reuse semantically equivalent Python service-implementation bindings and higher-order graph wrappers
- canonicalize native service boundary, shared-output, and map runtime node types
- replace the process-lifetime map context container with immutable builder/runtime-node-owned scalar context
- add matching Python and native regression tests asserting registry counts plateau after the first equivalent wiring

## Root cause

Repeated service-adaptor execution created fresh Python wrapper identities and fresh native service/map node descriptors. Map nodes also stored each `MapNodeContext` in an intentionally process-lifetime container so raw operation-context pointers could never dangle. Each context retained its `MapNodeSpec` and child `GraphBuilder`, which kept otherwise equivalent graph/type records alive.

This change separates canonical runtime type information from per-wiring configuration. A map node type now contains only reusable schema, callbacks, storage plan, and debug layout. Its immutable `shared_ptr<const MapNodeContext>` is copied through the builder into each runtime node's scalar storage and is released when the builder and graph instances release their last references.

## Impact

After 50 equivalent service-adaptor executions:

| Retained registry | Before | After |
| --- | ---: | ---: |
| Node runtime types | 407 | 12 |
| Graph programs | 51 | 2 |
| Graph runtime types | 102 | 4 |
| Executor runtime types | 1 | 1 |
| Type records | 603 | 153 |

All five counters now remain unchanged after the first execution. Measured repeat RSS growth fell from approximately 1.422 MiB to 0.031 MiB on macOS and 0.070 MiB on physical Linux.

Caching remains deliberately disabled for registration-context captures and unhashable configuration, where semantic equivalence cannot be established safely.

## Validation

Final pushed commit `1231eef2`, rebased onto current `main`:

- macOS fresh native acceptance build: 1367/1367 passed
- macOS stable-ABI Python 3.12 wheel in fresh Python 3.14 environment: 1772 passed, 10 skipped
- physical `hg-linux` fresh native acceptance build with GCC 14: 1367/1367 passed
- physical `hg-linux` stable-ABI Python 3.12 wheel in fresh Python 3.14 environment with `polars[rtcompat]`: 1772 passed, 10 skipped

Additional ownership validation before the final rebase:

- physical Linux full native ASan+UBSan: 1367/1367 passed
- physical Linux ASan Python bridge registry suite: 4/4 passed
