### PR TITLE
Kafka adaptor: match released hgraph API and behavior

### DIFF
--- a/docs/source/developer_guide/parity_matrix.rst
+++ b/docs/source/developer_guide/parity_matrix.rst
@@ -603,8 +603,8 @@ Wiring and node-authoring surface
        one time-series request and one time-series response; bundles carry
        multi-field protocols. Tornado HTTP/WebSocket/REST, catalogue, JSON,
        SQL, Delta Lake, Kafka, Perspective, dataframe, executor, and threaded
-       graph families use that boundary. See :doc:`roadmap` for the explicit
-       advanced-feature restrictions.
+       graph families use that boundary. See :doc:`roadmap` for the remaining
+       explicit advanced-feature restrictions.
    * - Contexts
      - Full (wiring and compiled children)
      - Named/default/required compatibility plus native context capture across

--- a/docs/source/developer_guide/roadmap.rst
+++ b/docs/source/developer_guide/roadmap.rst
@@ -488,10 +488,17 @@ Optional clients are declared as ``sql``, ``snowflake``, ``kafka``, ``delta``,
 may inject a DB-API connection, ``DeltaBackend``, Kafka producer/consumer
 factory, or Perspective client, which also keeps transport tests deterministic.
 
+Kafka retains the released hgraph user contract. Publishers and subscribers
+accept raw bytes or structured ``KafkaMessage`` values; replay-aware graphs
+receive historical messages from the graph start time together with the
+``recovered`` signal. Partition offsets are selected by timestamp, historical
+records are ordered deterministically, and the same per-topic consumer is
+handed to the native live reference service after recovery so there is no
+history-to-live subscription gap. Producer flushing and consumer-thread
+teardown remain graph lifecycle operations.
+
 The following deliberate restrictions replace advanced Python-first code:
 
-- Kafka historical replay is rejected explicitly; normal publish/subscribe,
-  structured messages, headers, lifecycle flush, and consumer cleanup work.
 - SQL's batch adaptor preserves query/result behaviour but does not coalesce
   requests in Python. Normal read/write/execute and catalogue routing work.
 - Delta scheduled maintenance and a second Python batching buffer are omitted;

--- a/docs/source/developer_guide/services.rst
+++ b/docs/source/developer_guide/services.rst
@@ -667,5 +667,5 @@ Deferred (see :doc:`roadmap` Priority 1):
 - application-specific authentication, retry, and deployment policy for
   external resources;
 - ``@component`` and the recordable-id/traits ecosystem it depends on;
-- the advanced compatibility restrictions recorded in :doc:`roadmap`, such as
-  Kafka history replay and Perspective multi-client reduction.
+- the remaining advanced compatibility restrictions recorded in
+  :doc:`roadmap`, such as Perspective multi-client reduction.

--- a/python/hgraph/adaptors/kafka/__init__.py
+++ b/python/hgraph/adaptors/kafka/__init__.py
@@ -1,14 +1,10 @@
-from ._api import *
-from ._impl import *
+from ._api import KafkaMessage, MessageState, message_publisher, message_subscriber
+from ._impl import register_kafka_adaptor
 
-__all__ = [
-    "KafkaMessage",
-    "MessageState",
-    "get_message_state",
+__all__ = (
     "message_publisher",
     "message_subscriber",
-    "message_publisher_operator",
-    "KafkaMessageState",
+    "MessageState",
+    "KafkaMessage",
     "register_kafka_adaptor",
-    "message_source",
-]
+)

--- a/python/hgraph/adaptors/kafka/_api.py
+++ b/python/hgraph/adaptors/kafka/_api.py
@@ -1,46 +1,79 @@
 import inspect
 from abc import ABC, abstractmethod
-from dataclasses import dataclass
+from dataclasses import dataclass, fields
+from datetime import timedelta
+from typing import Callable
 
 from frozendict import frozendict
 
 from hgraph import (
     CompoundScalar,
+    EvaluationEngineApi,
+    EvaluationMode,
+    SCHEDULER,
     TS,
     TSB,
     compute_node,
-    const,
+    default,
     graph,
+    if_then_else,
+    reference_service,
     sink_node,
 )
 from hgraph._types import _TsExpr
 from hgraph._wiring import _unwrap
+from hgraph._wiring._markers import _INJECTABLE_MARKERS, _StateExpr
 
 __all__ = (
-    "KafkaMessage",
-    "MessageState",
-    "get_message_state",
     "message_publisher",
     "message_subscriber",
-    "message_publisher_operator",
+    "MessageState",
+    "KafkaMessage",
 )
 
 
 @dataclass(frozen=True)
 class KafkaMessage(CompoundScalar):
+    """A structured Kafka message.
+
+    ``content_type`` is transported in the Kafka ``content-type`` header;
+    the remaining headers are preserved in ``headers``.
+    """
+
     payload: bytes
     key: bytes = None
     content_type: str = None
     headers: frozendict[str, bytes] = frozendict()
 
+    def to_dict(self):
+        """Return the upstream ``CompoundScalar`` dictionary shape."""
+        return {
+            field.name: value
+            for field in fields(self)
+            if (value := getattr(self, field.name, None)) is not None
+        }
+
+    @classmethod
+    def from_dict(cls, d: dict) -> "CompoundScalar":
+        """Construct from known schema fields, ignoring unknown fields."""
+        names = {field.name for field in fields(cls)}
+        return cls(**{name: value for name, value in d.items() if name in names})
+
 
 class MessageState(ABC):
     @abstractmethod
     def add_publisher(self, topic: str):
+        """Register the graph's single publisher for ``topic``."""
         ...
 
     @abstractmethod
-    def add_subscriber(self, topic: str):
+    def add_subscriber(self, topic: str, replay: bool = False):
+        """Register a live subscriber, retaining replay handoff when requested."""
+        ...
+
+    @abstractmethod
+    def add_historical_subscriber(self, topic: str):
+        """Register a historical subscriber for ``topic``."""
         ...
 
 
@@ -50,9 +83,25 @@ def get_message_state():
     return KafkaMessageState.instance()
 
 
+def _publish_and_flush(msg, topic, message_state, scheduler, api):
+    flush_due = scheduler.is_scheduled_now
+    if msg.modified:
+        message_state.publish(topic, msg.value)
+        scheduler.schedule(
+            timedelta(milliseconds=100),
+            tag="flush_timer",
+            on_wall_clock=api.evaluation_mode == EvaluationMode.REAL_TIME,
+        )
+    if flush_due:
+        message_state.flush()
+
+
 @sink_node
-def _publish_bytes(msg: TS[bytes], topic: str, message_state: object):
-    message_state.publish(topic, msg.value)
+def _publish_bytes(
+        msg: TS[bytes], topic: str, message_state: object,
+        _scheduler: SCHEDULER = None,
+        _api: EvaluationEngineApi = None):
+    _publish_and_flush(msg, topic, message_state, _scheduler, _api)
 
 
 @_publish_bytes.start
@@ -67,8 +116,11 @@ def _stop_publish_bytes(message_state: object):
 
 
 @sink_node
-def _publish_message(msg: TS[KafkaMessage], topic: str, message_state: object):
-    message_state.publish(topic, msg.value)
+def _publish_message(
+        msg: TS[KafkaMessage], topic: str, message_state: object,
+        _scheduler: SCHEDULER = None,
+        _api: EvaluationEngineApi = None):
+    _publish_and_flush(msg, topic, message_state, _scheduler, _api)
 
 
 @_publish_message.start
@@ -95,41 +147,85 @@ def message_publisher_operator(msg, topic: str):
 def _decorator_signature(fn, excluded, topic):
     target = getattr(fn, "fn", fn)
     signature = inspect.signature(target, eval_str=True)
