### PR TITLE
Validate Tornado core API and behavioral parity

### DIFF
--- a/docs/source/developer_guide/index.rst
+++ b/docs/source/developer_guide/index.rst
@@ -25,6 +25,7 @@ The developer guide describes the internal design of the C++ implementation. The
    operators
    parity_matrix
    parity_testing
+   tornado_parity
    record_replay_table
    python_integration
    python_bridge

--- a/docs/source/developer_guide/tornado_parity.rst
+++ b/docs/source/developer_guide/tornado_parity.rst
@@ -1,0 +1,112 @@
+Tornado parity disposition
+==========================
+
+This is the test disposition for the Tornado API audit against released Python
+``hgraph`` 0.5.34.  The upstream tests are a design reference as well as an
+output oracle.  All of their user-observable workflows are retained; obsolete
+Python runtime ownership and implementation-object layouts are not.
+
+Upstream test mapping
+---------------------
+
+``hgraph_unit_tests/adaptors/http_adaptor/test_http_adaptor.py``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. list-table::
+   :header-rows: 1
+
+   * - Upstream test
+     - hg_cpp coverage
+   * - ``test_single_request_graph``
+     - ``test_http_server_handler_registers_and_maps_single_requests``
+   * - ``test_multiple_request_graph``
+     - ``test_http_server_handler_registers_batch_requests``
+   * - ``test_http_server_adaptor_graph``
+     - ``test_http_server_supports_late_manual_handler_and_idempotent_call``
+       and the keyed auxiliary-output tests
+   * - ``test_single_request_graph_client``
+     - Near-verbatim
+       ``test_http_client_concurrent_requests_match_upstream_recorded_flow``
+
+The local module additionally covers all four methods and request fields,
+direct client registration, authentication challenge loading, pending and
+cancelled requests, teardown, overlapping-route precedence and invalid
+handler signatures.
+
+``hgraph_unit_tests/adaptors/rest_adaptor/test_rest_adaptor.py``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. list-table::
+   :header-rows: 1
+
+   * - Upstream test
+     - hg_cpp coverage
+   * - ``test_to_request`` (five cases)
+     - ``test_http_request_converts_to_rest_request``
+   * - ``test_from_response`` (six cases)
+     - ``test_rest_response_converts_to_http_response`` plus
+       ``test_http_response_converts_to_typed_rest_response``
+   * - ``test_single_rest_request_graph``
+     - ``test_rest_handler_maps_live_delete_request``
+   * - ``test_multiple_request_graph``
+     - ``test_rest_handler_maps_batch_requests``
+   * - ``test_rest_list_client``, ``test_rest_read_client``,
+       ``test_rest_create_client``, ``test_rest_update_client`` and
+       ``test_rest_delete_client``
+     - ``test_rest_client_helpers_round_trip_against_rest_handler`` executes
+       all five helpers together against a live registered server
+
+Single and batch auxiliary outputs and ``GlobalState`` cleanup have separate
+regressions in the same local module.
+
+``hgraph_unit_tests/adaptors/websocket_adaptor/test_websocket_adaptor.py``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. list-table::
+   :header-rows: 1
+
+   * - Upstream test
+     - hg_cpp coverage
+   * - ``test_single_websocket_request_graph``
+     - ``test_websocket_server_handler_round_trips_binary_messages`` uses a
+       bare graph function and ordered two-message exchange
+   * - ``test_multiple_websocket_request_graph``
+     - ``test_websocket_server_handler_multiplexes_batch_requests`` includes a
+       runtime ``STATE`` injectable
+   * - ``test_websocket_server_adaptor_graph``
+     - The single-handler test explicitly registers the helper and wires a
+       required application input; the upstream xfail is a transport fixture
+       limitation and is not retained
+   * - ``test_single_request_graph_client``
+     - ``test_websocket_client_service_adaptor_infers_message_specialization``
+       runs both ``str`` and ``bytes`` through default implementation
+       registration
+
+Manager buffering/removal, message-type and port isolation, invalid handler
+signatures, explicit connection rejection and lifecycle cleanup have
+additional focused coverage.  The
+upstream module's broad ``ImportError`` guard and xdist-related xfail markers
+are test infrastructure, not supported runtime behaviour.
+
+C++-first correspondence
+------------------------
+
+The transport layer adapts Tornado events to native adaptor clients:
+
+- ordinary server streams use the public C++ adaptor contract exercised by
+  ``tests/cpp/test_adaptor_wiring.cpp`` (paths, duplex routing,
+  multi-interface wiring, generic identity and duplicate rejection);
+- HTTP and WebSocket clients use the native service-adaptor request/reply
+  exchange exercised by ``tests/cpp/test_service_wiring.cpp`` (keyed clients,
+  successive-cycle feedback, recursive bundle deltas, map/mesh ownership and
+  generic specialization);
+- Python handlers compile to native graph/node callables.  Borrowed wrappers
+  alias the owning ``Wiring`` and must not select or mutate graph/run
+  configuration;
+- Python managers own only Tornado sockets, futures and queues.  Queue senders
+  are copied through the graph's ``GlobalState`` seed/result lifecycle and
+  removed by native node stop hooks.
+
+No upstream Python graph executor, service registry or time-series runtime is
+used.  Differences in manager methods and implementation-token classes are
+therefore intentional representation differences outside the curated API.

--- a/docs/source/user_guide/index.rst
+++ b/docs/source/user_guide/index.rst
@@ -14,3 +14,4 @@ The user guide describes the HGraph model from a user point of view: what the fr
    testing_graphs_cpp
    data_and_analytics
    python_compatibility
+   tornado_adaptors

