### PR TITLE
Python-node diagnostic identity and reliable service request delivery — closes #247

### DIFF
--- a/docs/source/developer_guide/services.rst
+++ b/docs/source/developer_guide/services.rst
@@ -67,6 +67,8 @@ source/capture pair** — applied with different payloads:
     and the capture schedules the service source for
     ``evaluation_time + MIN_TD`` (current time during ``start``). The temporal
     request mutation does not run the implementation in the capture cycle.
+    A request/reply input source retains its earliest outstanding publication
+    time, so a later request cannot postpone work that is already due.
   - **Request/reply responses** cross an explicit feedback source/sink pair in
     the graph that owns the implementation, then publish through the ordinary
     same-cycle shared-output relay. Request/reply clients are omitted from
@@ -105,10 +107,11 @@ The per-flavour payloads:
   the cycle after capture; releases are reference-counted across captures
   (``tests/cpp/test_service_node.cpp``).
 - **Request/reply service**: the source owns ``TSD<int, request_schema>``.
-  Each client has a **stable wiring-time request id**; capture sinks update
-  source-local mutable delta state; the source applies that delta in one
-  mutation when scheduled and then resets it. Multiple captures can update
-  before the source emits, so the final request delta is **cumulative**
+  Each live client instance has a stable runtime request id; capture sinks
+  queue source-local deltas. Same-cycle captures for one client combine into
+  one delta, while captures from successive cycles are published in order, at
+  most one per client per cycle. Different clients can still be published in
+  the same source mutation, so the request delta is **cumulative**
   (``make_request_input_source_node`` / ``make_request_input_capture_node``;
   proven by "request/reply source emits cumulative client requests" in
   ``test_service_wiring.cpp``). The implementation output is captured by an

--- a/include/hgraph/types/graph_wiring.h
+++ b/include/hgraph/types/graph_wiring.h
@@ -810,6 +810,17 @@ namespace hgraph
          * is the build artifact stored for ``finish`` (the ``scalars`` are recorded
          * on it). Pass an empty ``Value`` for a node with no scalar inputs.
          */
+        /**
+         * Diagnostic label hint (issue #247): the next ``add_node`` whose
+         * builder schema is named ``expected_operator`` labels its node
+         * (unless already labeled), then the hint clears. Lets erased wire
+         * paths attach user-facing identity (a python function name) without
+         * threading a label through every candidate wire signature; the
+         * operator-name guard keeps auxiliary nodes (const lifts) unlabeled.
+         */
+        void set_pending_node_label(std::string expected_operator, std::string label);
+        void clear_pending_node_label() noexcept;
+
         WiringPortRef add_node(std::type_index def, NodeBuilder builder, std::span<const WiringInputRef> inputs,
                                Value scalars);
 

--- a/python/hgraph/_wiring/_core.py
+++ b/python/hgraph/_wiring/_core.py
@@ -52,6 +52,7 @@ def wire(name, *args, __output_type__=None, **kwargs):
             out_type = _TS[out_type]   # json_encode[str] names the SCALAR
         out_type = out_type.handle if isinstance(out_type, _TsExpr) else out_type
     w = _current_wiring()
+    node_label = kwargs.pop("__node_label__", None)
     sizes = kwargs.pop("__sizes__", None)
     resolutions = kwargs.pop("__resolutions__", None)
     resolution_scope = None
@@ -75,6 +76,8 @@ def wire(name, *args, __output_type__=None, **kwargs):
         # sources inside the C++ call normalisation (the scalar-kwargs rule) -
         # no python-side retry.
         wire_options = {"output_type": out_type}
+        if node_label:
+            wire_options["node_label"] = str(node_label)
         if sizes is not None:
             wire_options["sizes"] = sizes
         if resolution_scope is not None:

--- a/python/hgraph/_wiring/_node.py
+++ b/python/hgraph/_wiring/_node.py
@@ -319,6 +319,11 @@ class _PyNode:
         raise WiringError(
             f"AUTO_RESOLVE could not resolve '{param.name}' ({arguments[0]!r}) from the wired arguments")
 
