### PR TITLE
Reduce TargetLink observer storage

### DIFF
--- a/docs/source/developer_guide/data_structures/linking_strategies.rst
+++ b/docs/source/developer_guide/data_structures/linking_strategies.rst
@@ -53,6 +53,28 @@ observer identity; evaluation time belongs on endpoint views, not in the
 link's stored state. Endpoint views recreate transient ``TSDataView``
 cursors from the stored output handle when they need target behaviour.
 
+The wiring-time schema selects one of two target-link storage plans. Scalar,
+fixed, window, reference, and signal terminals allocate only the common
+tracking and binding state plus a non-null no-op structural ops pointer.
+``TSS`` and ``TSD`` terminals allocate the structural representation, which
+adds a compact ``SlotObserverList`` and a lazy sampled-transition record. The
+semantic target-link code dispatches through the selected passive ops table;
+it does not inspect a representation tag or schema kind on the runtime path.
+
+The structural observer list has a narrower purpose than the target-modified
+and scheduling observers below. It is populated only when another keyed-slot
+consumer observes the target link itself, as happens in forwarding and proxy
+chains. The link retains those observer identities across an unbound period,
+subscribes them directly to the current output key store on bind/rebind, and
+unsubscribes or sends ``on_clear`` before the borrowed target disappears. Its
+empty and one-observer forms occupy one tagged pointer; only two or more
+observers allocate a spill list.
+
+A link-local delegation hub was measured but is not used. In the representative
+workloads and complete native suite every exercised forwarding list had one
+observer, so direct and delegated registration retained the same number of
+pointers. Delegation would only add a callback hop in that measured shape.
+
 A subtle point: a peered input terminal carries **two** notification paths:
 
 - **Target-modified path.** Subscribed to the target's modification

--- a/docs/source/developer_guide/data_structures/plans_and_ops/time_series.rst
+++ b/docs/source/developer_guide/data_structures/plans_and_ops/time_series.rst
@@ -378,13 +378,21 @@ collection. The final scheduling target is a ``Notifiable`` supplied by
 the owning runtime node.
 
 TargetLink in-plan storage is deliberately small: the ordinary
-``TSDataTracking`` record plus inline target-link state. The link state
-owns a borrowed ``TSOutputHandle`` containing the output identity and
-output-owned ``TSDataView``, the target-modified observer, the
-scheduling notifier, and an optional active descendant trie rooted at
-the peered boundary. The state is inline because the normal runtime case
-is a bound link; only the sparse descendant trie nodes are allocated on
-demand.
+``TSDataTracking`` record plus inline target-link state. The common plan owns
+a borrowed ``TSOutputHandle`` containing the output identity and output-owned
+``TSDataView``, the target-modified observer, the scheduling notifier, an
+optional active descendant trie rooted at the peered boundary, and a pointer
+to the immutable structural ops table. The state is inline because the normal
+runtime case is a bound link; only the sparse descendant trie nodes are
+allocated on demand.
+
+Wiring selects a larger concrete plan only for ``TSS`` and ``TSD`` peered
+terminals. That implementation-only representation adds a one-word compact
+slot-observer list and a lazy structural-transition allocation. All other
+terminal kinds use the canonical no-op structural table and pay for neither
+field. Raw storage access is selected alongside the plan, so the rest of the
+input endpoint machinery continues to consume the common TargetLink contract
+without naming the structural representation.
 
 Views are not stored in TargetLink state. Endpoint views materialize
 transient ``TSDataView`` cursors from the stored ``TSOutputHandle`` when

--- a/include/hgraph/types/time_series/ts_input/target_link.h
+++ b/include/hgraph/types/time_series/ts_input/target_link.h
@@ -3,8 +3,8 @@
 
 #include <hgraph/types/time_series/ts_data.h>
 #include <hgraph/types/time_series/ts_output/base_view.h>
+#include <hgraph/types/time_series/ts_input/target_link_structural_state.h>
 #include <hgraph/types/utils/small_dense_ptr_map.h>
-#include <hgraph/types/utils/slot_observer.h>
 
 #include <cstddef>
 #include <cstdint>
@@ -20,6 +20,7 @@ namespace hgraph::detail
 
     struct TSInputTargetLinkState;
     struct TSInputTargetLinkStorage;
+    struct TSInputTargetLinkStructuralStorage;
 
     /**
      * Non-pruning invariant (RFC 0008 stage 5): an active-trie node, once
@@ -81,8 +82,6 @@ namespace hgraph::detail
 
     struct TSInputTargetLinkStorage
     {
-        struct StructuralTransition;
-
         TSInputTargetLinkStorage() noexcept;
         TSInputTargetLinkStorage(const TSInputTargetLinkStorage &other);
         TSInputTargetLinkStorage &operator=(const TSInputTargetLinkStorage &other);
@@ -132,20 +131,23 @@ namespace hgraph::detail
 
         TSDataTracking tracking{};
         TSInputTargetLinkState state_;
-        SlotObserverList slot_observers_{};
-        bool slot_observers_subscribed_{false};
-        mutable std::unique_ptr<StructuralTransition> structural_transition_{};
 
       private:
+        friend struct TSInputTargetLinkStructuralStorage;
+
+        explicit TSInputTargetLinkStorage(
+            const TSInputTargetLinkStructuralOps &structural_ops) noexcept;
+        TSInputTargetLinkStorage(const TSInputTargetLinkStorage &other,
+                                 const TSInputTargetLinkStructuralOps &structural_ops);
+        TSInputTargetLinkStorage(TSInputTargetLinkStorage &&other,
+                                 const TSInputTargetLinkStructuralOps &structural_ops) noexcept;
+
+        void set_structural_ops(const TSInputTargetLinkStructuralOps &structural_ops) noexcept;
         void bind_impl(const TSValueTypeMetaData &schema, const TSOutputView &output,
                        DateTime modified_time, bool sampled, bool replay_source_time);
         void detach_target(bool retain_structural_target, DateTime modified_time);
-        void subscribe_slot_observers();
-        void unsubscribe_slot_observers();
-        void unsubscribe_slot_observers_noexcept() noexcept;
-        void subscribe_key_set_tracking();
-        void unsubscribe_key_set_tracking() noexcept;
-        [[nodiscard]] StructuralTransition &ensure_structural_state() const;
+
+        const TSInputTargetLinkStructuralOps *structural_ops_{&target_link_no_structural_ops()};
     };
 
     [[nodiscard]] const TSInputTargetLinkStorage *target_link_storage(const TSDataView &view) noexcept;

--- a/include/hgraph/types/time_series/ts_input/target_link_structural_state.h
+++ b/include/hgraph/types/time_series/ts_input/target_link_structural_state.h
@@ -1,0 +1,81 @@
+#ifndef HGRAPH_CPP_TS_INPUT_TARGET_LINK_STRUCTURAL_STATE_H
+#define HGRAPH_CPP_TS_INPUT_TARGET_LINK_STRUCTURAL_STATE_H
+
+#include <hgraph/hgraph_export.h>
+#include <hgraph/types/storage_metrics.h>
+#include <hgraph/types/temporal.h>
+#include <hgraph/types/time_series/ts_data.h>
+#include <hgraph/types/utils/memory_utils.h>
+#include <hgraph/types/utils/slot_observer.h>
+
+namespace hgraph::detail
+{
+    struct TSInputTargetLinkStorage;
+
+    /**
+     * Passive type-erased contract for target-link structural state.
+     *
+     * The selected ops table is immutable for a planned storage object and is
+     * always non-null. Non-structural links bind the canonical no-op table;
+     * TSS/TSD links bind the concrete structural implementation without
+     * exposing that representation to the semantic target-link owner.
+     */
+    struct HGRAPH_EXPORT TSInputTargetLinkStructuralOps
+    {
+        bool supports_structural{false};
+
+        void (*clear_transition)(TSInputTargetLinkStorage &owner) noexcept;
+        void (*subscribe_key_set_tracking)(TSInputTargetLinkStorage &owner);
+        void (*subscribe_slot_observers)(TSInputTargetLinkStorage &owner);
+        void (*publish_sampled_transition)(TSInputTargetLinkStorage &owner,
+                                           DateTime modified_time);
+        void (*detach_target)(TSInputTargetLinkStorage &owner,
+                              bool retain_structural_target,
+                              DateTime modified_time);
+        void (*unbind_noexcept)(TSInputTargetLinkStorage &owner) noexcept;
+        void (*source_invalidated)(TSInputTargetLinkStorage &owner) noexcept;
+
+        void (*add_slot_observer)(TSInputTargetLinkStorage &owner,
+                                  SlotObserver *observer);
+        void (*remove_slot_observer)(TSInputTargetLinkStorage &owner,
+                                     SlotObserver *observer);
+
+        const TSDataTracking &(*key_set_tracking)(TSInputTargetLinkStorage &owner);
+        TSDataTracking &(*mutable_key_set_tracking)(TSInputTargetLinkStorage &owner);
+        void (*record_key_set_modified)(TSInputTargetLinkStorage &owner,
+                                        DateTime modified_time);
+        void (*key_set_source_invalidated)(TSInputTargetLinkStorage &owner,
+                                           const TSDataTracking *source) noexcept;
+
+        TSDataView (*previous_target_view)(const TSInputTargetLinkStorage &owner) noexcept;
+        bool (*transition_active)(const TSInputTargetLinkStorage &owner) noexcept;
+        bool (*sampled_transition)(const TSInputTargetLinkStorage &owner) noexcept;
+        DateTime (*transition_time)(const TSInputTargetLinkStorage &owner) noexcept;
+        DynamicStorageMetrics (*dynamic_storage_metrics)(
+            const TSInputTargetLinkStorage &owner) noexcept;
+
+        void (*before_move_assignment_source)(TSInputTargetLinkStorage &owner) noexcept;
+        void (*resubscribe_after_move_assignment)(TSInputTargetLinkStorage &owner) noexcept;
+    };
+
+    /** Raw-storage access selected alongside the storage plan. */
+    struct HGRAPH_EXPORT TSInputTargetLinkStorageAccessOps
+    {
+        const TSInputTargetLinkStorage *(*get_const)(const void *memory) noexcept;
+        TSInputTargetLinkStorage *(*get_mutable)(void *memory) noexcept;
+    };
+
+    /** Canonical no-op structural table used by default and moved-from owners. */
+    [[nodiscard]] HGRAPH_EXPORT const TSInputTargetLinkStructuralOps &
+    target_link_no_structural_ops() noexcept;
+
+    /** Wiring-time storage plan selected from immutable schema metadata. */
+    [[nodiscard]] HGRAPH_EXPORT const MemoryUtils::StoragePlan &
+    target_link_storage_plan_for(TSTypeKind kind) noexcept;
+
+    /** Raw-storage caster paired with ``target_link_storage_plan_for``. */
+    [[nodiscard]] HGRAPH_EXPORT const TSInputTargetLinkStorageAccessOps &
+    target_link_storage_access_for(TSTypeKind kind) noexcept;
+}  // namespace hgraph::detail
+
+#endif  // HGRAPH_CPP_TS_INPUT_TARGET_LINK_STRUCTURAL_STATE_H