-    parameters = [
-        parameter
-        for parameter in signature.parameters.values()
-        if parameter.name not in excluded
-    ]
-    parameters.append(
-        inspect.Parameter(
-            "topic",
-            inspect.Parameter.KEYWORD_ONLY,
-            default=topic if topic is not None else inspect.Parameter.empty,
-            annotation=str,
-        )
+    parameters = []
+    for parameter in signature.parameters.values():
+        if parameter.name in excluded:
+            continue
+        if (parameter.annotation in _INJECTABLE_MARKERS
+                or isinstance(parameter.annotation, _StateExpr)):
+            continue
+        if parameter.kind is inspect.Parameter.VAR_POSITIONAL:
+            raise TypeError(
+                "Kafka publisher/subscriber graphs do not support variadic "
+                "positional inputs")
+        if parameter.kind is not inspect.Parameter.VAR_KEYWORD:
+            parameter = parameter.replace(kind=inspect.Parameter.KEYWORD_ONLY)
+        parameters.append(parameter)
+    topic_parameter = inspect.Parameter(
+        "topic",
+        inspect.Parameter.KEYWORD_ONLY,
+        default=topic if topic is not None else inspect.Parameter.empty,
+        annotation=str,
     )
+    var_keyword = next(
+        (index for index, parameter in enumerate(parameters)
+         if parameter.kind is inspect.Parameter.VAR_KEYWORD),
+        len(parameters),
+    )
+    parameters.insert(var_keyword, topic_parameter)
     return signature, signature.replace(parameters=parameters)
 
 
-def message_publisher(fn=None, *, topic: str = None):
+def message_publisher(fn: Callable = None, *, topic: str = None):
+    """Publish the wrapped graph's message output to a Kafka topic.
+
+    The output may be ``TS[bytes]``, ``TS[KafkaMessage]``, or a ``TSB`` with
+    a ``msg`` field of either type. ``topic`` can be supplied on the
+    decorator or when the wrapped graph is called. A graph declaring both
+    ``msg`` and ``recovered`` inputs receives historical topic messages from
+    the graph start time before recovery is signalled.
+    """
     if fn is None:
         return lambda value: message_publisher(value, topic=topic)
     if not hasattr(fn, "signature"):
         fn = graph(fn)
 
-    signature, public_signature = _decorator_signature(fn, {"msg", "recovered"}, topic)
-    if "msg" in signature.parameters or "recovered" in signature.parameters:
-        raise NotImplementedError(
-            "Kafka historical replay is not supported by the C++-first adaptor"
-        )
+    signature, public_signature = _decorator_signature(
+        fn, {"msg", "recovered", "topic"}, topic)
+    replay_parameters = {
+        name: signature.parameters.get(name) for name in ("msg", "recovered")
+    }
+    replay_history = any(parameter is not None for parameter in replay_parameters.values())
+    replay_msg_is_bytes = True
+    if replay_history:
+        if any(parameter is None for parameter in replay_parameters.values()):
+            raise TypeError(
+                "message_publisher replay requires both msg and recovered inputs")
+        msg_annotation = replay_parameters["msg"].annotation
+        if msg_annotation not in (TS[bytes], TS[KafkaMessage]):
+            raise TypeError(
+                "message_publisher replay requires msg: TS[bytes] or "
+                "msg: TS[KafkaMessage]")
+        if replay_parameters["recovered"].annotation != TS[bool]:
+            raise TypeError(
+                "message_publisher replay requires recovered: TS[bool]")
+        replay_msg_is_bytes = msg_annotation == TS[bytes]
+
     output_type = signature.return_annotation
     if not isinstance(output_type, _TsExpr):
         raise TypeError("message_publisher requires a time-series output")
     is_bundle = output_type.handle.is_tsb
 
     fields = tuple(__import__("_hgraph").ts_field_types(output_type.handle)) if is_bundle else ()
+    message_type = dict(fields).get("msg") if is_bundle else output_type.handle
+    if is_bundle and message_type is None:
+        raise TypeError("message_publisher TSB output must contain a 'msg' field")
+    if message_type not in (TS[bytes].handle, TS[KafkaMessage].handle):
+        raise TypeError(
+            "message_publisher output must be TS[bytes], TS[KafkaMessage], "
+            "or a TSB with a matching 'msg' field")
     return_type = output_type
-    if tuple(name for name, _ in fields) == ("msg", "out"):
+    if len(fields) == 2 and "out" in dict(fields):
         out_handle = dict(fields)["out"]
         return_type = _TsExpr(out_handle, repr(out_handle))
 
@@ -141,12 +237,19 @@ def message_publisher(fn=None, *, topic: str = None):
             raise ValueError(f"topic must be provided to {fn.__name__}")
         state = get_message_state()
         state.add_publisher(selected_topic)
+        if replay_history:
+            state.add_historical_subscriber(selected_topic)
+            history = message_history_subscriber_service(path=selected_topic)
+            replay_message = history["msg"]
+            bound.arguments["msg"] = (
+                _payload(replay_message) if replay_msg_is_bytes else replay_message)
+            bound.arguments["recovered"] = history["recovered"]
         out = fn(**bound.arguments)
         message = out["msg"] if is_bundle else out
         message_publisher_operator(message, selected_topic)
         if not is_bundle:
             return None
-        if tuple(name for name, _ in fields) == ("msg", "out"):
+        if len(fields) == 2 and "out" in dict(fields):
             return out["out"]
         return out
 
@@ -162,39 +265,59 @@ def _payload(message: TS[KafkaMessage]) -> TS[bytes]:
     return message.value.payload
 
 
-def message_subscriber(fn=None, *, topic: str = None):
+def message_subscriber(fn: Callable = None, *, topic: str = None):
+    """Supply Kafka topic messages to the wrapped graph's ``msg`` input.
+
+    ``msg`` must be ``TS[bytes]`` or ``TS[KafkaMessage]``. When the wrapped
+    graph also declares ``recovered: TS[bool]``, history is replayed from the
+    graph start time, ``recovered`` changes from false to true, and the same
+    Kafka consumer continues with live messages.
+    """
     if fn is None:
         return lambda value: message_subscriber(value, topic=topic)
     if not hasattr(fn, "signature"):
         fn = graph(fn)
 
-    signature, public_signature = _decorator_signature(fn, {"msg", "recovered"}, topic)
+    signature, public_signature = _decorator_signature(
+        fn, {"msg", "recovered", "topic"}, topic)
     message_annotation = signature.parameters.get("msg")
     if message_annotation is None or message_annotation.annotation not in (TS[bytes], TS[KafkaMessage]):
         raise TypeError("message_subscriber requires msg: TS[bytes] or msg: TS[KafkaMessage]")
     has_recovered = "recovered" in signature.parameters
-    if has_recovered:
-        raise NotImplementedError(
-            "Kafka historical replay is not supported by the C++-first adaptor"
-        )
+    if has_recovered and signature.parameters["recovered"].annotation != TS[bool]:
+        raise TypeError("message_subscriber recovered input must be TS[bool]")
 
     def subscriber(*args, **kwargs):
-        from ._impl import message_source
-
         bound = public_signature.bind(*args, **kwargs)
         bound.apply_defaults()
         selected_topic = bound.arguments.pop("topic")
         if selected_topic is None:
             raise ValueError(f"topic must be provided to {fn.__name__}")
         state = get_message_state()
-        state.add_subscriber(selected_topic)
-        message = message_source(selected_topic, state)
-        bound.arguments["msg"] = _payload(message) if message_annotation.annotation == TS[bytes] else message
+        state.add_subscriber(selected_topic, replay=has_recovered)
+        message = message_subscriber_service(path=selected_topic)
         if has_recovered:
-            bound.arguments["recovered"] = const(True, tp=TS[bool])
+            state.add_historical_subscriber(selected_topic)
+            history = message_history_subscriber_service(path=selected_topic)
+            recovered = history["recovered"]
+            bound.arguments["recovered"] = recovered
+            message = if_then_else(
+                default(recovered, False), message, history["msg"])
+        bound.arguments["msg"] = _payload(message) if message_annotation.annotation == TS[bytes] else message
         return fn(**bound.arguments)
 
     publisher_return = signature.return_annotation
     subscriber.__name__ = fn.__name__
     subscriber.__signature__ = public_signature.replace(return_annotation=publisher_return)
     return graph(subscriber)
+
+
+@reference_service
+def message_history_subscriber_service(
+        path: str) -> TSB["msg" : TS[KafkaMessage], "recovered" : TS[bool]]:
+    """Shared historical topic stream and recovery signal."""
+
+
+@reference_service
+def message_subscriber_service(path: str) -> TS[KafkaMessage]:
+    """Shared real-time topic stream."""

--- a/python/hgraph/adaptors/kafka/_api.py
+++ b/python/hgraph/adaptors/kafka/_api.py
@@ -11,6 +11,7 @@ from hgraph import (
     EvaluationEngineApi,
     EvaluationMode,
     SCHEDULER,
+    STATE,
     TS,
     TSB,
     compute_node,
@@ -30,6 +31,14 @@ __all__ = (
     "MessageState",
     "KafkaMessage",
 )
+
+_FLUSH_INTERVAL = timedelta(milliseconds=100)
+_FLUSH_MESSAGE_COUNT = 1000
+
+
+@dataclass
+class _PublisherFlushState:
+    pending_count: int = 0
 
 
 @dataclass(frozen=True)
@@ -83,25 +92,32 @@ def get_message_state():
     return KafkaMessageState.instance()
 
 
-def _publish_and_flush(msg, topic, message_state, scheduler, api):
+def _publish_and_flush(msg, topic, message_state, scheduler, api, state):
     flush_due = scheduler.is_scheduled_now
     if msg.modified:
         message_state.publish(topic, msg.value)
+        state.pending_count += 1
+
+    if flush_due or state.pending_count >= _FLUSH_MESSAGE_COUNT:
+        message_state.flush()
+        state.pending_count = 0
+        scheduler.reset()
+    elif msg.modified and not scheduler.is_scheduled:
         scheduler.schedule(
-            timedelta(milliseconds=100),
+            _FLUSH_INTERVAL,
             tag="flush_timer",
             on_wall_clock=api.evaluation_mode == EvaluationMode.REAL_TIME,
         )
-    if flush_due:
-        message_state.flush()
 
 
 @sink_node
 def _publish_bytes(
         msg: TS[bytes], topic: str, message_state: object,
         _scheduler: SCHEDULER = None,
-        _api: EvaluationEngineApi = None):
-    _publish_and_flush(msg, topic, message_state, _scheduler, _api)
+        _api: EvaluationEngineApi = None,
+        _state: STATE[_PublisherFlushState] = None):
+    _publish_and_flush(
+        msg, topic, message_state, _scheduler, _api, _state)
 
 
 @_publish_bytes.start
@@ -119,8 +135,10 @@ def _stop_publish_bytes(message_state: object):
 def _publish_message(
         msg: TS[KafkaMessage], topic: str, message_state: object,
         _scheduler: SCHEDULER = None,
-        _api: EvaluationEngineApi = None):
-    _publish_and_flush(msg, topic, message_state, _scheduler, _api)
+        _api: EvaluationEngineApi = None,
+        _state: STATE[_PublisherFlushState] = None):
+    _publish_and_flush(
+        msg, topic, message_state, _scheduler, _api, _state)
 
 
 @_publish_message.start