+    def _diagnostic_label(self):
+        """User-facing node identity for diagnostics (issue #247): trace,
+        wiring-trace, and profiler render implementation:label."""
+        return self._label or getattr(self.fn, "__name__", None) or self.__name__
+
     def _check_binding(self, scope, param, value):
         """Match the wired port against the parameter's TYPE PATTERN,
         binding type variables into the scope. A mismatch on a concrete
@@ -785,8 +790,10 @@ class _PyNode:
                 raise TypeError(f"@compute_node '{self.__name__}' needs a TS[...] return annotation")
             op_name = ("__py_compute_recordable" if recordable_state_type is not None
                        else "__py_compute")
-            return wire(op_name, packed, output_type=out_tp, **node_kwargs)
-        return wire("__py_sink", packed, **node_kwargs)
+            return wire(op_name, packed, output_type=out_tp,
+                        __node_label__=self._diagnostic_label(), **node_kwargs)
+        return wire("__py_sink", packed,
+                    __node_label__=self._diagnostic_label(), **node_kwargs)
 
 
 def _make_py_node(fn, *, has_output, active, valid, all_valid, resolvers,
@@ -1044,6 +1051,7 @@ class _Generator:
                 stop_scalars.append(value)
         return wire(
             "__py_generator",
+            __node_label__=self._label or getattr(self.fn, "__name__", None),
             fn=_hgraph.node_ref(self.fn),
             config=config,
             scalars=_hgraph.any_list(scalars),

--- a/python/hgraph/_wiring/_node.py
+++ b/python/hgraph/_wiring/_node.py
@@ -319,10 +319,23 @@ class _PyNode:
         raise WiringError(
             f"AUTO_RESOLVE could not resolve '{param.name}' ({arguments[0]!r}) from the wired arguments")
 
-    def _diagnostic_label(self):
+    def _diagnostic_label(self, scalar_values=None):
         """User-facing node identity for diagnostics (issue #247): trace,
-        wiring-trace, and profiler render implementation:label."""
-        return self._label or getattr(self.fn, "__name__", None) or self.__name__
+        wiring-trace, and profiler render implementation:label. Explicit
+        labels resolve ``{scalar}`` placeholders with the call's wiring-time
+        scalar values (upstream parity: label="custom_label {i}")."""
+        if self._label:
+            if scalar_values and "{" in self._label:
+                class _Keep(dict):
+                    def __missing__(self, key):
+                        return "{" + key + "}"
+
+                try:
+                    return self._label.format_map(_Keep(scalar_values))
+                except (ValueError, IndexError):
+                    return self._label
+            return self._label
+        return getattr(self.fn, "__name__", None) or self.__name__
 
     def _check_binding(self, scope, param, value):
         """Match the wired port against the parameter's TYPE PATTERN,
@@ -791,9 +804,11 @@ class _PyNode:
             op_name = ("__py_compute_recordable" if recordable_state_type is not None
                        else "__py_compute")
             return wire(op_name, packed, output_type=out_tp,
-                        __node_label__=self._diagnostic_label(), **node_kwargs)
+                        __node_label__=self._diagnostic_label(scalar_values),
+                        **node_kwargs)
         return wire("__py_sink", packed,
-                    __node_label__=self._diagnostic_label(), **node_kwargs)
+                    __node_label__=self._diagnostic_label(scalar_values),
+                    **node_kwargs)
 
 
 def _make_py_node(fn, *, has_output, active, valid, all_valid, resolvers,

--- a/python/py_wiring.cpp
+++ b/python/py_wiring.cpp
@@ -1081,7 +1081,8 @@ namespace hgraph::python_bridge
              nb::arg("capture_values") = false)
         .def("wire", &PyWiring::wire, nb::arg("name"), nb::arg("args") = nb::tuple(),
              nb::arg("kwargs") = nb::dict(), nb::arg("output_type") = nb::none(),
-             nb::arg("sizes") = nb::none(), nb::arg("initial_resolution").none() = nb::none())
+             nb::arg("sizes") = nb::none(), nb::arg("initial_resolution").none() = nb::none(),
+             nb::arg("node_label") = nb::none())
         .def("set_replay", &PyWiring::set_replay, nb::arg("key"), nb::arg("values"),
              nb::arg("ts_type") = nb::none())
         .def("feedback", &PyWiring::feedback, nb::arg("ts_type"), nb::arg("initial") = nb::none())

--- a/python/py_wiring.h
+++ b/python/py_wiring.h
@@ -178,9 +178,19 @@ namespace hgraph::python_bridge
         [[nodiscard]] nb::object wire(const std::string &name, nb::tuple args, nb::dict kwargs,
                                       std::optional<PyTsType> output_type,
                                       std::optional<std::vector<std::size_t>> sizes = std::nullopt,
-                                      PyResolutionScope *initial_resolution = nullptr)
+                                      PyResolutionScope *initial_resolution = nullptr,
+                                      std::optional<std::string> node_label = std::nullopt)
         {
             ensure_open();
+            // Diagnostic label (issue #247): hint the wiring so the operator's
+            // own node carries the user-facing identity.
+            if (node_label.has_value())
+            {
+                wiring_ref().set_pending_node_label(name, *node_label);
+            }
+            auto clear_label_hint = UnwindCleanupGuard([&] {
+                wiring_ref().clear_pending_node_label();
+            });
             // Target-directed scalar conversion: with an explicit output
             // type, a leading plain-python scalar converts AT the target's
             // value schema (const((1,2,3), tp=TS[tuple[int,...]]) builds

--- a/python/tests/adaptors/sql/test_sql_adaptor.py
+++ b/python/tests/adaptors/sql/test_sql_adaptor.py
@@ -33,8 +33,8 @@ class _Row(hg.CompoundScalar):
     value: int
 
 
-def _end_time():
-    return datetime.now(timezone.utc).replace(tzinfo=None) + timedelta(seconds=5)
+def _end_time(seconds=5):
+    return datetime.now(timezone.utc).replace(tzinfo=None) + timedelta(seconds=seconds)
 
 
 def _environment(path):
@@ -82,7 +82,6 @@ def test_sql_raw_adaptor_serves_repeated_requests_from_the_same_client(
 ):
     import importlib
     import threading
-    import time
 
     database = tmp_path / "repeated-read.sqlite"
     with sqlite3.connect(database) as connection:
@@ -90,7 +89,11 @@ def test_sql_raw_adaptor_serves_repeated_requests_from_the_same_client(
         connection.executemany("insert into rows values (?)", [(1,), (2,)])
     target = f"sqlite:///{database}"
     captured = []
+    first_query_started = threading.Event()
+    first_response_captured = threading.Event()
     release_first = threading.Event()
+    feeder_errors = []
+    feeder_threads = []
     sql_module = importlib.import_module("hgraph.adaptors.sql.sql_connection")
     connection_type = sql_module.SqlAdaptorConnectionSQLServer
     original_read = connection_type.read_database
@@ -100,7 +103,11 @@ def test_sql_raw_adaptor_serves_repeated_requests_from_the_same_client(
         nonlocal calls
         calls += 1
         if calls == 1:
-            release_first.wait(timeout=2.0)
+            first_query_started.set()
+            if not release_first.wait(timeout=10.0):
+                raise TimeoutError("the second request was not sent while the first SQL read was blocked")
+        elif calls == 2 and not first_response_captured.wait(timeout=10.0):
+            raise TimeoutError("the first SQL response was not captured before the second completed")
         return original_read(connection, statement)
 
     monkeypatch.setattr(connection_type, "read_database", blocked_first_read)
@@ -108,18 +115,27 @@ def test_sql_raw_adaptor_serves_repeated_requests_from_the_same_client(
     @hg.push_queue(hg.TS[str])
     def query(sender):
         def feed():
-            sender("select value from rows where value = 1")
-            time.sleep(0.05)
-            sender("select value from rows where value = 2")
-            release_first.set()
+            try:
+                sender("select value from rows where value = 1")
+                if not first_query_started.wait(timeout=10.0):
+                    raise TimeoutError("the first SQL request did not start")
+                sender("select value from rows where value = 2")
+            except Exception as error:
+                feeder_errors.append(error)
+            finally:
+                release_first.set()
 
-        threading.Thread(target=feed, daemon=True).start()
+        thread = threading.Thread(target=feed, daemon=True)
+        feeder_threads.append(thread)
+        thread.start()
 
     @hg.sink_node
     def capture(response: hg.TSB[hg.stream.Stream[hg.stream.Data[hg.Frame]]],
                 engine: hg.EvaluationEngineApi = None):
         if response.status.value is StreamStatus.OK:
             captured.append(response["values"].value.column("value")[0].as_py())
+            if captured == [1]:
+                first_response_captured.set()
             if len(captured) == 2:
                 engine.request_engine_stop()
 
@@ -129,7 +145,12 @@ def test_sql_raw_adaptor_serves_repeated_requests_from_the_same_client(
         capture(sql_read_adaptor_raw(query(), path=target))
 
     with hg.GlobalContext(hg.GlobalState()):
-        hg.run_graph(app, run_mode=hg.EvaluationMode.REAL_TIME, end_time=_end_time())
+        hg.run_graph(app, run_mode=hg.EvaluationMode.REAL_TIME, end_time=_end_time(15))
+
+    for thread in feeder_threads:
+        thread.join(timeout=1.0)
+        assert not thread.is_alive()
+    assert not feeder_errors
 
     assert captured == [1, 2]
 

--- a/python/tests/ported/_wiring/test_error_handling.py
+++ b/python/tests/ported/_wiring/test_error_handling.py
@@ -57,7 +57,8 @@ def test_try_except_wraps_python_value_graph():
     assert isinstance(result[1]["exception"], NodeError)
     assert "division by zero" in result[1]["exception"].error_msg
     assert result[1]["exception"].additional_context is None
-    assert "__py_compute" in result[1]["exception"].activation_back_trace
+    # issue #247: the back trace names the USER function (upstream parity)
+    assert "divide" in result[1]["exception"].activation_back_trace
     assert "*args*: value={_0: 9, _1: 0}" in result[1]["exception"].activation_back_trace
     assert result[2] == {"out": 2}
 
@@ -83,7 +84,8 @@ def test_try_except_uses_native_error_output_for_python_compute_node():
 
     assert result[0] == {"out": 5}
     assert "division by zero" in result[1]["exception"].error_msg
-    assert "__py_compute" in result[1]["exception"].activation_back_trace
+    # issue #247: the back trace names the USER function (upstream parity)
+    assert "divide" in result[1]["exception"].activation_back_trace
     assert "*args*: value={_0: 9, _1: 0}" in result[1]["exception"].activation_back_trace
     assert result[2] == {"out": 2}
 
@@ -135,7 +137,8 @@ def test_try_except_preserves_keyed_map_errors():
     assert result[0]["out"] == {0: 5}
     assert result[0]["exception"] == {}
     assert "division by zero" in result[1]["exception"][1].error_msg
-    assert "__py_compute" in result[1]["exception"][1].activation_back_trace
+    # issue #247: the back trace names the USER function (upstream parity)
+    assert "divide" in result[1]["exception"][1].activation_back_trace
     assert "value={_0: 9, _1: 0}" in result[1]["exception"][1].activation_back_trace
     assert result[1]["out"] == {}
     assert result[2]["out"] == {2: 2}

--- a/python/tests/test_diagnostic_labels.py
+++ b/python/tests/test_diagnostic_labels.py
@@ -43,3 +43,21 @@ def test_explicit_label_wins_over_function_name():
     assert eval_node(g, [7], __observers__=[profiler]) == [7]
     labels = [entry.label for entry in profiler.snapshot().entries]
     assert any("my_custom" in label for label in labels), labels
+
+
+def test_label_placeholders_resolve_with_wiring_scalars():
+    # Review coverage (PR #250): label="prefix {scalar}" resolves against the
+    # call's wiring-time scalar values (upstream custom-label parity), and
+    # the resolved form is what diagnostics render.
+    @compute_node(label="custom_label {i}")
+    def delta(v: TS[int], i: str) -> TS[int]:
+        return v.value
+
+    @graph
+    def g(t: TS[int]) -> TS[int]:
+        return delta(t, i="one")
+
+    profiler = EvaluationProfiler()
+    assert eval_node(g, [3], __observers__=[profiler]) == [3]
+    labels = [entry.label for entry in profiler.snapshot().entries]
+    assert any("custom_label one" in label for label in labels), labels

--- a/python/tests/test_diagnostic_labels.py
+++ b/python/tests/test_diagnostic_labels.py
@@ -1,0 +1,45 @@
+"""Python-node diagnostic identity (issue #247): trace/profiler/wiring-trace
+must name the user's function, not only the erased operator."""
+
+from hgraph import TS, compute_node, graph
+from hgraph.test import EvaluationProfiler, eval_node
+
+
+@compute_node
+def alpha(v: TS[int]) -> TS[int]:
+    return v.value + 1
+
+
+@compute_node
+def beta(v: TS[int]) -> TS[int]:
+    return v.value * 10
+
+
+@graph
+def _chain(t: TS[int]) -> TS[int]:
+    return beta(alpha(t))
+
+
+def test_profiler_entries_carry_user_function_labels():
+    profiler = EvaluationProfiler()
+    assert eval_node(_chain, [1, 2], __observers__=[profiler]) == [20, 30]
+    labels = [entry.label for entry in profiler.snapshot().entries]
+    assert any("alpha" in label for label in labels), labels
+    assert any("beta" in label for label in labels), labels
+    # the two python nodes are DISTINGUISHABLE, not both "__py_compute"
+    assert len({l for l in labels if "alpha" in l or "beta" in l}) >= 2
+
+
+def test_explicit_label_wins_over_function_name():
+    @compute_node(label="my_custom")
+    def gamma(v: TS[int]) -> TS[int]:
+        return v.value
+
+    @graph
+    def g(t: TS[int]) -> TS[int]:
+        return gamma(t)
+
+    profiler = EvaluationProfiler()
+    assert eval_node(g, [7], __observers__=[profiler]) == [7]
+    labels = [entry.label for entry in profiler.snapshot().entries]
+    assert any("my_custom" in label for label in labels), labels

--- a/python/tests/test_lifecycle_configuration.py
+++ b/python/tests/test_lifecycle_configuration.py
@@ -157,7 +157,8 @@ def test_graph_configuration_controls_uncaught_error_detail():
     message = str(exc_info.value)
     assert "division by zero" in message
     assert "Activation Back Trace" in message
-    assert "__py_compute" in message
+    # issue #247: the failing node is named by the user function
+    assert "divide" in message
     assert "value={_0: 9, _1: 0}" in message
 
 

--- a/python/tests/test_service_timing_semantics.py
+++ b/python/tests/test_service_timing_semantics.py
@@ -37,8 +37,8 @@ def test_service_adaptor_roundtrip_takes_one_transport_cycle():
         hg.register_adaptor(None, echo_impl)
         return echo(value)
 
-    out = eval_node(roundtrip, [1], __end_time__=hg.MIN_ST + 3 * hg.MIN_TD)
-    assert out == [None, 1]
+    out = eval_node(roundtrip, [1, 2, 3], __end_time__=hg.MIN_ST + 5 * hg.MIN_TD)
+    assert out == [None, 1, 2, 3]
 
 
 def test_resubscription_samples_existing_value_in_the_same_cycle():

--- a/src/hgraph/runtime/service_node.cpp
+++ b/src/hgraph/runtime/service_node.cpp
@@ -98,15 +98,16 @@ namespace hgraph
 
         struct RequestInputChange
         {
-            Int   request_id{0};
-            Value delta{};
+            Int      request_id{0};
+            Value    delta{};
             DateTime observed_at{};
-            bool  remove{false};
+            bool     remove{false};
         };
 
         struct RequestInputSourceStorage
         {
             std::vector<RequestInputChange> pending{};
+            DateTime                        publish_time{MAX_DT};
         };
 
         struct RequestInputCaptureStorage
@@ -348,16 +349,16 @@ namespace hgraph
                 {
                     existing->delta  = std::move(delta);
                     existing->remove = false;
-                    schedule(schedule_time);
+                    schedule_publication(schedule_time);
                     return;
                 }
                 pending.push_back(RequestInputChange{
-                    .request_id = request_id,
-                    .delta      = std::move(delta),
+                    .request_id  = request_id,
+                    .delta       = std::move(delta),
                     .observed_at = observed_at,
-                    .remove     = false,
+                    .remove      = false,
                 });
-                schedule(schedule_time);
+                schedule_publication(schedule_time);
             }
 
             void remove(Int request_id, DateTime schedule_time,
@@ -373,16 +374,30 @@ namespace hgraph
                 {
                     existing->delta  = Value{};
                     existing->remove = true;
-                    schedule(schedule_time);
+                    schedule_publication(schedule_time);
                     return;
                 }
                 pending.push_back(RequestInputChange{
-                    .request_id = request_id,
-                    .delta      = Value{},
+                    .request_id  = request_id,
+                    .delta       = Value{},
                     .observed_at = observed_at,
-                    .remove     = true,
+                    .remove      = true,
                 });
-                schedule(schedule_time);
+                schedule_publication(schedule_time);
+            }
+
+            void schedule_publication(DateTime schedule_time) const
+            {
+                auto &storage = source_storage_of(view_, *context_);
+                if (schedule_time >= storage.publish_time) { return; }
+
+                GraphValue *graph = view_.graph_value();
+                if (graph == nullptr)
+                {
+                    throw std::logic_error("request input source node is not attached to a graph");
+                }
+                graph->schedule_node(view_.node_index(), schedule_time);
+                storage.publish_time = schedule_time;
             }
 
             [[nodiscard]] std::size_t node_index() const noexcept { return view_.node_index(); }
@@ -392,16 +407,6 @@ namespace hgraph
                 : view_(std::move(view)),
                   context_(context)
             {
-            }
-
-            void schedule(DateTime schedule_time) const
-            {
-                GraphValue *graph = view_.graph_value();
-                if (graph == nullptr)
-                {
-                    throw std::logic_error("request input source node is not attached to a graph");
-                }
-                graph->schedule_node(view_.node_index(), schedule_time);
             }
 
             NodeView                         view_{};
@@ -580,12 +585,14 @@ namespace hgraph
             const auto &context = *static_cast<const RequestInputSourceContext *>(
                 view.type().ops_ref().extended_view_context);
             auto &storage = source_storage_of(view, context);
+            storage.publish_time = MAX_DT;
             if (storage.pending.empty()) { return true; }
 
             apply_pending_request_input_changes(storage, view.output(evaluation_time), evaluation_time);
             if (!storage.pending.empty())
             {
-                view.graph().schedule_node(view.node_index(), evaluation_time + MIN_TD);
+                RequestInputSourceView::from_node(NodeView{view.pointer()}, &context).schedule_publication(
+                    evaluation_time + MIN_TD);
             }
             return true;
         }
