### PR TITLE
Require injected runtime GlobalState

### DIFF
--- a/benchmarks/results/global-state-injection-20260801-hg-linux.md
+++ b/benchmarks/results/global-state-injection-20260801-hg-linux.md
@@ -1,0 +1,81 @@
+# Injected GlobalState snapshot — hg-linux
+
+This snapshot measures replacing the Python bridge's run-scoped C++
+thread-local runtime state with direct `GlobalStateView` injection. A general
+Python node owns one guarded Python projection for its lifetime and advances
+only the projection's call generation at each callback. Nodes whose layouts do
+not request `GlobalState` do not construct a projection. `GlobalState.instance()`
+remains a wiring/configuration convenience and is rejected during execution.
+
+The C++ execution and callback paths contain no thread-local lookup. The
+existing Python wiring-context `threading.local` still holds the wiring seed and
+the once-per-run misuse marker used by `GlobalState.instance()`; node callbacks
+do not read it.
+
+## Environment
+
+- Date: 2026-08-01
+- Host: `hg-linux` (physical host, not OrbStack), Linux 7.0.0-28-generic x86_64
+- CPU: Intel Core Ultra 7 155H, both variants pinned to CPU 2 with `taskset`
+- Python: 3.12.13
+- Compiler: GCC 14.3.0
+- Build: optimized Release stable-ABI wheel with LTO
+- Baseline: merged `main` at `84a52af0765ce6305318e7fe5ff56b868a073896`
+- Baseline source fingerprint: `3b62ceaa6404e4d10ec9899724ae0f334e7b26c3129d38e314a93dbeedef7262`
+- Candidate source fingerprint: `7f2046ee5b6d77eb4589afd8a569a3d9bba6e739aded3282fcf397cd2205c20a`
+- Samples: nine fresh processes per variant and workload, alternating
+  baseline/candidate order for every sample
+- Scale: `--cycle-scale 10 --size-scale 1`
+
+## Results
+
+Wall-clock values are median seconds; `+/-` is median absolute deviation.
+Lower is better. RSS is the median process-wide maximum reported by the same
+fresh processes, so it includes the interpreter and imported dependencies.
+
+| workload | cycles | baseline seconds | injected-state seconds | change | baseline RSS | injected-state RSS | RSS change |
+|---|---:|---:|---:|---:|---:|---:|---:|
+| Native feedback loop (`tick_std`) | 1,000,000 | 0.483228 +/- 0.001173 | 0.482044 +/- 0.001205 | -0.25% | 67.1 MiB | 67.2 MiB | +0.1 MiB |
+| Generator to native sink (`python_generator_boundary`) | 200,000 | 0.115201 +/- 0.000448 | 0.115190 +/- 0.000763 | -0.01% | 67.2 MiB | 67.2 MiB | 0.0 MiB |
+| Generator to Python sink (`python_sink_boundary`) | 200,000 | 0.175498 +/- 0.001969 | 0.177597 +/- 0.001935 | +1.20% | 66.2 MiB | 66.1 MiB | -0.1 MiB |
+| Five-node Python compute chain (`tick_py`) | 200,000 | 0.312475 +/- 0.001415 | 0.314079 +/- 0.001859 | +0.51% | 67.3 MiB | 67.2 MiB | -0.1 MiB |
+| Python compute with injected `GlobalState` (`python_global_state_boundary`) | 200,000 | 0.272155 +/- 0.001991 | 0.278843 +/- 0.000545 | +2.46% | 67.1 MiB | 67.2 MiB | +0.1 MiB |
+
+The native control and ordinary Python boundaries are neutral at this sample
+size: their median changes are between -0.25% and +1.20%. The directly affected
+injected `GlobalState` path has a small measurable +2.46% cost, approximately
+33 ns per callback at this scale. Maximum RSS is neutral to the 0.1 MiB
+resolution of these process-level samples.
+
+An initial implementation allocated a guard and Python projection per callback
+and regressed the injected path by 5.27%. It was rejected. The final design
+caches both objects on the owning node, advances only the generation used for
+retained-view safety, and reduces the measured difference by more than half.
+The targeted `python_global_state_boundary` scenario remains in
+`benchmarks/scenarios.py` for future optimization work.
+
+## Lifetime and compatibility gates
+
+On the same physical Linux host, the Release stable-ABI wheel built with Python
+3.12 and installed into a fresh Python 3.14 environment passed 1,793 tests with
+10 skipped. The fresh native suite passed all 1,372 tests. The same stable-ABI
+wheel gate on macOS passed 1,793 tests with 10 skipped.
+
+The complete Python 3.14 non-WIP suite also passed under a Debug
+AddressSanitizer build on `hg-linux`: 1,793 passed and 10 skipped, with no
+sanitizer report.
+
+## Reproduction shape
+
+Each sample invokes `benchmarks/runner.py` in the already-built baseline or
+candidate environment, for example:
+
+```sh
+HGRAPH_BENCHMARK_SOURCE_FINGERPRINT="$fingerprint" \
+  taskset -c 2 "$python" benchmarks/runner.py \
+  --scenario python_global_state_boundary \
+  --cycle-scale 10 --size-scale 1
+```
+
+The variant order is reversed on every other sample. The same procedure is
+used for all five workloads.

--- a/benchmarks/scenarios.py
+++ b/benchmarks/scenarios.py
@@ -395,6 +395,13 @@ def _discard_py(value: TS[int]):
     pass
 
 
+@compute_node
+def _read_injected_global_state(
+    value: TS[int], global_state: hg.GlobalState = None
+) -> TS[int]:
+    return value.value + global_state.get("benchmark_offset", 0)
+
+
 def scheduler_fan_out_std(cycle_scale: float, size_scale: float):
     cycles = int(20_000 * cycle_scale)
     width = max(2, int(32 * size_scale))
@@ -453,6 +460,16 @@ def python_sink_boundary(scale: float):
     @graph
     def g():
         _discard_py(_int_pulse(cycles))
+
+    return g, cycles
+
+
+def python_global_state_boundary(scale: float):
+    cycles = int(20_000 * scale)
+
+    @graph
+    def g():
+        null_sink(_read_injected_global_state(_int_pulse(cycles)))
 
     return g, cycles
 