--- a/include/hgraph/types/utils/slot_observer.h
+++ b/include/hgraph/types/utils/slot_observer.h
@@ -3,11 +3,14 @@
 
 #include <hgraph/hgraph_export.h>
 #include <hgraph/types/storage_metrics.h>
+#include <hgraph/util/tagged_ptr.h>
 
-#include <algorithm>
-#include <cassert>
 #include <cstddef>
-#include <vector>
+#include <cstdint>
+#include <functional>
+#include <memory>
+#include <type_traits>
+#include <utility>
 
 namespace hgraph
 {
@@ -40,179 +43,94 @@ namespace hgraph
     };
 
     /**
-     * Small observer list with de-duplicated registration and explicit
+     * Compact observer list with de-duplicated registration and explicit
      * structural notifications.
      *
-     * Owned by each slot store; observers register and unregister themselves
-     * during their own construction and destruction. Removal uses a swap-
-     * with-back-and-pop so the list stays compact, and re-registration of
-     * the same pointer is asserted against in debug builds.
+     * Empty and single-observer states occupy one tagged pointer. A spill
+     * allocation is introduced only for two or more observers. Traversal is
+     * representation-neutral: callbacks see the non-null observers present
+     * when traversal starts, removals before an observer's turn suppress that
+     * callback, and additions are deferred until the next traversal.
      */
-    class SlotObserverList
+    class HGRAPH_EXPORT SlotObserverList
     {
       public:
-        /** Register an observer; ignored if ``observer`` is null. Asserts on duplicate registration. */
-        void add(SlotObserver *observer)
-        {
-            if (observer == nullptr) {
-                return;
-            }
+        SlotObserverList() noexcept = default;
+        SlotObserverList(const SlotObserverList &other);
+        SlotObserverList &operator=(const SlotObserverList &other);
+        SlotObserverList(SlotObserverList &&other) noexcept;
+        SlotObserverList &operator=(SlotObserverList &&other) noexcept;
+        ~SlotObserverList() noexcept;
 
-            const auto it = std::find(m_observers.begin(), m_observers.end(), observer);
-            assert(it == m_observers.end() && "slot observer registered twice");
-            if (it == m_observers.end()) {
-                m_observers.push_back(observer);
-            }
-        }
-
-        /** Unregister an observer; ignored if ``observer`` is null. Asserts when not registered. */
-        void remove(SlotObserver *observer)
-        {
-            if (observer == nullptr) {
-                return;
-            }
-
-            const auto it = std::find(m_observers.begin(), m_observers.end(), observer);
-            assert(it != m_observers.end() && "removing unregistered slot observer");
-            if (it == m_observers.end()) {
-                return;
-            }
-
-            if (m_notify_depth != 0) {
-                *it = nullptr;
-                m_compact_pending = true;
-                return;
-            }
-
-            if (it != m_observers.end() - 1) {
-                *it = m_observers.back();
-            }
-            m_observers.pop_back();
-        }
+        /** Register an observer; ignored if null and asserted against when duplicated. */
+        void add(SlotObserver *observer);
+        /** Unregister an observer; ignored if null and asserted when not registered. */
+        void remove(SlotObserver *observer);
 
         /** True when no observers are registered. */
-        [[nodiscard]] bool empty() const noexcept { return m_observers.empty(); }
-        /** Read-only access to the registered observer pointers. */
-        [[nodiscard]] const std::vector<SlotObserver *> &entries() const noexcept { return m_observers; }
+        [[nodiscard]] bool empty() const noexcept;
+        /** Number of currently registered, non-null observers. */
+        [[nodiscard]] std::size_t size() const noexcept;
+        /** True when ``observer`` is currently registered. */
+        [[nodiscard]] bool contains(const SlotObserver *observer) const noexcept;
 
-        /** Exact occupied/retained heap bytes for observer pointer storage. */
-        [[nodiscard]] DynamicStorageMetrics dynamic_storage_metrics() const noexcept
+        /**
+         * Visit each observer without exposing the concrete storage strategy.
+         * The visitor may re-enter this list and may add, remove, or clear
+         * observers. Cleanup remains exception-safe.
+         */
+        template <typename Visitor>
+        void for_each(Visitor &&visitor) const
         {
-            return {
-                .live_bytes = m_observers.size() * sizeof(SlotObserver *),
-                .reserved_bytes = m_observers.capacity() * sizeof(SlotObserver *),
-            };
+            using VisitorType = std::remove_reference_t<Visitor>;
+            auto *context = const_cast<void *>(
+                static_cast<const void *>(std::addressof(visitor)));
+            for_each_erased(context, [](void *erased, SlotObserver *observer) {
+                std::invoke(*static_cast<VisitorType *>(erased), observer);
+            });
         }
+
+        /** Exact occupied/retained heap bytes for multi-observer spill storage. */
+        [[nodiscard]] DynamicStorageMetrics dynamic_storage_metrics() const noexcept;
 
         /** Drop every registered observer without notifying. */
-        void clear() noexcept
-        {
-            if (m_notify_depth != 0) {
-                std::fill(m_observers.begin(), m_observers.end(), nullptr);
-                m_compact_pending = true;
-                return;
-            }
-            m_observers.clear();
-        }
+        void clear() noexcept;
 
         /** Invoke ``on_capacity`` on every registered observer. */
-        void notify_capacity(size_t old_capacity, size_t new_capacity) const
-        {
-            NotifyGuard guard{*this};
-            const auto limit = m_observers.size();
-            for (size_t index = 0; index < limit; ++index) {
-                auto *observer = m_observers[index];
-                if (observer != nullptr) {
-                    observer->on_capacity(old_capacity, new_capacity);
-                }
-            }
-        }
-
+        void notify_capacity(std::size_t old_capacity, std::size_t new_capacity) const;
         /** Invoke ``on_insert`` on every registered observer. */
-        void notify_insert(size_t slot) const
-        {
-            NotifyGuard guard{*this};
-            const auto limit = m_observers.size();
-            for (size_t index = 0; index < limit; ++index) {
-                auto *observer = m_observers[index];
-                if (observer != nullptr) {
-                    observer->on_insert(slot);
-                }
-            }
-        }
-
+        void notify_insert(std::size_t slot) const;
         /** Invoke ``on_remove`` on every registered observer. */
-        void notify_remove(size_t slot) const
-        {
-            NotifyGuard guard{*this};
-            const auto limit = m_observers.size();
-            for (size_t index = 0; index < limit; ++index) {
-                auto *observer = m_observers[index];
-                if (observer != nullptr) {
-                    observer->on_remove(slot);
-                }
-            }
-        }
-
+        void notify_remove(std::size_t slot) const;
         /** Invoke ``on_erase`` on every registered observer. */
-        void notify_erase(size_t slot) const
-        {
-            NotifyGuard guard{*this};
-            const auto limit = m_observers.size();
-            for (size_t index = 0; index < limit; ++index) {
-                auto *observer = m_observers[index];
-                if (observer != nullptr) {
-                    observer->on_erase(slot);
-                }
-            }
-        }
-
+        void notify_erase(std::size_t slot) const;
         /** Invoke ``on_clear`` on every registered observer. */
-        void notify_clear() const
-        {
-            NotifyGuard guard{*this};
-            const auto limit = m_observers.size();
-            for (size_t index = 0; index < limit; ++index) {
-                auto *observer = m_observers[index];
-                if (observer != nullptr) {
-                    observer->on_clear();
-                }
-            }
-        }
+        void notify_clear() const;
 
       private:
-        struct NotifyGuard
+        struct ObserverList;
+
+        enum class Representation : std::uintptr_t
         {
-            explicit NotifyGuard(const SlotObserverList &owner) noexcept
-                : owner(owner)
-            {
-                ++owner.m_notify_depth;
-            }
-
-            NotifyGuard(const NotifyGuard &) = delete;
-            NotifyGuard &operator=(const NotifyGuard &) = delete;
-
-            ~NotifyGuard() noexcept
-            {
-                --owner.m_notify_depth;
-                if (owner.m_notify_depth == 0 && owner.m_compact_pending) {
-                    owner.compact();
-                }
-            }
-
-            const SlotObserverList &owner;
+            single = 0,
+            many = 1,
         };
 
-        void compact() const noexcept
-        {
-            std::erase(m_observers, nullptr);
-            m_compact_pending = false;
-        }
+        using ObserverStorage = tagged_void_ptr<1, Representation>;
+        using ErasedVisitor = void (*)(void *context, SlotObserver *observer);
 
-        mutable std::vector<SlotObserver *> m_observers{};
-        mutable size_t                      m_notify_depth{0};
-        mutable bool                        m_compact_pending{false};
+        [[nodiscard]] SlotObserver *single() const noexcept;
+        [[nodiscard]] ObserverList *many() const noexcept;
+        void set_single(SlotObserver *observer) noexcept;
+        void set_many(ObserverList *observers) noexcept;
+        void compact_many(ObserverList &observers) noexcept;
+        void for_each_erased(void *context, ErasedVisitor visitor) const;
+
+        ObserverStorage observers_{};
     };