--- a/docs/source/user_guide/tornado_adaptors.rst
+++ b/docs/source/user_guide/tornado_adaptors.rst
@@ -1,0 +1,77 @@
+Tornado HTTP, REST and WebSocket adaptors
+==========================================
+
+Install the ``web`` extra to use the Tornado transports.  Application code
+normally imports from the curated package and registers one transport entry
+point in its top-level graph:
+
+.. code-block:: python
+
+   from hgraph import graph
+   from hgraph.adaptors.tornado import (
+       register_http_server_adaptor,
+       register_rest_client,
+       register_websocket_server_adaptor,
+   )
+
+   @graph
+   def application():
+       register_http_server_adaptor(port=8080)
+       register_websocket_server_adaptor(port=8081)
+       register_rest_client()
+
+The HTTP surface consists of ``Credentials``, the ``HttpRequest`` base and
+``HttpGetRequest``, ``HttpDeleteRequest``, ``HttpPutRequest`` and
+``HttpPostRequest`` leaves, ``HttpResponse``, ``http_server_handler``,
+``register_http_server_adaptor``, ``http_client_adaptor`` and
+``http_client_adaptor_impl``.  REST adds the corresponding
+``Rest*Request``/``Rest*Response`` values, ``RestResultEnum``,
+``rest_handler``, ``register_rest_client`` and the five ``rest_list``,
+``rest_read``, ``rest_create``, ``rest_update`` and ``rest_delete`` helpers.
+WebSocket applications use ``WebSocketConnectRequest``,
+``WebSocketServerRequest``, ``WebSocketClientRequest``, ``WebSocketResponse``,
+the server handler/registration functions, and the client adaptor and its
+implementation token.  These names are the explicit
+``hgraph.adaptors.tornado.__all__`` contract.
+
+Handlers accept either one request or a keyed ``TSD`` batch.  A handler with
+no additional required arguments is wired by its server registration
+function.  A handler with application inputs is called explicitly from the
+graph.  Bare annotated functions, ``@graph`` functions and Python-authored
+nodes are supported.  Runtime injectables such as ``STATE`` and
+``EvaluationEngineApi`` are supplied by the runtime and are not handler call
+arguments.
+
+Advanced raw wiring
+-------------------
+
+Most code should use the registration functions.  Five lower-level names are
+also supported for applications and independently built extensions that wire
+or register an adaptor directly:
+
+- ``http_server_adaptor`` and ``http_server_adaptor_impl``;
+- ``websocket_server_adaptor``, ``websocket_server_adaptor_helper`` and
+  ``websocket_server_adaptor_impl``.
+
+The WebSocket helper is a registration marker for manually wired handler
+graphs.  The C++ registry discovers their specialized graph-side clients and
+the shared implementation owns the route, so its Python representation is not
+the upstream implementation object's representation.  The public operation
+is stable: pass it to ``register_adaptor`` with the server port.
+
+Transport managers and Tornado handlers are implementation details.  In
+particular, ``HttpAdaptorManager``, ``HttpHandler``,
+``WebSocketAdaptorManager``, ``WebSocketHandler``, ``TornadoWeb`` and
+``BaseHandler`` are not package exports.  ``REST_RESPONSE`` and
+``STR_OR_BYTES`` are internal type variables; bind concrete payload and
+``str``/``bytes`` types instead.
+
+Runtime ownership
+-----------------
+
+Python owns Tornado sockets, futures and event-loop tasks.  Adaptor/service
+registration, keyed request/reply multiplexing, feedback, deltas, scheduling
+and graph execution use the native runtime.  Per-run queue senders live in
+``GlobalState`` and are removed during graph stop.  Route declaration order is
+preserved when Tornado installs overlapping patterns, and server state is
+partitioned by port and WebSocket message type.

--- a/python/hgraph/_types.py
+++ b/python/hgraph/_types.py
@@ -1577,7 +1577,7 @@ class _TsExpr:
                         call["__strict__"] = False
                 return _wire("combine", output_type=self, **call)
 
-        strict_cs = kwargs.pop("__strict__", True)
+        strict_cs = kwargs.pop("__strict__", None)
         if (kwargs and not ports and self.handle.is_ts_bundle and not getattr(self, "_json", False)):
             # combine[TS[CompoundScalar]](field=...): a structural TSB of the
             # provided fields feeds the erased combine_cs node (CS IS a
@@ -1585,6 +1585,11 @@ class _TsExpr:
             # const-lift at their inferred types.
             call = dict(kwargs)
             cs_class = getattr(self, "_cs_class", None)