--- a/python/hgraph/adaptors/kafka/_impl.py
+++ b/python/hgraph/adaptors/kafka/_impl.py
@@ -7,7 +7,6 @@ from frozendict import frozendict
 
 from hgraph import (
     EvaluationEngineApi,
-    EvaluationMode,
     GlobalState,
     MIN_TD,
     TS,
@@ -80,6 +79,7 @@ def _record_order(record):
     return (
         getattr(record, "timestamp", 0),
         getattr(record, "topic", ""),
+        getattr(record, "partition", 0),
         getattr(record, "offset", 0),
     )
 
@@ -336,34 +336,51 @@ def _message_subscriber_history_aggregator(
 ) -> TSB["msg" : TS[KafkaMessage], "recovered" : TS[bool]]:
     consumer, topic_partitions = session.prepare()
     start_time = _api.start_time
-    end_time = (
-        _api.end_time
-        if _api.evaluation_mode == EvaluationMode.SIMULATION
-        else _api.evaluation_clock.now
-    )
+    recovery_offsets = consumer.end_offsets(topic_partitions)
+    recovery_offsets_by_partition = {
+        (partition.topic, partition.partition): offset
+        for partition, offset in recovery_offsets.items()
+    }
     timestamp_ms = int(start_time.replace(tzinfo=UTC).timestamp() * 1000)
     offsets = consumer.offsets_for_times(
         {partition: timestamp_ms for partition in topic_partitions})
-    for partition, offset in offsets.items():
-        if offset is not None:
-            consumer.seek(partition, offset.offset)
+    for partition in topic_partitions:
+        offset = offsets.get(partition)
+        consumer.seek(
+            partition,
+            offset.offset if offset is not None else recovery_offsets[partition],
+        )
+
+    def recovery_complete():
+        return all(
+            consumer.position(partition) >= recovery_offsets[partition]
+            for partition in topic_partitions
+        )
 
     last_time = start_time
     try:
         yield start_time, {"recovered": False}
-        while last_time < end_time:
+        while not recovery_complete():
             records = consumer.poll(timeout_ms=500, max_records=1000) or {}
-            if not records:
-                break
             messages = [record for batch in records.values() for record in batch]
             if len(records) > 1:
                 messages.sort(key=_record_order)
             for record in messages:
+                boundary = recovery_offsets_by_partition[
+                    (record.topic, record.partition)]
+                if record.offset >= boundary:
+                    continue
                 message_time = _timestamp_to_datetime(record.timestamp)
                 if message_time <= last_time:
                     message_time = last_time + MIN_TD
                 last_time = message_time
                 yield message_time, {"msg": _record_to_kafka_message(record)}
+
+        # A poll may fetch records published after the recovery snapshot. Rewind
+        # each partition to that snapshot so the same consumer's live phase
+        # observes every post-recovery record exactly once.
+        for partition in topic_partitions:
+            consumer.seek(partition, recovery_offsets[partition])
         yield last_time + MIN_TD, {"recovered": True}
     finally:
         session.history_finished()

--- a/python/hgraph/adaptors/kafka/_impl.py
+++ b/python/hgraph/adaptors/kafka/_impl.py
@@ -1,23 +1,45 @@
+import logging
 import threading
 from dataclasses import dataclass, field
+from datetime import UTC, datetime
 
 from frozendict import frozendict
 
-from hgraph import GlobalState, TS, push_queue, sink_node
-
-from ._api import KafkaMessage, MessageState
-
-__all__ = (
-    "KafkaMessageState",
-    "register_kafka_adaptor",
-    "message_source",
+from hgraph import (
+    EvaluationEngineApi,
+    EvaluationMode,
+    GlobalState,
+    MIN_TD,
+    TS,
+    TSB,
+    combine,
+    const,
+    generator,
+    nothing,
+    push_queue,
+    register_service,
+    service_impl,
+    set_service_output,
+    sink_node,
 )
+
+from ._api import (
+    KafkaMessage,
+    MessageState,
+    message_history_subscriber_service,
+    message_subscriber_service,
+)
+
+__all__ = ("register_kafka_adaptor",)
 
 CONTENT_TYPE_HEADER = "content-type"
 _STATE_KEY = ":adaptors:kafka:state"
+_CONFIG_HELPERS = {"consumer_factory", "producer_factory"}
+logger = logging.getLogger(__name__)
 
 
 def _record_to_kafka_message(record):
+    """Convert a Kafka ConsumerRecord while lifting content-type."""
     content_type = None
     headers = {}
     for key, value in record.headers or ():
@@ -33,19 +55,153 @@ def _record_to_kafka_message(record):
     )
 
 
+@dataclass(frozen=True)
+class _FallbackTopicPartition:
+    """Test-double partition key used when kafka-python is not installed."""
+
+    topic: str
+    partition: int
+
+
+def _topic_partition(topic, partition):
+    try:
+        from kafka import TopicPartition
+    except ModuleNotFoundError:
+        return _FallbackTopicPartition(topic, partition)
+    return TopicPartition(topic, partition)
+
+
+def _timestamp_to_datetime(timestamp_ms):
+    """Kafka timestamps are UTC epoch milliseconds; hgraph times are naive UTC."""
+    return datetime.fromtimestamp(timestamp_ms / 1000, UTC).replace(tzinfo=None)
+
+
+def _record_order(record):
+    return (
+        getattr(record, "timestamp", 0),
+        getattr(record, "topic", ""),
+        getattr(record, "offset", 0),
+    )
+
+
+class _ConsumerSession:
+    """One consumer shared by historical replay and its live continuation."""
+
+    def __init__(self, state, topic, *, live_requested):
+        self.state = state
+        self.topic = topic
+        self.live_requested = live_requested
+        self.consumer = None
+        self.topic_partitions = ()
+        self.sender = None
+        self.thread = None
+        self.stop_event = threading.Event()
+        self.start_requested = False
+        self.closed = False
+        self.lock = threading.RLock()
+
+    def prepare(self):
+        with self.lock:
+            if self.closed:
+                raise RuntimeError(f"Kafka consumer for topic {self.topic!r} is closed")
+            if self.consumer is not None:
+                return self.consumer, self.topic_partitions
+
+            consumer = self.state.create_consumer()
+            try:
+                partitions = consumer.partitions_for_topic(self.topic)
+                if not partitions:
+                    raise ValueError(f"No partitions found for topic {self.topic!r}")
+                topic_partitions = tuple(
+                    _topic_partition(self.topic, partition)
+                    for partition in sorted(partitions)
+                )
+                consumer.assign(topic_partitions)
+            except BaseException:
+                consumer.close()
+                raise
+
+            self.consumer = consumer
+            self.topic_partitions = topic_partitions
+            return consumer, topic_partitions
+
+    def attach_sender(self, sender):
+        with self.lock:
+            self.sender = sender
+            launch = self.start_requested and self.thread is None and not self.closed
+        if launch:
+            self._launch()
+
+    def request_start(self):
+        with self.lock:
+            self.start_requested = True
+            launch = self.sender is not None and self.thread is None and not self.closed
+        if launch:
+            self._launch()
+
+    def _launch(self):
+        consumer, _ = self.prepare()
+        with self.lock:
+            if self.thread is not None or self.closed:
+                return
+            thread = threading.Thread(
+                target=self._consume,
+                args=(consumer,),
+                name=f"hgraph-kafka-{self.topic}",
+                daemon=False,
+            )
+            self.thread = thread
+            thread.start()
+
+    def _consume(self, consumer):
+        try:
+            while not self.stop_event.is_set():
+                records = consumer.poll(timeout_ms=100, max_records=1000) or {}
+                messages = [record for batch in records.values() for record in batch]
+                if len(records) > 1:
+                    messages.sort(key=_record_order)
+                for record in messages:
+                    if self.stop_event.is_set():
+                        break
+                    self.sender(_record_to_kafka_message(record))
+        except BaseException:
+            logger.exception(
+                "Failure occurred while reading Kafka topic %s", self.topic)
+        finally:
+            self._close_consumer()
+
+    def history_finished(self):
+        if not self.live_requested:
+            self.stop()
+
+    def _close_consumer(self):
+        with self.lock:
+            if self.closed:
+                return
+            self.closed = True
+            consumer = self.consumer
+        if consumer is not None:
+            consumer.close()
+
+    def stop(self):
+        self.stop_event.set()
+        with self.lock:
+            thread = self.thread
+        if thread is not None and thread is not threading.current_thread():
+            thread.join()
+        self._close_consumer()
+
+
 @dataclass
 class KafkaMessageState(MessageState):
     config: dict = field(default_factory=dict)
     publishers: set[str] = field(default_factory=set)
     subscribers: set[str] = field(default_factory=set)
-    # The shared Kafka producer, reference-counted across live publisher
-    # nodes (upstream parity: created on the first acquire, closed when the
-    # last publisher releases it). An INJECTED producer (via config) is left
-    # open for the caller that owns it.
+    history_subscribers: set[str] = field(default_factory=set)
     _kafka_producer: object = None
     _kafka_producer_count: int = 0
     _producer_injected: bool = False
-    _consumers: dict = field(default_factory=dict)
+    _sessions: dict[str, _ConsumerSession] = field(default_factory=dict)
 
     @classmethod
     def instance(cls):
@@ -63,39 +219,66 @@ class KafkaMessageState(MessageState):
             self._kafka_producer = producer
             self._producer_injected = True
 
+    def _register(self, topic):
+        if topic not in self.subscribers and topic not in self.history_subscribers:
+            register_service(topic, _message_subscriber_impl, topic=topic)
+
     def add_publisher(self, topic):
         if topic in self.publishers:
             raise ValueError(f"topic {topic!r} already has a publisher")
         self.publishers.add(topic)
 
-    def add_subscriber(self, topic):
+    def add_subscriber(self, topic, replay=False):
+        del replay  # The history service records replay demand separately.
+        self._register(topic)
         self.subscribers.add(topic)
 
+    def add_historical_subscriber(self, topic):
+        self._register(topic)
+        self.history_subscribers.add(topic)
+
+    def _client_options(self):
+        return {
+            key: value
+            for key, value in self.config.items()
+            if key not in _CONFIG_HELPERS
+        }
+
+    def create_consumer(self):
+        factory = self.config.get("consumer_factory")
+        if factory is None:
+            try:
+                from kafka import KafkaConsumer
+            except ModuleNotFoundError as error:
+                raise RuntimeError(
+                    "Kafka subscribing requires the 'kafka' extra") from error
+            factory = KafkaConsumer
+        return factory(**self._client_options())
+
+    def consumer_session(self, topic):
+        session = self._sessions.get(topic)
+        if session is None or session.closed:
+            session = _ConsumerSession(
+                self, topic, live_requested=topic in self.subscribers)
+            self._sessions[topic] = session
+        return session
+
     def acquire_producer(self):
-        """Acquire the shared producer for a publisher node (ref-counted).
-        Creates it lazily on the first acquire; every publisher must release
-        it with ``close_producer`` on stop."""
         if self._kafka_producer is None:
             factory = self.config.get("producer_factory")
-            options = {
-                key: value
-                for key, value in self.config.items()
-                if key not in {"producer_factory", "consumer_factory"}
-            }
             if factory is None:
                 try:
                     from kafka import KafkaProducer
                 except ModuleNotFoundError as error:
-                    raise RuntimeError("Kafka publishing requires the 'kafka' extra") from error
+                    raise RuntimeError(
+                        "Kafka publishing requires the 'kafka' extra") from error
                 factory = KafkaProducer
-            self._kafka_producer = factory(**options)
+            self._kafka_producer = factory(**self._client_options())
+            self._producer_injected = False
         self._kafka_producer_count += 1
         return self._kafka_producer
 
     def close_producer(self):
-        """Release one publisher's producer reference. The shared producer is
-        closed when the last publisher releases it (an injected producer is
-        left open for its owner)."""
         if self._kafka_producer is None:
             return
         self._kafka_producer_count -= 1
@@ -106,8 +289,6 @@ class KafkaMessageState(MessageState):
             self._kafka_producer_count = 0
 
     def producer(self):
-        """The shared producer (defensively acquired if a publisher never
-        did)."""
         if self._kafka_producer is None:
             return self.acquire_producer()
         return self._kafka_producer
@@ -117,7 +298,8 @@ class KafkaMessageState(MessageState):
         if isinstance(message, KafkaMessage):
             headers = list(message.headers.items())
             if message.content_type is not None:
-                headers.append((CONTENT_TYPE_HEADER, message.content_type.encode("utf-8")))
+                headers.append(
+                    (CONTENT_TYPE_HEADER, message.content_type.encode("utf-8")))
             producer.send(
                 topic,
                 message.payload,
@@ -131,52 +313,10 @@ class KafkaMessageState(MessageState):
         if self._kafka_producer is not None:
             self._kafka_producer.flush()
 
-    def start_consumer(self, topic, sender):
-        if topic in self._consumers:
-            raise ValueError(f"topic {topic!r} already has a running subscriber")
-        factory = self.config.get("consumer_factory")
-        options = {
-            key: value
-            for key, value in self.config.items()
-            if key not in {"producer_factory", "consumer_factory"}
-        }
-        if factory is None:
-            try:
-                from kafka import KafkaConsumer
-            except ModuleNotFoundError as error:
-                raise RuntimeError("Kafka subscribing requires the 'kafka' extra") from error
-            factory = KafkaConsumer
-        consumer = factory(topic, **options)
-        stop = threading.Event()
-
-        def consume():
-            try:
-                while not stop.is_set():
-                    records = consumer.poll(timeout_ms=100, max_records=1000) or {}
-                    messages = [record for batch in records.values() for record in batch]
-                    messages.sort(key=lambda record: (record.timestamp, record.topic, record.offset))
-                    for record in messages:
-                        sender(_record_to_kafka_message(record))
-            finally:
-                consumer.close()
-
-        thread = threading.Thread(target=consume, name=f"hgraph-kafka-{topic}", daemon=False)
-        self._consumers[topic] = (consumer, stop, thread)
-        thread.start()
-
-    def stop_consumer(self, topic):
-        entry = self._consumers.pop(topic, None)
-        if entry is None:
-            return
-        _, stop, thread = entry
-        stop.set()
-        thread.join()
-
     def close(self):
-        for topic in tuple(self._consumers):
-            self.stop_consumer(topic)
-        # Backstop: if any producer reference outlives its publisher's stop
-        # (or none was ref-counted), flush and close the owned producer here.
+        for session in tuple(self._sessions.values()):
+            session.stop()
+        self._sessions.clear()
         if self._kafka_producer is not None:
             self._kafka_producer.flush()
             if not self._producer_injected:
@@ -189,19 +329,91 @@ def register_kafka_adaptor(config: dict):
     KafkaMessageState.instance().configure(config)
 
 
-def message_source(topic, state):
-    @push_queue(TS[KafkaMessage])
-    def source(sender):
-        state.start_consumer(topic, sender)
+@generator
+def _message_subscriber_history_aggregator(
+        session: object,
+        _api: EvaluationEngineApi = None,
+) -> TSB["msg" : TS[KafkaMessage], "recovered" : TS[bool]]:
+    consumer, topic_partitions = session.prepare()
+    start_time = _api.start_time
+    end_time = (
+        _api.end_time
+        if _api.evaluation_mode == EvaluationMode.SIMULATION
+        else _api.evaluation_clock.now
+    )
+    timestamp_ms = int(start_time.replace(tzinfo=UTC).timestamp() * 1000)
+    offsets = consumer.offsets_for_times(
+        {partition: timestamp_ms for partition in topic_partitions})
+    for partition, offset in offsets.items():
+        if offset is not None:
+            consumer.seek(partition, offset.offset)
 
-    @sink_node
-    def lifetime(message: TS[KafkaMessage]):
-        pass
+    last_time = start_time
+    try:
+        yield start_time, {"recovered": False}
+        while last_time < end_time:
+            records = consumer.poll(timeout_ms=500, max_records=1000) or {}
+            if not records:
+                break
+            messages = [record for batch in records.values() for record in batch]
+            if len(records) > 1:
+                messages.sort(key=_record_order)
+            for record in messages:
+                message_time = _timestamp_to_datetime(record.timestamp)
+                if message_time <= last_time:
+                    message_time = last_time + MIN_TD
+                last_time = message_time
+                yield message_time, {"msg": _record_to_kafka_message(record)}
+        yield last_time + MIN_TD, {"recovered": True}
+    finally:
+        session.history_finished()
 
-    @lifetime.stop
-    def stop():
-        state.stop_consumer(topic)
 
-    message = source()
-    lifetime(message)
-    return message
+@push_queue(TS[KafkaMessage])
+def _message_subscriber_queue(sender, *, session: object):
+    session.attach_sender(sender)
+
+
+@sink_node
+def _start_realtime_message_subscriber(
+        start_real_time_service: TS[bool], session: object):
+    if start_real_time_service.value:
+        start_real_time_service.make_passive()
+        session.request_start()
+
+
+@sink_node
+def _consumer_lifetime(trigger: TS[bool], session: object):
+    pass
+
+
+@_consumer_lifetime.stop
+def _stop_consumer_lifetime(session: object):
+    session.stop()
+
+
+@service_impl(
+    interfaces=(message_history_subscriber_service, message_subscriber_service))
+def _message_subscriber_impl(path: str, topic: str):
+    state = KafkaMessageState.instance()
+    session = state.consumer_session(topic)
+    _consumer_lifetime(const(True, tp=TS[bool]), session=session)
+
+    if topic in state.history_subscribers:
+        historical = _message_subscriber_history_aggregator(session=session)
+        start_real_time = historical["recovered"]
+    else:
+        historical = combine(
+            msg=nothing(TS[KafkaMessage]),
+            recovered=const(True, tp=TS[bool]),
+        )
+        start_real_time = const(True, tp=TS[bool])
+    set_service_output(path, message_history_subscriber_service, historical)
+
+    if topic in state.subscribers:
+        real_time = _message_subscriber_queue(session=session)
+        _start_realtime_message_subscriber(
+            start_real_time, session=session)
+    else:
+        real_time = nothing(TS[KafkaMessage])
+    set_service_output(path, message_subscriber_service, real_time)

--- a/python/tests/adaptors/kafka/test_kafka_api.py
+++ b/python/tests/adaptors/kafka/test_kafka_api.py
@@ -19,12 +19,20 @@ from hgraph.adaptors.kafka._impl import KafkaMessageState
 
 
 class _Consumer:
-    def __init__(self, batches, partitions=(0, 1)):
+    def __init__(
+            self, batches, partitions=(0, 1), *,
+            start_offsets=None, end_offsets=None):
         self._batches = list(batches)
         self._partitions = set(partitions)
+        self._start_offsets = start_offsets or {
+            partition: 0 for partition in self._partitions}
+        self._end_offsets = end_offsets or dict(self._start_offsets)
+        self._positions = {}
         self._lock = threading.Lock()
         self.assigned = None
         self.offset_requests = None
+        self.end_offset_requests = None
+        self.position_requests = []
         self.seeked = []
         self.close_count = 0
 
@@ -38,18 +46,43 @@ class _Consumer:
     def offsets_for_times(self, timestamps):
         self.offset_requests = dict(timestamps)
         return {
-            partition: SimpleNamespace(offset=10 + partition.partition)
+            partition: (
+                SimpleNamespace(offset=self._start_offsets[partition.partition])
+                if self._start_offsets.get(partition.partition) is not None
+                else None
+            )
             for partition in timestamps
         }
 
+    def end_offsets(self, partitions):
+        self.end_offset_requests = tuple(partitions)
+        return {
+            partition: self._end_offsets[partition.partition]
+            for partition in partitions
+        }
+
     def seek(self, partition, offset):
-        self.seeked.append((partition, offset))
+        with self._lock:
+            self.seeked.append((partition, offset))
+            self._positions[partition.partition] = offset
+
+    def position(self, partition):
+        with self._lock:
+            self.position_requests.append(partition)
+            return self._positions[partition.partition]
 
     def poll(self, **kwargs):
         del kwargs
         with self._lock:
             if self._batches:
-                return self._batches.pop(0)
+                batch = self._batches.pop(0)
+                for records in batch.values():
+                    for record in records:
+                        self._positions[record.partition] = max(
+                            self._positions.get(record.partition, 0),
+                            record.offset + 1,
+                        )
+                return batch
         time.sleep(0.005)
         return {}
 
@@ -169,6 +202,54 @@ def test_message_publisher_uses_the_configured_producer_via_eval_node():
 
     producer.send.assert_called_once_with("test", b"payload")
     # One timer-driven flush plus the lifecycle flush on stop.
+    assert producer.flush.call_count == 2
+
+
+def test_publisher_flush_timer_is_not_postponed_by_continuous_messages():
+    producer = MagicMock()
+
+    @hg.generator
+    def messages() -> hg.TS[bytes]:
+        for index in range(5):
+            yield (
+                hg.MIN_ST + timedelta(milliseconds=50 * index),
+                str(index).encode(),
+            )
+
+    @message_publisher(topic="test")
+    def publisher(value: hg.TS[bytes]) -> hg.TS[bytes]:
+        return value
+
+    @hg.graph
+    def app():
+        register_kafka_adaptor({"producer": producer})
+        publisher(value=messages())
+
+    with hg.GlobalContext(hg.GlobalState()):
+        assert hg.eval_node(app) is None
+
+    assert producer.send.call_count == 5
+    # Flush at 100 ms and 250 ms, then once more during lifecycle stop.
+    assert producer.flush.call_count == 3
+
+
+def test_publisher_flushes_after_1000_pending_messages():
+    producer = MagicMock()
+
+    @message_publisher(topic="test")
+    def publisher(value: hg.TS[bytes]) -> hg.TS[bytes]:
+        return value
+
+    @hg.graph
+    def app(value: hg.TS[bytes]):
+        register_kafka_adaptor({"producer": producer})
+        publisher(value=value)
+
+    with hg.GlobalContext(hg.GlobalState()):
+        assert hg.eval_node(app, [b"payload"] * 1000) is None
+
+    assert producer.send.call_count == 1000
+    # One count-driven flush plus the lifecycle flush on stop.
     assert producer.flush.call_count == 2
 
 
@@ -306,12 +387,20 @@ def test_live_subscribers_share_one_consumer_and_preserve_structured_message():
     seen_b = []
 
     @hg.sink_node
-    def capture_a(msg: hg.TS[KafkaMessage]):
+    def capture_a(
+            msg: hg.TS[KafkaMessage],
+            _engine: hg.EvaluationEngineApi = None):
         seen_a.append(msg.value)
+        if seen_b:
+            _engine.request_engine_stop()
 
     @hg.sink_node
-    def capture_b(msg: hg.TS[KafkaMessage]):
+    def capture_b(
+            msg: hg.TS[KafkaMessage],
+            _engine: hg.EvaluationEngineApi = None):
         seen_b.append(msg.value)
+        if seen_a:
+            _engine.request_engine_stop()
 
     @message_subscriber(topic="test")
     def subscriber_a(msg: hg.TS[KafkaMessage]):
@@ -331,7 +420,7 @@ def test_live_subscribers_share_one_consumer_and_preserve_structured_message():
         hg.run_graph(
             app,
             run_mode=hg.EvaluationMode.REAL_TIME,
-            end_time=hg.utc_now() + timedelta(seconds=0.2),
+            end_time=hg.utc_now() + timedelta(seconds=5),
         )
 
     expected = KafkaMessage(
@@ -350,20 +439,26 @@ def test_live_subscribers_share_one_consumer_and_preserve_structured_message():
 def test_replay_seeks_from_graph_start_orders_history_and_hands_off_to_live():
     start_time = hg.utc_now() - timedelta(milliseconds=100)
     start_ms = int(start_time.replace(tzinfo=UTC).timestamp() * 1000)
-    later = _record(b"history-2", start_ms + 20, partition=1, offset=2)
-    earlier = _record(b"history-1", start_ms + 10, partition=0, offset=1)
-    live = _record(b"live", start_ms + 120, partition=0, offset=3)
+    partition_one = _record(
+        b"history-1", start_ms + 10, partition=1, offset=20)
+    partition_zero = _record(
+        b"history-0", start_ms + 10, partition=0, offset=10)
+    live = _record(b"live", start_ms + 120, partition=0, offset=11)
     consumer = _Consumer([
-        {1: [later], 0: [earlier]},
         {},
+        {1: [partition_one], 0: [partition_zero]},
         {0: [live]},
-    ])
+    ], start_offsets={0: 10, 1: 20}, end_offsets={0: 11, 1: 21})
     messages = []
     recovered_values = []
 
     @hg.sink_node
-    def capture_message(msg: hg.TS[bytes]):
+    def capture_message(
+            msg: hg.TS[bytes],
+            _engine: hg.EvaluationEngineApi = None):
         messages.append(msg.value)
+        if msg.value == b"live":
+            _engine.request_engine_stop()
 
     @hg.sink_node
     def capture_recovered(recovered: hg.TS[bool]):
@@ -384,13 +479,15 @@ def test_replay_seeks_from_graph_start_orders_history_and_hands_off_to_live():
             app,
             run_mode=hg.EvaluationMode.REAL_TIME,
             start_time=start_time,
-            end_time=hg.utc_now() + timedelta(seconds=0.25),
+            end_time=hg.utc_now() + timedelta(seconds=5),
         )
 