@@ -609,7 +616,9 @@ namespace hgraph
         {
             const auto *context = static_cast<const RequestInputSourceContext *>(
                 view.type().ops_ref().extended_view_context);
-            source_storage_of(view, *context).pending.clear();
+            auto &storage = source_storage_of(view, *context);
+            storage.pending.clear();
+            storage.publish_time = MAX_DT;
 
             auto output   = view.output(evaluation_time);
             auto dict     = output.as_dict();

--- a/src/hgraph/types/graph_wiring.cpp
+++ b/src/hgraph/types/graph_wiring.cpp
@@ -1148,6 +1148,12 @@ struct Wiring::Impl {
     const WiringInstance *source{nullptr};
   };
 
+  // Pending diagnostic label (issue #247): applied by add_node to the next
+  // builder whose schema name matches expected_label_operator, then cleared.
+  // The operator-name guard keeps auxiliary nodes (const lifts) unlabeled.
+  std::string pending_label{};
+  std::string expected_label_operator{};
+
   std::deque<WiringInstance> instances{};
   std::unordered_map<InstanceKey, WiringInstance *, InstanceKeyHash> interned{};
   std::unordered_map<std::string, std::string> built_service_paths{};
@@ -1497,9 +1503,32 @@ WiringScopeEvent make_node_wiring_event(
 }
 } // namespace
 