+
+    static_assert(sizeof(SlotObserverList) <= sizeof(void *),
+                  "SlotObserverList should remain a one-word tagged observer handle");
 }  // namespace hgraph
 
 #endif  // HGRAPH_CPP_ROOT_V2_SLOT_OBSERVER_H

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -32,6 +32,7 @@ set(HGRAPH_RUNTIME_SOURCES
     hgraph/types/time_zone_provider.cpp
     hgraph/types/type_pointer.cpp
     hgraph/types/utils/stable_slot_store.cpp
+    hgraph/types/utils/slot_observer.cpp
     hgraph/types/metadata/debug_descriptor.cpp
     hgraph/types/metadata/ts_data_atomic_ops.cpp
     hgraph/types/metadata/ts_data_dynamic_list_ops.cpp

--- a/src/hgraph/types/time_series/ts_input.cpp
+++ b/src/hgraph/types/time_series/ts_input.cpp
@@ -512,7 +512,15 @@ namespace hgraph
 
         [[nodiscard]] const MemoryUtils::StoragePlan &input_storage_plan(const TSEndpointSchema &endpoint_schema)
         {
-            if (endpoint_schema.is_peered()) { return MemoryUtils::plan_for<detail::TSInputTargetLinkStorage>(); }
+            if (endpoint_schema.is_peered())
+            {
+                const auto *schema = endpoint_schema.schema();
+                if (schema == nullptr)
+                {
+                    throw std::logic_error("TSInput peered endpoint storage requires a TSData schema");
+                }
+                return detail::target_link_storage_plan_for(schema->kind);
+            }
             if (endpoint_schema.is_owned())
             {
                 const auto type = regular_ts_data_type_for(endpoint_schema.schema());

--- a/src/hgraph/types/time_series/ts_input/impl/target_link_structural_storage.h
+++ b/src/hgraph/types/time_series/ts_input/impl/target_link_structural_storage.h
@@ -1,0 +1,28 @@
+#ifndef HGRAPH_CPP_TS_INPUT_IMPL_TARGET_LINK_STRUCTURAL_STORAGE_H
+#define HGRAPH_CPP_TS_INPUT_IMPL_TARGET_LINK_STRUCTURAL_STORAGE_H
+
+#include <hgraph/types/time_series/ts_input/target_link.h>
+
+#include <memory>
+
+namespace hgraph::detail
+{
+    /** Concrete TSS/TSD representation; selected only by the structural plan. */
+    struct TSInputTargetLinkStructuralStorage final : TSInputTargetLinkStorage
+    {
+        struct StructuralTransition;
+
+        TSInputTargetLinkStructuralStorage() noexcept;
+        TSInputTargetLinkStructuralStorage(const TSInputTargetLinkStructuralStorage &other);
+        TSInputTargetLinkStructuralStorage &operator=(const TSInputTargetLinkStructuralStorage &other);
+        TSInputTargetLinkStructuralStorage(TSInputTargetLinkStructuralStorage &&other) noexcept;
+        TSInputTargetLinkStructuralStorage &operator=(TSInputTargetLinkStructuralStorage &&other) noexcept;
+        ~TSInputTargetLinkStructuralStorage() noexcept;
+
+        SlotObserverList slot_observers{};
+        bool slot_observers_subscribed{false};
+        mutable std::unique_ptr<StructuralTransition> structural_transition{};
+    };
+}  // namespace hgraph::detail
+
+#endif  // HGRAPH_CPP_TS_INPUT_IMPL_TARGET_LINK_STRUCTURAL_STORAGE_H

--- a/src/hgraph/types/time_series/ts_input/target_link.cpp
+++ b/src/hgraph/types/time_series/ts_input/target_link.cpp
@@ -1,5 +1,6 @@
 #include <hgraph/types/time_series/ts_input/target_link.h>
 
+#include "impl/target_link_structural_storage.h"
 #include "target_link_ops.h"
 
 #include <hgraph/types/metadata/type_registry.h>
@@ -15,7 +16,7 @@
 
 namespace hgraph::detail
 {
-    struct TSInputTargetLinkStorage::StructuralTransition
+    struct TSInputTargetLinkStructuralStorage::StructuralTransition
     {
         struct KeySetNotifier final : Notifiable
         {
@@ -153,6 +154,324 @@ namespace hgraph::detail
             return structural.as_set();
         }
 
+        [[nodiscard]] TSInputTargetLinkStructuralStorage &
+        structural_storage(TSInputTargetLinkStorage &owner) noexcept
+        {
+            return static_cast<TSInputTargetLinkStructuralStorage &>(owner);
+        }
+
+        [[nodiscard]] const TSInputTargetLinkStructuralStorage &
+        structural_storage(const TSInputTargetLinkStorage &owner) noexcept
+        {
+            return static_cast<const TSInputTargetLinkStructuralStorage &>(owner);
+        }
+
+        [[nodiscard]] TSInputTargetLinkStructuralStorage::StructuralTransition &
+        ensure_structural_transition(TSInputTargetLinkStorage &owner)
+        {
+            auto &storage = structural_storage(owner);
+            if (!storage.structural_transition)
+            {
+                storage.structural_transition =
+                    std::make_unique<TSInputTargetLinkStructuralStorage::StructuralTransition>(owner);
+            }
+            return *storage.structural_transition;
+        }
+
+        void structural_clear_transition(TSInputTargetLinkStorage &owner) noexcept
+        {
+            auto &transition = structural_storage(owner).structural_transition;
+            if (transition) { transition->clear(); }
+        }
+
+        void structural_record_key_set_modified(TSInputTargetLinkStorage &owner,
+                                                DateTime modified_time)
+        {
+            auto &transition = ensure_structural_transition(owner);
+            static_cast<void>(transition.key_set_tracking.record_modified(modified_time));
+        }
+
+        void structural_key_set_source_invalidated(TSInputTargetLinkStorage &owner,
+                                                   const TSDataTracking *source) noexcept
+        {
+            static_cast<void>(source);
+            auto &transition = structural_storage(owner).structural_transition;
+            if (transition) { transition->key_set_subscribed = false; }
+        }
+
+        void structural_subscribe_key_set_tracking(TSInputTargetLinkStorage &owner)
+        {
+            auto &transition = structural_storage(owner).structural_transition;
+            if (!owner.bound() || !transition || transition->key_set_subscribed) { return; }
+            auto key_set = target_slot_set(owner);
+            key_set.base().subscribe(&transition->key_set_notifier);
+            transition->key_set_subscribed = true;
+            const auto modified_time = key_set.last_modified_time();
+            if (modified_time != MIN_DT) { structural_record_key_set_modified(owner, modified_time); }
+        }
+
+        void structural_unsubscribe_key_set_tracking(TSInputTargetLinkStorage &owner) noexcept
+        {
+            auto &transition = structural_storage(owner).structural_transition;
+            if (!owner.bound() || !transition || !transition->key_set_subscribed) { return; }
+            auto clear_subscribed = make_scope_exit([&] { transition->key_set_subscribed = false; });
+            static_cast<void>(fallback_on_exception(false, [&] {
+                target_slot_set(owner).base().unsubscribe(&transition->key_set_notifier);
+                return true;
+            }));
+        }
+
+        void structural_subscribe_slot_observers(TSInputTargetLinkStorage &owner)
+        {
+            auto &storage = structural_storage(owner);
+            if (!owner.bound() || storage.slot_observers.empty()) { return; }
+
+            auto set = target_slot_set(owner);
+            std::vector<SlotObserver *> subscribed;
+            subscribed.reserve(storage.slot_observers.size());
+            auto rollback = make_scope_exit<true>([&] {
+                for (SlotObserver *observer : subscribed) { set.unsubscribe_slot_observer(observer); }
+            });
+            storage.slot_observers.for_each([&](SlotObserver *observer) {
+                set.subscribe_slot_observer(observer);
+                subscribed.push_back(observer);
+            });
+            storage.slot_observers_subscribed = true;
+            rollback.release();
+        }
+
+        void structural_unsubscribe_slot_observers(TSInputTargetLinkStorage &owner)
+        {
+            auto &storage = structural_storage(owner);
+            if (!owner.bound() || !storage.slot_observers_subscribed) { return; }
+            auto clear_subscribed = make_scope_exit([&] { storage.slot_observers_subscribed = false; });
+            auto set = target_slot_set(owner);
+            storage.slot_observers.for_each(
+                [&](SlotObserver *observer) { set.unsubscribe_slot_observer(observer); });
+        }
+
+        void structural_unsubscribe_slot_observers_noexcept(TSInputTargetLinkStorage &owner) noexcept
+        {
+            auto &storage = structural_storage(owner);
+            if (!owner.bound() || !storage.slot_observers_subscribed) { return; }
+            static_cast<void>(fallback_on_exception(false, [&] {
+                structural_unsubscribe_slot_observers(owner);
+                return true;
+            }));
+        }
+
+        void structural_publish_sampled_transition(TSInputTargetLinkStorage &owner,
+                                                   DateTime modified_time)
+        {
+            auto &transition = ensure_structural_transition(owner);
+            transition.modified_time = modified_time;
+            transition.sampled_current = true;
+            structural_record_key_set_modified(owner, modified_time);
+        }
+
+        void structural_detach_target(TSInputTargetLinkStorage &owner,
+                                      bool retain_structural_target,
+                                      DateTime modified_time)
+        {
+            auto &storage = structural_storage(owner);
+            structural_unsubscribe_key_set_tracking(owner);
+            if (owner.state_.target.bound() && storage.slot_observers_subscribed)
+            {
+                storage.slot_observers.notify_clear();
+                structural_unsubscribe_slot_observers(owner);
+            }
+            if (retain_structural_target)
+            {
+                auto &transition = ensure_structural_transition(owner);
+                transition.previous_target = owner.state_.target;
+                transition.modified_time = modified_time;
+                transition.sampled_current = false;
+            }
+            else { structural_clear_transition(owner); }
+        }
+
+        void structural_unbind_noexcept(TSInputTargetLinkStorage &owner) noexcept
+        {
+            auto &storage = structural_storage(owner);
+            structural_unsubscribe_key_set_tracking(owner);
+            if (owner.state_.target.bound() && storage.slot_observers_subscribed)
+            {
+                static_cast<void>(fallback_on_exception(false, [&] {
+                    storage.slot_observers.notify_clear();
+                    return true;
+                }));
+                structural_unsubscribe_slot_observers_noexcept(owner);
+            }
+            structural_clear_transition(owner);
+        }
+
+        void structural_source_invalidated(TSInputTargetLinkStorage &owner) noexcept
+        {
+            auto &storage = structural_storage(owner);
+            const bool notify_slot_clear = storage.slot_observers_subscribed;
+            storage.slot_observers_subscribed = false;
+            if (storage.structural_transition)
+            {
+                storage.structural_transition->key_set_subscribed = false;
+                storage.structural_transition->clear();
+            }
+            if (notify_slot_clear)
+            {
+                static_cast<void>(fallback_on_exception(false, [&] {
+                    storage.slot_observers.notify_clear();
+                    return true;
+                }));
+            }
+        }
+
+        void structural_add_slot_observer(TSInputTargetLinkStorage &owner,
+                                          SlotObserver *observer)
+        {
+            auto &storage = structural_storage(owner);
+            storage.slot_observers.add(observer);
+            auto rollback = make_scope_exit<true>([&] { storage.slot_observers.remove(observer); });
+            if (owner.bound()) { target_slot_set(owner).subscribe_slot_observer(observer); }
+            if (owner.bound()) { storage.slot_observers_subscribed = true; }
+            rollback.release();
+        }
+
+        void structural_remove_slot_observer(TSInputTargetLinkStorage &owner,
+                                             SlotObserver *observer)
+        {
+            auto &storage = structural_storage(owner);
+            if (owner.bound() && storage.slot_observers_subscribed)
+            {
+                target_slot_set(owner).unsubscribe_slot_observer(observer);
+            }
+            storage.slot_observers.remove(observer);
+            if (storage.slot_observers.empty()) { storage.slot_observers_subscribed = false; }
+        }
+
+        const TSDataTracking &structural_key_set_tracking(TSInputTargetLinkStorage &owner)
+        {
+            auto &transition = ensure_structural_transition(owner);
+            structural_subscribe_key_set_tracking(owner);
+            return transition.key_set_tracking;
+        }
+
+        TSDataTracking &structural_mutable_key_set_tracking(TSInputTargetLinkStorage &owner)
+        {
+            auto &transition = ensure_structural_transition(owner);
+            structural_subscribe_key_set_tracking(owner);
+            return transition.key_set_tracking;
+        }
+
+        TSDataView structural_previous_target_view(const TSInputTargetLinkStorage &owner) noexcept
+        {
+            const auto &transition = structural_storage(owner).structural_transition;
+            return transition ? transition->previous_target.data_view() : TSDataView{};
+        }
+
+        bool structural_transition_active(const TSInputTargetLinkStorage &owner) noexcept
+        {
+            const auto &transition = structural_storage(owner).structural_transition;
+            return transition && transition->modified_time != MIN_DT &&
+                   owner.tracking.last_modified_time == transition->modified_time;
+        }
+
+        bool structural_sampled_transition(const TSInputTargetLinkStorage &owner) noexcept
+        {
+            const auto &transition = structural_storage(owner).structural_transition;
+            return structural_transition_active(owner) && transition->sampled_current;
+        }
+
+        DateTime structural_transition_time(const TSInputTargetLinkStorage &owner) noexcept
+        {
+            const auto &transition = structural_storage(owner).structural_transition;
+            return transition ? transition->modified_time : MIN_DT;
+        }
+
+        DynamicStorageMetrics structural_dynamic_storage_metrics(
+            const TSInputTargetLinkStorage &owner) noexcept
+        {
+            const auto &storage = structural_storage(owner);
+            DynamicStorageMetrics result = storage.slot_observers.dynamic_storage_metrics();
+            if (storage.structural_transition)
+            {
+                result.live_bytes += sizeof(TSInputTargetLinkStructuralStorage::StructuralTransition);
+                result.reserved_bytes += sizeof(TSInputTargetLinkStructuralStorage::StructuralTransition);
+                result += storage.structural_transition->key_set_tracking.observers.dynamic_storage_metrics();
+            }
+            return result;
+        }
+
+        void structural_before_move_assignment_source(TSInputTargetLinkStorage &owner) noexcept
+        {
+            auto &storage = structural_storage(owner);
+            if (storage.slot_observers.empty()) { return; }
+            static_cast<void>(fallback_on_exception(false, [&] {
+                storage.slot_observers.notify_clear();
+                return true;
+            }));
+            structural_unsubscribe_slot_observers_noexcept(owner);
+            storage.slot_observers.clear();
+            storage.slot_observers_subscribed = false;
+        }
+
+        void structural_resubscribe_after_move_assignment(TSInputTargetLinkStorage &owner) noexcept
+        {
+            static_cast<void>(fallback_on_exception(false, [&] {
+                structural_subscribe_slot_observers(owner);
+                return true;
+            }));
+        }
+
+        void no_structural_action(TSInputTargetLinkStorage &) noexcept {}
+        void no_structural_action_at(TSInputTargetLinkStorage &, DateTime) {}
+        void no_structural_detach(TSInputTargetLinkStorage &, bool, DateTime) {}
+        void no_structural_source_invalidated(TSInputTargetLinkStorage &) noexcept {}
+        void no_structural_key_source_invalidated(TSInputTargetLinkStorage &,
+                                                  const TSDataTracking *) noexcept {}
+        void no_structural_add(TSInputTargetLinkStorage &, SlotObserver *)
+        {
+            throw std::logic_error("non-structural target links do not support slot observers");
+        }
+        const TSDataTracking &no_structural_key_tracking(TSInputTargetLinkStorage &)
+        {
+            throw std::logic_error("non-structural target links do not expose key-set tracking");
+        }
+        TSDataTracking &no_structural_mutable_key_tracking(TSInputTargetLinkStorage &)
+        {
+            throw std::logic_error("non-structural target links do not expose key-set tracking");
+        }
+        TSDataView no_structural_previous_target(const TSInputTargetLinkStorage &) noexcept { return {}; }
+        bool no_structural_flag(const TSInputTargetLinkStorage &) noexcept { return false; }
+        DateTime no_structural_time(const TSInputTargetLinkStorage &) noexcept { return MIN_DT; }
+        DynamicStorageMetrics no_structural_metrics(const TSInputTargetLinkStorage &) noexcept { return {}; }
+
+        [[nodiscard]] const TSInputTargetLinkStructuralOps &target_link_structural_ops() noexcept
+        {
+            static const TSInputTargetLinkStructuralOps ops{
+                .supports_structural = true,
+                .clear_transition = &structural_clear_transition,
+                .subscribe_key_set_tracking = &structural_subscribe_key_set_tracking,
+                .subscribe_slot_observers = &structural_subscribe_slot_observers,
+                .publish_sampled_transition = &structural_publish_sampled_transition,
+                .detach_target = &structural_detach_target,
+                .unbind_noexcept = &structural_unbind_noexcept,
+                .source_invalidated = &structural_source_invalidated,
+                .add_slot_observer = &structural_add_slot_observer,
+                .remove_slot_observer = &structural_remove_slot_observer,
+                .key_set_tracking = &structural_key_set_tracking,
+                .mutable_key_set_tracking = &structural_mutable_key_set_tracking,
+                .record_key_set_modified = &structural_record_key_set_modified,
+                .key_set_source_invalidated = &structural_key_set_source_invalidated,
+                .previous_target_view = &structural_previous_target_view,
+                .transition_active = &structural_transition_active,
+                .sampled_transition = &structural_sampled_transition,
+                .transition_time = &structural_transition_time,
+                .dynamic_storage_metrics = &structural_dynamic_storage_metrics,
+                .before_move_assignment_source = &structural_before_move_assignment_source,
+                .resubscribe_after_move_assignment = &structural_resubscribe_after_move_assignment,
+            };
+            return ops;
+        }
+
         [[nodiscard]] bool project_target_path(TSDataView &current,
                                                const TSValueTypeMetaData *&current_schema,
                                                const TSInputTargetActiveNode *node)
@@ -220,6 +539,71 @@ namespace hgraph::detail
             });
         }
     }  // namespace
+
+    const TSInputTargetLinkStructuralOps &target_link_no_structural_ops() noexcept
+    {
+        static const TSInputTargetLinkStructuralOps ops{
+            .supports_structural = false,
+            .clear_transition = &no_structural_action,
+            .subscribe_key_set_tracking = &no_structural_action,
+            .subscribe_slot_observers = &no_structural_action,
+            .publish_sampled_transition = &no_structural_action_at,
+            .detach_target = &no_structural_detach,
+            .unbind_noexcept = &no_structural_action,
+            .source_invalidated = &no_structural_source_invalidated,
+            .add_slot_observer = &no_structural_add,
+            .remove_slot_observer = &no_structural_add,
+            .key_set_tracking = &no_structural_key_tracking,
+            .mutable_key_set_tracking = &no_structural_mutable_key_tracking,
+            .record_key_set_modified = &no_structural_action_at,
+            .key_set_source_invalidated = &no_structural_key_source_invalidated,
+            .previous_target_view = &no_structural_previous_target,
+            .transition_active = &no_structural_flag,
+            .sampled_transition = &no_structural_flag,
+            .transition_time = &no_structural_time,
+            .dynamic_storage_metrics = &no_structural_metrics,
+            .before_move_assignment_source = &no_structural_action,
+            .resubscribe_after_move_assignment = &no_structural_action,
+        };
+        return ops;
+    }
+
+    const MemoryUtils::StoragePlan &target_link_storage_plan_for(TSTypeKind kind) noexcept
+    {
+        if (kind == TSTypeKind::TSS || kind == TSTypeKind::TSD)
+        {
+            return MemoryUtils::plan_for<TSInputTargetLinkStructuralStorage>();
+        }
+        return MemoryUtils::plan_for<TSInputTargetLinkStorage>();
+    }
+
+    const TSInputTargetLinkStorageAccessOps &target_link_storage_access_for(
+        TSTypeKind kind) noexcept
+    {
+        static const TSInputTargetLinkStorageAccessOps common{
+            .get_const = [](const void *memory) noexcept -> const TSInputTargetLinkStorage * {
+                return memory != nullptr ? MemoryUtils::cast<TSInputTargetLinkStorage>(memory) : nullptr;
+            },
+            .get_mutable = [](void *memory) noexcept -> TSInputTargetLinkStorage * {
+                return memory != nullptr ? MemoryUtils::cast<TSInputTargetLinkStorage>(memory) : nullptr;
+            },
+        };
+        static const TSInputTargetLinkStorageAccessOps structural{
+            .get_const = [](const void *memory) noexcept -> const TSInputTargetLinkStorage * {
+                return memory != nullptr
+                           ? static_cast<const TSInputTargetLinkStorage *>(
+                                 MemoryUtils::cast<TSInputTargetLinkStructuralStorage>(memory))
+                           : nullptr;
+            },
+            .get_mutable = [](void *memory) noexcept -> TSInputTargetLinkStorage * {
+                return memory != nullptr
+                           ? static_cast<TSInputTargetLinkStorage *>(
+                                 MemoryUtils::cast<TSInputTargetLinkStructuralStorage>(memory))
+                           : nullptr;
+            },
+        };
+        return kind == TSTypeKind::TSS || kind == TSTypeKind::TSD ? structural : common;
+    }
 
     TSInputTargetActiveNode *TSInputTargetActiveNode::child_at(std::size_t slot_index) const noexcept
     {
@@ -346,13 +730,28 @@ namespace hgraph::detail
     }
 
     TSInputTargetLinkStorage::TSInputTargetLinkStorage() noexcept
-        : state_(*this)
+        : TSInputTargetLinkStorage(target_link_no_structural_ops())
+    {
+    }
+
+    TSInputTargetLinkStorage::TSInputTargetLinkStorage(
+        const TSInputTargetLinkStructuralOps &structural_ops) noexcept
+        : state_(*this),
+          structural_ops_(&structural_ops)
     {
     }
 
     TSInputTargetLinkStorage::TSInputTargetLinkStorage(const TSInputTargetLinkStorage &other)
+        : TSInputTargetLinkStorage(other, target_link_no_structural_ops())
+    {
+    }
+
+    TSInputTargetLinkStorage::TSInputTargetLinkStorage(
+        const TSInputTargetLinkStorage &other,
+        const TSInputTargetLinkStructuralOps &structural_ops)
         : tracking(other.tracking),
-          state_(*this)
+          state_(*this),
+          structural_ops_(&structural_ops)
     {
     }
 
@@ -369,14 +768,17 @@ namespace hgraph::detail
     }
 
     TSInputTargetLinkStorage::TSInputTargetLinkStorage(TSInputTargetLinkStorage &&other) noexcept