-    assert messages == [b"history-1", b"history-2", b"live"]
+    assert messages == [b"history-0", b"history-1", b"live"]
     assert recovered_values == [False, True]
     assert set(consumer.offset_requests.values()) == {start_ms}
-    assert [offset for _, offset in consumer.seeked] == [10, 11]
+    assert len(consumer.end_offset_requests) == 2
+    assert consumer.position_requests
+    assert [offset for _, offset in consumer.seeked] == [10, 20, 11, 21]
     assert consumer.close_count == 1
 
 
@@ -398,9 +495,8 @@ def test_replay_aware_publisher_republishes_history_and_closes_history_consumer(
     start_time = hg.utc_now() - timedelta(milliseconds=50)
     start_ms = int(start_time.replace(tzinfo=UTC).timestamp() * 1000)
     consumer = _Consumer([
-        {0: [_record(b"history", start_ms + 10, offset=1)]},
-        {},
-    ], partitions=(0,))
+        {0: [_record(b"history", start_ms + 10, offset=10)]},
+    ], partitions=(0,), start_offsets={0: 10}, end_offsets={0: 11})
     producer = MagicMock()
 
     @message_publisher(topic="test")

--- a/python/tests/adaptors/kafka/test_kafka_api.py
+++ b/python/tests/adaptors/kafka/test_kafka_api.py
@@ -1,3 +1,8 @@
+import inspect
+import threading
+import time
+from datetime import UTC, timedelta
+from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 from frozendict import frozendict
@@ -5,16 +10,146 @@ from frozendict import frozendict
 import hgraph as hg
 from hgraph.adaptors.kafka import (
     KafkaMessage,
-    KafkaMessageState,
+    MessageState,
     message_publisher,
+    message_subscriber,
     register_kafka_adaptor,
 )