@@ -1440,6 +1457,9 @@ SCENARIOS = {
     "python_sink_boundary": _scenario(
         "Python boundary", "Python scalar generator to Python sink",
         python_sink_boundary, suite="diagnostic"),
+    "python_global_state_boundary": _scenario(
+        "Python boundary", "Python compute with injected GlobalState",
+        python_global_state_boundary, suite="diagnostic", modes=HG_CPP_ONLY),
 
     "type_int_std": _scenario(
         "Value types", "Integer arithmetic", type_int_std),

--- a/docs/source/developer_guide/python_bridge.rst
+++ b/docs/source/developer_guide/python_bridge.rst
@@ -190,6 +190,17 @@ still performs exactly one acquire/release pair. The GIL is free during native
 executor scheduling and while the real-time loop waits between cycles,
 preserving the sender-liveness guarantee for Python feeder threads.
 
+Runtime ``GlobalState`` access follows the normal injectable path. A Python
+graph or node declares a ``GlobalState`` parameter; the bridge constructs its
+guarded projection directly from the native ``GlobalStateView`` injected into
+that callback. ``GlobalState.instance()`` is wiring/configuration convenience
+only and raises during graph execution, preventing an ambient runtime-state
+path from competing with injection. Nodes that do not request the injectable
+perform no runtime-state lookup or wrapper construction. The fast compute path
+does not accept injectable arguments and keeps its transient-view guard in its
+node-owned cache, so evaluation uses neither C++ thread-local state nor a
+process-global runtime context.
+
 The phase runner is an optional, first-class C++ executor facility and is
 unset for ordinary native C++ execution. Nodes that need an embedding context
 declare ``requires_phase_runner``; Python nodes do so, and nested-node builders

--- a/docs/source/developer_guide/python_integration.rst
+++ b/docs/source/developer_guide/python_integration.rst
@@ -481,10 +481,11 @@ Recorded divergences / gaps (the morning-summary list):
   compatibility shorthand.  A top-level Python ``Wiring`` copies from the
   selected seed, the C++ builder and root graph then use their normal owned-copy
   lifecycle, and the bridge replaces the Python seed with the root graph's final
-  state after execution.  At run entry the bridge publishes one guarded
-  ``RuntimeGlobalState`` projection in Python thread-local state; every Python
-  callback in that run sees that same object, and the projection is invalidated
-  when execution ends.  The C++ graph never borrows Python storage.
+  state after execution.  Runtime access is explicit: a graph or node declares
+  the ``GlobalState`` injectable, and each callback receives a guarded projection
+  built from its native ``GlobalStateView``. ``GlobalState.instance()`` is not a
+  runtime lookup and raises during execution. The C++ graph never borrows Python
+  storage.
 - **Services** are surfaced per the runtime-identity rulings
   (services.rst *Runtime service identity*): ``@reference_service`` /
   ``@subscription_service`` / ``@request_reply_service`` decorate

--- a/python/hgraph/_wiring/__init__.py
+++ b/python/hgraph/_wiring/__init__.py
@@ -11,7 +11,7 @@ from ._sentinels import (
 from ._state import (
     GlobalContext, GlobalState, RecordReplayContext, RecordReplayEnum, _GLOBAL_MISSING,
     _MemoryRecording, _RecordReplayModes, _friendly_recording_delta, _global_state_local,
-    _pop_runtime_global_state, _push_runtime_global_state, comparison_summary, evaluate_const,
+    _enter_runtime, _exit_runtime, comparison_summary, evaluate_const,
     record_replay_scope, set_as_of, set_record_replay_config, set_record_replay_model,
     set_table_schema_as_of_key, set_table_schema_date_key, get_recorded_value,
     get_recorder_api, get_recording_label, set_recorder_api, set_recording_label, utc_now
@@ -81,9 +81,9 @@ __all__ = [
     "_dispatch_key_node", "_dispatch_keys_node", "_dispatch_specificity",
     "_friendly_recording_delta", "_global_state_local", "_graph_auto_resolve", "_infer_ts_type",
     "_is_object_vt", "_make_py_node", "_merge_cs", "_overload_registry_name",
-    "_overload_wire_trampoline", "_pop_runtime_global_state", "_port_enter", "_port_exit",
+    "_enter_runtime", "_exit_runtime", "_overload_wire_trampoline", "_port_enter", "_port_exit",
     "_port_getattr", "_port_getitem", "_port_iter", "_port_keys", "_port_len", "_port_reduce",
-    "_published_contexts", "_push_runtime_global_state", "_register_overload",
+    "_published_contexts", "_register_overload",
     "_requires_bridge", "_resolve_context", "_resolve_requested_target", "_run_requires",
     "_simplify_delta", "_times_for", "_tsw_kind", "_type_pattern_for_target",
     "_unbounded_tuple_kind", "_unwrap", "_wiring_stack", "_wrap_graph_fn", "adaptor",

--- a/python/hgraph/_wiring/_state.py
+++ b/python/hgraph/_wiring/_state.py
@@ -1,7 +1,4 @@
-"""GlobalState/GlobalContext and record/replay configuration.
-
-``_push_runtime_global_state``/``_pop_runtime_global_state`` are called from
-C++ (py_nodes: the GlobalState injectable) — keep the names stable."""
+"""GlobalState/GlobalContext and record/replay configuration."""
 import threading
 
 import _hgraph
@@ -164,9 +161,11 @@ class GlobalState:
 
     @staticmethod
     def instance():
-        runtime_state = getattr(_global_state_local, "runtime_state", None)
-        if runtime_state is not None:
-            return runtime_state
+        if getattr(_global_state_local, "runtime_active", False):
+            raise RuntimeError(
+                "GlobalState.instance() is wiring-only during graph execution; "
+                "declare a GlobalState injectable on the graph or node instead"
+            )
         state = getattr(_global_state_local, "state", None)
         if state is None:
             state = GlobalState()
@@ -215,15 +214,15 @@ class GlobalContext:
         return False
 
 
-def _push_runtime_global_state(state):
-    if getattr(_global_state_local, "runtime_state", None) is not None:
+def _enter_runtime():
+    if getattr(_global_state_local, "runtime_active", False):
         raise RuntimeError("a runtime GlobalState is already active on this thread")
-    _global_state_local.runtime_state = state
+    _global_state_local.runtime_active = True
 
 
-def _pop_runtime_global_state():
-    if getattr(_global_state_local, "runtime_state", None) is not None:
-        del _global_state_local.runtime_state
+def _exit_runtime():
+    if getattr(_global_state_local, "runtime_active", False):
+        del _global_state_local.runtime_active
 
 
 def set_record_replay_config(model):

--- a/python/hgraph/adaptors/data_catalogue/catalogue.py
+++ b/python/hgraph/adaptors/data_catalogue/catalogue.py
@@ -55,8 +55,8 @@ class DataCatalogue:
         self._previous = self._MISSING
 
     @classmethod
-    def instance(cls):
-        state = GlobalState.instance()
+    def instance(cls, global_state=None):
+        state = global_state if global_state is not None else GlobalState.instance()
         catalogue = state.get(cls._STATE_KEY)
         if catalogue is None:
             catalogue = cls()

--- a/python/hgraph/adaptors/data_catalogue/publish.py
+++ b/python/hgraph/adaptors/data_catalogue/publish.py
@@ -5,7 +5,7 @@ import inspect
 from frozendict import frozendict
 
 from hgraph import (
-    AUTO_RESOLVE, DEFAULT, SCHEMA, CompoundScalar, Frame, TS, TSB, TSD, TSS,
+    AUTO_RESOLVE, DEFAULT, SCHEMA, CompoundScalar, Frame, GlobalState, TS, TSB, TSD, TSS,
     WiringPort, combine, compute_node, const, dispatch, downcast_ref, emit, feedback, graph,
     len_, map_, max_, nothing, null_sink, operator, reduce, service_adaptor, service_adaptor_impl,
     switch_,
@@ -38,10 +38,11 @@ class DataCatalogSinkResult(CompoundScalar):
 @compute_node
 def find_data_catalogue_entries(
     dataset: TS[str], options: TS[object], schema: object,
+    global_state: GlobalState = None,
 ) -> TSS[DataCatalogSinkResult]:
     return frozenset(
         DataCatalogSinkResult(entry, resolved)
-        for entry, resolved in DataCatalogue.instance().matching_entries(
+        for entry, resolved in DataCatalogue.instance(global_state).matching_entries(
             schema, dataset.value, DataSink, options.value or {})
     )
 

--- a/python/hgraph/adaptors/data_catalogue/subscribe.py
+++ b/python/hgraph/adaptors/data_catalogue/subscribe.py
@@ -5,6 +5,7 @@ from frozendict import frozendict
 
 from hgraph import (
     CompoundScalar,
+    GlobalState,
     AUTO_RESOLVE,
     Frame,
     SCHEMA,
@@ -55,9 +56,10 @@ class FindDCEResult(CompoundScalar):
 
 @compute_node
 def find_data_catalogue_entry(
-    dataset: TS[str], options: TS[object], schema: object
+    dataset: TS[str], options: TS[object], schema: object,
+    global_state: GlobalState = None,
 ) -> TS[FindDCEResult]:
-    match = DataCatalogue.instance().matching_entries(
+    match = DataCatalogue.instance(global_state).matching_entries(
         schema, dataset.value, DataSource, options.value or {}
     )[0]
     return FindDCEResult(*match)

--- a/python/hgraph/adaptors/data_frame/_data_frame_record_replay.py
+++ b/python/hgraph/adaptors/data_frame/_data_frame_record_replay.py
@@ -121,8 +121,9 @@ class DataFrameStorage(ABC):
         self._previous = self._MISSING
 
     @classmethod
-    def instance(cls):
-        return GlobalState.instance().get(_STORAGE_KEY)
+    def instance(cls, global_state=None):
+        state = global_state if global_state is not None else GlobalState.instance()
+        return state.get(_STORAGE_KEY)
 
     def set_as_instance(self):
         state = GlobalState.instance()
@@ -289,7 +290,9 @@ def _df_model_active(m):
             and GlobalState.instance().get("__record_replay_model__") == DATA_FRAME_RECORD_REPLAY)
 
 
-def _configured_as_of(default=None):
+def _configured_as_of(default=None, global_state=None):
+    if global_state is not None:
+        return global_state.get("__as_of__", default)
     if GlobalState.has_instance():
         return GlobalState.instance().get("__as_of__", default)
     return default
@@ -344,17 +347,18 @@ _LITERAL_FRAMES = {}
 _LITERAL_FRAMES = {}
 
 
-def _storage_frame(key, recordable_id):
+def _storage_frame(key, recordable_id, global_state):
     # Internal replay consumption: a user-implemented storage (or a
     # user-supplied literal frame) may return the user-facing form —
     # normalize back to the canonical Arrow representation (issue #80).
     literal = _LITERAL_FRAMES.get((key, recordable_id))
     if literal is not None:
         return _as_arrow(literal)
-    storage = DataFrameStorage.instance()
+    storage = DataFrameStorage.instance(global_state)
     if storage is None:
         raise RuntimeError("data-frame record/replay requires an active DataFrameStorage")
-    return _as_arrow(storage.read_frame(f"{recordable_id}.{key}", as_of=_configured_as_of()))
+    return _as_arrow(storage.read_frame(
+        f"{recordable_id}.{key}", as_of=_configured_as_of(global_state=global_state)))
 
 
 _REPLAY_SCHEMAS = {}
@@ -373,8 +377,9 @@ def _register_data_frame_record_replay():
     @sink_node
     def _df_record_rows(rows: TIME_SERIES_TYPE, key: str, recordable_id: str,
                         col_indices: tuple, col_names: tuple, multi_row: bool,
-                        _state: STATE = None):
-        storage = DataFrameStorage.instance()
+                        _state: STATE = None,
+                        global_state: GlobalState = None):
+        storage = DataFrameStorage.instance(global_state)
         if storage is None:
             raise RuntimeError("data-frame record requires an active DataFrameStorage")
         row_values = list(rows.value) if multi_row else [rows.value]
@@ -407,11 +412,12 @@ def _register_data_frame_record_replay():
 
     @generator(resolvers={TIME_SERIES_TYPE: _replay_rows_type})
     def _df_replay_rows(key: str, recordable_id: str,
-                        multi_row: bool) -> TIME_SERIES_TYPE:
+                        multi_row: bool,
+                        global_state: GlobalState = None) -> TIME_SERIES_TYPE:
         # upstream filter: rows strictly before the evaluation start are
         # dropped (dt_col >= start_time)
         schema, overrides, start = _REPLAY_SCHEMAS[(key, recordable_id)]
-        frame = _storage_frame(key, recordable_id)
+        frame = _storage_frame(key, recordable_id, global_state)
         for when, rows in _read_row_groups(frame, schema, overrides):
             if start is not None and when < start:
                 continue
@@ -419,11 +425,12 @@ def _register_data_frame_record_replay():
 
     @generator(resolvers={TIME_SERIES_TYPE: _replay_rows_type})
     def _df_replay_const_rows(key: str, recordable_id: str,
-                              multi_row: bool) -> TIME_SERIES_TYPE:
+                              multi_row: bool,
+                              global_state: GlobalState = None) -> TIME_SERIES_TYPE:
         # const semantics (upstream replay_const_from_data_frame): the FIRST
         # group at/after the evaluation start, emitted once.
         schema, overrides, start = _REPLAY_SCHEMAS[(key, recordable_id)]
-        frame = _storage_frame(key, recordable_id)
+        frame = _storage_frame(key, recordable_id, global_state)
         for when, rows in _read_row_groups(frame, schema, overrides):
             if start is not None and when < start:
                 continue

--- a/python/hgraph/adaptors/tornado/http_client_adaptor.py
+++ b/python/hgraph/adaptors/tornado/http_client_adaptor.py
@@ -12,7 +12,6 @@ from frozendict import frozendict
 from tornado.httpclient import AsyncHTTPClient, HTTPError
 
 from hgraph import (
-    GlobalState,
     TS,
     TSD,
     push_queue,
@@ -267,11 +266,11 @@ def http_client_adaptor_impl(
             max_clients=max_clients,
         )
 
-    queue_key = f"http_client_adaptor://{path}/queue"
+    sender_ref = {}
 
     @push_queue(TSD[int, TS[HttpResponse]])
     def from_web(sender) -> None:
-        GlobalState.instance()[queue_key] = sender
+        sender_ref["sender"] = sender
 
     async def make_http_request(
         request_id: int,
@@ -340,9 +339,8 @@ def http_client_adaptor_impl(
     @sink_node
     def to_web(
         requests: TSD[int, TS[HttpRequest]],
-        _global_state: GlobalState = None,
     ) -> None:
-        sender = _global_state[queue_key]
+        sender = sender_ref["sender"]
         loop = TornadoWeb.get_loop()
         for request_id, request_value in requests.modified_items():
             loop.add_callback(
@@ -357,12 +355,11 @@ def http_client_adaptor_impl(
         TornadoWeb.start_loop()
 
     @to_web.stop
-    def to_web_stop(_global_state: GlobalState = None) -> None:
+    def to_web_stop() -> None:
         try:
             TornadoWeb.stop_loop()
         finally:
-            if queue_key in _global_state:
-                del _global_state[queue_key]
+            sender_ref.clear()
 
     to_web(request)
     return from_web()

--- a/python/hgraph/adaptors/tornado/http_server_adaptor.py
+++ b/python/hgraph/adaptors/tornado/http_server_adaptor.py
@@ -13,7 +13,6 @@ from frozendict import frozendict
 
 from hgraph import (
     CompoundScalar,
-    GlobalState,
     TS,
     TSD,
     adaptor,
@@ -479,12 +478,12 @@ def http_server_adaptor_impl(path: str, port: int = 80) -> None:
     routes.sort(key=lambda base: handler_priority.get(
         http_server_adaptor.path_from_full_path(base), len(handler_priority)))
 
-    queue_key = f"http_server_adaptor://{port}/queue"
+    sender_ref = {}
     manager = HttpAdaptorManager.instance(port)
 
     @push_queue(TSD[int, TS[HttpRequest]])
     def from_web(sender) -> None:
-        GlobalState.instance()[queue_key] = sender
+        sender_ref["sender"] = sender
 
     @sink_node
     def to_web(responses: TSD[int, TS[HttpResponse]]) -> None:
@@ -493,19 +492,18 @@ def http_server_adaptor_impl(path: str, port: int = 80) -> None:
             loop.add_callback(manager.complete_request, request_id, response.value)
 
     @to_web.start
-    def to_web_start(_global_state: GlobalState = None) -> None:
+    def to_web_start() -> None:
         manager.start_routes(
             tuple(http_server_adaptor.path_from_full_path(base) for base in routes),
-            _global_state[queue_key])
+            sender_ref["sender"])
 
     @to_web.stop
-    def to_web_stop(_global_state: GlobalState = None) -> None:
+    def to_web_stop() -> None:
         try:
             manager.stop_routes(tuple(
                 http_server_adaptor.path_from_full_path(base) for base in routes))
         finally:
-            if queue_key in _global_state:
-                del _global_state[queue_key]
+            sender_ref.clear()
 
     requests = from_web()
 

--- a/python/hgraph/adaptors/tornado/websocket_client_adaptor.py
+++ b/python/hgraph/adaptors/tornado/websocket_client_adaptor.py
@@ -8,7 +8,6 @@ from tornado import httpclient
 from tornado.websocket import websocket_connect
 
 from hgraph import (
-    GlobalState,
     STATE,
     TSB,
     TSD,
@@ -55,14 +54,11 @@ def _client_implementation(message_type: type):
         request: requests_type,
         path: str = "websocket_client",
     ) -> responses_type:
-        queue_key = (
-            f"websocket_client_adaptor://{path}/"
-            f"{message_type.__module__}.{message_type.__qualname__}/queue"
-        )
+        sender_ref = {}
 
         @push_queue(responses_type)
         def from_web(sender) -> None:
-            GlobalState.instance()[queue_key] = sender
+            sender_ref["sender"] = sender
 
         async def make_websocket_request(state, request_id, request_value, sender):
             try:
@@ -135,9 +131,8 @@ def _client_implementation(message_type: type):
         def to_web(
             requests: requests_type,
             _state: STATE = None,
-            _global_state: GlobalState = None,
         ) -> None:
-            sender = _global_state[queue_key]
+            sender = sender_ref["sender"]
             loop = TornadoWeb.get_loop()
             for request_id in requests.removed_keys():
                 loop.add_callback(remove_request, _state, request_id)
@@ -169,7 +164,6 @@ def _client_implementation(message_type: type):
         @to_web.stop
         def to_web_stop(
             _state: STATE = None,
-            _global_state: GlobalState = None,
         ) -> None:
             completed = threading.Event()
 
@@ -195,8 +189,7 @@ def _client_implementation(message_type: type):
                     raise RuntimeError("WebSocket client tasks did not stop")
             finally:
                 TornadoWeb.stop_loop()
-                if queue_key in _global_state:
-                    del _global_state[queue_key]
+                sender_ref.clear()
 
         to_web(request)
         return from_web()

--- a/python/hgraph/adaptors/tornado/websocket_server_adaptor.py
+++ b/python/hgraph/adaptors/tornado/websocket_server_adaptor.py
@@ -12,7 +12,6 @@ from frozendict import frozendict
 
 from hgraph import (
     CompoundScalar,
-    GlobalState,
     REMOVE_IF_EXISTS,
     TS,
     TSB,
@@ -373,17 +372,15 @@ def _wire_websocket_message_type(port, message_type, entries):
         for base in entries
     }
     manager = WebSocketAdaptorManager.instance(port, message_type)
-    type_label = message_type.__name__
-    connect_key = f"websocket_server_adaptor://{port}/{type_label}/connect_queue"
-    message_key = f"websocket_server_adaptor://{port}/{type_label}/message_queue"
+    sender_refs = {}
 
     @push_queue(TSD[int, TS[WebSocketConnectRequest]])
     def connections_from_web(sender) -> None:
-        GlobalState.instance()[connect_key] = sender
+        sender_refs["connect"] = sender
 
     @push_queue(TSD[int, message_ts])
     def messages_from_web(sender) -> None:
-        GlobalState.instance()[message_key] = sender
+        sender_refs["message"] = sender
 
     @graph
     def make_request(
@@ -407,19 +404,17 @@ def _wire_websocket_message_type(port, message_type, entries):
                 manager.complete_request, request_id, response.delta_value)
 
     @to_web.start
-    def to_web_start(_global_state: GlobalState = None) -> None:
+    def to_web_start() -> None:
         manager.start_routes(
             tuple(routes.values()),
-            _global_state[connect_key], _global_state[message_key])
+            sender_refs["connect"], sender_refs["message"])
 
     @to_web.stop
-    def to_web_stop(_global_state: GlobalState = None) -> None:
+    def to_web_stop() -> None:
         try:
             manager.stop_routes(tuple(routes.values()))
         finally:
-            for key in (connect_key, message_key):
-                if key in _global_state:
-                    del _global_state[key]
+            sender_refs.clear()
 
     connections = connections_from_web()
     messages = messages_from_web()

--- a/python/hgraph/temporal.py
+++ b/python/hgraph/temporal.py
@@ -16,8 +16,8 @@ import _hgraph
 from ._wiring._state import GlobalState
 
 
-def _active_state_handle():
-    state = GlobalState.instance()
+def _active_state_handle(global_state=None):
+    state = global_state if global_state is not None else GlobalState.instance()
     return state._impl if isinstance(state, GlobalState) else state
 
 
@@ -26,15 +26,16 @@ def checked_add(
     rhs: Any,
     *,
     month_end_policy=_hgraph.MonthEndPolicy.REJECT,
+    global_state=None,
 ):
     """Checked value addition with the same contracts as ``hgraph.add_``."""
     if isinstance(lhs, _hgraph.ZonedDateTime):
         return _hgraph._temporal_checked_add_zoned(
-            _active_state_handle(), lhs, rhs
+            _active_state_handle(global_state), lhs, rhs
         )
     if isinstance(rhs, _hgraph.ZonedDateTime):
         return _hgraph._temporal_checked_add_zoned(
-            _active_state_handle(), rhs, lhs
+            _active_state_handle(global_state), rhs, lhs
         )
     if isinstance(rhs, _hgraph.Period):
         if isinstance(lhs, datetime):
@@ -51,11 +52,12 @@ def checked_subtract(
     rhs: Any,
     *,
     month_end_policy=_hgraph.MonthEndPolicy.REJECT,
+    global_state=None,
 ):
     """Checked value subtraction with the same contracts as ``hgraph.sub_``."""
     if isinstance(lhs, _hgraph.ZonedDateTime):
         return _hgraph._temporal_checked_add_zoned(
-            _active_state_handle(), lhs, -rhs
+            _active_state_handle(global_state), lhs, -rhs
         )
     if isinstance(rhs, _hgraph.Period):
         if isinstance(lhs, datetime):
@@ -92,9 +94,9 @@ def apply_period(
     )
 
 
-def at_zone(instant, zone):
+def at_zone(instant, zone, *, global_state=None):
     return _hgraph._temporal_at_zone(
-        _active_state_handle(), instant, zone
+        _active_state_handle(global_state), instant, zone
     )
 
 
@@ -104,18 +106,19 @@ def resolve(
     *,
     ambiguous=_hgraph.AmbiguousTimePolicy.REJECT,
     nonexistent=_hgraph.NonexistentTimePolicy.REJECT,
+    global_state=None,
 ):
     return _hgraph._temporal_resolve(
-        _active_state_handle(), local, zone, ambiguous, nonexistent
+        _active_state_handle(global_state), local, zone, ambiguous, nonexistent
     )
 
 
 resolve_civil = resolve
 
 
-def convert_zone(value, zone):
+def convert_zone(value, zone, *, global_state=None):
     return _hgraph._temporal_convert_zone(
-        _active_state_handle(), value, zone
+        _active_state_handle(global_state), value, zone
     )
 
 

--- a/python/py_nodes.cpp
+++ b/python/py_nodes.cpp
@@ -346,16 +346,10 @@ struct PyInvocationState {
 struct PyFastComputeCache {
   PyFastComputeCache(const PyNodeRecord *record_, PyCallShape shape_,
                      TSInputView input_, ValueView scalars_,
-                     TSOutputHandle output_, GlobalStateView global_state_)
+                     TSOutputHandle output_)
       : record(record_), shape(std::move(shape_)), input(std::move(input_)),
-        scalars(std::move(scalars_)), output(std::move(output_)),
-        global_state(std::move(global_state_)) {
-    auto &active_guard = py_active_runtime_guard();
-    if (active_guard == nullptr) {
-      throw std::logic_error(
-          "fast python node requires an active runtime lease guard");
-    }
-    call_lease.guard = active_guard;
+        scalars(std::move(scalars_)), output(std::move(output_)) {
+    call_lease.guard = std::make_shared<PyTsGuard>();
   }
 
   const PyNodeRecord *record{nullptr};
@@ -363,8 +357,7 @@ struct PyFastComputeCache {
   TSInputView input{};
   ValueView scalars{};
   TSOutputHandle output{};
-  GlobalStateView global_state{};
-  // The runtime guard is shared once for the node lifetime. Per-evaluation
+  // The guard is allocated once for the node lifetime. Per-evaluation
   // code advances only the generation, avoiding shared_ptr reference-count
   // traffic at every Python callback while preserving retained-view safety.
   PyTsLease call_lease{};
@@ -833,25 +826,15 @@ py_peel_kwargs(nb::list &call_args,
 [[nodiscard]] nb::object
 py_call_with_contexts(const nb::object &fn, nb::list &call_args,
                       const std::optional<nb::list> &context_values,
-                      const nb::object &runtime_global_state,
                       std::optional<nb::dict> call_kwargs = std::nullopt) {
-  const bool publish_runtime_state = !py_has_active_runtime_global_state();
-  if (!publish_runtime_state && !context_values.has_value()) {
+  if (!context_values.has_value()) {
     return py_invoke(fn, call_args, call_kwargs);
-  }
-  nb::object runtime;
-  if (publish_runtime_state) {
-    runtime = nb::module_::import_("hgraph._wiring._state");
-    runtime.attr("_push_runtime_global_state")(runtime_global_state);
   }
   std::vector<nb::object> entered;
   entered.reserve(context_values.has_value() ? nb::len(*context_values) : 0);
   auto unwind = UnwindCleanupGuard([&] {
     for (auto it = entered.rbegin(); it != entered.rend(); ++it) {
       (*it).attr("__exit__")(nb::none(), nb::none(), nb::none());
-    }
-    if (publish_runtime_state) {
-      runtime.attr("_pop_runtime_global_state")();
     }
   });
   if (context_values.has_value()) {
@@ -869,9 +852,6 @@ py_call_with_contexts(const nb::object &fn, nb::list &call_args,
     entered.pop_back();
     holder.attr("__exit__")(nb::none(), nb::none(), nb::none());
   }
-  if (publish_runtime_state) {
-    runtime.attr("_pop_runtime_global_state")();
-  }
   unwind.release();
   return result;
 }
@@ -888,16 +868,16 @@ void py_call_lifecycle(const PyNodeRef &fn, bool enabled,
   translate_python_error([&] {
     nb::list call_args;
     std::optional<nb::list> context_values;
-    auto lease = py_ts_lease_for_call();
+    auto lease = py_ts_lease_for_node(state);
     auto invalid = UnwindCleanupGuard([&] { lease.invalidate(); });
     nb::object runtime_state =
-        py_runtime_global_state_for_call(global_state, lease.guard);
+        py_runtime_global_state_for_call(config, global_state, lease,
+                                         state.get().call_lease);
     py_assemble_lifecycle_args(config, scalars, &state, nullptr,
                                engine.evaluation_clock().evaluation_time(),
                                scheduler, runtime_state, engine, lease, node,
                                call_args, inputs);
-    (void)py_call_with_contexts(fn.record->fn, call_args, context_values,
-                                runtime_state);
+    (void)py_call_with_contexts(fn.record->fn, call_args, context_values);
     invalid.release();
     lease.invalidate();
   });
@@ -953,11 +933,12 @@ struct py_compute_node {
     translate_python_error([&] {
       nb::list call_args;
       std::optional<nb::list> context_values;
-      auto lease = py_ts_lease_for_call();
+      auto lease = py_ts_lease_for_node(state);
       auto invalid = UnwindCleanupGuard([&] { lease.invalidate(); });
       const auto &out_view = static_cast<const TSOutputView &>(out);
       nb::object runtime_state =
-          py_runtime_global_state_for_call(global_state, lease.guard);
+          py_runtime_global_state_for_call(shape.layout, global_state, lease,
+                                           state.get().call_lease);
       if (!py_assemble_args(shape.layout, args.base(), scalars.value(),
                             PyInvocationState{.local = &state}, scheduler, now,
                             call_args, context_values, lease, runtime_state,
@@ -966,7 +947,7 @@ struct py_compute_node {
       }
       auto call_kwargs = py_peel_kwargs(call_args, shape.kw_names);
       apply_py_result(py_call_with_contexts(fn.value().record->fn, call_args,
-                                            context_values, runtime_state,
+                                            context_values,
                                             std::move(call_kwargs)),
                       out);
       invalid.release();
@@ -1024,7 +1005,7 @@ struct py_fast_compute_node {
         Scalar<"fn", PyNodeRef> fn, Scalar<"config", Str> config,
         Scalar<"scalars", ScalarVar<"SV">> scalars,
         State<PyFastComputeStateRef> state, SingleShotScheduler initial_sample,
-        GlobalStateView global_state, Out<TsVar<"O">> out) {
+        Out<TsVar<"O">> out) {
     PyCallShape shape = parse_py_call_shape(config.value());
     py_apply_input_activity(shape.layout, args.base());
     py_schedule_initial_reference_sample(shape.layout, args.base(),
@@ -1059,7 +1040,7 @@ struct py_fast_compute_node {
     }
     auto cache = std::make_unique<PyFastComputeCache>(
         fn.value().record, std::move(shape), std::move(cached_input),
-        scalars.value(), out.handle(), global_state);
+        scalars.value(), out.handle());
     cache->arg_routes = std::move(arg_routes);
     state.set(PyFastComputeStateRef{cache.get()});
     static_cast<void>(cache.release());
@@ -1081,17 +1062,7 @@ struct py_fast_compute_node {
         if (!py_make_direct_ts_arg(*cache, now, lease, ts_obj)) {
           return;
         }
-        if (py_has_active_runtime_global_state()) {
-          result = cache->record->fn(ts_obj);
-        } else {
-          nb::list call_args;
-          call_args.append(ts_obj);
-          std::optional<nb::list> context_values;
-          nb::object runtime_state = py_runtime_global_state_for_call(
-              cache->global_state, lease.guard);
-          result = py_call_with_contexts(cache->record->fn, call_args,
-                                         context_values, runtime_state);
-        }
+        result = cache->record->fn(ts_obj);
       } else if (cache->direct_pair()) {
         TSInputView input = cache->input.borrowed_ref(now);
         auto bundle = input.as_bundle();
@@ -1105,18 +1076,7 @@ struct py_fast_compute_node {
                                         rhs)) {
           return;
         }
-        if (py_has_active_runtime_global_state()) {
-          result = cache->record->fn(lhs, rhs);
-        } else {
-          nb::list call_args;
-          call_args.append(lhs);
-          call_args.append(rhs);
-          std::optional<nb::list> context_values;
-          nb::object runtime_state = py_runtime_global_state_for_call(
-              cache->global_state, lease.guard);
-          result = py_call_with_contexts(cache->record->fn, call_args,
-                                         context_values, runtime_state);
-        }
+        result = cache->record->fn(lhs, rhs);
       } else {
         TSInputView input = cache->input.borrowed_ref(now);
         nb::list call_args;
@@ -1125,12 +1085,8 @@ struct py_fast_compute_node {
           return;
         }
         auto call_kwargs = py_peel_kwargs(call_args, cache->shape.kw_names);
-        std::optional<nb::list> context_values;
-        nb::object runtime_state =
-            py_runtime_global_state_for_call(cache->global_state, lease.guard);
-        result =
-            py_call_with_contexts(cache->record->fn, call_args, context_values,
-                                  runtime_state, std::move(call_kwargs));
+        result = py_invoke(cache->record->fn, call_args,
+                           std::move(call_kwargs));
       }
 
       auto output_view = cache->output.view(now);
@@ -1153,6 +1109,7 @@ struct py_fast_compute_node {
       cache->input_wrapper = nullptr;
     }
     if (cache != nullptr) {
+      cache->call_lease.guard->alive = false;
       for (std::size_t slot = 0; slot < cache->pair_objects.size(); ++slot) {
         if (cache->pair_objects[slot] == nullptr) {
           continue;
@@ -1220,14 +1177,14 @@ struct py_compute_recordable_node {
       TSOutputView state_view =
           static_cast<const TSOutputView &>(state).borrowed_ref();
       nb::object runtime_state =
-          py_runtime_global_state_for_call(global_state, lease.guard);
+          py_runtime_global_state_for_call(config.value(), global_state, lease);
       py_assemble_lifecycle_args(
           config.value(), scalars.value(),
           static_cast<PyStateRef *>(nullptr), &state_view,
           state.evaluation_time(), scheduler, runtime_state, engine, lease,
           node, call_args);
       (void)py_call_with_contexts(fn.value().record->fn, call_args,
-                                  std::nullopt, runtime_state);
+                                  std::nullopt);
       invalid.release();
       lease.invalidate();
     });
@@ -1251,7 +1208,7 @@ struct py_compute_recordable_node {
       TSOutputView state_view =
           static_cast<const TSOutputView &>(state).borrowed_ref();
       nb::object runtime_state =
-          py_runtime_global_state_for_call(global_state, lease.guard);
+          py_runtime_global_state_for_call(shape.layout, global_state, lease);
       if (!py_assemble_args(shape.layout, args.base(), scalars.value(),
                             PyInvocationState{.recordable = &state_view},
                             scheduler, now, call_args, context_values, lease,
@@ -1260,7 +1217,7 @@ struct py_compute_recordable_node {
       }
       auto call_kwargs = py_peel_kwargs(call_args, shape.kw_names);
       apply_py_result(py_call_with_contexts(fn.value().record->fn, call_args,
-                                            context_values, runtime_state,
+                                            context_values,
                                             std::move(call_kwargs)),
                       out);
       invalid.release();
@@ -1290,14 +1247,14 @@ struct py_compute_recordable_node {
       TSOutputView state_view =
           static_cast<const TSOutputView &>(state).borrowed_ref();
       nb::object runtime_state =
-          py_runtime_global_state_for_call(global_state, lease.guard);
+          py_runtime_global_state_for_call(config.value(), global_state, lease);
       py_assemble_lifecycle_args(
           config.value(), scalars.value(),
           static_cast<PyStateRef *>(nullptr), &state_view,
           state.evaluation_time(), scheduler, runtime_state, engine, lease,
           node, call_args, &args.base());
       (void)py_call_with_contexts(fn.value().record->fn, call_args,
-                                  std::nullopt, runtime_state);
+                                  std::nullopt);
       invalid.release();
       lease.invalidate();
     });
@@ -1349,10 +1306,11 @@ struct py_sink_node {
     translate_python_error([&] {
       nb::list call_args;
       std::optional<nb::list> context_values;
-      auto lease = py_ts_lease_for_call();
+      auto lease = py_ts_lease_for_node(state);
       auto invalid = UnwindCleanupGuard([&] { lease.invalidate(); });
       nb::object runtime_state =
-          py_runtime_global_state_for_call(global_state, lease.guard);
+          py_runtime_global_state_for_call(shape.layout, global_state, lease,
+                                           state.get().call_lease);
       if (!py_assemble_args(shape.layout, args.base(), scalars.value(),
                             PyInvocationState{.local = &state}, scheduler, now,
                             call_args, context_values, lease, runtime_state,
@@ -1361,7 +1319,7 @@ struct py_sink_node {
       }
       auto call_kwargs = py_peel_kwargs(call_args, shape.kw_names);
       (void)py_call_with_contexts(fn.value().record->fn, call_args,
-                                  context_values, runtime_state,
+                                  context_values,
                                   std::move(call_kwargs));
       invalid.release();
       lease.invalidate();
@@ -1467,7 +1425,8 @@ struct py_generator_node {
       const auto shape = parse_py_call_shape(config.value());
       nb::list call_args;
       nb::object runtime_state =
-          py_runtime_global_state_for_call(global_state, handle->lease.guard);
+          py_runtime_global_state_for_call(shape.layout, global_state,
+                                           handle->lease);
       py_assemble_lifecycle_args(
           shape.layout, scalars.value(), &handle->local_state, nullptr,
           engine.evaluation_clock().evaluation_time(), sched, runtime_state,
@@ -1475,7 +1434,7 @@ struct py_generator_node {
       auto call_kwargs = py_peel_kwargs(call_args, shape.kw_names);
       nb::object iterable =
           py_call_with_contexts(fn.value().record->fn, call_args, std::nullopt,
-                                runtime_state, std::move(call_kwargs));
+                                std::move(call_kwargs));
       handle->iterator = nb::steal(PyObject_GetIter(iterable.ptr()));
       if (!handle->iterator.is_valid()) {
         throw nb::python_error();
@@ -1532,14 +1491,14 @@ struct py_generator_node {
         translate_python_error([&] {
           nb::list call_args;
           nb::object runtime_state = py_runtime_global_state_for_call(
-              global_state, handle->lease.guard);
+              config.value(), global_state, handle->lease);
           py_assemble_lifecycle_args(
               config.value(), scalars.value(), &handle->local_state,
               static_cast<TSOutputView *>(nullptr),
               engine.evaluation_clock().evaluation_time(), scheduler,
               runtime_state, engine, handle->lease, node, call_args);
           (void)py_call_with_contexts(fn.value().record->fn, call_args,
-                                      std::nullopt, runtime_state);
+                                      std::nullopt);
         });
       }
       release.release();

--- a/python/py_runtime.h
+++ b/python/py_runtime.h
@@ -3,8 +3,7 @@
  * the lazy TimeSeries/Output views, per-node python STATE, scheduler and
  * clock views, recordable state, and the guarded GlobalState view. See
  * docs/source/developer_guide/python_bridge.rst (GIL boundaries; transient
- * node/time-series views are call-scoped, while RuntimeGlobalState is scoped
- * to the complete graph execution).
+ * node/time-series views and RuntimeGlobalState are call-scoped).
  */
 #ifndef HGRAPH_PYTHON_PY_RUNTIME_H
 #define HGRAPH_PYTHON_PY_RUNTIME_H
@@ -91,9 +90,12 @@ namespace hgraph::python_bridge
      * fields must hold values before the python function is called (the
      * all-valid gate).
      */
+    struct PyCallLeaseState;
+
     struct PyStateRef
     {
-        PyObject *ns{nullptr};   ///< a SimpleNamespace, lazily created (per-node python STATE)
+        PyObject         *ns{nullptr};   ///< a SimpleNamespace, lazily created (per-node python STATE)
+        PyCallLeaseState *call_lease{nullptr};
         friend bool operator==(const PyStateRef &, const PyStateRef &) noexcept = default;
     };
 
@@ -158,30 +160,13 @@ namespace hgraph::python_bridge
         return value;
     }
 
-    inline void py_release_state(State<PyStateRef> &state)
-    {
-        PyStateRef ref = state.get();
-        if (ref.ns != nullptr)
-        {
-            nb::steal(nb::handle(ref.ns));   // drop the held reference
-            state.set(PyStateRef{});
-        }
-    }
-
-    inline void py_release_state(PyStateRef &state)
-    {
-        if (state.ns != nullptr)
-        {
-            nb::steal(nb::handle(state.ns));
-            state = PyStateRef{};
-        }
-    }
-
     /** Call-scope lifetime guard: python must not use a view after its eval. */
     struct PyTsGuard
     {
         bool          alive{true};
         std::uint64_t generation{0};
+        std::size_t   deferred_users{0};
+        bool          owner_released{false};
     };
 
     struct PyTsLease
@@ -204,55 +189,98 @@ namespace hgraph::python_bridge
         {
             if (guard == nullptr) { return; }
             if (guard->generation == generation) { ++guard->generation; }
-            if (owns_guard_lifetime) { guard->alive = false; }
+            if (owns_guard_lifetime)
+            {
+                guard->owner_released = true;
+                if (guard->deferred_users == 0) { guard->alive = false; }
+            }
+        }
+
+        void retain_for_deferred_call() const noexcept
+        {
+            if (guard != nullptr) { ++guard->deferred_users; }
+        }
+
+        void release_from_deferred_call() const noexcept
+        {
+            if (guard == nullptr || guard->deferred_users == 0) { return; }
+            if (--guard->deferred_users == 0 && guard->owner_released)
+            {
+                guard->alive = false;
+            }
         }
     };
 
+    struct PyRuntimeGlobalState;
+
+    /** Node-owned guard and injectable cache for general compute and sink callbacks. */
+    struct PyCallLeaseState
+    {
+        std::shared_ptr<PyTsGuard> guard{std::make_shared<PyTsGuard>()};
+        PyObject                  *runtime_global_state{nullptr};
+        PyRuntimeGlobalState      *runtime_global_state_view{nullptr};
+    };
+
+    [[nodiscard]] inline PyTsLease py_ts_lease_for_node(State<PyStateRef> &state)
+    {
+        PyStateRef ref = state.get();
+        if (ref.call_lease == nullptr)
+        {
+            ref.call_lease = new PyCallLeaseState{};
+            state.set(ref);
+        }
+        auto &guard = ref.call_lease->guard;
+        return PyTsLease{
+            .guard = guard,
+            .generation = ++guard->generation,
+            .owns_guard_lifetime = false,
+        };
+    }
+
+    inline void py_release_call_lease(PyStateRef &state) noexcept
+    {
+        if (state.call_lease == nullptr) { return; }
+        auto &guard = state.call_lease->guard;
+        guard->owner_released = true;
+        if (guard->deferred_users == 0) { guard->alive = false; }
+        if (state.call_lease->runtime_global_state != nullptr)
+        {
+            nb::steal(nb::handle(state.call_lease->runtime_global_state));
+        }
+        delete state.call_lease;
+        state.call_lease = nullptr;
+    }
+
+    inline void py_release_state(State<PyStateRef> &state)
+    {
+        PyStateRef ref = state.get();
+        if (ref.ns != nullptr) { nb::steal(nb::handle(ref.ns)); }
+        py_release_call_lease(ref);
+        state.set(PyStateRef{});
+    }
+
+    inline void py_release_state(PyStateRef &state)
+    {
+        if (state.ns != nullptr) { nb::steal(nb::handle(state.ns)); }
+        py_release_call_lease(state);
+        state = PyStateRef{};
+    }
+
     struct PyRuntimeGlobalState
     {
-        GlobalStateView            state;
-        std::shared_ptr<PyTsGuard> guard;
+        GlobalStateView state;
+        PyTsLease      lease;
 
         [[nodiscard]] GlobalStateView checked() const
         {
-            if (guard == nullptr || !guard->alive)
-            {
-                throw std::logic_error("a GlobalState view was accessed outside its graph execution");
-            }
+            lease.require_alive(
+                "a GlobalState view was accessed outside its node's evaluation");
             return state;
         }
     };
 
-    /**
-     * The Python projection of GlobalState is run-scoped, matching the native
-     * GlobalState lifetime. PyWiring installs the exact Python object here
-     * before releasing the GIL; user-node calls borrow it instead of creating
-     * and publishing a new wrapper on every evaluation.
-     */
-    inline thread_local PyObject *py_active_runtime_global_state{nullptr};
-
-    [[nodiscard]] inline std::shared_ptr<PyTsGuard> &py_active_runtime_guard()
-    {
-        static thread_local std::shared_ptr<PyTsGuard> guard{};
-        return guard;
-    }
-
-    [[nodiscard]] inline bool py_has_active_runtime_global_state() noexcept
-    {
-        return py_active_runtime_global_state != nullptr;
-    }
-
     [[nodiscard]] inline PyTsLease py_ts_lease_for_call()
     {
-        auto &active_guard = py_active_runtime_guard();
-        if (active_guard != nullptr)
-        {
-            return PyTsLease{
-                .guard = active_guard,
-                .generation = ++active_guard->generation,
-                .owns_guard_lifetime = false,
-            };
-        }
         auto guard = std::make_shared<PyTsGuard>();
         return PyTsLease{
             .guard = guard,
@@ -262,14 +290,33 @@ namespace hgraph::python_bridge
     }
 
     [[nodiscard]] inline nb::object
-    py_runtime_global_state_for_call(GlobalStateView state,
-                                     const std::shared_ptr<PyTsGuard> &fallback_guard)
+    py_runtime_global_state_for_call(std::string_view layout,
+                                     GlobalStateView state,
+                                     const PyTsLease &lease,
+                                     PyCallLeaseState *call_state = nullptr)
     {
-        if (py_active_runtime_global_state != nullptr)
+        if (layout.find('g') == std::string_view::npos) { return nb::object{}; }
+        if (call_state != nullptr)
         {
-            return nb::borrow(nb::handle(py_active_runtime_global_state));
+            if (call_state->runtime_global_state == nullptr)
+            {
+                nb::object wrapper = nb::cast(PyRuntimeGlobalState{state, lease});
+                call_state->runtime_global_state_view =
+                    nb::inst_ptr<PyRuntimeGlobalState>(wrapper.ptr());
+                call_state->runtime_global_state = wrapper.release().ptr();
+            }
+            else
+            {
+                // The cached wrapper and its guard are both node-owned.  Only
+                // the call generation changes between evaluations; replacing
+                // the whole lease here would add shared_ptr reference-count
+                // traffic to every injected GlobalState access.
+                call_state->runtime_global_state_view->state = state;
+                call_state->runtime_global_state_view->lease.generation = lease.generation;
+            }
+            return nb::borrow(nb::handle(call_state->runtime_global_state));
         }
-        return nb::cast(PyRuntimeGlobalState{state, fallback_guard});
+        return nb::cast(PyRuntimeGlobalState{state, lease});
     }
 
     /** Call-scoped Python projection over the native engine-control view. */

--- a/python/py_state_services.cpp
+++ b/python/py_state_services.cpp
@@ -24,9 +24,8 @@ namespace hgraph::python_bridge
             boundary). */
 
         /** Temporarily reactivate the registering Python call's lease while
-            its notification runs. The run guard still owns the hard lifetime
-            bound; restoring only the generation lets documented callbacks
-            safely read the captured TimeSeries/API views at their boundary. */
+            its notification runs. The queue holder keeps the call-owned guard
+            alive until all deferred callbacks using it have drained. */
         class PyNotificationLeaseScope
         {
           public:
@@ -66,7 +65,14 @@ namespace hgraph::python_bridge
             struct GilSafeCallable
             {
                 PyObject *fn;
-                explicit GilSafeCallable(nb::object object) : fn(object.release().ptr()) {}
+                PyTsLease lease;
+
+                GilSafeCallable(nb::object object, PyTsLease call_lease)
+                    : fn(object.release().ptr()), lease(std::move(call_lease))
+                {
+                    lease.retain_for_deferred_call();
+                }
+
                 ~GilSafeCallable()
                 {
                     if (fn != nullptr)
@@ -74,11 +80,12 @@ namespace hgraph::python_bridge
                         nb::gil_scoped_acquire gil;
                         Py_DECREF(fn);
                     }
+                    lease.release_from_deferred_call();
                 }
             };
-            auto holder = std::make_shared<GilSafeCallable>(std::move(fn));
-            return [holder, lease = std::move(lease)]() {
-                PyNotificationLeaseScope active_lease{lease};
+            auto holder = std::make_shared<GilSafeCallable>(std::move(fn), std::move(lease));
+            return [holder]() {
+                PyNotificationLeaseScope active_lease{holder->lease};
                 nb::borrow<nb::object>(nb::handle(holder->fn))();
             };
         }

--- a/python/py_wiring.cpp
+++ b/python/py_wiring.cpp
@@ -1161,12 +1161,6 @@ namespace hgraph::python_bridge
            const std::string &date_column, const std::string &as_of_column,
            bool no_as_of_support, std::optional<DateTime> start_time,
            std::optional<DateTime> end_time, EvaluationTrace *trace) -> nb::object {
-            if (py_has_active_runtime_global_state())
-            {
-                throw std::logic_error(
-                    "lower cannot run while a runtime GlobalState is active");
-            }
-
             std::vector<Frame> frames;
             frames.reserve(nb::len(input_frames));
             for (nb::handle object : input_frames)
@@ -1189,18 +1183,10 @@ namespace hgraph::python_bridge
                 function.fn, std::span<const Frame>{frames.data(), frames.size()},
                 std::move(options));
 
-            auto guard = std::make_shared<PyTsGuard>();
-            nb::object runtime_state = nb::cast(PyRuntimeGlobalState{
-                execution.global_state(), guard});
             nb::object runtime = nb::module_::import_("hgraph._wiring._state");
-            runtime.attr("_push_runtime_global_state")(runtime_state);
-            py_active_runtime_global_state = runtime_state.ptr();
-            py_active_runtime_guard() = guard;
+            runtime.attr("_enter_runtime")();
             auto clear_runtime_state = UnwindCleanupGuard([&] {
-                py_active_runtime_global_state = nullptr;
-                py_active_runtime_guard().reset();
-                guard->alive = false;
-                runtime.attr("_pop_runtime_global_state")();
+                runtime.attr("_exit_runtime")();
             });
             {
                 nb::gil_scoped_release release;

--- a/python/py_wiring.h
+++ b/python/py_wiring.h
@@ -324,22 +324,10 @@ namespace hgraph::python_bridge
             }
             run->executor = eb.make_executor();
 
-            if (py_has_active_runtime_global_state())
-            {
-                throw std::logic_error("a runtime GlobalState is already active on this thread");
-            }
-            auto guard = std::make_shared<PyTsGuard>();
-            nb::object runtime_state = nb::cast(PyRuntimeGlobalState{
-                run->executor.view().graph().global_state(), guard});
             nb::object runtime = nb::module_::import_("hgraph._wiring._state");
-            runtime.attr("_push_runtime_global_state")(runtime_state);
-            py_active_runtime_global_state = runtime_state.ptr();
-            py_active_runtime_guard() = guard;
+            runtime.attr("_enter_runtime")();
             auto clear_runtime_state = UnwindCleanupGuard([&] {
-                py_active_runtime_global_state = nullptr;
-                py_active_runtime_guard().reset();
-                guard->alive = false;
-                runtime.attr("_pop_runtime_global_state")();
+                runtime.attr("_exit_runtime")();
             });
             auto copy_runtime_state = UnwindCleanupGuard([&] {
                 if (python_state != nullptr)

--- a/python/tests/ported/_wiring/test_lower.py
+++ b/python/tests/ported/_wiring/test_lower.py
@@ -46,9 +46,10 @@ def test_lower_replays_arrow_frames_through_native_graph():
 
 def test_lower_captures_scalar_arguments_and_copies_global_state_back():
     @compute_node
-    def remember(ts: TS[int], factor: int) -> TS[int]:
-        value = ts.value * factor + GlobalState.instance()["seed"]
-        GlobalState.instance()["lower.last"] = value
+    def remember(ts: TS[int], factor: int,
+                 global_state: GlobalState = None) -> TS[int]:
+        value = ts.value * factor + global_state["seed"]
+        global_state["lower.last"] = value
         return value
 
     @graph

--- a/python/tests/ported/arrow/test_arrow.py
+++ b/python/tests/ported/arrow/test_arrow.py
@@ -307,8 +307,8 @@ def test_debug_():
 def test_side_effects():
 
     @compute_node
-    def side_effect(ts: TS[int]) -> TS[int]:
-        GlobalState.instance()["t"] = ts.value
+    def side_effect(ts: TS[int], global_state: GlobalState = None) -> TS[int]:
+        global_state["t"] = ts.value
 
     @graph
     def g():

--- a/python/tests/test_global_state_wiring.py
+++ b/python/tests/test_global_state_wiring.py
@@ -61,8 +61,8 @@ def test_wiring_time_state_entries_reach_the_run_and_copy_back():
     # An entry written at wiring time lives on the SELECTED state, seeds the
     # run's isolation copy, and the state remains the user's afterwards.
     @hg.compute_node
-    def read_marker(ts: TS[int]) -> TS[str]:
-        return GlobalState.instance()["marker"]
+    def read_marker(ts: TS[int], global_state: GlobalState = None) -> TS[str]:
+        return global_state["marker"]
 
     @hg.graph
     def wired(ts: TS[int]) -> TS[str]:

--- a/python/tests/test_python_authoring.py
+++ b/python/tests/test_python_authoring.py
@@ -496,10 +496,17 @@ def test_runtime_global_state_and_graph_seed_injection():
 
     @hg.compute_node
     def apply_offset(value: TS[int], global_state: hg.GlobalState = None) -> TS[int]:
-        check(global_state is hg.GlobalState.instance(), "runtime state identity")
-        runtime_states.append(global_state)
+        runtime_states.append(("eval", global_state))
         global_state["calls"] = global_state.get("calls", 0) + 1
         return value.value + global_state["offset"]
+
+    @apply_offset.start
+    def start(global_state: hg.GlobalState = None):
+        runtime_states.append(("start", global_state))
+
+    @apply_offset.stop
+    def stop(global_state: hg.GlobalState = None):
+        runtime_states.append(("stop", global_state))
 
     @graph
     def app(value: TS[int], global_state: hg.GlobalState = None) -> TS[int]:
@@ -509,9 +516,24 @@ def test_runtime_global_state_and_graph_seed_injection():
     with hg.GlobalContext(state):
         check(eval_node(app, [1, 2]) == [6, 7], "runtime global state")
     check(state["calls"] == 2, "runtime state copied back")
-    check(runtime_states[0] is runtime_states[1], "runtime state is stable for the run")
-    expect_raises(RuntimeError, lambda: runtime_states[0].get("calls"),
-                  "outside its graph execution")
+    check([phase for phase, _ in runtime_states] == ["start", "eval", "eval", "stop"],
+          "runtime state spans complete executor phases")
+    check(all(runtime_state is runtime_states[0][1]
+              for _, runtime_state in runtime_states),
+          "runtime state projection is cached by the owning node")
+    for _, runtime_state in runtime_states:
+        expect_raises(RuntimeError, lambda runtime_state=runtime_state: runtime_state.get("calls"),
+                      "outside its node's evaluation")
+
+
+def test_runtime_global_state_must_be_injected():
+    @hg.compute_node
+    def invalid(value: TS[int]) -> TS[int]:
+        return value.value + hg.GlobalState.instance().get("offset", 0)
+
+    with hg.GlobalContext(hg.GlobalState(offset=5)):
+        expect_raises(RuntimeError, lambda: eval_node(invalid, [1]),
+                      "declare a GlobalState injectable")
 
 
 def test_wiring_failure_releases_global_context():

--- a/python/tests/test_temporal_types.py
+++ b/python/tests/test_temporal_types.py
@@ -220,15 +220,21 @@ def test_provider_backed_value_operations_match_graph_operators_inside_compute_n
     def at_zone_value(
         value: hg.TS[dt.datetime],
         zone_value: hg.TS[hg.ZoneId],
+        global_state: hg.GlobalState = None,
     ) -> hg.TS[hg.ZonedDateTime]:
-        return hg.temporal.at_zone(value.value, zone_value.value)
+        return hg.temporal.at_zone(
+            value.value, zone_value.value, global_state=global_state
+        )
 
     @hg.compute_node
     def add_zoned_value(
         value: hg.TS[hg.ZonedDateTime],
         amount: hg.TS[dt.timedelta],
+        global_state: hg.GlobalState = None,
     ) -> hg.TS[hg.ZonedDateTime]:
-        return hg.temporal.checked_add(value.value, amount.value)
+        return hg.temporal.checked_add(
+            value.value, amount.value, global_state=global_state
+        )
 
     with hg.GlobalContext(hg.GlobalState()):
         hg.set_time_zone_provider()


### PR DESCRIPTION
## Summary

- Make runtime `GlobalState` access explicit through graph/node injection; `GlobalState.instance()` now raises during graph execution.
- Remove the Python bridge's run-scoped C++ thread-local state and guard publication.
- Cache one guarded runtime-state projection per owning general Python node, advance only its call generation, and avoid all runtime-state work for fast nodes that do not request the injectable.
- Retain explicit lease ownership for deferred notifications and migrate temporal, data catalogue, data-frame, and Tornado adaptor runtime consumers.
- Add lifecycle/retained-view coverage, bridge documentation, and a dedicated performance/RSS snapshot.

The existing Python `threading.local` remains only for the wiring seed and the once-per-run `GlobalState.instance()` misuse marker; it is not read by node callbacks.

## Compatibility impact

Python runtime code that calls `GlobalState.instance()` must declare a `GlobalState` injectable and use the injected value. Wiring-time configuration continues to use `GlobalState.instance()`, with the existing copy-in before execution and copy-out after execution behavior.

## Performance

Physical `hg-linux`, nine alternating fresh-process samples per workload, CPU-pinned:

- Native feedback loop: -0.25%
- Python generator boundary: -0.01%
- Python sink boundary: +1.20%
- Five-node Python chain: +0.51%
- Injected `GlobalState` boundary: +2.46% (approximately 33 ns/callback)
- Median maximum RSS: neutral within 0.1 MiB

The first per-callback allocation prototype was rejected at +5.27%; node-owned caching reduced the final affected-path difference by more than half. Full details are in `benchmarks/results/global-state-injection-20260801-hg-linux.md`.

## Validation

- macOS fresh native C++ suite: 1,372/1,372 passed
- macOS stable-ABI wheel built with Python 3.12, installed/tested with Python 3.14: 1,793 passed, 10 skipped
- Physical `hg-linux` fresh native C++ suite: 1,372/1,372 passed
- Physical `hg-linux` stable-ABI wheel built with Python 3.12, installed/tested with Python 3.14: 1,793 passed, 10 skipped
- Physical `hg-linux` Debug ASan Python 3.14 suite: 1,793 passed, 10 skipped; no sanitizer report