+        : TSInputTargetLinkStorage(std::move(other), target_link_no_structural_ops())
+    {
+    }
+
+    TSInputTargetLinkStorage::TSInputTargetLinkStorage(
+        TSInputTargetLinkStorage &&other,
+        const TSInputTargetLinkStructuralOps &structural_ops) noexcept
         : tracking(std::move(other.tracking)),
           state_(*this),
-          slot_observers_(std::move(other.slot_observers_)),
-          slot_observers_subscribed_(std::exchange(other.slot_observers_subscribed_, false)),
-          structural_transition_(std::move(other.structural_transition_))
+          structural_ops_(&structural_ops)
     {
-        other.slot_observers_.clear();
-        if (structural_transition_) { structural_transition_->rebind_owner(*this); }
         state_.move_from(other.state_);
     }
 
@@ -390,23 +792,10 @@ namespace hgraph::detail
             // Published target links are stable and are not move-assigned.
             // Preserve any observers of this destination identity; observers
             // of the moved-from identity see that source disappear.
-            if (!other.slot_observers_.empty())
-            {
-                static_cast<void>(fallback_on_exception(false, [&] {
-                    other.slot_observers_.notify_clear();
-                    return true;
-                }));
-                other.unsubscribe_slot_observers_noexcept();
-                other.slot_observers_.clear();
-            }
+            other.structural_ops_->before_move_assignment_source(other);
             tracking = std::move(other.tracking);
             state_.move_from(other.state_);