+from hgraph.adaptors.kafka._impl import KafkaMessageState
+
+
+class _Consumer:
+    def __init__(self, batches, partitions=(0, 1)):
+        self._batches = list(batches)
+        self._partitions = set(partitions)
+        self._lock = threading.Lock()
+        self.assigned = None
+        self.offset_requests = None
+        self.seeked = []
+        self.close_count = 0
+
+    def partitions_for_topic(self, topic):
+        self.topic = topic
+        return self._partitions
+
+    def assign(self, partitions):
+        self.assigned = tuple(partitions)
+
+    def offsets_for_times(self, timestamps):
+        self.offset_requests = dict(timestamps)
+        return {
+            partition: SimpleNamespace(offset=10 + partition.partition)
+            for partition in timestamps
+        }
+
+    def seek(self, partition, offset):
+        self.seeked.append((partition, offset))
+
+    def poll(self, **kwargs):
+        del kwargs
+        with self._lock:
+            if self._batches:
+                return self._batches.pop(0)
+        time.sleep(0.005)
+        return {}
+
+    def close(self):
+        with self._lock:
+            self.close_count += 1
+
+
+def _record(payload, timestamp, *, partition=0, offset=0, headers=()):
+    return SimpleNamespace(
+        value=payload,
+        key=f"key-{offset}".encode(),
+        headers=headers,
+        timestamp=timestamp,
+        topic="test",
+        partition=partition,
+        offset=offset,
+    )
 
 
 def _state_with_producer(producer):
     state = KafkaMessageState.instance()
     state.configure({"producer": producer})
     return state