+void Wiring::set_pending_node_label(std::string expected_operator, std::string label) {
+  impl_->expected_label_operator = std::move(expected_operator);
+  impl_->pending_label = std::move(label);
+}
+
+void Wiring::clear_pending_node_label() noexcept {
+  impl_->pending_label.clear();
+  impl_->expected_label_operator.clear();
+}
+
 WiringPortRef Wiring::add_node(std::type_index def, NodeBuilder builder,
                                std::span<const WiringInputRef> inputs,
                                Value scalars) {
+  // Diagnostic label hint (issue #247): consumed before the wiring-observer
+  // event so wiring-trace sees the label too.
+  if (!impl_->pending_label.empty()) {
+    const auto *node_type = builder.type().schema();
+    if (node_type != nullptr &&
+        node_type->name() == impl_->expected_label_operator) {
+      if (builder.label().empty()) {
+        builder.label(impl_->pending_label);
+      }
+      impl_->pending_label.clear();
+      impl_->expected_label_operator.clear();
+    }
+  }
   auto add = [&]() -> WiringPortRef {
   // The passive marker (Python's ``passive(ts)``): a Passive-tagged
   // source removes the receiving slot from THIS node's active list.

--- a/tests/cpp/test_operators.cpp
+++ b/tests/cpp/test_operators.cpp
@@ -1269,6 +1269,17 @@ namespace
     struct kw_sum_ : Operator<"kw_sum", In<"base", TS<Int>>, VarKwIn<"kwargs">, Out<TS<Int>>>
     {
     };
+    // issue #247 pending-label probes
+    struct label_probe_
+    {
+        static constexpr auto name = "label_probe";
+        static void eval(In<"ts", TS<Int>> ts, Out<TS<Int>> out) { out.set(ts.value()); }
+    };
+    struct other_probe_
+    {
+        static constexpr auto name = "other_probe";
+        static void eval(In<"ts", TS<Int>> ts, Out<TS<Int>> out) { out.set(ts.value()); }
+    };
     // Issue #224 (review): VarKwIn<Name, Schema> retains the declared pack
     // pattern; dispatch matches it against the synthesized pack of the
     // supplied keywords and rejects on mismatch.
@@ -1420,6 +1431,43 @@ TEST_CASE("operators: unmatched keyword time-series collect into **kwargs")
     std::array<WiringArg, 3> duplicate_args{ts_arg(ts_int), named_ts_arg("x", ts_int), named_ts_arg("x", ts_int)};
     REQUIRE_THROWS_WITH(OperatorRegistry::instance().resolve("kw_sum", std::span<const WiringArg>{duplicate_args}),
                         Catch::Matchers::ContainsSubstring("multiple values for argument 'x'"));
+}
+
+TEST_CASE("wiring: a pending node label attaches to the matching operator only")
+{
+    using namespace hgraph;
+    (void)TypeRegistry::instance().register_scalar<Int>("int");
+
+    // Issue #247: the hint labels the next node whose schema name matches;
+    // non-matching nodes (const lifts et al) pass through unlabeled, and the
+    // hint is one-shot.
+    Wiring w;
+    w.set_pending_node_label("label_probe", "user_fn");
+
+    NodeBuilder other;
+    other.implementation<other_probe_>();
+    struct other_tag {};
+    const WiringPortRef other_ref = w.add_node(
+        std::type_index(typeid(other_tag)), std::move(other),
+        std::span<const WiringPortRef>{}, Value{});
+    CHECK(other_ref.peered_node()->builder.label().empty());
+
+    NodeBuilder target;
+    target.implementation<label_probe_>();
+    struct target_tag {};
+    const WiringPortRef target_ref = w.add_node(
+        std::type_index(typeid(target_tag)), std::move(target),
+        std::span<const WiringPortRef>{}, Value{});
+    CHECK(target_ref.peered_node()->builder.label() == "user_fn");
+
+    // one-shot: a second matching node stays unlabeled
+    NodeBuilder again;
+    again.implementation<label_probe_>();
+    struct again_tag {};
+    const WiringPortRef again_ref = w.add_node(
+        std::type_index(typeid(again_tag)), std::move(again),
+        std::span<const WiringPortRef>{}, Value{});
+    CHECK(again_ref.peered_node()->builder.label().empty());
 }
 
 TEST_CASE("operators: a typed **kwargs collector gates candidates on its pack pattern")

--- a/tests/cpp/test_service_wiring.cpp
+++ b/tests/cpp/test_service_wiring.cpp
@@ -1589,6 +1589,19 @@ namespace
         }
     };
 