-            structural_transition_ = std::move(other.structural_transition_);
-            if (structural_transition_) { structural_transition_->rebind_owner(*this); }
-            static_cast<void>(fallback_on_exception(false, [&] {
-                subscribe_slot_observers();
-                return true;
-            }));
+            structural_ops_->resubscribe_after_move_assignment(*this);
         }
         return *this;
     }
@@ -414,6 +803,59 @@ namespace hgraph::detail
     TSInputTargetLinkStorage::~TSInputTargetLinkStorage() noexcept
     {
         unbind_noexcept();
+    }
+
+    void TSInputTargetLinkStorage::set_structural_ops(
+        const TSInputTargetLinkStructuralOps &structural_ops) noexcept
+    {
+        structural_ops_ = &structural_ops;
+    }
+
+    TSInputTargetLinkStructuralStorage::TSInputTargetLinkStructuralStorage() noexcept
+        : TSInputTargetLinkStorage(target_link_structural_ops())
+    {
+    }
+
+    TSInputTargetLinkStructuralStorage::TSInputTargetLinkStructuralStorage(
+        const TSInputTargetLinkStructuralStorage &other)
+        : TSInputTargetLinkStorage(other, target_link_structural_ops())
+    {
+    }
+
+    TSInputTargetLinkStructuralStorage &TSInputTargetLinkStructuralStorage::operator=(
+        const TSInputTargetLinkStructuralStorage &other)
+    {
+        TSInputTargetLinkStorage::operator=(other);
+        return *this;
+    }
+
+    TSInputTargetLinkStructuralStorage::TSInputTargetLinkStructuralStorage(
+        TSInputTargetLinkStructuralStorage &&other) noexcept
+        : TSInputTargetLinkStorage(std::move(other), target_link_structural_ops()),
+          slot_observers(std::move(other.slot_observers)),
+          slot_observers_subscribed(std::exchange(other.slot_observers_subscribed, false)),
+          structural_transition(std::move(other.structural_transition))
+    {
+        other.slot_observers.clear();
+        if (structural_transition) { structural_transition->rebind_owner(*this); }
+    }
+
+    TSInputTargetLinkStructuralStorage &TSInputTargetLinkStructuralStorage::operator=(
+        TSInputTargetLinkStructuralStorage &&other) noexcept
+    {
+        if (this != &other)
+        {
+            TSInputTargetLinkStorage::operator=(std::move(other));
+            structural_transition = std::move(other.structural_transition);
+            if (structural_transition) { structural_transition->rebind_owner(*this); }
+        }
+        return *this;
+    }
+
+    TSInputTargetLinkStructuralStorage::~TSInputTargetLinkStructuralStorage() noexcept
+    {
+        unbind_noexcept();
+        set_structural_ops(target_link_no_structural_ops());
     }
 
     bool TSInputTargetLinkStorage::bound() const noexcept
@@ -477,8 +919,7 @@ namespace hgraph::detail
             throw std::invalid_argument("TSInput target binding schema does not match the input slot schema");
         }
 
-        const bool structural =
-            input_endpoint_ops_for(&schema).structural_observation != nullptr;
+        const bool structural = structural_ops_->supports_structural;
         const bool previous_was_valid =
             sampled && state_.target.bound() && state_.target.view(modified_time).valid();
         const bool previous_has_published_state =
@@ -487,7 +928,7 @@ namespace hgraph::detail
         if (state_.target.bound()) { detach_target(sampled && structural, modified_time); }
         else if (!sampled || structural_transition_time() != modified_time)
         {
-            if (structural_transition_) { structural_transition_->clear(); }
+            structural_ops_->clear_transition(*this);
         }
 
         auto &state = state_;
@@ -502,26 +943,17 @@ namespace hgraph::detail
         {
             record_target_modified(state.target.data_view().last_modified_time());
         }
-        subscribe_key_set_tracking();
-        subscribe_slot_observers();
+        structural_ops_->subscribe_key_set_tracking(*this);
+        structural_ops_->subscribe_slot_observers(*this);
         resubscribe_active_target(schema);
         const bool publish_sampled_transition =
             sampled && (output.valid() || previous_was_valid || previous_has_published_state);
         if (publish_sampled_transition)
         {
-            if (structural)
-            {
-                if (!structural_transition_)
-                {
-                    structural_transition_ = std::make_unique<StructuralTransition>(*this);
-                }
-                structural_transition_->modified_time = modified_time;
-                structural_transition_->sampled_current = true;
-                record_key_set_modified(modified_time);
-            }
+            structural_ops_->publish_sampled_transition(*this, modified_time);
             record_target_modified(modified_time);
         }
-        else if (sampled && structural && structural_transition_) { structural_transition_->clear(); }
+        else if (sampled) { structural_ops_->clear_transition(*this); }
         rollback.release();
     }
 