+
+
+def test_public_surface_and_message_state_signatures_match_upstream():
+    import hgraph.adaptors.kafka as kafka
+    from hgraph.adaptors.kafka import _api, _impl
+
+    assert kafka.__all__ == (
+        "message_publisher",
+        "message_subscriber",
+        "MessageState",
+        "KafkaMessage",
+        "register_kafka_adaptor",
+    )
+    assert _api.__all__ == (
+        "message_publisher",
+        "message_subscriber",
+        "MessageState",
+        "KafkaMessage",
+    )
+    assert _impl.__all__ == ("register_kafka_adaptor",)
+    assert str(inspect.signature(MessageState.add_subscriber)) == (
+        "(self, topic: str, replay: bool = False)")
+    assert str(inspect.signature(MessageState.add_historical_subscriber)) == (
+        "(self, topic: str)")
+
+
+def test_kafka_message_compound_scalar_dictionary_conversion():
+    message = KafkaMessage(
+        payload=b"payload",
+        key=b"key",
+        content_type="application/json",
+        headers=frozendict({"trace": b"1"}),
+    )
+    assert message.to_dict() == {
+        "payload": b"payload",
+        "key": b"key",
+        "content_type": "application/json",
+        "headers": frozendict({"trace": b"1"}),
+    }
+    assert KafkaMessage(payload=b"payload").to_dict() == {
+        "payload": b"payload",
+        "headers": frozendict(),
+    }
+    assert KafkaMessage.from_dict({
+        **message.to_dict(), "ignored": "upstream ignores unknown fields"
+    }) == message
+
+
+def test_wrapped_graph_user_signatures_match_upstream_keyword_interface():
+    @message_publisher(topic="published")
+    def publisher(
+            msg: hg.TS[bytes], recovered: hg.TS[bool],
+            scale: hg.TS[int] = None) -> hg.TS[bytes]:
+        return msg
+
+    @message_subscriber
+    def subscriber(
+            msg: hg.TS[bytes], recovered: hg.TS[bool],
+            scale: hg.TS[int] = None) -> hg.TS[bytes]:
+        return msg
+
+    publisher_signature = inspect.signature(publisher)
+    assert tuple(publisher_signature.parameters) == ("scale", "topic")
+    assert all(
+        parameter.kind is inspect.Parameter.KEYWORD_ONLY
+        for parameter in publisher_signature.parameters.values())
+    assert publisher_signature.parameters["topic"].default == "published"
+    assert publisher_signature.return_annotation is None
+
+    subscriber_signature = inspect.signature(subscriber)
+    assert tuple(subscriber_signature.parameters) == ("scale", "topic")
+    assert all(
+        parameter.kind is inspect.Parameter.KEYWORD_ONLY
+        for parameter in subscriber_signature.parameters.values())
+    assert subscriber_signature.parameters["topic"].default is inspect.Parameter.empty
+    assert subscriber_signature.return_annotation == hg.TS[bytes]
 
 
 def test_message_publisher_uses_the_configured_producer_via_eval_node():