+            if strict_cs is None:
+                # A TimeSeriesSchema bundle publishes each available field
+                # delta independently.  A TS[CompoundScalar] remains strict by
+                # default because it constructs one atomic scalar value.
+                strict_cs = cs_class is not None
             field_types = {}
             if cs_class is not None:
                 field_types.update(_structured_specialized_field_types(

--- a/python/hgraph/_wiring/_services.py
+++ b/python/hgraph/_wiring/_services.py
@@ -599,6 +599,7 @@ class _AdaptorStub(_AdaptorClientStub):
         self._registered_resolutions = (
             registered_resolutions if registered_resolutions is not None else [])
         sig = inspect.signature(fn, eval_str=True)
+        self.__signature__ = sig
         params = [p for p in sig.parameters.values() if _is_ts_annotation(p.annotation)]
         self._signature = sig
         self._request_params = tuple(params)
@@ -732,6 +733,7 @@ class _ServiceAdaptorStub(_AdaptorClientStub):
         self._registered_resolutions = (
             registered_resolutions if registered_resolutions is not None else [])
         sig = inspect.signature(fn, eval_str=True)
+        self.__signature__ = sig
         params = [p for p in sig.parameters.values() if _is_ts_annotation(p.annotation)]
         if not params:
             raise TypeError(
@@ -866,6 +868,19 @@ class _AdaptorImplGroup:
 
     def __init__(self, *implementations):
         self.implementations = implementations
+
+    def _register_adaptor(self, path, *, resolution_dict=None, **kwargs):
+        for implementation in self.implementations:
+            concrete_path = path
+            if concrete_path is None:
+                interface = implementation.interfaces[0]
+                concrete_path = interface._default_path
+            register_adaptor(
+                concrete_path,
+                implementation,
+                resolution_dict=resolution_dict,
+                **kwargs,
+            )
 
     def wire_impl_inputs_stub(self, path=""):
         return _ServiceInputs(impl_input(self, self._resolved_path(path)))

--- a/python/hgraph/adaptors/tornado/__init__.py
+++ b/python/hgraph/adaptors/tornado/__init__.py
@@ -10,10 +10,8 @@ from .http_client_adaptor import (
     http_client_adaptor_impl,
 )
 from .http_server_adaptor import (
-    HttpAdaptorManager,
     HttpDeleteRequest,
     HttpGetRequest,
-    HttpHandler,
     HttpPostRequest,
     HttpPutRequest,
     HttpRequest,
@@ -24,11 +22,8 @@ from .http_server_adaptor import (
     register_http_server_adaptor,
 )
 from .websocket_server_adaptor import (
-    STR_OR_BYTES,
-    WebSocketAdaptorManager,
     WebSocketClientRequest,
     WebSocketConnectRequest,
-    WebSocketHandler,
     WebSocketResponse,
     WebSocketServerRequest,
     register_websocket_server_adaptor,
@@ -42,7 +37,6 @@ from .websocket_client_adaptor import (
     websocket_client_adaptor_impl,
 )
 from ._rest_handler import (
-    REST_RESPONSE,
     RestCreateRequest,
     RestCreateResponse,
     RestDeleteRequest,
@@ -69,10 +63,8 @@ from ._rest_client import (
 
 __all__ = (
     "Credentials",
-    "HttpAdaptorManager",
     "HttpDeleteRequest",
     "HttpGetRequest",
-    "HttpHandler",
     "HttpPostRequest",
     "HttpPutRequest",
     "HttpRequest",
@@ -83,7 +75,6 @@ __all__ = (
     "http_server_adaptor_impl",
     "http_server_handler",
     "register_http_server_adaptor",
-    "REST_RESPONSE",
     "RestCreateRequest",
     "RestCreateResponse",
     "RestDeleteRequest",
@@ -104,11 +95,8 @@ __all__ = (
     "rest_list",
     "rest_read",
     "rest_update",
-    "STR_OR_BYTES",
-    "WebSocketAdaptorManager",
     "WebSocketClientRequest",
     "WebSocketConnectRequest",
-    "WebSocketHandler",
     "WebSocketResponse",
     "WebSocketServerRequest",
     "register_websocket_server_adaptor",

--- a/python/hgraph/adaptors/tornado/_rest_handler.py
+++ b/python/hgraph/adaptors/tornado/_rest_handler.py
@@ -460,7 +460,6 @@ def convert_from_rest_response(
 
 
 __all__ = (
-    "REST_RESPONSE",
     "RestCreateRequest",
     "RestCreateResponse",
     "RestDeleteRequest",

--- a/python/hgraph/adaptors/tornado/http_server_adaptor.py
+++ b/python/hgraph/adaptors/tornado/http_server_adaptor.py
@@ -429,9 +429,29 @@ def http_server_handler(fn=None, *, url: str):
 @adaptor
 def http_server_adaptor(
     response: TSD[int, TS[HttpResponse]],
-    path: str = "http_server",
+    path: str,
 ) -> TSD[int, TS[HttpRequest]]:
     """Expose a graph request/response stream as an HTTP route."""
+
+
+class _HttpServerAdaptorHelperRegistration:
+    """Compatibility marker for explicitly wired HTTP handler graphs.
+
+    The C++ registry discovers those graph-side clients directly, so this
+    marker deliberately leaves ownership with the shared catch-all
+    implementation instead of registering a second implementation per route.
+    """
+
+    __name__ = "http_server_adaptor_helper"
+
+    @staticmethod
+    def _register_adaptor(path, *, resolution_dict=None, port=80):
+        del path, port
+        if resolution_dict:
+            raise TypeError("http_server_adaptor_helper is not generic")
+
+
+_http_server_adaptor_helper = _HttpServerAdaptorHelperRegistration()
 
 
 @adaptor_impl(interfaces=())
@@ -442,7 +462,8 @@ def http_server_adaptor_impl(path: str, port: int = 80) -> None:
     clients = WiringGraphContext.instance().registered_service_clients(
         http_server_adaptor)
     endpoints = set()
-    routes = set()
+    routes = []
+    seen_routes = set()
     for endpoint, type_map, _node, receive in clients:
         if type_map:
             raise TypeError("HTTP server adaptor does not support generic bindings")
@@ -451,7 +472,15 @@ def http_server_adaptor_impl(path: str, port: int = 80) -> None:
                 f"duplicate HTTP adaptor client for {endpoint!r} and direction {receive}")
         endpoints.add((endpoint, receive))
         base = endpoint.removesuffix("/from_graph").removesuffix("/to_graph")
-        routes.add(base)
+        if base not in seen_routes:
+            routes.append(base)
+            seen_routes.add(base)
+
+    handler_priority = {
+        route: index for index, route in enumerate(_HTTP_SERVER_HANDLERS)
+    }
+    routes.sort(key=lambda base: handler_priority.get(
+        http_server_adaptor.path_from_full_path(base), len(handler_priority)))
 
     queue_key = f"http_server_adaptor://{port}/queue"
     manager = HttpAdaptorManager.instance(port)
@@ -503,6 +532,7 @@ def register_http_server_adaptor(port: int) -> None:
     registration = _HTTP_SERVER_REGISTRATIONS.setdefault(wiring, port)
     if registration != port:
         raise ValueError("one wiring graph cannot register the HTTP server on two ports")
+    register_adaptor(None, _http_server_adaptor_helper, port=port)
     register_adaptor("http_server_adaptor", http_server_adaptor_impl, port=port)
     for _path, handler in handlers:
         if handler.auto_wire:
@@ -510,10 +540,8 @@ def register_http_server_adaptor(port: int) -> None:
 
 
 __all__ = (
-    "HttpAdaptorManager",
     "HttpDeleteRequest",
     "HttpGetRequest",
-    "HttpHandler",
     "HttpPostRequest",
     "HttpPutRequest",
     "HttpRequest",

--- a/python/hgraph/adaptors/tornado/http_server_adaptor.py
+++ b/python/hgraph/adaptors/tornado/http_server_adaptor.py
@@ -32,11 +32,7 @@ from hgraph import (
 from hgraph._types import _TsExpr
 from hgraph._wiring import _GraphFn, _PyNode
 from hgraph._wiring._core import _current_wiring
-from hgraph._wiring._markers import (
-    LOGGER,
-    _INJECTABLE_MARKERS,
-    _RecordableStateExpr,
-)
+from hgraph._wiring._operator import _is_hidden_node_parameter
 
 from ._tornado_web import BaseHandler, TornadoWeb
 
@@ -44,13 +40,14 @@ logger = logging.getLogger(__name__)
 
 
 def _handler_parameters(signature):
+    # The canonical runtime-supplied-parameter predicate covers the full
+    # injectable family (markers, LOGGER, STATE[T]/RECORDABLE_STATE/context
+    # expressions, _output) — a hand-rolled subset here silently leaked
+    # typed STATE parameters into the public handler signature.
     return tuple(
         parameter
         for name, parameter in signature.parameters.items()
-        if name != "request"
-        and parameter.annotation not in _INJECTABLE_MARKERS
-        and parameter.annotation is not LOGGER
-        and not isinstance(parameter.annotation, _RecordableStateExpr)
+        if name != "request" and not _is_hidden_node_parameter(parameter)
     )
 
 

--- a/python/hgraph/adaptors/tornado/websocket_server_adaptor.py
+++ b/python/hgraph/adaptors/tornado/websocket_server_adaptor.py
@@ -13,7 +13,7 @@ from frozendict import frozendict
 from hgraph import (
     CompoundScalar,
     GlobalState,
-    REMOVE,
+    REMOVE_IF_EXISTS,
     TS,
     TSB,
     TSD,
@@ -32,7 +32,13 @@ from hgraph import (
     sink_node,
     to_graph,
 )
+from hgraph._wiring import _GraphFn, _PyNode
 from hgraph._wiring._core import _current_wiring
+from hgraph._wiring._markers import (
+    LOGGER,
+    _INJECTABLE_MARKERS,
+    _RecordableStateExpr,
+)
 
 from ._tornado_web import BaseHandler, TornadoWeb
 
@@ -213,8 +219,11 @@ class WebSocketAdaptorManager:
                 self._pending_connect.pop(path, None)
         senders = self._queues.get(path)
         if senders is not None:
-            senders[0]({request_id: REMOVE})
-            senders[1]({request_id: REMOVE})
+            # A rejected connection never creates a message-series key, and
+            # shutdown may race a sparse keyed input.  Teardown is therefore
+            # deliberately idempotent for both streams.
+            senders[0]({request_id: REMOVE_IF_EXISTS})
+            senders[1]({request_id: REMOVE_IF_EXISTS})
 
 
 class WebSocketHandler(tornado.websocket.WebSocketHandler):
@@ -270,14 +279,14 @@ class WebSocketHandler(tornado.websocket.WebSocketHandler):
 @adaptor
 def websocket_server_adaptor(
     response: TSD[int, TSB[WebSocketResponse[STR_OR_BYTES]]],
-    path: str = "websocket_server",
+    path: str,
 ) -> TSD[int, TSB[WebSocketServerRequest[STR_OR_BYTES]]]:
     """Expose a typed graph request/response stream as a WebSocket route."""
 
 
 class _WebSocketServerHandler:
     def __init__(self, fn, url: str):
-        self._fn = fn
+        self._fn = fn if isinstance(fn, (_GraphFn, _PyNode)) else graph(fn)
         self.url = url
         self.__name__ = getattr(fn, "__name__", "websocket_server_handler")
 
@@ -316,6 +325,9 @@ class _WebSocketServerHandler:
             parameter
             for name, parameter in signature.parameters.items()
             if name != "request"
+            and parameter.annotation not in _INJECTABLE_MARKERS
+            and parameter.annotation is not LOGGER
+            and not isinstance(parameter.annotation, _RecordableStateExpr)
         )
         self.__signature__ = signature.replace(parameters=parameters)
         self.auto_wire = all(
@@ -439,7 +451,8 @@ def _websocket_server_catch_all(path: str, port: int = 80) -> None:
     clients = WiringGraphContext.instance().registered_service_clients(
         websocket_server_adaptor)
     endpoints = set()
-    grouped = {str: set(), bytes: set()}
+    grouped = {str: [], bytes: []}
+    seen = {str: set(), bytes: set()}
     for endpoint, type_map, _node, receive in clients:
         if (endpoint, receive) in endpoints:
             raise ValueError(
@@ -447,9 +460,17 @@ def _websocket_server_catch_all(path: str, port: int = 80) -> None:
         endpoints.add((endpoint, receive))
         message_type = resolved_type(type_map[STR_OR_BYTES])
         base = endpoint.removesuffix("/from_graph").removesuffix("/to_graph")
-        grouped[message_type].add(base)
+        if base not in seen[message_type]:
+            grouped[message_type].append(base)
+            seen[message_type].add(base)
+    handler_priority = {
+        route: index for index, route in enumerate(_WEBSOCKET_SERVER_HANDLERS)
+    }
     for message_type, entries in grouped.items():
         if entries:
+            interface = websocket_server_adaptor[STR_OR_BYTES:message_type]
+            entries.sort(key=lambda base: handler_priority.get(
+                interface.path_from_full_path(base), len(handler_priority)))
             _wire_websocket_message_type(port, message_type, entries)
 
 def websocket_server_handler(fn=None, *, url: str):
@@ -461,12 +482,32 @@ def websocket_server_handler(fn=None, *, url: str):
     return handler
 
 
+class _WebSocketServerAdaptorHelperRegistration:
+    """Compatibility marker for explicitly wired WebSocket handler graphs.
+
+    Specialized graph-side clients are discovered by the shared catch-all, so
+    the marker must not compete with it for ownership in the C++ registry.
+    """
+
+    __name__ = "websocket_server_adaptor_helper"
+
+    @staticmethod
+    def _register_adaptor(path, *, resolution_dict=None, port=80):
+        del path, port
+        if resolution_dict:
+            raise TypeError("websocket_server_adaptor_helper resolves from its handlers")
+
+
+websocket_server_adaptor_helper = _WebSocketServerAdaptorHelperRegistration()
+
+
 def register_websocket_server_adaptor(port: int) -> None:
     """Register all declared WebSocket routes on ``port``."""
     wiring = _current_wiring()
     registration = _WEBSOCKET_SERVER_REGISTRATIONS.setdefault(wiring, port)
     if registration != port:
         raise ValueError("one wiring graph cannot register the WebSocket server on two ports")
+    register_adaptor(None, websocket_server_adaptor_helper, port=port)
     register_adaptor(
         "websocket_server_adaptor", _websocket_server_catch_all, port=port)
     for _url, handler in tuple(_WEBSOCKET_SERVER_HANDLERS.items()):
@@ -475,9 +516,13 @@ def register_websocket_server_adaptor(port: int) -> None:
 
 
 class _WebSocketServerAdaptorImplementation:
-    """Materialize every typed route behind the generic adaptor registration."""
+    """Public registration token for the shared typed server implementation."""
 
-    def _register_adaptor(self, path, *, resolution_dict=None, port=80):
+    __name__ = "websocket_server_adaptor_impl"
+
+    @staticmethod
+    def _register_adaptor(path, *, resolution_dict=None, port=80):
+        del path
         if resolution_dict:
             raise TypeError(
                 "websocket_server_adaptor_impl resolves message types from its handlers"
@@ -486,17 +531,11 @@ class _WebSocketServerAdaptorImplementation:
 
 
 websocket_server_adaptor_impl = _WebSocketServerAdaptorImplementation()
-# The upstream helper and implementation are two registration entry points
-# for the same generic path-routed graph.
-websocket_server_adaptor_helper = websocket_server_adaptor_impl
 
 
 __all__ = (
-    "STR_OR_BYTES",
-    "WebSocketAdaptorManager",
     "WebSocketClientRequest",
     "WebSocketConnectRequest",
-    "WebSocketHandler",
     "WebSocketResponse",
     "WebSocketServerRequest",
     "register_websocket_server_adaptor",

--- a/python/hgraph/adaptors/tornado/websocket_server_adaptor.py
+++ b/python/hgraph/adaptors/tornado/websocket_server_adaptor.py
@@ -34,11 +34,6 @@ from hgraph import (
 )
 from hgraph._wiring import _GraphFn, _PyNode
 from hgraph._wiring._core import _current_wiring
-from hgraph._wiring._markers import (
-    LOGGER,
-    _INJECTABLE_MARKERS,
-    _RecordableStateExpr,
-)
 
 from ._tornado_web import BaseHandler, TornadoWeb
 
@@ -321,13 +316,14 @@ class _WebSocketServerHandler:
                 f"WebSocket handler output must be {expected_output!r} with the same message type"
             )
 
+        from hgraph._wiring._operator import _is_hidden_node_parameter
+
+        # Canonical predicate: covers the whole injectable family incl.
+        # typed STATE[T] expressions (review catch on this PR).
         parameters = tuple(
             parameter
             for name, parameter in signature.parameters.items()
-            if name != "request"
-            and parameter.annotation not in _INJECTABLE_MARKERS
-            and parameter.annotation is not LOGGER
-            and not isinstance(parameter.annotation, _RecordableStateExpr)
+            if name != "request" and not _is_hidden_node_parameter(parameter)
         )
         self.__signature__ = signature.replace(parameters=parameters)
         self.auto_wire = all(

--- a/python/py_wiring.h
+++ b/python/py_wiring.h
@@ -80,6 +80,10 @@ namespace hgraph::python_bridge
 
     struct PyWiring
     {
+        struct BorrowedTag
+        {
+        };
+
         // Owned by default; a BORROWED PyWiring (python graph callables run
         // against a Wiring the C++ side owns - e.g. a sub-graph compile)
         // aliases without ownership and cannot be run/finished.
@@ -117,10 +121,14 @@ namespace hgraph::python_bridge
         {
         }
 
+        explicit PyWiring(BorrowedTag) noexcept {}
+
         [[nodiscard]] static PyWiring borrow(Wiring &target)
         {
-            PyWiring result;
-            result.owned.reset();
+            // A borrowed wrapper aliases an already-configured wiring. It
+            // must not select the dense top-level testing model while a
+            // seeded graph is compiling a nested Python graph.
+            PyWiring result{BorrowedTag{}};
             result.raw = &target;
             return result;
         }

--- a/python/tests/adaptors/tornado/test_http_client_adaptor.py
+++ b/python/tests/adaptors/tornado/test_http_client_adaptor.py
@@ -289,6 +289,76 @@ def test_http_client_service_adaptor(
     assert f"http_client_adaptor://{path}/queue" not in state
 
 
+def test_http_client_concurrent_requests_match_upstream_recorded_flow(free_tcp_port):
+    """Near-verbatim port of upstream's real-time HTTP client graph test."""
+    route = f"/recorded-client-{free_tcp_port}/(.*)"
+
+    @http_server_handler(url=route)
+    def echo(request: hg.TS[HttpRequest]) -> hg.TS[HttpResponse]:
+        return hg.combine[hg.TS[HttpResponse]](
+            status_code=200,
+            body=hg.convert[hg.TS[bytes]](request.url_parsed_args[0]),
+        )
+
+    @hg.sink_node
+    def stop_when_all_done(
+        values: hg.TSD[str, hg.TS[bool]],
+        expected_count: int,
+        _engine: hg.EvaluationEngineApi = None,
+        _state: hg.STATE = None,
+    ) -> None:
+        _state.done_count = getattr(_state, "done_count", 0)
+        _state.done_count += sum(bool(value) for value in values.delta_value.values())
+        if _state.done_count >= expected_count:
+            _engine.request_engine_stop()
+
+    @hg.graph
+    def application() -> None:
+        register_http_server_adaptor(free_tcp_port)
+        hg.register_adaptor("http_client", http_client_adaptor_impl)
+        queries = {
+            str(index): HttpGetRequest(
+                f"http://127.0.0.1:{free_tcp_port}/recorded-client-"
+                f"{free_tcp_port}/{index}"
+            )
+            for index in range(10)
+        }
+
+        @hg.graph
+        def send_query(key: hg.TS[str], query: hg.TS[HttpRequest]) -> hg.TS[bool]:
+            response = http_client_adaptor(query)
+            return key == hg.convert[hg.TS[str]](response.body)
+
+        result = hg.map_(
+            send_query,
+            query=hg.const(
+                queries,
+                tp=hg.TSD[str, hg.TS[HttpRequest]],
+                delay=timedelta(milliseconds=2),
+            ),
+        )
+        hg.record(result)
+        stop_when_all_done(result, 10)
+
+    state = hg.GlobalState()
+    with hg.GlobalContext(state):
+        hg.evaluate_graph(
+            application,
+            hg.GraphConfiguration(
+                run_mode=hg.EvaluationMode.REAL_TIME,
+                end_time=timedelta(seconds=3),
+            ),
+        )
+        recorded = hg.get_recorded_value()
+
+    accumulated = {}
+    for _timestamp, delta in recorded:
+        accumulated.update(delta)
+    assert accumulated == {str(index): True for index in range(10)}
+    assert not any(key.startswith("http_client_adaptor://") for key in state.keys())
+    assert not any(key.startswith("http_server_adaptor://") for key in state.keys())
+
+
 def test_http_server_adaptor_round_trips_all_methods(free_tcp_port):
     route = "/items/(.*)"
     received = []
@@ -535,7 +605,7 @@ def test_http_server_supports_late_manual_handler_and_idempotent_call(free_tcp_p
 
 
 def test_http_manager_buffers_request_until_route_queue_starts(free_tcp_port):
-    from hgraph.adaptors.tornado import HttpAdaptorManager
+    from hgraph.adaptors.tornado.http_server_adaptor import HttpAdaptorManager
 
     route = f"/pending-{free_tcp_port}"
     manager = HttpAdaptorManager(free_tcp_port)
@@ -554,7 +624,7 @@ def test_http_manager_buffers_request_until_route_queue_starts(free_tcp_port):
 
 
 def test_http_manager_stop_routes_cancels_outstanding_requests(free_tcp_port):
-    from hgraph.adaptors.tornado import HttpAdaptorManager
+    from hgraph.adaptors.tornado.http_server_adaptor import HttpAdaptorManager
 
     route = f"/stopping-{free_tcp_port}"
     manager = HttpAdaptorManager(free_tcp_port)
@@ -571,6 +641,91 @@ def test_http_manager_stop_routes_cancels_outstanding_requests(free_tcp_port):
         assert request_id not in manager._requests
 
     asyncio.run(exercise())
+
+
+def test_http_route_precedence_follows_handler_registration_order(free_tcp_port):
+    prefix = f"/precedence-{free_tcp_port}"
+    specific_route = f"{prefix}/specific/(.*)"
+    broad_route = f"{prefix}/(.*)"
+    result = []
+    errors = []
+
+    @http_server_handler(url=specific_route)
+    @hg.compute_node
+    def specific(request: hg.TS[HttpRequest]) -> hg.TS[HttpResponse]:
+        return HttpResponse(status_code=200, body=b"specific")
+
+    @http_server_handler(url=broad_route)
+    @hg.compute_node
+    def broad(request: hg.TS[HttpRequest]) -> hg.TS[HttpResponse]:
+        return HttpResponse(status_code=200, body=b"broad")
+
+    @hg.push_queue(hg.TS[bool])
+    def drive_client(sender):
+        def run():
+            try:
+                deadline = time.monotonic() + 10.0
+                while True:
+                    connection = http.client.HTTPConnection(
+                        "127.0.0.1", free_tcp_port, timeout=2.0)
+                    try:
+                        connection.request("GET", f"{prefix}/specific/item")
+                        response = connection.getresponse()
+                        if response.status == 404 and time.monotonic() < deadline:
+                            time.sleep(0.02)
+                            continue
+                        result.append(response.read())
+                        break
+                    except (ConnectionRefusedError, OSError):
+                        if time.monotonic() >= deadline:
+                            raise
+                        time.sleep(0.02)
+                    finally:
+                        connection.close()
+            except BaseException as error:
+                errors.append(error)
+            finally:
+                sender(True)
+
+        Thread(target=run, name="hgraph-http-precedence-test", daemon=True).start()
+
+    @hg.sink_node
+    def stop_when_done(
+        done: hg.TS[bool],
+        _engine: hg.EvaluationEngineApi = None,
+    ) -> None:
+        _engine.request_engine_stop()
+
+    @hg.graph
+    def application() -> None:
+        done = drive_client()
+        register_http_server_adaptor(free_tcp_port)
+        stop_when_done(done)
+
+    with hg.GlobalContext(hg.GlobalState()):
+        hg.run_graph(
+            application,
+            end_time=datetime.now(timezone.utc).replace(tzinfo=None)
+            + timedelta(seconds=5),
+            run_mode=hg.EvaluationMode.REAL_TIME,
+        )
+
+    assert errors == []
+    assert result == [b"specific"]
+
+
+def test_http_server_handler_rejects_invalid_authoring_signatures():
+    with pytest.raises(TypeError, match="requires a 'request'"):
+
+        @http_server_handler(url="/invalid/missing-request")
+        def missing_request(value: hg.TS[int]) -> hg.TS[HttpResponse]:
+            return value
+
+    with pytest.raises(TypeError, match="HTTP handler request must be"):
+
+        @http_server_handler(url="/invalid/request-type")
+        def wrong_request(request: hg.TS[int]) -> hg.TS[HttpResponse]:
+            return request
 
 
 def test_http_server_handler_registers_batch_requests(free_tcp_port):

--- a/python/tests/adaptors/tornado/test_public_api.py
+++ b/python/tests/adaptors/tornado/test_public_api.py
@@ -1,0 +1,140 @@
+import inspect
+from importlib import import_module
+
+import hgraph.adaptors.tornado as tornado
+
+
+CORE_API = {
+    "Credentials",
+    "HttpRequest",
+    "HttpGetRequest",
+    "HttpDeleteRequest",
+    "HttpPutRequest",
+    "HttpPostRequest",
+    "HttpResponse",
+    "http_server_handler",
+    "register_http_server_adaptor",
+    "http_client_adaptor",
+    "http_client_adaptor_impl",
+    "RestRequest",
+    "RestCreateRequest",
+    "RestUpdateRequest",
+    "RestReadRequest",
+    "RestDeleteRequest",
+    "RestListRequest",
+    "RestResponse",
+    "RestCreateResponse",
+    "RestUpdateResponse",
+    "RestReadResponse",
+    "RestDeleteResponse",
+    "RestListResponse",
+    "RestResultEnum",
+    "rest_handler",
+    "register_rest_client",
+    "rest_list",
+    "rest_read",
+    "rest_create",
+    "rest_update",
+    "rest_delete",
+    "WebSocketConnectRequest",
+    "WebSocketServerRequest",
+    "WebSocketClientRequest",
+    "WebSocketResponse",
+    "websocket_server_handler",
+    "register_websocket_server_adaptor",
+    "websocket_client_adaptor",
+    "websocket_client_adaptor_impl",
+}
+
+ADVANCED_API = {
+    "http_server_adaptor",
+    "http_server_adaptor_impl",
+    "websocket_server_adaptor",
+    "websocket_server_adaptor_helper",
+    "websocket_server_adaptor_impl",
+}
+
+INTERNAL_NAMES = {
+    "HttpAdaptorManager",
+    "HttpHandler",
+    "WebSocketAdaptorManager",
+    "WebSocketHandler",
+    "TornadoWeb",
+    "BaseHandler",
+    "REST_RESPONSE",
+    "STR_OR_BYTES",
+}
+
+
+def test_tornado_package_exports_only_the_supported_user_api():
+    assert set(tornado.__all__) == CORE_API | ADVANCED_API
+    assert not INTERNAL_NAMES.intersection(tornado.__all__)
+    for name in CORE_API | ADVANCED_API:
+        assert getattr(tornado, name) is not None
+
+
+def test_public_adaptor_stubs_preserve_their_declared_signatures():
+    expected = {
+        "http_client_adaptor": ("request", "path"),
+        "http_server_adaptor": ("response", "path"),
+        "websocket_client_adaptor": ("request", "path"),
+        "websocket_server_adaptor": ("response", "path"),
+    }
+
+    for name, parameters in expected.items():
+        signature = inspect.signature(getattr(tornado, name))
+        assert tuple(signature.parameters) == parameters
+        assert signature.return_annotation is not inspect.Signature.empty
+
+    assert inspect.signature(tornado.http_server_adaptor).parameters[
+        "path"
+    ].default is inspect.Signature.empty
+    assert inspect.signature(tornado.websocket_server_adaptor).parameters[
+        "path"
+    ].default is inspect.Signature.empty
+
+
+def test_supported_names_remain_available_from_their_documented_modules():
+    http_client_module = import_module("hgraph.adaptors.tornado.http_client_adaptor")
+    http_server_module = import_module("hgraph.adaptors.tornado.http_server_adaptor")
+    rest_client_module = import_module("hgraph.adaptors.tornado._rest_client")
+    rest_handler_module = import_module("hgraph.adaptors.tornado._rest_handler")
+    websocket_client_module = import_module("hgraph.adaptors.tornado.websocket_client_adaptor")
+    websocket_server_module = import_module("hgraph.adaptors.tornado.websocket_server_adaptor")
+
+    module_names = {
+        http_client_module: {
+            "Credentials", "http_client_adaptor", "http_client_adaptor_impl",
+        },
+        http_server_module: {
+            "HttpRequest", "HttpGetRequest", "HttpDeleteRequest",
+            "HttpPutRequest", "HttpPostRequest", "HttpResponse",
+            "http_server_handler", "register_http_server_adaptor",
+            "http_server_adaptor", "http_server_adaptor_impl",
+        },
+        rest_handler_module: {
+            "RestRequest", "RestCreateRequest", "RestUpdateRequest",
+            "RestReadRequest", "RestDeleteRequest", "RestListRequest",
+            "RestResponse", "RestCreateResponse", "RestUpdateResponse",
+            "RestReadResponse", "RestDeleteResponse", "RestListResponse",
+            "RestResultEnum", "rest_handler",
+        },
+        rest_client_module: {
+            "register_rest_client", "rest_list", "rest_read", "rest_create",
+            "rest_update", "rest_delete",
+        },
+        websocket_server_module: {
+            "WebSocketConnectRequest", "WebSocketServerRequest",
+            "WebSocketClientRequest", "WebSocketResponse",
+            "websocket_server_handler", "register_websocket_server_adaptor",
+            "websocket_server_adaptor", "websocket_server_adaptor_helper",
+            "websocket_server_adaptor_impl",
+        },
+        websocket_client_module: {
+            "websocket_client_adaptor", "websocket_client_adaptor_impl",
+        },
+    }
+
+    for module, names in module_names.items():
+        for name in names:
+            assert getattr(module, name) is not None

--- a/python/tests/adaptors/tornado/test_public_api.py
+++ b/python/tests/adaptors/tornado/test_public_api.py
@@ -138,3 +138,42 @@ def test_supported_names_remain_available_from_their_documented_modules():
     for module, names in module_names.items():
         for name in names:
             assert getattr(module, name) is not None
+
+
+def test_handler_signatures_exclude_all_runtime_injectables():
+    # Review catch (PR #242): typed STATE[T] annotations (_StateExpr) are
+    # runtime-supplied like the marker injectables — a handler declaring one
+    # must not expose it as a public parameter (nor receive it from a
+    # caller). The filter is the canonical _is_hidden_node_parameter.
+    import inspect
+
+    from hgraph import STATE, TS, TSB, compute_node
+    from hgraph.adaptors.tornado.websocket_server_adaptor import (
+        WebSocketServerRequest,
+        WebSocketResponse,
+        websocket_server_handler,
+    )
+    from hgraph.adaptors.tornado.http_server_adaptor import _handler_parameters
+
+    class _S:
+        count: int = 0
+
+    @websocket_server_handler(url="/state-probe")
+    @compute_node
+    def handler(request: TSB[WebSocketServerRequest[str]],
+                _state: STATE[_S] = None) -> TSB[WebSocketResponse[str]]:
+        """typed-state handler"""
+
+    assert "request" not in inspect.signature(handler).parameters
+    assert "_state" not in inspect.signature(handler).parameters
+
+    # And the shared http-side filter agrees for every injectable family.
+    from hgraph import CLOCK, LOGGER, SCHEDULER
+
+    def probe(request: TS[str], _state: STATE[_S] = None, _clock: CLOCK = None,
+              _log: LOGGER = None, _sched: SCHEDULER = None,
+              plain: TS[int] = None) -> TS[str]:
+        """probe"""
+
+    names = [p.name for p in _handler_parameters(inspect.signature(probe))]
+    assert names == ["plain"]

--- a/python/tests/adaptors/tornado/test_rest_adaptor.py
+++ b/python/tests/adaptors/tornado/test_rest_adaptor.py
@@ -10,7 +10,6 @@ import pytest
 
 import hgraph as hg
 from hgraph.adaptors.tornado import (
-    HttpAdaptorManager,
     HttpDeleteRequest,
     HttpGetRequest,
     HttpPostRequest,
@@ -39,6 +38,7 @@ from hgraph.adaptors.tornado import (
     rest_read,
     rest_update,
 )
+from hgraph.adaptors.tornado.http_server_adaptor import HttpAdaptorManager
 
 
 URL = "http://localhost/test"

--- a/python/tests/adaptors/tornado/test_websocket_adaptor.py
+++ b/python/tests/adaptors/tornado/test_websocket_adaptor.py
@@ -10,7 +10,6 @@ from tornado.websocket import websocket_connect
 
 import hgraph as hg
 from hgraph.adaptors.tornado import (
-    WebSocketAdaptorManager,
     WebSocketClientRequest,
     WebSocketConnectRequest,
     WebSocketResponse,
@@ -19,8 +18,10 @@ from hgraph.adaptors.tornado import (
     websocket_client_adaptor,
     websocket_client_adaptor_impl,
     websocket_server_handler,
+    websocket_server_adaptor_helper,
     websocket_server_adaptor_impl,
 )
+from hgraph.adaptors.tornado.websocket_server_adaptor import WebSocketAdaptorManager
 
 
 @pytest.fixture
@@ -63,31 +64,55 @@ def test_websocket_manager_buffers_open_until_route_queues_start(free_tcp_port):
         assert await accepted is True
 
         manager.remove_request(request_id)
-        assert connect_events[-1] == {request_id: hg.REMOVE}
-        assert message_events == [{request_id: hg.REMOVE}]
+        assert connect_events[-1] == {request_id: hg.REMOVE_IF_EXISTS}
+        assert message_events == [{request_id: hg.REMOVE_IF_EXISTS}]
 
     asyncio.run(exercise())
 
 
+def test_websocket_managers_are_isolated_by_port_and_message_type(free_tcp_port):
+    text_manager = WebSocketAdaptorManager.instance(free_tcp_port, str)
+    binary_manager = WebSocketAdaptorManager.instance(free_tcp_port, bytes)
+    with socket.socket() as sock:
+        sock.bind(("127.0.0.1", 0))
+        other_port = sock.getsockname()[1]
+    other_manager = WebSocketAdaptorManager.instance(other_port, str)
+
+    assert text_manager is not binary_manager
+    assert text_manager is not other_manager
+    assert text_manager._web is binary_manager._web
+    assert text_manager._web is not other_manager._web
+
+
+def test_websocket_server_handler_rejects_invalid_authoring_signatures():
+    with pytest.raises(TypeError, match="requires a 'request'"):
+
+        @websocket_server_handler(url="/invalid/missing-request")
+        def missing_request(value: hg.TS[int]) -> hg.TSB[WebSocketResponse[str]]:
+            return value
+
+    with pytest.raises(TypeError, match="WebSocket handler request must be"):
+
+        @websocket_server_handler(url="/invalid/request-type")
+        def wrong_request(request: hg.TS[int]) -> hg.TSB[WebSocketResponse[str]]:
+            return request
+
+
 def test_websocket_server_handler_round_trips_binary_messages(free_tcp_port):
     route = f"/websocket-{free_tcp_port}/(.*)"
-    connections = []
     client_results = []
     client_errors = []
     threads = []
 
     @websocket_server_handler(url=route)
-    @hg.compute_node
     def echo(
         request: hg.TSB[WebSocketServerRequest[bytes]],
+        suffix: hg.TS[bytes],
     ) -> hg.TSB[WebSocketResponse[bytes]]:
-        result = {}
-        if request.connect_request.modified:
-            connections.append(request.connect_request.value)
-            result["connect_response"] = True
-        if request.messages.modified:
-            result["message"] = request.messages.value[-1]
-        return result
+        return hg.combine[hg.TSB[WebSocketResponse[bytes]]](
+            connect_response=suffix == suffix,
+            message=request.messages[-1],
+        )
 
     @hg.push_queue(hg.TS[bool])
     def drive_client(sender):
@@ -135,10 +160,16 @@ def test_websocket_server_handler_round_trips_binary_messages(free_tcp_port):
     def server_graph() -> None:
         done = drive_client()
         hg.register_adaptor(
+            None,
+            websocket_server_adaptor_helper,
+            port=free_tcp_port,
+        )
+        hg.register_adaptor(
             "websocket_server_adaptor",
             websocket_server_adaptor_impl,
             port=free_tcp_port,
         )
+        echo(suffix=hg.const(b"-reply"))
         stop_when_done(done)
 
     state = hg.GlobalState()
@@ -154,9 +185,74 @@ def test_websocket_server_handler_round_trips_binary_messages(free_tcp_port):
 
     assert client_errors == []
     assert client_results == [b"one", b"two"]
-    assert len(connections) == 1
-    assert isinstance(connections[0], WebSocketConnectRequest)
-    assert connections[0].url_parsed_args == ("client",)
+    assert not any(key.startswith("websocket_server_adaptor://") for key in state.keys())
+
+
+def test_websocket_server_handler_rejects_connection(free_tcp_port):
+    route = f"/websocket-reject-{free_tcp_port}/(.*)"
+    client_results = []
+    client_errors = []
+
+    @websocket_server_handler(url=route)
+    @hg.compute_node
+    def reject(
+        request: hg.TSB[WebSocketServerRequest[str]],
+    ) -> hg.TSB[WebSocketResponse[str]]:
+        if request.connect_request.modified:
+            return {"connect_response": False}
+
+    @hg.push_queue(hg.TS[bool])
+    def drive_client(sender):
+        async def communicate():
+            deadline = time.monotonic() + 10.0
+            while True:
+                try:
+                    connection = await websocket_connect(
+                        f"ws://127.0.0.1:{free_tcp_port}/"
+                        f"websocket-reject-{free_tcp_port}/client",
+                        connect_timeout=3.0,
+                    )
+                    client_results.append(await connection.read_message())
+                    return
+                except (ConnectionRefusedError, OSError):
+                    if time.monotonic() >= deadline:
+                        raise
+                    await asyncio.sleep(0.02)
+
+        def run():
+            try:
+                asyncio.run(communicate())
+            except BaseException as error:
+                client_errors.append(error)
+            finally:
+                sender(True)
+
+        Thread(target=run, name="hgraph-websocket-reject-test", daemon=True).start()
+
+    @hg.sink_node
+    def stop_when_done(
+        done: hg.TS[bool],
+        _engine: hg.EvaluationEngineApi = None,
+    ) -> None:
+        _engine.request_engine_stop()
+
+    @hg.graph
+    def server_graph() -> None:
+        done = drive_client()
+        register_websocket_server_adaptor(free_tcp_port)
+        stop_when_done(done)
+
+    state = hg.GlobalState()
+    with hg.GlobalContext(state):
+        hg.run_graph(
+            server_graph,
+            end_time=datetime.now(timezone.utc).replace(tzinfo=None)
+            + timedelta(seconds=5),
+            run_mode=hg.EvaluationMode.REAL_TIME,
+        )
+
+    assert client_errors == []
+    assert client_results == [None]
     assert not any(key.startswith("websocket_server_adaptor://") for key in state.keys())
 
 
@@ -170,7 +266,9 @@ def test_websocket_server_handler_multiplexes_batch_requests(free_tcp_port):
     @hg.compute_node
     def echo(
         request: hg.TSD[int, hg.TSB[WebSocketServerRequest[bytes]]],
+        _state: hg.STATE = None,
     ) -> hg.TSD[int, hg.TSB[WebSocketResponse[bytes]]]:
+        _state.evaluations = getattr(_state, "evaluations", 0) + 1
         responses = {}
         for request_id, request_value in request.modified_items():
             response = {}
@@ -316,7 +414,7 @@ def test_websocket_client_service_adaptor_infers_message_specialization(
     @hg.graph
     def application() -> None:
         register_websocket_server_adaptor(free_tcp_port)
-        hg.register_adaptor("websocket-client-test", websocket_client_adaptor_impl)
+        hg.register_adaptor(None, websocket_client_adaptor_impl)
         request = hg.combine[client_request_type](
             connect_request=hg.const(
                 WebSocketConnectRequest(
@@ -329,7 +427,6 @@ def test_websocket_client_service_adaptor_infers_message_specialization(
         )
         response = websocket_client_adaptor(
             request,
-            path="websocket-client-test",
         )
         capture(response.message)
 

--- a/tools/parity/surface_known.json
+++ b/tools/parity/surface_known.json
@@ -2663,6 +2663,81 @@
       "name": "EvaluationEngineApi.add_after_evaluation_notification",
       "kind": "method-signature-mismatch",
       "reason": "nanobind builtin: inspect.signature unavailable; keyword calling via nb::arg('fn') and behaviour pinned by test_eval_notifications"
+    },
+    {
+      "module": "hgraph.adaptors.tornado",
+      "kind": "name-missing",
+      "side": "candidate",
+      "reason": "issue #215 defines hgraph.adaptors.tornado.__all__ as the curated Tornado user API; upstream imported symbols, transport managers, handlers and type variables are not package API"
+    },
+    {
+      "module": "hgraph.adaptors.tornado.*",
+      "kind": "name-missing",
+      "side": "candidate",
+      "reason": "issue #215 makes each Tornado module's __all__ authoritative; upstream import leaks and internal managers/handlers/markers are excluded while retained names are pinned by test_public_api"
+    },
+    {
+      "module": "hgraph.adaptors.tornado*",
+      "name": "*.from_dict",
+      "kind": "method-missing",
+      "side": "candidate",
+      "reason": "Tornado CompoundScalar values use the native typed value-conversion contract; upstream inherited dict serialization helpers are a Python representation detail outside issue #215's curated API"
+    },
+    {
+      "module": "hgraph.adaptors.tornado*",
+      "name": "*.to_dict",
+      "kind": "method-missing",
+      "side": "candidate",
+      "reason": "Tornado CompoundScalar values use the native typed value-conversion contract; upstream inherited dict serialization helpers are a Python representation detail outside issue #215's curated API"
+    },
+    {
+      "module": "hgraph.adaptors.tornado*",
+      "name": "*.to_scalar_schema",
+      "kind": "method-missing",
+      "side": "candidate",
+      "reason": "Tornado TimeSeriesSchema classes are wiring annotations; scalar-schema reflection is native and upstream's Python conversion helper is not user API"
+    },
+    {
+      "module": "hgraph.adaptors.tornado.websocket_server_adaptor",
+      "name": "WebSocket*.__init__",
+      "kind": "constructor-signature-mismatch",
+      "reason": "WebSocketServerRequest, WebSocketClientRequest and WebSocketResponse are TimeSeriesSchema wiring annotations, not user-constructed values; construction uses typed TSB wiring"
+    },
+    {
+      "module": "hgraph.adaptors.tornado*",
+      "name": "rest_create",
+      "kind": "signature-mismatch",
+      "reason": "AUTO_RESOLVE is the native authoring layer's stable representation of upstream's anonymous object sentinel; parameter order, optionality and generic resolution behaviour match"
+    },
+    {
+      "module": "hgraph.adaptors.tornado*",
+      "name": "rest_read",
+      "kind": "signature-mismatch",
+      "reason": "AUTO_RESOLVE is the native authoring layer's stable representation of upstream's anonymous object sentinel; parameter order, optionality and generic resolution behaviour match"
+    },
+    {
+      "module": "hgraph.adaptors.tornado*",
+      "name": "rest_update",
+      "kind": "signature-mismatch",
+      "reason": "AUTO_RESOLVE is the native authoring layer's stable representation of upstream's anonymous object sentinel; parameter order, optionality and generic resolution behaviour match"
+    },
+    {
+      "module": "hgraph.adaptors.tornado*",
+      "name": "*adaptor_impl",
+      "kind": "kind-mismatch",
+      "reason": "C++-first adaptor implementations are passive registration tokens (including the typed WebSocket implementation group), not directly invoked Python graph callables; register_adaptor behaviour is parity-tested"
+    },
+    {
+      "module": "hgraph.adaptors.tornado*",
+      "name": "websocket_server_adaptor_helper",
+      "kind": "kind-mismatch",
+      "reason": "the public helper is a passive registration marker because the shared C++ registry owns discovered typed routes; its register_adaptor operation matches upstream without duplicating implementations"
+    },
+    {
+      "module": "hgraph.adaptors.tornado._tornado_web",
+      "name": "TornadoWeb.add_handler",
+      "kind": "method-signature-mismatch",
+      "reason": "TornadoWeb is an internal transport manager excluded by issue #215; the candidate's optional options argument supports the same internal calls"
     }
   ]
 }


### PR DESCRIPTION
## Summary

- define and test the supported Tornado HTTP, REST, WebSocket, and advanced raw-adaptor API
- align handler registration, route precedence, generic adaptor specialization, rejection cleanup, and partial bundle publication with released Python hgraph behavior
- prevent borrowed Python wiring wrappers from selecting or mutating top-level graph/run configuration
- add upstream-test disposition, runtime-design correspondence, user documentation, and narrow surface-audit reasons

## Why

Issue #215 found that the raw surface audit mixed genuine application API with upstream import leakage and Python runtime implementation objects. Public user code is sparse, so this change validates the retained interface using released hgraph 0.5.34 tests as both the behavioral oracle and design reference while preserving hg_cpp's C++-owned runtime and wiring model.

The nested real-time HTTP parity flow also exposed a bridge ownership bug: constructing a borrowed `PyWiring` through its default constructor selected the dense testing model before replacing ownership. The borrowed-tag constructor now aliases the existing configured wiring without changing run configuration.

## User impact

Applications receive a documented, explicit Tornado authoring surface with stable signatures and behavior for HTTP, REST, and WebSocket handlers and clients. Transport managers, concrete Tornado handlers, internal type variables, and imported implementation details are no longer package exports.

## Validation

- macOS fresh native C++ suite: **1,365/1,365 passed**
- macOS Python 3.12 ABI3 wheel on Python 3.14: **1,779 passed, 10 skipped**
- `hg-linux` GCC 14 native suite: **1,365/1,365 passed**
- `hg-linux` Python 3.12 ABI3 wheel on Python 3.14.4: **1,779 passed, 10 skipped**
- `hg-linux` ASan focused Tornado suite: **54/54 passed**
- `hg-linux` ASan full Python non-WIP suite: **1,779 passed, 10 skipped**
- differential parity recipes: **56 validated**
- Sphinx warnings-as-errors build: **passed**
- scoped Tornado surface audit: **0 actionable findings**
- `git diff --check`: **clean**

The repository-wide surface audit still reports 245 pre-existing, non-Tornado baseline findings.

Closes #215