@@ -547,125 +979,35 @@ namespace hgraph::detail
 
     void TSInputTargetLinkStorage::detach_target(bool retain_structural_target, DateTime modified_time)
     {
-        unsubscribe_key_set_tracking();
-        if (state_.target.bound() && slot_observers_subscribed_)
-        {
-            slot_observers_.notify_clear();
-            unsubscribe_slot_observers();
-        }
+        structural_ops_->detach_target(*this, retain_structural_target, modified_time);
         unsubscribe_active_target();
         if (state_.target.bound()) { state_.target.data_view().unsubscribe(&state_); }
-        if (retain_structural_target)
-        {
-            if (!structural_transition_)
-            {
-                structural_transition_ = std::make_unique<StructuralTransition>(*this);
-            }
-            structural_transition_->previous_target = state_.target;
-            structural_transition_->modified_time = modified_time;
-            structural_transition_->sampled_current = false;
-        }
-        else if (structural_transition_) { structural_transition_->clear(); }
         state_.target.reset();
     }
 
     void TSInputTargetLinkStorage::unbind_noexcept() noexcept
     {
-        unsubscribe_key_set_tracking();
-        if (state_.target.bound() && slot_observers_subscribed_)
-        {
-            static_cast<void>(fallback_on_exception(false, [&] {
-                slot_observers_.notify_clear();
-                return true;
-            }));
-            unsubscribe_slot_observers_noexcept();
-        }
+        structural_ops_->unbind_noexcept(*this);
         if (state_.active_root_node) { unsubscribe_tree_noexcept(*state_.active_root_node, state_.scheduling_notifier); }
         unsubscribe_handle_noexcept(state_.target, &state_);
-        if (structural_transition_) { structural_transition_->clear(); }
     }
 
     void TSInputTargetLinkStorage::source_invalidated(const TSDataTracking *source) noexcept
     {
         static_cast<void>(source);
-        const bool notify_slot_clear = slot_observers_subscribed_;
-        slot_observers_subscribed_ = false;
         state_.clear_active_observed();
         state_.target.reset();
-        if (structural_transition_)
-        {
-            structural_transition_->key_set_subscribed = false;
-            structural_transition_->clear();
-        }
-        if (notify_slot_clear)
-        {
-            static_cast<void>(fallback_on_exception(false, [&] {
-                slot_observers_.notify_clear();
-                return true;
-            }));
-        }
+        structural_ops_->source_invalidated(*this);
     }
 
     void TSInputTargetLinkStorage::add_slot_observer(SlotObserver *observer)
     {
-        slot_observers_.add(observer);
-        auto rollback = make_scope_exit<true>([&] { slot_observers_.remove(observer); });
-        if (bound())
-        {
-            target_slot_set(*this).subscribe_slot_observer(observer);
-        }
-        if (bound()) { slot_observers_subscribed_ = true; }
-        rollback.release();
+        structural_ops_->add_slot_observer(*this, observer);
     }
 
     void TSInputTargetLinkStorage::remove_slot_observer(SlotObserver *observer)
     {
-        if (bound() && slot_observers_subscribed_)
-        {
-            target_slot_set(*this).unsubscribe_slot_observer(observer);
-        }
-        slot_observers_.remove(observer);
-        if (slot_observers_.empty()) { slot_observers_subscribed_ = false; }
-    }
-
-    void TSInputTargetLinkStorage::subscribe_slot_observers()
-    {
-        if (!bound() || slot_observers_.empty()) { return; }
-
-        auto set = target_slot_set(*this);
-        std::vector<SlotObserver *> subscribed;
-        subscribed.reserve(slot_observers_.entries().size());
-        auto rollback = make_scope_exit<true>([&] {
-            for (SlotObserver *observer : subscribed) { set.unsubscribe_slot_observer(observer); }
-        });
-        for (SlotObserver *observer : slot_observers_.entries())
-        {
-            if (observer == nullptr) { continue; }
-            set.subscribe_slot_observer(observer);
-            subscribed.push_back(observer);
-        }
-        slot_observers_subscribed_ = true;
-        rollback.release();
-    }
-
-    void TSInputTargetLinkStorage::unsubscribe_slot_observers()
-    {
-        if (!bound() || !slot_observers_subscribed_) { return; }
-        auto clear_subscribed = make_scope_exit([&] { slot_observers_subscribed_ = false; });
-        auto set = target_slot_set(*this);
-        for (SlotObserver *observer : slot_observers_.entries())
-        {
-            if (observer != nullptr) { set.unsubscribe_slot_observer(observer); }
-        }
-    }
-
-    void TSInputTargetLinkStorage::unsubscribe_slot_observers_noexcept() noexcept
-    {
-        if (!bound() || !slot_observers_subscribed_) { return; }
-        static_cast<void>(fallback_on_exception(false, [&] {
-            unsubscribe_slot_observers();
-            return true;
-        }));
+        structural_ops_->remove_slot_observer(*this, observer);
     }
 
     void TSInputTargetLinkStorage::record_target_modified(DateTime modified_time)
@@ -674,64 +1016,25 @@ namespace hgraph::detail
         tracking.parent.notify_child_modified(modified_time);
     }
 
-    TSInputTargetLinkStorage::StructuralTransition &
-    TSInputTargetLinkStorage::ensure_structural_state() const
-    {
-        if (!structural_transition_)
-        {
-            structural_transition_ =
-                std::make_unique<StructuralTransition>(*const_cast<TSInputTargetLinkStorage *>(this));
-        }
-        return *structural_transition_;
-    }
-
     const TSDataTracking &TSInputTargetLinkStorage::key_set_tracking() const
     {
         auto &self = *const_cast<TSInputTargetLinkStorage *>(this);
-        auto &state = self.ensure_structural_state();
-        self.subscribe_key_set_tracking();
-        return state.key_set_tracking;
+        return structural_ops_->key_set_tracking(self);
     }
 
     TSDataTracking &TSInputTargetLinkStorage::mutable_key_set_tracking()
     {
-        auto &state = ensure_structural_state();
-        subscribe_key_set_tracking();
-        return state.key_set_tracking;
+        return structural_ops_->mutable_key_set_tracking(*this);
     }
 
     void TSInputTargetLinkStorage::record_key_set_modified(DateTime modified_time)
     {
-        auto &state = ensure_structural_state();
-        static_cast<void>(state.key_set_tracking.record_modified(modified_time));
+        structural_ops_->record_key_set_modified(*this, modified_time);
     }
 
     void TSInputTargetLinkStorage::key_set_source_invalidated(const TSDataTracking *source) noexcept
     {
-        static_cast<void>(source);
-        if (structural_transition_) { structural_transition_->key_set_subscribed = false; }
-    }
-
-    void TSInputTargetLinkStorage::subscribe_key_set_tracking()
-    {
-        if (!bound() || !structural_transition_ || structural_transition_->key_set_subscribed) { return; }
-        auto key_set = target_slot_set(*this);
-        key_set.base().subscribe(&structural_transition_->key_set_notifier);
-        structural_transition_->key_set_subscribed = true;
-        const auto modified_time = key_set.last_modified_time();
-        if (modified_time != MIN_DT) { record_key_set_modified(modified_time); }
-    }
-
-    void TSInputTargetLinkStorage::unsubscribe_key_set_tracking() noexcept
-    {
-        if (!bound() || !structural_transition_ || !structural_transition_->key_set_subscribed) { return; }
-        auto clear_subscribed = make_scope_exit([&] {
-            structural_transition_->key_set_subscribed = false;
-        });
-        static_cast<void>(fallback_on_exception(false, [&] {
-            target_slot_set(*this).base().unsubscribe(&structural_transition_->key_set_notifier);
-            return true;
-        }));
+        structural_ops_->key_set_source_invalidated(*this, source);
     }
 
     TSInputTargetActiveNode &TSInputTargetLinkStorage::root_node()
@@ -829,9 +1132,7 @@ namespace hgraph::detail
 
     TSDataView TSInputTargetLinkStorage::previous_target_view() const noexcept
     {
-        return structural_transition_ != nullptr
-                   ? structural_transition_->previous_target.data_view()
-                   : TSDataView{};
+        return structural_ops_->previous_target_view(*this);
     }
 
     const TSOutputHandle &TSInputTargetLinkStorage::target_output() const noexcept
@@ -841,19 +1142,17 @@ namespace hgraph::detail
 
     bool TSInputTargetLinkStorage::structural_transition_active() const noexcept
     {
-        return structural_transition_ != nullptr &&
-               structural_transition_->modified_time != MIN_DT &&
-               tracking.last_modified_time == structural_transition_->modified_time;
+        return structural_ops_->transition_active(*this);
     }
 
     bool TSInputTargetLinkStorage::sampled_structural_transition() const noexcept
     {
-        return structural_transition_active() && structural_transition_->sampled_current;
+        return structural_ops_->sampled_transition(*this);
     }
 
     DateTime TSInputTargetLinkStorage::structural_transition_time() const noexcept
     {
-        return structural_transition_ != nullptr ? structural_transition_->modified_time : MIN_DT;
+        return structural_ops_->transition_time(*this);
     }
 
     const TSInputTargetLinkState *TSInputTargetLinkStorage::state() const noexcept
@@ -863,18 +1162,12 @@ namespace hgraph::detail
 
     DynamicStorageMetrics TSInputTargetLinkStorage::dynamic_storage_metrics() const noexcept
     {
-        DynamicStorageMetrics result = slot_observers_.dynamic_storage_metrics();
+        DynamicStorageMetrics result = structural_ops_->dynamic_storage_metrics(*this);
         if (state_.active_root_node != nullptr)
         {
             result.live_bytes += sizeof(TSInputTargetActiveNode);
             result.reserved_bytes += sizeof(TSInputTargetActiveNode);
             result += state_.active_root_node->dynamic_storage_metrics();
-        }
-        if (structural_transition_ != nullptr)
-        {
-            result.live_bytes += sizeof(StructuralTransition);
-            result.reserved_bytes += sizeof(StructuralTransition);
-            result += structural_transition_->key_set_tracking.observers.dynamic_storage_metrics();
         }
         return result;
     }

--- a/src/hgraph/types/time_series/ts_input/target_link_ops.cpp
+++ b/src/hgraph/types/time_series/ts_input/target_link_ops.cpp
@@ -1181,6 +1181,7 @@ namespace hgraph::detail
         {
             context.schema = &schema;
             context.storage_offset = storage_offset;
+            context.storage_access = &target_link_storage_access_for(schema.kind);
         }
 
         [[nodiscard]] std::unique_ptr<TSInputTargetLinkContext>
@@ -1377,13 +1378,13 @@ namespace hgraph::detail
     const TSInputTargetLinkStorage *target_link_storage_at(const TSInputTargetLinkContext &context,
                                                            const void *memory) noexcept
     {
-        return MemoryUtils::cast<TSInputTargetLinkStorage>(advance(memory, context.storage_offset));
+        return context.storage_access->get_const(advance(memory, context.storage_offset));
     }
 
     TSInputTargetLinkStorage *target_link_storage_at(const TSInputTargetLinkContext &context,
                                                      void *memory) noexcept
     {
-        return MemoryUtils::cast<TSInputTargetLinkStorage>(advance(memory, context.storage_offset));
+        return context.storage_access->get_mutable(advance(memory, context.storage_offset));
     }
 
     namespace

