### PR TITLE
Reject unknown eval_node resolution_dict keys

### DIFF
--- a/python/hgraph/_wiring/_runner.py
+++ b/python/hgraph/_wiring/_runner.py
@@ -1,5 +1,6 @@
 """Graph execution entry points: run_graph/evaluate_graph and the
 eval_node test harness."""
+import functools
 import inspect
 import logging
 import time
@@ -7,8 +8,9 @@ from datetime import timedelta
 
 import _hgraph
 
-from .._types import (_ContextExpr, _GenericTsExpr, _TsExpr,
-                      _TypeVarSentinel, _type_var_is_scalar)
+from .._signature import _is_time_series
+from .._types import (_GenericTsExpr, _TsExpr, _TypeVarSentinel,
+                      _type_var_is_scalar)
 from ._core import (WiringError, WiringPort, _OperatorFunction, _unwrap,
                     _wiring_stack, wire)
 from ._graph import _GraphFn
@@ -412,10 +414,10 @@ def eval_node(node, *args, output_type=None, resolution_dict=None,
         fn_sig = inspect.signature(
             fn.fn if isinstance(fn, _GraphFn) or hasattr(fn, "_delegate") else fn,
             eval_str=True)
-        params = list(fn_sig.parameters.values())
+        declared_params = list(fn_sig.parameters.values())
     except (TypeError, ValueError):
-        params = []
-    params = [p for p in params
+        declared_params = None
+    params = [p for p in (declared_params or ())
               if p.kind not in (inspect.Parameter.VAR_POSITIONAL, inspect.Parameter.VAR_KEYWORD)]
     param_names = {p.name for p in params}
     annotations_by_name = {p.name: p.annotation for p in params}
@@ -425,18 +427,27 @@ def eval_node(node, *args, output_type=None, resolution_dict=None,
     # through to inference. Native operators deliberately retain their
     # positional/variadic resolution fallback because overload families do
     # not yet expose one complete set of accepted parameter names.
-    if resolution_dict and isinstance(fn, (_GraphFn, _PyNode)):
-        if isinstance(fn, _PyNode):
-            # Vararg nodes rewrite their runtime callable to receive one
-            # packed TSL/TSB input, so inspect.signature(fn.fn) no longer
-            # carries the original annotation. _ts_names is calculated from
-            # the user signature before that rewrite.
-            resolution_parameters = fn._ts_names - {
-                param.name for param in fn._params
-                if isinstance(param.annotation, _ContextExpr)
-            }
-        else:
-            resolution_parameters = fn.signature.time_series_args
+    decorated_target = fn
+    while isinstance(decorated_target, functools.partial):
+        decorated_target = decorated_target.func
+    if (resolution_dict and declared_params is not None
+            and isinstance(decorated_target, (_GraphFn, _PyNode))):
+        resolution_parameters = {
+            param.name for param in declared_params
+            if (param.kind is not inspect.Parameter.VAR_KEYWORD
+                and _is_time_series(param.annotation))
+        }
+        if (not params and any(
+                param.kind is inspect.Parameter.VAR_KEYWORD
+                and _is_time_series(param.annotation)
+                for param in declared_params)):
+            # A time-series **collector expands its user-supplied keyword
+            # names into individual series when there are no fixed inputs.
+            # Only those actual series names are useful resolution keys; the
+            # formal collector name is not.
+            resolution_parameters.update(
+                name for name, value in kwargs.items()
+                if isinstance(value, (list, tuple)))
         unknown_parameters = set(resolution_dict) - resolution_parameters
         if unknown_parameters:
             unknown = ", ".join(repr(name) for name in sorted(

--- a/python/hgraph/_wiring/_runner.py
+++ b/python/hgraph/_wiring/_runner.py
@@ -7,10 +7,10 @@ from datetime import timedelta
 
 import _hgraph
 
-from .._types import (_GenericTsExpr, _TsExpr, _TypeVarSentinel,
-                      _type_var_is_scalar)
-from ._core import (WiringPort, _OperatorFunction, _unwrap, _wiring_stack,
-                    wire)
+from .._types import (_ContextExpr, _GenericTsExpr, _TsExpr,
+                      _TypeVarSentinel, _type_var_is_scalar)
+from ._core import (WiringError, WiringPort, _OperatorFunction, _unwrap,
+                    _wiring_stack, wire)
 from ._graph import _GraphFn
 from ._node import _PyNode
 from ._sentinels import _simplify_delta
@@ -419,6 +419,33 @@ def eval_node(node, *args, output_type=None, resolution_dict=None,
               if p.kind not in (inspect.Parameter.VAR_POSITIONAL, inspect.Parameter.VAR_KEYWORD)]
     param_names = {p.name for p in params}
     annotations_by_name = {p.name: p.annotation for p in params}
+
+    # Decorated Python graphs and nodes expose an authoritative set of
+    # time-series inputs. Reject misspellings before they silently fall
+    # through to inference. Native operators deliberately retain their
+    # positional/variadic resolution fallback because overload families do
+    # not yet expose one complete set of accepted parameter names.
+    if resolution_dict and isinstance(fn, (_GraphFn, _PyNode)):
+        if isinstance(fn, _PyNode):
+            # Vararg nodes rewrite their runtime callable to receive one
+            # packed TSL/TSB input, so inspect.signature(fn.fn) no longer
+            # carries the original annotation. _ts_names is calculated from
+            # the user signature before that rewrite.
+            resolution_parameters = fn._ts_names - {
+                param.name for param in fn._params
+                if isinstance(param.annotation, _ContextExpr)
+            }
+        else:
+            resolution_parameters = fn.signature.time_series_args
+        unknown_parameters = set(resolution_dict) - resolution_parameters
+        if unknown_parameters:
+            unknown = ", ".join(repr(name) for name in sorted(
+                unknown_parameters, key=repr))
+            valid = ", ".join(repr(name) for name in sorted(
+                resolution_parameters, key=repr)) or "<none>"
+            raise WiringError(
+                f"eval_node resolution_dict contains unknown parameter(s): {unknown}; "
+                f"valid time-series parameters: {valid}")
 
     pinned_scope = None
     if isinstance(fn, _PyNode) and fn._pins:

--- a/python/tests/test_hgraph_api.py
+++ b/python/tests/test_hgraph_api.py
@@ -231,8 +231,41 @@ def test_eval_node_resolution_dict_validates_decorated_targets():
     ):
         eval_node(passthrough, [1], resolution_dict={"scale": TS[int]})
 
+    @graph
+    def generic_passthrough(tsd: hg.TIME_SERIES_TYPE) -> hg.TIME_SERIES_TYPE:
+        return tsd
+
+    specialized = generic_passthrough[hg.TIME_SERIES_TYPE: TS[int]]
+    check(
+        eval_node(specialized, [1], resolution_dict={"tsd": TS[int]}) == [1],
+        "valid subscripted graph resolution",
+    )
+    with pytest.raises(
+        hg.WiringError,
+        match=r"unknown parameter\(s\): 'typo'.*valid time-series parameters: 'tsd'",
+    ):
+        eval_node(specialized, [1], resolution_dict={"typo": TS[int]})
 
 
+def test_eval_node_resolution_dict_accepts_expanded_variadic_keyword_keys():
+    @graph
+    def expanded_graph(**bundle: TSB[hg.TS_SCHEMA]) -> TS[int]:
+        return bundle["a"]
+
+    @hg.compute_node
+    def expanded_node(**bundle: TSB[hg.TS_SCHEMA]) -> TS[int]:
+        return bundle["a"].value
+
+    for target in (expanded_graph, expanded_node):
+        check(
+            eval_node(target, a=[None], resolution_dict={"a": TS[int]}) is None,
+            "expanded all-None series resolution",
+        )
+        with pytest.raises(
+            hg.WiringError,
+            match=r"unknown parameter\(s\): 'typo'.*valid time-series parameters: 'a'",
+        ):
+            eval_node(target, a=[None], resolution_dict={"typo": TS[int]})
 
 
 def test_map_and_reduce_over_tsd():

--- a/python/tests/test_hgraph_api.py
+++ b/python/tests/test_hgraph_api.py
@@ -180,6 +180,58 @@ def test_eval_node_scalar_inputs_follow_ts_annotations():
     check(eval_node(total, 4.0, 5.0, 6.0) == [15.0], "scalar eval_node inputs")
 
 
+def test_eval_node_resolution_dict_validates_decorated_targets():
+    @graph
+    def passthrough(tsd: TS[int], scale: int = 1) -> TS[int]:
+        return tsd * scale
+
+    @hg.compute_node
+    def python_passthrough(tsd: TS[int]) -> TS[int]:
+        return tsd.value
+
+    @hg.compute_node
+    def packed_passthrough(*values: TSL[TS[int], Size[2]]) -> TS[int]:
+        return sum(value.value for value in values)
+
+    check(
+        eval_node(passthrough, [1, 2], resolution_dict={"tsd": TS[int]}) == [1, 2],
+        "valid graph resolution",
+    )
+    check(
+        eval_node(python_passthrough, [1, 2], resolution_dict={"tsd": TS[int]}) == [1, 2],
+        "valid node resolution",
+    )
+    check(
+        eval_node(
+            packed_passthrough,
+            [1, 3],
+            [2, 4],
+            resolution_dict={"values": TS[int]},
+        ) == [3, 7],
+        "valid packed vararg resolution",
+    )
+
+    for target in (passthrough, python_passthrough):
+        with pytest.raises(
+            hg.WiringError,
+            match=(
+                r"resolution_dict contains unknown parameter\(s\): 'other', 'ts'; "
+                r"valid time-series parameters: 'tsd'"
+            ),
+        ):
+            eval_node(
+                target,
+                [1],
+                resolution_dict={"ts": TS[str], "other": TS[int]},
+            )
+
+    with pytest.raises(
+        hg.WiringError,
+        match=r"unknown parameter\(s\): 'scale'.*valid time-series parameters: 'tsd'",
+    ):
+        eval_node(passthrough, [1], resolution_dict={"scale": TS[int]})
+
+
 
 
 


### PR DESCRIPTION
## Summary

- validate `eval_node(..., resolution_dict=...)` keys for decorated Python graphs and nodes
- raise `WiringError` with the unknown keys and valid time-series parameters
- preserve existing native/raw-operator positional, variadic, and partial-resolution behavior
- preserve valid decorated graph, node, and packed-vararg resolutions

## Root cause

`eval_node` only applied entries whose names matched positional parameters. Unmatched entries were left over and silently ignored, allowing a misspelled key to fall through to inference and produce confusing downstream behavior.

The new validation uses authoritative decorated-target metadata before wiring starts. Native operators remain outside this check because overload families do not yet expose one complete accepted-name set.

## User impact

Misspelled or scalar `resolution_dict` keys now fail immediately with a deterministic wiring error. Valid calls retain their existing behavior.

Closes #230

## Validation

- 548 tests across files exercising `resolution_dict`
- complete native suite: 1,372 passed
- fresh stable-ABI wheel under Python 3.14: 1,793 passed, 10 skipped
- differential PR campaign: 104/104 attempted, zero new mismatches
- parity corpus validation: 56 recipes