+    struct ServiceAdaptorSingleClientGraph
+    {
+        [[maybe_unused]] static constexpr auto name = "service_adaptor_single_client_graph";
+
+        static Port<TS<Int>> compose(Wiring &w, Port<TS<Int>> request)
+        {
+            const auto custom = service_adaptor::path("single_client");
+            service_adaptor::register_service_adaptor<AddTwentyServiceAdaptor, AddTwentyServiceAdaptorImpl>(
+                w, custom);
+            return wire<AddTwentyServiceAdaptor>(w, custom, request);
+        }
+    };
+
     struct ServiceAdaptorImplTwoClientGraph
     {
         [[maybe_unused]] static constexpr auto name = "service_adaptor_impl_two_client_graph";
@@ -2139,6 +2152,14 @@ TEST_CASE("service wiring: service adaptors collect multiple client requests")
 
     CHECK_OUTPUT(eval_node<ServiceAdaptorTwoClientGraph>(values<Int>(1), values<Int>(10)),
                  values<Int>(none, 51));
+}
+
+TEST_CASE("service wiring: service adaptors preserve successive requests from one client")
+{
+    hgraph::stdlib::register_standard_operators();
+
+    CHECK_OUTPUT(eval_node<ServiceAdaptorSingleClientGraph>(values<Int>(1, 2, 3)),
+                 values<Int>(none, 21, 22, 23));
 }
 
 TEST_CASE("service wiring: service_adaptor_impl auto-wires single-interface implementations")