--- a/src/hgraph/types/time_series/ts_input/target_link_ops.h
+++ b/src/hgraph/types/time_series/ts_input/target_link_ops.h
@@ -19,6 +19,8 @@ namespace hgraph::detail
 
         const TSValueTypeMetaData *schema{nullptr};
         std::size_t                storage_offset{0};
+        const TSInputTargetLinkStorageAccessOps *storage_access{
+            &target_link_storage_access_for(TSTypeKind::TS)};
         const TSDataLayout        *active_layout{nullptr};
         const TSDataOps           *active_ops{nullptr};
         const TSInputTargetLinkSlotAccess *slot_access{nullptr};

--- a/src/hgraph/types/utils/slot_observer.cpp
+++ b/src/hgraph/types/utils/slot_observer.cpp
@@ -1,0 +1,286 @@
+#include <hgraph/types/utils/slot_observer.h>
+
+#include <hgraph/util/scope.h>
+
+#include <algorithm>
+#include <cassert>
+#include <stdexcept>
+#include <utility>
+#include <vector>
+
+namespace hgraph
+{
+    struct SlotObserverList::ObserverList
+    {
+        std::vector<SlotObserver *> entries{};
+        std::size_t                 notify_depth{0};
+        bool                        compact_pending{false};
+    };
+
+    SlotObserverList::SlotObserverList(const SlotObserverList &other)
+    {
+        auto rollback = make_scope_exit([this] { clear(); });
+        other.for_each([this](SlotObserver *observer) { add(observer); });
+        rollback.release();
+    }
+
+    SlotObserverList &SlotObserverList::operator=(const SlotObserverList &other)
+    {
+        if (this != &other)
+        {
+            clear();
+            other.for_each([this](SlotObserver *observer) { add(observer); });
+        }
+        return *this;
+    }
+
+    SlotObserverList::SlotObserverList(SlotObserverList &&other) noexcept
+        : observers_(std::exchange(other.observers_, ObserverStorage{}))
+    {
+    }
+
+    SlotObserverList &SlotObserverList::operator=(SlotObserverList &&other) noexcept
+    {
+        if (this != &other)
+        {
+            clear();
+            observers_ = std::exchange(other.observers_, ObserverStorage{});
+        }
+        return *this;
+    }
+
+    SlotObserverList::~SlotObserverList() noexcept
+    {
+        clear();
+    }
+
+    void SlotObserverList::add(SlotObserver *observer)
+    {
+        if (observer == nullptr) { return; }
+
+        if (!observers_)
+        {
+            set_single(observer);
+            return;
+        }
+
+        if (auto *entry = single(); entry != nullptr)
+        {
+            assert(entry != observer && "slot observer registered twice");
+            if (entry == observer) { return; }
+
+            auto entries = std::make_unique<ObserverList>();
+            entries->entries.reserve(2);
+            entries->entries.push_back(entry);
+            entries->entries.push_back(observer);
+            set_many(entries.release());
+            return;
+        }
+
+        auto *entries = many();
+        assert(entries != nullptr && "slot observer storage is corrupt");
+        if (entries == nullptr) { throw std::logic_error("slot observer storage is corrupt"); }
+
+        const auto it = std::find(entries->entries.begin(), entries->entries.end(), observer);
+        assert(it == entries->entries.end() && "slot observer registered twice");
+        if (it == entries->entries.end()) { entries->entries.push_back(observer); }
+    }
+
+    void SlotObserverList::remove(SlotObserver *observer)
+    {
+        if (observer == nullptr) { return; }
+
+        if (auto *entry = single(); entry != nullptr)
+        {
+            assert(entry == observer && "removing unregistered slot observer");
+            if (entry == observer) { observers_.clear(); }
+            return;
+        }
+
+        auto *entries = many();
+        if (entries == nullptr)
+        {
+            assert(false && "removing unregistered slot observer");
+            return;
+        }
+
+        const auto it = std::find(entries->entries.begin(), entries->entries.end(), observer);
+        assert(it != entries->entries.end() && "removing unregistered slot observer");
+        if (it == entries->entries.end()) { return; }
+
+        if (entries->notify_depth != 0)
+        {
+            *it = nullptr;
+            entries->compact_pending = true;
+            return;
+        }
+
+        *it = entries->entries.back();
+        entries->entries.pop_back();
+        compact_many(*entries);
+    }
+
+    bool SlotObserverList::empty() const noexcept
+    {
+        return !observers_;
+    }
+
+    std::size_t SlotObserverList::size() const noexcept
+    {
+        if (single() != nullptr) { return 1; }
+        const auto *entries = many();
+        if (entries == nullptr) { return 0; }
+        return static_cast<std::size_t>(
+            std::count_if(entries->entries.begin(), entries->entries.end(),
+                          [](const SlotObserver *observer) { return observer != nullptr; }));
+    }
+
+    bool SlotObserverList::contains(const SlotObserver *observer) const noexcept
+    {
+        if (observer == nullptr) { return false; }
+        if (auto *entry = single(); entry != nullptr) { return entry == observer; }
+        const auto *entries = many();
+        return entries != nullptr &&
+               std::find(entries->entries.begin(), entries->entries.end(), observer) != entries->entries.end();
+    }
+
+    DynamicStorageMetrics SlotObserverList::dynamic_storage_metrics() const noexcept
+    {
+        const auto *entries = many();
+        if (entries == nullptr) { return {}; }
+        return {
+            .live_bytes = sizeof(ObserverList) + entries->entries.size() * sizeof(SlotObserver *),
+            .reserved_bytes = sizeof(ObserverList) + entries->entries.capacity() * sizeof(SlotObserver *),
+        };
+    }
+
+    void SlotObserverList::clear() noexcept
+    {
+        if (auto *entries = many(); entries != nullptr)
+        {
+            if (entries->notify_depth == 0) { delete entries; }
+            else
+            {
+                std::ranges::fill(entries->entries, nullptr);
+                entries->compact_pending = true;
+            }
+        }
+        observers_.clear();
+    }
+
+    void SlotObserverList::notify_capacity(std::size_t old_capacity, std::size_t new_capacity) const
+    {
+        for_each([=](SlotObserver *observer) { observer->on_capacity(old_capacity, new_capacity); });
+    }
+
+    void SlotObserverList::notify_insert(std::size_t slot) const
+    {
+        for_each([=](SlotObserver *observer) { observer->on_insert(slot); });
+    }
+
+    void SlotObserverList::notify_remove(std::size_t slot) const
+    {
+        for_each([=](SlotObserver *observer) { observer->on_remove(slot); });
+    }
+
+    void SlotObserverList::notify_erase(std::size_t slot) const
+    {
+        for_each([=](SlotObserver *observer) { observer->on_erase(slot); });
+    }
+
+    void SlotObserverList::notify_clear() const
+    {
+        for_each([](SlotObserver *observer) { observer->on_clear(); });
+    }
+
+    SlotObserver *SlotObserverList::single() const noexcept
+    {
+        return observers_.has_enum(Representation::single)
+                   ? observers_.as<SlotObserver>()
+                   : nullptr;
+    }
+
+    SlotObserverList::ObserverList *SlotObserverList::many() const noexcept
+    {
+        return observers_.has_enum(Representation::many)
+                   ? observers_.as<ObserverList>()
+                   : nullptr;
+    }
+
+    void SlotObserverList::set_single(SlotObserver *observer) noexcept
+    {
+        observers_.set(observer, Representation::single);
+    }
+
+    void SlotObserverList::set_many(ObserverList *observers) noexcept
+    {
+        observers_.set(observers, Representation::many);
+    }
+
+    void SlotObserverList::compact_many(ObserverList &observers) noexcept
+    {
+        if (observers.notify_depth != 0)
+        {
+            observers.compact_pending = true;
+            return;
+        }
+
+        for (std::size_t index = 0; index < observers.entries.size();)
+        {
+            if (observers.entries[index] != nullptr)
+            {
+                ++index;
+                continue;
+            }
+            observers.entries[index] = observers.entries.back();
+            observers.entries.pop_back();
+        }
+        observers.compact_pending = false;
+
+        if (observers.entries.empty())
+        {
+            delete &observers;
+            observers_.clear();
+            return;
+        }
+
+        if (observers.entries.size() == 1)
+        {
+            auto *remaining = observers.entries.front();
+            delete &observers;
+            set_single(remaining);
+        }
+    }
+
+    void SlotObserverList::for_each_erased(void *context, ErasedVisitor visitor) const
+    {
+        if (context == nullptr || visitor == nullptr) { return; }
+
+        if (auto *entry = single(); entry != nullptr)
+        {
+            visitor(context, entry);
+            return;
+        }
+
+        auto *entries = many();
+        if (entries == nullptr) { return; }
+
+        ++entries->notify_depth;
+        auto guard = make_scope_exit([this, entries]() noexcept {
+            --entries->notify_depth;
+            if (entries->notify_depth == 0 && entries->compact_pending)
+            {
+                auto *self = const_cast<SlotObserverList *>(this);
+                if (self->many() == entries) { self->compact_many(*entries); }
+                else { delete entries; }
+            }
+        });
+
+        const auto limit = entries->entries.size();
+        for (std::size_t index = 0; index < limit; ++index)
+        {
+            auto *observer = entries->entries[index];
+            if (observer != nullptr) { visitor(context, observer); }
+        }
+    }
+}  // namespace hgraph

--- a/tests/cpp/test_slot_utils.cpp
+++ b/tests/cpp/test_slot_utils.cpp
@@ -8,6 +8,7 @@
 
 #include <array>
 #include <cstdint>
+#include <functional>
 #include <stdexcept>
 #include <string>
 #include <type_traits>
@@ -140,6 +141,22 @@ namespace
             list->remove(this);
         }
 