@@ -33,6 +168,8 @@ def test_message_publisher_uses_the_configured_producer_via_eval_node():
         assert hg.eval_node(app) is None
 
     producer.send.assert_called_once_with("test", b"payload")
+    # One timer-driven flush plus the lifecycle flush on stop.
+    assert producer.flush.call_count == 2
 
 
 def test_structured_message_maps_headers_without_a_second_protocol():
@@ -155,3 +292,184 @@ def test_producer_is_reference_counted_across_publishers():
 
     assert len(created) == 1                     # one shared producer
     created[0].close.assert_called_once()        # closed exactly once
+
+
+def test_live_subscribers_share_one_consumer_and_preserve_structured_message():
+    now_ms = int(hg.utc_now().replace(tzinfo=UTC).timestamp() * 1000)
+    consumer = _Consumer([
+        {0: [_record(
+            b"ready", now_ms, offset=1,
+            headers=(("content-type", b"application/json"), ("trace", b"7")),
+        )]},
+    ], partitions=(0,))
+    seen_a = []
+    seen_b = []
+
+    @hg.sink_node
+    def capture_a(msg: hg.TS[KafkaMessage]):
+        seen_a.append(msg.value)
+
+    @hg.sink_node
+    def capture_b(msg: hg.TS[KafkaMessage]):
+        seen_b.append(msg.value)
+
+    @message_subscriber(topic="test")
+    def subscriber_a(msg: hg.TS[KafkaMessage]):
+        capture_a(msg)
+
+    @message_subscriber(topic="test")
+    def subscriber_b(msg: hg.TS[KafkaMessage]):
+        capture_b(msg)
+
+    @hg.graph
+    def app():
+        register_kafka_adaptor({"consumer_factory": lambda **opts: consumer})
+        subscriber_a()
+        subscriber_b()
+
+    with hg.GlobalContext(hg.GlobalState()):
+        hg.run_graph(
+            app,
+            run_mode=hg.EvaluationMode.REAL_TIME,
+            end_time=hg.utc_now() + timedelta(seconds=0.2),
+        )
+
+    expected = KafkaMessage(
+        payload=b"ready",
+        key=b"key-1",
+        content_type="application/json",
+        headers=frozendict({"trace": b"7"}),
+    )
+    assert seen_a == [expected]
+    assert seen_b == [expected]
+    assert consumer.topic == "test"
+    assert len(consumer.assigned) == 1
+    assert consumer.close_count == 1
+
+
+def test_replay_seeks_from_graph_start_orders_history_and_hands_off_to_live():
+    start_time = hg.utc_now() - timedelta(milliseconds=100)
+    start_ms = int(start_time.replace(tzinfo=UTC).timestamp() * 1000)
+    later = _record(b"history-2", start_ms + 20, partition=1, offset=2)
+    earlier = _record(b"history-1", start_ms + 10, partition=0, offset=1)
+    live = _record(b"live", start_ms + 120, partition=0, offset=3)
+    consumer = _Consumer([
+        {1: [later], 0: [earlier]},
+        {},
+        {0: [live]},
+    ])
+    messages = []
+    recovered_values = []
+
+    @hg.sink_node
+    def capture_message(msg: hg.TS[bytes]):
+        messages.append(msg.value)
+
+    @hg.sink_node
+    def capture_recovered(recovered: hg.TS[bool]):
+        recovered_values.append(recovered.value)
+
+    @message_subscriber(topic="test")
+    def subscriber(msg: hg.TS[bytes], recovered: hg.TS[bool]):
+        capture_message(msg)
+        capture_recovered(recovered)
+
+    @hg.graph
+    def app():
+        register_kafka_adaptor({"consumer_factory": lambda **opts: consumer})
+        subscriber()
+
+    with hg.GlobalContext(hg.GlobalState()):
+        hg.run_graph(
+            app,
+            run_mode=hg.EvaluationMode.REAL_TIME,
+            start_time=start_time,
+            end_time=hg.utc_now() + timedelta(seconds=0.25),
+        )
+
+    assert messages == [b"history-1", b"history-2", b"live"]
+    assert recovered_values == [False, True]
+    assert set(consumer.offset_requests.values()) == {start_ms}
+    assert [offset for _, offset in consumer.seeked] == [10, 11]
+    assert consumer.close_count == 1
+
+
+def test_replay_aware_publisher_republishes_history_and_closes_history_consumer():
+    start_time = hg.utc_now() - timedelta(milliseconds=50)
+    start_ms = int(start_time.replace(tzinfo=UTC).timestamp() * 1000)
+    consumer = _Consumer([
+        {0: [_record(b"history", start_ms + 10, offset=1)]},
+        {},
+    ], partitions=(0,))
+    producer = MagicMock()
+
+    @message_publisher(topic="test")
+    def publisher(msg: hg.TS[bytes], recovered: hg.TS[bool]) -> hg.TS[bytes]:
+        return msg
+
+    @hg.graph
+    def app():
+        register_kafka_adaptor({
+            "consumer_factory": lambda **opts: consumer,
+            "producer": producer,
+        })
+        publisher()
+
+    with hg.GlobalContext(hg.GlobalState()):
+        hg.run_graph(
+            app,
+            run_mode=hg.EvaluationMode.REAL_TIME,
+            start_time=start_time,
+            end_time=hg.utc_now() + timedelta(seconds=0.1),
+        )
+
+    producer.send.assert_called_once_with("test", b"history")
+    assert consumer.close_count == 1
+
+
+def test_replay_parameters_are_required_together_and_typed():
+    def missing_recovered(msg: hg.TS[bytes]) -> hg.TS[bytes]:
+        return msg
+
+    try:
+        message_publisher(missing_recovered, topic="test")
+    except TypeError as error:
+        assert "both msg and recovered" in str(error)
+    else:
+        raise AssertionError("missing recovered input was accepted")
+
+    def wrong_recovered(msg: hg.TS[bytes], recovered: hg.TS[int]) -> hg.TS[bytes]:
+        return msg
+
+    try:
+        message_subscriber(wrong_recovered, topic="test")
+    except TypeError as error:
+        assert "recovered input must be TS[bool]" in str(error)
+    else:
+        raise AssertionError("wrong recovered type was accepted")
+
+
+def test_subscriber_fails_clearly_when_topic_has_no_partitions():
+    consumer = _Consumer([], partitions=())
+
+    @message_subscriber(topic="missing")
+    def subscriber(msg: hg.TS[bytes]):
+        pass
+
+    @hg.graph
+    def app():
+        register_kafka_adaptor({"consumer_factory": lambda **opts: consumer})
+        subscriber()
+
+    with hg.GlobalContext(hg.GlobalState()):
+        try:
+            hg.run_graph(
+                app,
+                run_mode=hg.EvaluationMode.REAL_TIME,
+                end_time=hg.utc_now() + timedelta(seconds=0.05),
+            )
+        except RuntimeError as error:
+            assert "No partitions found for topic 'missing'" in str(error)
+        else:
+            raise AssertionError("missing topic partitions were accepted")
+    assert consumer.close_count == 1