### PR DESCRIPTION
Closes #247.

## Python-node diagnostic identity

Python-authored nodes now carry the user function name through the existing native diagnostic-label path. A one-shot pending-label hint on `Wiring` is paired with the operator name it must match and consumed by `add_node`; this avoids changing every erased wire-candidate signature and prevents auxiliary nodes such as lifted constants from taking the user label. `PyWiring::wire` exposes `node_label`, and `_PyNode` supplies the function name unless an explicit label was given.

The label now appears consistently in trace output, wiring trace events, profiler entries, and `NodeError` backtraces. Review cleanup also removes leaked rig files and resolves scalar placeholders used by labels.

## Request/reply service transport

The branch is rebased onto current `main` and retains its queued request-input behavior, including the first full bundle snapshot and same-time teardown supersession. This PR adds the missing earliest-publication invariant: once a request-input source is due, a later capture cannot reschedule it to a later cycle. Successive changes from one live client are therefore delivered in order rather than being starved or lost when captures overlap.

Coverage includes:

- public C++ `eval_node` coverage for three successive requests from one client;
- Python timing coverage for the same multi-tick request sequence;
- a deterministic real-time SQL adaptor regression that blocks the first request and sends the second concurrently, without sleep-based timing;
- documentation of stable runtime request IDs, same-cycle coalescing, ordered successive publication, and multi-client batching.

This patch does not change `map_`, cancellation-before-work behavior, subscriptions, generic graph scheduling, or Python GIL-retention semantics.

## Validation

- macOS fresh native gate: 1,380/1,380 passed;
- macOS stable-ABI wheel built with Python 3.12, installed into fresh Python 3.14: 1,820 passed, 11 skipped;
- `hg-linux` fresh native gate: 1,380/1,380 passed;
- `hg-linux` stable-ABI wheel built with Python 3.12, installed into fresh Python 3.14 with Polars rtcompat: 1,820 passed, 11 skipped;
- differential parity against released Python hgraph 0.5.34: 104/104 recipes attempted, 89 matched, 15 known mismatches, 0 verified new mismatches.