+        void on_remove(size_t) override {}
+        void on_erase(size_t) override {}
+        void on_clear() override {}
+    };
+
+    struct CallbackSlotObserver final : SlotObserver
+    {
+        std::function<void(std::size_t)> insert{};
+        int                             calls{0};
+
+        void on_capacity(size_t, size_t) override {}
+        void on_insert(size_t slot) override
+        {
+            ++calls;
+            if (insert) { insert(slot); }
+        }
         void on_remove(size_t) override {}
         void on_erase(size_t) override {}
         void on_clear() override {}
@@ -591,6 +608,96 @@ TEST_CASE("slot observer list supports reentrant removal", "[v2 slot utils]") {
     observers.notify_insert(4);
     REQUIRE(first.calls == 1);
     REQUIRE(second.events == std::vector<std::string>{"insert:3", "insert:4"});
+}
+
+TEST_CASE("slot observer list uses compact null one many storage", "[v2 slot utils][memory]") {
+    STATIC_REQUIRE(sizeof(SlotObserverList) == sizeof(void *));
+
+    SlotObserverList  observers;
+    RecordingObserver first;
+    RecordingObserver second;
+
+    CHECK(observers.empty());
+    CHECK(observers.size() == 0);
+    CHECK(observers.dynamic_storage_metrics().live_bytes == 0);
+    CHECK(observers.dynamic_storage_metrics().reserved_bytes == 0);
+
+    observers.add(&first);
+    CHECK_FALSE(observers.empty());
+    CHECK(observers.size() == 1);
+    CHECK(observers.contains(&first));
+    CHECK(observers.dynamic_storage_metrics().live_bytes == 0);
+    CHECK(observers.dynamic_storage_metrics().reserved_bytes == 0);
+
+    observers.add(&second);
+    CHECK(observers.size() == 2);
+    CHECK(observers.contains(&second));
+    CHECK(observers.dynamic_storage_metrics().live_bytes > 2 * sizeof(void *));
+
+    std::vector<SlotObserver *> visited;
+    observers.for_each([&](SlotObserver *observer) { visited.push_back(observer); });
+    CHECK(visited == std::vector<SlotObserver *>{&first, &second});
+
+    observers.remove(&second);
+    CHECK(observers.size() == 1);
+    CHECK(observers.contains(&first));
+    CHECK(observers.dynamic_storage_metrics().live_bytes == 0);
+    CHECK(observers.dynamic_storage_metrics().reserved_bytes == 0);
+
+    SlotObserverList copied{observers};
+    CHECK(copied.size() == 1);
+    CHECK(copied.contains(&first));
+
+    SlotObserverList moved{std::move(copied)};
+    CHECK(copied.empty());
+    CHECK(moved.size() == 1);
+    CHECK(moved.contains(&first));
+}
+
+TEST_CASE("slot observer visitor defers additions and survives reentrant clear", "[v2 slot utils]") {
+    SlotObserverList     observers;
+    CallbackSlotObserver first;
+    CallbackSlotObserver second;
+    CallbackSlotObserver added;
+
+    first.insert = [&](std::size_t) {
+        if (!observers.contains(&added)) { observers.add(&added); }
+    };
+    observers.add(&first);
+    observers.add(&second);
+
+    observers.notify_insert(1);
+    CHECK(first.calls == 1);
+    CHECK(second.calls == 1);
+    CHECK(added.calls == 0);
+    CHECK(observers.size() == 3);
+
+    first.insert = [&](std::size_t) { observers.clear(); };
+    observers.notify_insert(2);
+    CHECK(first.calls == 2);
+    CHECK(second.calls == 1);
+    CHECK(added.calls == 0);
+    CHECK(observers.empty());
+    CHECK(observers.dynamic_storage_metrics().live_bytes == 0);
+    CHECK(observers.dynamic_storage_metrics().reserved_bytes == 0);
+}
+
+TEST_CASE("slot observer visitor restores traversal state after exceptions", "[v2 slot utils]") {
+    SlotObserverList     observers;
+    CallbackSlotObserver throwing;
+    CallbackSlotObserver survivor;
+    throwing.insert = [](std::size_t) { throw std::runtime_error("observer failed"); };
+
+    observers.add(&throwing);
+    observers.add(&survivor);
+    REQUIRE_THROWS_AS(observers.notify_insert(1), std::runtime_error);
+
+    observers.remove(&throwing);
+    observers.notify_insert(2);
+    CHECK(survivor.calls == 1);
+    CHECK(observers.size() == 1);
+    CHECK(observers.dynamic_storage_metrics().live_bytes == 0);
+    CHECK(observers.dynamic_storage_metrics().reserved_bytes == 0);
 }
 
 TEST_CASE("value slot store supports default construction before plan binding", "[v2 slot utils]") {

--- a/tests/cpp/test_ts_input.cpp
+++ b/tests/cpp/test_ts_input.cpp
@@ -3,6 +3,8 @@
 #include <hgraph/types/metadata/type_registry.h>
 #include <hgraph/types/time_series/ts_input.h>
 #include <hgraph/types/time_series/ts_input/detail.h>
+#include <hgraph/types/time_series/ts_input/target_link.h>
+#include <hgraph/types/time_series/ts_input/target_link_structural_state.h>
 #include <hgraph/types/value/value.h>
 
 #include <catch2/catch_test_macros.hpp>
@@ -103,6 +105,40 @@ namespace
         for (auto it = range.begin(); it != range.end(); ++it) { ++result; }
         return result;
     }
+}
+
+TEST_CASE("TSInput target-link plans allocate structural state only for keyed slots", "[memory]")
+{
+    using namespace hgraph;
+    using namespace hgraph::detail;
+
+    const auto &common_plan = target_link_storage_plan_for(TSTypeKind::TS);
+    const auto &set_plan = target_link_storage_plan_for(TSTypeKind::TSS);
+    const auto &dict_plan = target_link_storage_plan_for(TSTypeKind::TSD);
+
+    REQUIRE(&common_plan == &target_link_storage_plan_for(TSTypeKind::TSL));
+    REQUIRE(&common_plan == &target_link_storage_plan_for(TSTypeKind::TSW));
+    REQUIRE(&common_plan == &target_link_storage_plan_for(TSTypeKind::TSB));
+    REQUIRE(&common_plan == &target_link_storage_plan_for(TSTypeKind::REF));
+    REQUIRE(&common_plan == &target_link_storage_plan_for(TSTypeKind::SIGNAL));
+    REQUIRE(&set_plan == &dict_plan);
+    REQUIRE(&common_plan != &set_plan);
+    REQUIRE(common_plan.layout.size == sizeof(TSInputTargetLinkStorage));
+    REQUIRE(set_plan.layout.size > common_plan.layout.size);
+
+    MemoryUtils::ErasedOwner<> common_storage{common_plan};
+    MemoryUtils::ErasedOwner<> structural_storage{set_plan};
+    const auto *common_link =
+        target_link_storage_access_for(TSTypeKind::TS).get_const(common_storage.data());
+    const auto *structural_link =
+        target_link_storage_access_for(TSTypeKind::TSS).get_const(structural_storage.data());
+
+    REQUIRE(common_link != nullptr);
+    REQUIRE(structural_link != nullptr);
+    REQUIRE(static_cast<const void *>(common_link) == common_storage.data());
+    REQUIRE(static_cast<const void *>(structural_link) == structural_storage.data());
+    REQUIRE(static_cast<const void *>(&common_link->tracking) == common_storage.data());
+    REQUIRE(static_cast<const void *>(&structural_link->tracking) == structural_storage.data());
 }
 
 TEST_CASE("TSInput builds a non-peered TSB root with nested peered terminals")


### PR DESCRIPTION
## Summary

- replace `SlotObserverList`'s always-present vector with a one-word null/one/many erased representation
- replace the public `entries(): const std::vector&` API with representation-neutral visitor traversal
- split TargetLink storage at wiring time so only TSS/TSD links carry slot-observer and structural-transition state
- retain direct output observer registration after workload instrumentation showed no storage benefit from delegation
- document the storage strategies and add memory-layout, lifecycle, re-entrancy, and exception-safety coverage

## Why

TargetLinks previously carried structural observer state for every peered time-series kind even though that state is used only by keyed TSS/TSD links. Slot observer lists also paid for an empty vector in every owner and exposed that vector through the public API.

Measured 64-bit layouts after this change:

| Structure | Before | After | Reduction |
| --- | ---: | ---: | ---: |
| `SlotObserverList` | 40 B | 8 B | 32 B (80%) |
| Common `TargetLink` | 160 B | 112 B | 48 B (30%) |
| Structural TSS/TSD `TargetLink` | 160 B | 136 B | 24 B (15%) |

The structural representation is selected once from immutable schema/plan metadata and accessed through the project's passive ops-table plus erased-ownership pattern. Common TargetLinks never allocate structural state. Structural transitions remain lazy, and observer spill storage appears only at the second observer.

## Delegation decision

Instrumentation across representative benchmarks observed 69,871 TargetLink constructions, 60,068 non-structural binds, 527 structural binds, and no forwarded slot observers. Full native-suite instrumentation observed 22 registrations, all 0→1 and none 1→many.

A direct/delegated experiment registered the same number of output pointers in the observed cases, while delegation added callback hops and lifecycle coupling. Direct registration is therefore retained. Delegation can be reconsidered if real workloads demonstrate multiple observers per TargetLink.

## API impact

`SlotObserverList::entries()` is intentionally removed. Callers use `for_each`, `size`, and `contains`, so the API no longer exposes a concrete standard-library container or its invalidation behavior. The C++ ABI is still under development.

## Validation

- macOS fresh native acceptance: 1,371 passed
- stable-ABI wheel built with Python 3.12 and tested in fresh Python 3.14.6: 1,772 passed, 10 skipped
- physical `hg-linux`, GCC 14.3 fresh native acceptance: 1,371 passed
- physical `hg-linux`, ASan Debug with Python 3.14.4: 1,772 passed, 10 skipped; no ASan findings
- installed-SDK consumer: 1/1 passed
- Sphinx warning-as-error build: passed
- `git diff --check`: passed

Closes #243
Related to #213