--- a/tests/cpp/test_service_wiring.cpp
+++ b/tests/cpp/test_service_wiring.cpp
@@ -114,6 +114,107 @@ namespace
         using output_schema = TS<Int>;
     };
 
+    using KafkaReplayState =
+        TSB<"KafkaReplayState",
+            Field<"msg", TS<Int>>,
+            Field<"recovered", TS<Bool>>>;
+
+    struct KafkaHistoryService
+    {
+        static constexpr std::string_view name{"kafka_history"};
+        using output_schema = KafkaReplayState;
+    };
+
+    struct KafkaLiveService
+    {
+        static constexpr std::string_view name{"kafka_live"};
+        using output_schema = TS<Int>;
+    };
+
+    struct KafkaHistorySource
+    {
+        static constexpr auto name              = "kafka_history_source";
+        static constexpr bool schedule_on_start = true;
+
+        static void eval(NodeScheduler sched, State<Int> cycle,
+                         Out<KafkaReplayState> out)
+        {
+            if (cycle.get() == Int{0})
+            {
+                out.field<"msg">().set(Int{10});
+                out.field<"recovered">().set(Bool{false});
+                cycle.set(Int{1});
+                sched.schedule(MIN_TD);
+            }
+            else
+            {
+                out.field<"recovered">().set(Bool{true});
+            }
+        }
+    };
+
+    struct KafkaLiveSource
+    {
+        static constexpr auto name              = "kafka_live_source";
+        static constexpr bool schedule_on_start = true;
+
+        static void eval(Out<TS<Int>> out) { out.set(Int{20}); }
+    };
+
+    inline int kafka_service_compositions = 0;
+
+    struct KafkaReplayAndLiveImpl
+    {
+        [[maybe_unused]] static constexpr auto name =
+            "kafka_replay_and_live_impl";
+
+        static void compose(Wiring &w, Scalar<"path", Str> path)
+        {
+            ++kafka_service_compositions;
+            const auto custom = service::path(path.value());
+            service::impl_output<KafkaHistoryService>(
+                w, custom, wire<KafkaHistorySource>(w));
+            service::impl_output<KafkaLiveService>(
+                w, custom, wire<KafkaLiveSource>(w));
+        }
+    };
+
+    struct KafkaReplayAndLiveClientGraph
+    {
+        [[maybe_unused]] static constexpr auto name =
+            "kafka_replay_and_live_client_graph";
+
+        static Port<TS<Int>> compose(Wiring &w)
+        {
+            const auto topic = service::path("orders");
+            service::register_services<
+                KafkaReplayAndLiveImpl,
+                KafkaHistoryService,
+                KafkaLiveService>(w, topic);
+
+            auto history = wire<KafkaHistoryService>(w, topic);
+            auto recovered = wire<stdlib::getitem_>(
+                                 w, history, Str{"recovered"})
+                                 .as<TS<Bool>>();
+            auto historical_message = wire<stdlib::getitem_>(
+                                          w, history, Str{"msg"})
+                                          .as<TS<Int>>();
+
+            // Two public clients consume the same per-topic live reference.
+            // The one multi-service implementation is the native sharing
+            // boundary used by the Python Kafka adaptor.
+            auto first_live = wire<KafkaLiveService>(w, topic);
+            auto second_live = wire<KafkaLiveService>(w, topic);
+            auto first = wire<stdlib::if_then_else>(
+                             w, recovered, first_live, historical_message)
+                             .as<TS<Int>>();
+            auto second = wire<stdlib::if_then_else>(
+                              w, recovered, second_live, historical_message)
+                              .as<TS<Int>>();
+            return wire<stdlib::add_>(w, first, second).as<TS<Int>>();
+        }
+    };
+
     struct ReferencePricesImplNode
     {
         static constexpr auto name              = "reference_prices_impl_node";
@@ -1954,6 +2055,17 @@ TEST_CASE("service wiring: multi-interface implementation graph wires explicit s
     hgraph::stdlib::register_standard_operators();
 
     CHECK_OUTPUT(eval_node<MultiServiceClientGraph>(values<Int>(1)), values<Int>(none, none, 13));
+}
+
+TEST_CASE("service wiring: shared replay service hands clients to the live reference")
+{
+    hgraph::stdlib::register_standard_operators();
+
+    kafka_service_compositions = 0;
+    CHECK_OUTPUT(
+        eval_node<KafkaReplayAndLiveClientGraph>(),
+        values<Int>(20, 40));
+    CHECK(kafka_service_compositions == 1);
 }
 
 TEST_CASE("service wiring: service adaptors collect multiple client requests")


### PR DESCRIPTION
## Summary

- match the released Python hgraph Kafka public exports, signatures, defaults, and `KafkaMessage` conversion API
- support raw and structured publishing/subscribing, producer sharing and ownership, periodic flushing, and shutdown flushing
- add timestamp-based historical replay across all partitions with deterministic ordering, `recovered` signaling, same-consumer live handoff, per-topic sharing, and exact thread/consumer teardown
- add equivalent public C++ service-wiring coverage and expanded Python compatibility tests
- update the roadmap, service documentation, and parity matrix

## Why

Issue #220 previously allowed user-visible API and feature gaps relative to released hgraph. Kafka users need the same authoring surface and replay/live behavior so existing graphs can move to the C++-first engine without Kafka-specific rewrites.

## Design

Python owns the optional Kafka producer/consumer objects and adapts their values and callbacks. Shared service routing, history/live switching, graph scheduling, and lifecycle behavior continue through the native hgraph runtime. Historical and live delivery use the same per-topic consumer session to avoid a recovery handoff gap.

## User impact

The Kafka adaptor now exposes the released user API and supports bytes and structured messages, metadata preservation, historical replay from graph start time, recovery state, shared topic subscriptions, and deterministic teardown.

## Validation

- released-reference Kafka surface comparison: 0 actionable findings
- parity corpus validation: 56 recipes valid
- focused Kafka Python tests: 14 passed
- macOS fresh native acceptance: 1,368/1,368 passed
- macOS Python 3.12 ABI3 wheel on fresh Python 3.14: 1,780 passed, 10 skipped
- `hg-linux` fresh native acceptance with GCC 14.3: 1,368/1,368 passed
- `hg-linux` Python 3.12 ABI3 wheel on fresh Python 3.14: 1,780 passed, 10 skipped
- `hg-linux` ASan Debug build: Kafka 14 passed; full suite 1,780 passed, 10 skipped; no sanitizer findings
- `git diff --check`: clean

Kafka protocol behavior is exercised deterministically through injected producer/consumer clients; validation does not require an external broker.

Implements #220.