### PR TITLE
Match Perspective adaptor API and behavior

### DIFF
--- a/docs/source/developer_guide/index.rst
+++ b/docs/source/developer_guide/index.rst
@@ -26,6 +26,7 @@ The developer guide describes the internal design of the C++ implementation. The
    parity_matrix
    parity_testing
    tornado_parity
+   perspective_parity
    record_replay_table
    python_integration
    python_bridge

--- a/docs/source/developer_guide/perspective_parity.rst
+++ b/docs/source/developer_guide/perspective_parity.rst
@@ -68,14 +68,25 @@ the upstream constructor signature.
 constructor signature and ``to_scalar_schema`` helper are therefore not part
 of the curated contract; edits are created by the graph as a typed ``TSB``.
 
-C++-first correspondence
-------------------------
+C++-first correspondence: same behavior, different representation
+-------------------------------------------------------------------
 
-The native service-adaptor contract permits an input-only interface and omits
-``/to_graph`` storage and registration for it.  Multi-input clients are packed
-into one typed request bundle and the service transport snapshots all valid
-fields on the first request before applying later deltas.  This ensures static
-client fields remain present when another field ticks.  Equivalent C++ tests
-cover multiple clients, repeated cycles and static first-request fields; the
-Python tests cover the bridge, row shapes, editable teardown and multi-table
-publication.
+Released hgraph already exposes ``publish_multitable`` as a sink-only service
+adaptor.  hg_cpp preserves that public contract and behavior.  The differences
+described here are internal native representation choices, not parity
+deviations.
+
+The native service-adaptor contract represents an input-only interface
+directly, so it omits unused ``/to_graph`` storage and registration.  This
+changes internal storage and topology only; neither supported public surface
+has a reply channel for this adaptor.
+
+Released hgraph carries multi-input client fields on independent stateful
+request streams, which retain a static field when another field ticks.  hg_cpp
+packs the same fields into one typed native request bundle.  Its transport sends
+a full current-state snapshot for the first request and applies deltas
+thereafter, reproducing the same retained-field semantics.  Equivalent C++
+tests cover multiple clients, repeated cycles and static first-request fields;
+the Python tests cover the bridge, row shapes, editable teardown and
+multi-table publication.  Only the items explicitly listed under
+`Deliberate differences`_ are accepted issue #216 deviations.

--- a/docs/source/developer_guide/perspective_parity.rst
+++ b/docs/source/developer_guide/perspective_parity.rst
@@ -1,0 +1,81 @@
+Perspective parity disposition
+==============================
+
+This is the disposition for issue #216's API audit against released Python
+``hgraph``.  The public package surface is the explicit
+``hgraph.adaptors.perspective.__all__`` list.  Names imported by upstream
+implementation modules (typing helpers, ``Hg*TypeMetaData`` classes,
+Perspective dependency classes and decorators) are not package API and are
+recorded in ``tools/parity/surface_known.json`` rather than re-exported.
+
+Public workflows
+----------------
+
+The following upstream workflows are retained:
+
+* ``publish_table`` publishes scalar, compound-scalar, ``TSB`` and Arrow
+  ``Frame`` TSD values, with scalar, fixed-tuple or compound-scalar keys;
+* ``publish_table_editable`` creates an editable table and returns the typed
+  ``TSB[TableEdits[K, V]]`` feedback stream.  Its subscription is acquired and
+  released with graph lifecycle;
+* ``empty_row=True`` preserves the upstream synthetic ``_id`` protocol for row
+  insertion, deletion and key edits;
+* ``publish_multitable`` is a sink-only service adaptor.  It combines clients
+  by key, retaining the upstream unique-key and bundle-race modes without an
+  unused reply channel;
+* ``PerspectiveTablesManager`` retains table/view configuration, edit
+  subscriptions, statistics, temporary-table cleanup, current Perspective
+  server/client hosting and Tornado handlers; and
+* ``perspective_web`` retains the upstream callable signature and resolves its
+  manager through the runtime ``GlobalState`` injectable.
+
+The adaptor interfaces and their default implementations are real native
+adaptor/service-adaptor registrations.  Scalar options such as
+``index_col_name``, ``history``, ``unique`` and ``empty_row`` are immutable
+wiring-time configuration shared by clients at one path; disagreeing clients
+are rejected during wiring.
+
+Type-system confirmation
+------------------------
+
+``TableEdits`` intentionally mixes scalar and time-series type parameters::
+
+   class TableEdits(TimeSeriesSchema, Generic[K, TIME_SERIES_TYPE]):
+       edits: TSD[K, TIME_SERIES_TYPE]
+       removes: TSS[K]
+
+This is not a Perspective-only accident.  Released hgraph documents mixed
+``TimeSeriesSchema`` generics and uses the same pattern in error-handling and
+Arrow schemas, with type-resolution tests.  hg_cpp therefore supports this as
+a general schema contract.  Scalar and time-series parameters are resolved by
+kind and cross-kind specialisations are rejected.
+
+Perspective row planning uses the public ``hgraph.reflection`` API.  Container
+key annotations and ``Frame[Row]`` schemas remain recoverable through that API;
+the adaptor does not inspect ``_hgraph`` handles or private ``_TsExpr`` layout.
+
+Deliberate differences
+----------------------
+
+Only the current Perspective server/client API supported by the
+``perspective-python>=3.8`` extra is implemented.  The upstream compatibility
+branch for Perspective 2.10 is not restored.  The manager may additionally be
+given an injected compatible client through ``client=`` for deterministic
+tests; this is an extension carried through ``**kwargs`` and does not change
+the upstream constructor signature.
+
+``TableEdits`` is a wiring annotation, not a scalar value class.  Its synthetic
+constructor signature and ``to_scalar_schema`` helper are therefore not part
+of the curated contract; edits are created by the graph as a typed ``TSB``.
+
+C++-first correspondence
+------------------------
+
+The native service-adaptor contract permits an input-only interface and omits
+``/to_graph`` storage and registration for it.  Multi-input clients are packed
+into one typed request bundle and the service transport snapshots all valid
+fields on the first request before applying later deltas.  This ensures static
+client fields remain present when another field ticks.  Equivalent C++ tests
+cover multiple clients, repeated cycles and static first-request fields; the
+Python tests cover the bridge, row shapes, editable teardown and multi-table
+publication.

--- a/docs/source/developer_guide/roadmap.rst
+++ b/docs/source/developer_guide/roadmap.rst
@@ -503,9 +503,10 @@ The following deliberate restrictions replace advanced Python-first code:
   requests in Python. Normal read/write/execute and catalogue routing work.
 - Delta scheduled maintenance and a second Python batching buffer are omitted;
   TSD history publication consumes the native per-cycle table delta directly.
-- Perspective read-only and editable tables, typed edit feedback, and the
-  Perspective websocket endpoint work. Empty-row creation and multi-client
-  reduction must be expressed as a native TSD before publication.
+- Perspective read-only and editable tables, typed edit feedback, empty-row
+  creation, multi-client reduction, and the Perspective websocket endpoint
+  work. Perspective 2.10's legacy manager API is intentionally not restored;
+  the optional extra targets the current server/client API.
 - The dataframe record/replay names delegate to the C++ record/replay
   operators. Arrow memory/file storage remains a client utility; the old
   Polars-owned pluggable runtime store is not restored.

--- a/include/hgraph/types/graph_wiring.h
+++ b/include/hgraph/types/graph_wiring.h
@@ -788,6 +788,10 @@ namespace hgraph
         Wiring(Wiring &&) noexcept;
         Wiring &operator=(Wiring &&) noexcept;
 
+        /** Process-unique identity for associating wiring-lifetime adapter
+            state across owned and borrowed language wrappers. */
+        [[nodiscard]] std::uint64_t identity() const noexcept;
+
         /**
          * Intern a node with its input edges + scalar configuration and return its
          * output port. ``def`` is the node *definition's* stable identity

--- a/include/hgraph/types/graph_wiring.h
+++ b/include/hgraph/types/graph_wiring.h
@@ -793,6 +793,16 @@ namespace hgraph
         [[nodiscard]] std::uint64_t identity() const noexcept;
 
         /**
+         * Retain extension-owned state until this Wiring is destroyed.
+         *
+         * Language bridges use this for wiring-time state recorded through a
+         * borrowed wrapper: the wrapper may be ephemeral, while the state is
+         * still needed by a later build_services()/finish() call on the
+         * underlying Wiring. The runtime does not inspect the retained value.
+         */
+        void retain_extension_state(std::shared_ptr<void> state);
+
+        /**
          * Intern a node with its input edges + scalar configuration and return its
          * output port. ``def`` is the node *definition's* stable identity
          * (``typeid(T)`` for a C++ static node) — two calls with the same ``def``,

--- a/include/hgraph/types/service_runtime.h
+++ b/include/hgraph/types/service_runtime.h
@@ -143,7 +143,8 @@ namespace hgraph
         std::span<const WiringPortRef> implementation_inputs = {});
 
     /** Per-client keyed adaptor exchange (the erased counterpart of
-        ``service_adaptor::adaptor`` / ``wire<Interface>``). */
+        ``service_adaptor::adaptor`` / ``wire<Interface>``). Returns an empty
+        port for a sink-only descriptor with no output schema. */
     [[nodiscard]] HGRAPH_EXPORT WiringPortRef service_adaptor_client(
         Wiring &w, const RuntimeServiceDescriptor &descriptor, std::string_view path,
         const WiringPortRef &in);

--- a/include/hgraph/types/service_wiring.h
+++ b/include/hgraph/types/service_wiring.h
@@ -1444,9 +1444,11 @@ namespace hgraph::service_adaptor
      * Multi-client adaptor wiring.
      *
      * Client code calls ``wire<Interface>(w, input)`` and receives that client's
-     * output. Implementation graphs call ``from_graph<Interface>()`` to receive
-     * all client inputs as ``TSD<Int, input_schema>`` and ``to_graph`` to publish
-     * ``TSD<Int, output_schema>`` replies keyed by the same client id.
+     * output when the interface declares ``output_schema``. Implementation
+     * graphs call ``from_graph<Interface>()`` to receive all client inputs as
+     * ``TSD<Int, input_schema>``. Duplex interfaces additionally call
+     * ``to_graph`` to publish ``TSD<Int, output_schema>`` replies keyed by the
+     * same client id; sink-only interfaces have no reply endpoint.
      */
     namespace detail
     {
@@ -1473,8 +1475,7 @@ namespace hgraph::service_adaptor
         template <typename Interface>
         concept service_adaptor_interface =
             std::derived_from<Interface, interface> &&
-            has_input_schema<Interface>::value &&
-            has_output_schema<Interface>::value;
+            has_input_schema<Interface>::value;
 
         template <typename Interface>
         using input_schema_t = typename Interface::input_schema;
@@ -1606,8 +1607,11 @@ namespace hgraph::service_adaptor
         {
             endpoints.push_back(WiringServiceImplementationEndpoint{
                 adaptor_from_graph_path<Interface>(user_path), user_path.resolution});
-            endpoints.push_back(WiringServiceImplementationEndpoint{
-                adaptor_to_graph_path<Interface>(user_path), user_path.resolution});
+            if constexpr (has_output_schema<Interface>::value)
+            {
+                endpoints.push_back(WiringServiceImplementationEndpoint{
+                    adaptor_to_graph_path<Interface>(user_path), user_path.resolution});
+            }
         }
 
         [[nodiscard]] inline Value path_key_value(const std::string &full_path)
@@ -1879,7 +1883,6 @@ namespace hgraph::service_adaptor
     {
         static_assert(detail::service_adaptor_interface<Interface>,
                       "register_service_adaptor_impl requires a service adaptor interface");
-        using output_schema = detail::request_output_schema_t<Interface>;
 
         std::string base_path = detail::adaptor_base_path<Interface>(user_path);
         auto stored_args = std::tuple<std::decay_t<Args>...>{args...};
@@ -1892,11 +1895,21 @@ namespace hgraph::service_adaptor
                 auto scope = target.service_implementation_scope(
                     "service adaptor impl " + base_path, std::move(required_endpoints));
                 auto requests = from_graph<Interface>(target, user_path);
-                auto replies = std::apply([&](const auto &...stored) {
-                    return detail::wire_impl_output<Impl, output_schema>(
-                        target, user_path, requests, stored...);
-                }, stored_args);
-                to_graph<Interface>(target, user_path, replies);
+                if constexpr (detail::has_output_schema<Interface>::value)
+                {
+                    using output_schema = detail::request_output_schema_t<Interface>;
+                    auto replies = std::apply([&](const auto &...stored) {
+                        return detail::wire_impl_output<Impl, output_schema>(
+                            target, user_path, requests, stored...);
+                    }, stored_args);
+                    to_graph<Interface>(target, user_path, replies);
+                }
+                else
+                {
+                    std::apply([&](const auto &...stored) {
+                        detail::wire_impl<Impl>(target, user_path, requests, stored...);
+                    }, stored_args);
+                }
                 scope.complete();
             });
     }
@@ -1941,6 +1954,8 @@ namespace hgraph::service_adaptor
     {
         static_assert(detail::service_adaptor_interface<Interface>,
                       "service_adaptor::to_graph requires a service adaptor interface");
+        static_assert(detail::has_output_schema<Interface>::value,
+                      "service_adaptor::to_graph requires an interface with output_schema");
         const std::string endpoint = detail::adaptor_to_graph_path<Interface>(user_path);
         wiring_path_detail::merge_resolution(
             user_path.resolution, w.service_implementation_stub_resolution(endpoint));
@@ -1958,50 +1973,53 @@ namespace hgraph::service_adaptor
     }
 
     template <typename Interface>
-    [[nodiscard]] Port<detail::output_schema_t<Interface>> adaptor(
+    auto adaptor(
         Wiring &w,
         ServiceAdaptorPath user_path,
         auto input)
     {
         static_assert(detail::service_adaptor_interface<Interface>,
                       "service_adaptor::adaptor requires a service adaptor interface");
-        using replies_schema = detail::request_output_schema_t<Interface>;
-        using output_schema = detail::output_schema_t<Interface>;
 
         user_path = detail::resolve_client_path<Interface>(std::move(user_path), input);
         auto request_id      = service::detail::request_id_source(w);
         w.register_service_client_path(detail::adaptor_base_path<Interface>(user_path), "service adaptor");
         const std::string from_endpoint = detail::adaptor_from_graph_path<Interface>(user_path);
-        const std::string to_endpoint = detail::adaptor_to_graph_path<Interface>(user_path);
         auto requests        = detail::request_input_source<Interface>(w, user_path);
-        auto replies         = detail::output_source<Interface>(w, user_path);
         w.register_service_rank_anchor(from_endpoint, requests.node());
         const WiringInstance *capture =
             detail::capture_request_input<Interface>(w, std::move(input), requests, user_path, request_id);
         w.register_service_client_rank(from_endpoint, "service adaptor", capture, false);
-        w.register_service_client_rank(to_endpoint, "service adaptor", replies.node(), true);
-        if constexpr (schema_descriptor<replies_schema>::is_concrete())
+        if constexpr (detail::has_output_schema<Interface>::value)
         {
-            auto reply = wire<stdlib::getitem_>(w, replies.template as<replies_schema>(), request_id);
-            if constexpr (schema_descriptor<output_schema>::is_concrete())
+            using replies_schema = detail::request_output_schema_t<Interface>;
+            using output_schema = detail::output_schema_t<Interface>;
+            const std::string to_endpoint = detail::adaptor_to_graph_path<Interface>(user_path);
+            auto replies = detail::output_source<Interface>(w, user_path);
+            w.register_service_client_rank(to_endpoint, "service adaptor", replies.node(), true);
+            if constexpr (schema_descriptor<replies_schema>::is_concrete())
             {
-                return reply.template as<output_schema>();
+                auto reply = wire<stdlib::getitem_>(w, replies.template as<replies_schema>(), request_id);
+                if constexpr (schema_descriptor<output_schema>::is_concrete())
+                {
+                    return reply.template as<output_schema>();
+                }
+                else
+                {
+                    return Port<output_schema>{w, reply.erased()};
+                }
             }
             else
             {
+                auto dict = Port<replies_schema>{w, replies.erased()};
+                auto reply = wire<stdlib::getitem_>(w, dict, request_id);
                 return Port<output_schema>{w, reply.erased()};
             }
-        }
-        else
-        {
-            auto dict = Port<replies_schema>{w, replies.erased()};
-            auto reply = wire<stdlib::getitem_>(w, dict, request_id);
-            return Port<output_schema>{w, reply.erased()};
         }
     }
 
     template <typename Interface>
-    [[nodiscard]] Port<detail::output_schema_t<Interface>> adaptor(
+    auto adaptor(
         Wiring &w,
         auto input)
     {
@@ -2011,7 +2029,7 @@ namespace hgraph::service_adaptor
     /** Pack the fields of a TSB request schema from separate client ports. */
     template <typename Interface, typename... Inputs>
         requires(sizeof...(Inputs) > 1)
-    [[nodiscard]] Port<detail::output_schema_t<Interface>> adaptor(
+    auto adaptor(
         Wiring &w,
         ServiceAdaptorPath user_path,
         const Inputs &...inputs)
@@ -2026,7 +2044,7 @@ namespace hgraph::service_adaptor
     /** Pack the fields of a TSB request schema from separate client ports. */
     template <typename Interface, typename... Inputs>
         requires(sizeof...(Inputs) > 1)
-    [[nodiscard]] Port<detail::output_schema_t<Interface>> adaptor(
+    auto adaptor(
         Wiring &w,
         const Inputs &...inputs)
     {

--- a/include/hgraph/types/time_series/ts_delta.h
+++ b/include/hgraph/types/time_series/ts_delta.h
@@ -38,6 +38,12 @@ namespace hgraph
      */
     [[nodiscard]] HGRAPH_EXPORT Value capture_delta(const TSInputView &in);
 
+    /** Rebuild a canonical delta containing every currently-valid value.
+        Unlike ``capture_delta``, this is independent of per-cycle modified
+        flags and is used when a transport first observes an already-partial
+        composite input. */
+    [[nodiscard]] HGRAPH_EXPORT Value capture_current_delta(const TSInputView &in);
+
     HGRAPH_EXPORT void apply_delta(const TSOutputView &out, const ValueView &delta);
 
     /**

--- a/python/hgraph/_types.py
+++ b/python/hgraph/_types.py
@@ -34,6 +34,8 @@ _PYTHON_OBJECT_TYPE_CACHE = {}
 _PYTHON_OBJECT_REGISTRATIONS = {}
 _PYTHON_OBJECT_CLASSES = []
 _TSB_SCHEMA_CLASSES = {}
+_TS_SCALAR_TYPES = {}
+_VALUE_SCALAR_TYPES = {}
 
 
 def register_native_scalar_type(python_type, native_value_type):
@@ -1852,6 +1854,7 @@ class _TSMeta(type):
             expr = _TsExpr(_hgraph.ts(_value_type(scalar)), f"TS[{getattr(scalar, '__name__', scalar)}]")
         except _GenericType as e:
             return _GenericTsExpr(f"TS[{scalar!r}]", pattern=_hgraph.type_pattern_ts(e.pattern))
+        _TS_SCALAR_TYPES[expr.handle] = scalar
         from ._compat import CompoundScalar as _CS
 
         structured_origin = typing.get_origin(scalar) or scalar
@@ -1892,6 +1895,7 @@ class _TSSMeta(type):
     def __getitem__(cls, scalar):
         try:
             value_type = _value_type(scalar)
+            _VALUE_SCALAR_TYPES[value_type] = scalar
             if not value_type.is_hashable or not value_type.is_equatable:
                 raise TypeError(
                     f"TSS element type {scalar!r} must be hashable and equatable")
@@ -1924,6 +1928,7 @@ class _TSDMeta(type):
             if isinstance(value, (_GenericTsExpr, _TypeVarSentinel)):
                 raise _GenericType()
             key_type = _value_type(key)
+            _VALUE_SCALAR_TYPES[key_type] = key
             if not key_type.is_hashable or not key_type.is_equatable:
                 raise TypeError(
                     f"TSD key type {key!r} must be hashable and equatable")
@@ -2185,24 +2190,52 @@ class _TSBMeta(type):
         size_replacements = {}
         ts_replacements = {}
         for parameter, argument in zip(parameters, type_args):
+            if not _type_var_is_scalar(parameter):
+                if isinstance(argument, (typing.TypeVar, _TypeVarSentinel)):
+                    if _type_var_is_scalar(argument):
+                        raise TypeError(
+                            f"time-series schema parameter {parameter!r} cannot be "
+                            f"specialized with scalar type variable {argument!r}")
+                    # The common unresolved spelling, for example
+                    # ``TableEdits[K, TIME_SERIES_TYPE]``, already carries the
+                    # correct variable name in every field pattern.
+                    if _type_var_name(parameter) != _type_var_name(argument):
+                        raise TypeError(
+                            "renaming an unresolved time-series schema parameter "
+                            "is not supported; specialize it with a concrete "
+                            "time-series type")
+                    continue
+
+                ts_argument = None
+                if isinstance(argument, _TsExpr):
+                    ts_argument = argument
+                elif isinstance(argument, type) and issubclass(argument, TimeSeriesSchema):
+                    ts_argument = cls[argument]
+                if not isinstance(ts_argument, _TsExpr):
+                    raise TypeError(
+                        f"time-series schema parameter {parameter!r} requires a "
+                        f"concrete time-series type, got {argument!r}")
+                ts_replacements[_type_var_name(parameter)] = ts_argument.handle
+                continue
+
             if isinstance(argument, int) and not isinstance(argument, bool):
                 size_replacements[_type_var_name(parameter)] = _hgraph.size_pattern_value(argument)
                 continue
             if isinstance(argument, (_TypeVarSentinel, typing.TypeVar)):
+                if not _type_var_is_scalar(argument):
+                    raise TypeError(
+                        f"scalar schema parameter {parameter!r} cannot be "
+                        f"specialized with time-series type variable {argument!r}")
                 replacement = _hgraph.scalar_pattern_var(_type_var_name(argument))
                 size_replacements[_type_var_name(parameter)] = _hgraph.size_pattern_var(
                     _type_var_name(argument))
             else:
+                if isinstance(argument, (_TsExpr, _GenericTsExpr)):
+                    raise TypeError(
+                        f"scalar schema parameter {parameter!r} cannot be "
+                        f"specialized with time-series type {argument!r}")
                 replacement = _scalar_pattern(argument)
             scalar_replacements[_type_var_name(parameter)] = replacement
-
-            ts_argument = None
-            if isinstance(argument, _TsExpr):
-                ts_argument = argument
-            elif isinstance(argument, type) and issubclass(argument, TimeSeriesSchema):
-                ts_argument = cls[argument]
-            if isinstance(ts_argument, _TsExpr):
-                ts_replacements[_type_var_name(parameter)] = ts_argument.handle
 
         is_cs = issubclass(origin, _CS)
         is_python_object = _is_python_object_class(origin)
@@ -2403,14 +2436,14 @@ SCALAR_2 = _TypeVarSentinel("SCALAR_2", is_scalar=True)
 KEYABLE_SCALAR = _TypeVarSentinel("KEYABLE_SCALAR", is_scalar=True)
 NUMBER = _TypeVarSentinel("NUMBER", is_scalar=True, constraints=(int, float))
 NUMBER_2 = _TypeVarSentinel("NUMBER_2", is_scalar=True, constraints=(int, float))
-TIME_SERIES_TYPE = _TypeVarSentinel("TIME_SERIES_TYPE")
-TIME_SERIES_TYPE_1 = _TypeVarSentinel("TIME_SERIES_TYPE_1")
-TIME_SERIES_TYPE_2 = _TypeVarSentinel("TIME_SERIES_TYPE_2")
+TIME_SERIES_TYPE = _typing.TypeVar("TIME_SERIES_TYPE", bound=TimeSeriesSchema)
+TIME_SERIES_TYPE_1 = _typing.TypeVar("TIME_SERIES_TYPE_1", bound=TimeSeriesSchema)
+TIME_SERIES_TYPE_2 = _typing.TypeVar("TIME_SERIES_TYPE_2", bound=TimeSeriesSchema)
 OUT = _TypeVarSentinel("OUT")
-K_1 = _TypeVarSentinel("K_1", is_scalar=True)
+K_1 = _typing.TypeVar("K_1")
 SIZE = _typing.TypeVar("SIZE")
 V = _TypeVarSentinel("V")
-K = _TypeVarSentinel("K", is_scalar=True)
+K = _typing.TypeVar("K")
 WINDOW_SIZE = _TypeVarSentinel("WINDOW_SIZE", is_scalar=True)
 ENUM = _TypeVarSentinel("ENUM", is_scalar=True)
 WINDOW_SIZE_MIN = _TypeVarSentinel("WINDOW_SIZE_MIN", is_scalar=True)

--- a/python/hgraph/_wiring/_services.py
+++ b/python/hgraph/_wiring/_services.py
@@ -60,7 +60,7 @@ def _record_adaptor_client_config(stub, path, bound):
         and parameter.annotation not in _INJECTABLE_MARKERS
     }
     wiring = _wiring_stack[0] if _wiring_stack else _current_wiring()
-    identity = wiring._identity()
+    identity = wiring.identity()
     if identity not in _ADAPTOR_CLIENT_CONFIG_CLEANUPS:
         def clear_configs():
             for existing in tuple(_ADAPTOR_CLIENT_CONFIGS):
@@ -91,7 +91,7 @@ def _record_adaptor_client_config(stub, path, bound):
 def _adaptor_client_config(stub, path):
     wiring = _wiring_stack[0] if _wiring_stack else _current_wiring()
     key = (
-        wiring._identity(), stub.flavour, stub.__name__,
+        wiring.identity(), stub.flavour, stub.__name__,
         stub._specialization, path,
     )
     return _ADAPTOR_CLIENT_CONFIGS.get(key, {})

--- a/python/hgraph/_wiring/_services.py
+++ b/python/hgraph/_wiring/_services.py
@@ -3,6 +3,7 @@
 import inspect
 import itertools
 import typing
+import weakref
 
 import _hgraph
 
@@ -24,6 +25,10 @@ from ._node import _PyNode, _warn_deprecated
 
 _TS_ANNOTATIONS = (_TsExpr, _GenericTsExpr)
 _SERVICE_ADAPTOR_CLIENT_TOKENS = itertools.count()
+_ADAPTOR_CLIENT_CONFIGS = {}
+_ADAPTOR_CLIENT_CONFIG_FINALIZERS = weakref.WeakKeyDictionary()
+
+
 def _is_ts_annotation(annotation):
     return (
         isinstance(annotation, _TS_ANNOTATIONS)
@@ -32,6 +37,60 @@ def _is_ts_annotation(annotation):
             and not _type_var_is_scalar(annotation)
         )
     )
+
+
+def _is_resolution_annotation(annotation):
+    """A ``type[T]`` generic parameter is resolved by wiring, not supplied
+    independently by adaptor clients as scalar configuration."""
+    args = typing.get_args(annotation)
+    return (
+        typing.get_origin(annotation) is type
+        and bool(args)
+        and isinstance(args[0], (_TypeVarSentinel, typing.TypeVar))
+    )
+
+
+def _record_adaptor_client_config(stub, path, bound):
+    """Record the wiring-time scalar options shared by one adaptor path."""
+    config = {
+        parameter.name: bound.arguments[parameter.name]
+        for parameter in stub._signature.parameters.values()
+        if parameter.name != "path"
+        and not _is_ts_annotation(parameter.annotation)
+        and not _is_resolution_annotation(parameter.annotation)
+        and parameter.annotation not in _INJECTABLE_MARKERS
+    }
+    wiring = _wiring_stack[0] if _wiring_stack else _current_wiring()
+    identity = wiring._identity()
+    if wiring not in _ADAPTOR_CLIENT_CONFIG_FINALIZERS:
+        def clear_configs():
+            for existing in tuple(_ADAPTOR_CLIENT_CONFIGS):
+                if existing[0] == identity:
+                    del _ADAPTOR_CLIENT_CONFIGS[existing]
+
+        _ADAPTOR_CLIENT_CONFIG_FINALIZERS[wiring] = weakref.finalize(
+            wiring, clear_configs)
+    key = (
+        identity, stub.flavour, stub.__name__,
+        stub._specialization, path,
+    )
+    previous = _ADAPTOR_CLIENT_CONFIGS.setdefault(key, config)
+    if previous != config:
+        differences = sorted(
+            name for name in previous.keys() | config.keys()
+            if previous.get(name) != config.get(name)
+        )
+        raise WiringError(
+            f"{stub.flavour.replace('_', ' ')} '{stub.__name__}' clients at "
+            f"path {path!r} disagree on wiring-time option(s) {differences!r}")
+
+
+def _adaptor_client_config(stub, path):
+    wiring = _wiring_stack[0] if _wiring_stack else _current_wiring()
+    return _ADAPTOR_CLIENT_CONFIGS.get((
+        wiring._identity(), stub.flavour, stub.__name__,
+        stub._specialization, path,
+    ), {})
 
 
 def _resolved_service_path(stub, path):
@@ -570,6 +629,7 @@ class _AdaptorClientStub:
             specialization = _specialization_label(resolution)
             stub = self._specialized_stub(resolution, specialization)
         self._materialize_client_registration(stub)
+        _record_adaptor_client_config(stub, path, bound)
         request = (
             None if not requests else requests[0]
             if len(requests) == 1 else WiringPort(_hgraph.tsb_port(
@@ -739,8 +799,11 @@ class _ServiceAdaptorStub(_AdaptorClientStub):
             raise TypeError(
                 f"@service_adaptor '{self.__name__}' requires at least one time-series request parameter"
             )
-        if not _is_ts_annotation(sig.return_annotation):
-            raise TypeError(f"@service_adaptor '{self.__name__}' requires a time-series return annotation")
+        self._has_output = _is_ts_annotation(sig.return_annotation)
+        if sig.return_annotation not in (inspect.Signature.empty, None) and not self._has_output:
+            raise TypeError(
+                f"@service_adaptor '{self.__name__}' return annotation must be a "
+                "time-series type or None")
         self._signature = sig
         self._request_params = tuple(params)
         path_param = sig.parameters.get("path")
@@ -763,9 +826,11 @@ class _ServiceAdaptorStub(_AdaptorClientStub):
             if all(field_type is not None for _, field_type in request_fields)
             else None
         )
-        output = _resolve_annotation(sig.return_annotation, resolution)
+        output = (
+            _resolve_annotation(sig.return_annotation, resolution)
+            if self._has_output else None)
         self._request_type = request
-        self.descriptor = None if request is None or output is None else _hgraph.service_descriptor(
+        self.descriptor = None if request is None or (self._has_output and output is None) else _hgraph.service_descriptor(
             name=fn.__name__, flavour="service_adaptor",
             request=request, output=output,
             default_path=default_path, specialization=specialization)
@@ -844,6 +909,9 @@ class _ServiceAdaptorStub(_AdaptorClientStub):
     def to_graph(self, *, path="", __request_id__, __no_ts_inputs__=False):
         del __no_ts_inputs__  # compatibility with the old explicit client API
         stub = self
+        if not stub._has_output:
+            raise TypeError(
+                f"sink-only service adaptor '{self.__name__}' has no to_graph output")
         if stub.descriptor is None:
             raise TypeError(
                 f"generic service adaptor '{self.__name__}' must be specialized")
@@ -858,6 +926,8 @@ class _ServiceAdaptorStub(_AdaptorClientStub):
         _hgraph.service_adaptor_client_from_graph(
             _current_wiring(), stub._require_descriptor(), path,
             _unwrap(request), _unwrap(request_id))
+        if not stub._has_output:
+            return None
         return WiringPort(_hgraph.service_adaptor_client_to_graph(
             _current_wiring(), stub._require_descriptor(), path,
             _unwrap(request_id)))
@@ -1219,12 +1289,6 @@ def _bind_registered_impl(implementation, path, config):
         raise WiringError(
             f"implementation '{implementation.__name__}' has no scalar configuration {sorted(unknown)!r}"
         )
-    for param in scalar_parameters:
-        if param.name not in config and param.default is inspect.Parameter.empty:
-            raise WiringError(
-                f"implementation '{implementation.__name__}' requires scalar configuration '{param.name}'"
-            )
-
     from .._types import AUTO_RESOLVE
 
     resolved_config = dict(config)
@@ -1277,26 +1341,47 @@ def _bind_registered_impl(implementation, path, config):
             else list(ports)
         )
         arguments = dict(zip((param.name for param in port_parameters), user_ports))
+        effective_path = path
+        matched_stub = stub
+        materialized_path = _current_wiring().service_materialization_path()
+        if materialized_path:
+            _, _, qualified = materialized_path.partition("://")
+            matched_stub = next(
+                (candidate for candidate in implementation.interfaces
+                 if qualified.endswith(f"/{candidate.__name__}")),
+                stub,
+            )
+            if matched_stub is not None:
+                suffix = f"/{matched_stub.__name__}"
+                effective_path = qualified[:-len(suffix)]
+                specialization = getattr(matched_stub, "_specialization", "")
+                typed_suffix = f"[{specialization}]" if specialization else ""
+                if typed_suffix and effective_path.endswith(typed_suffix):
+                    effective_path = effective_path[:-len(typed_suffix)]
         if any(param.name == "path" for param in parameters):
-            effective_path = path
-            materialized_path = _current_wiring().service_materialization_path()
-            if materialized_path:
-                _, _, qualified = materialized_path.partition("://")
-                matched_stub = next(
-                    (candidate for candidate in implementation.interfaces
-                     if qualified.endswith(f"/{candidate.__name__}")),
-                    None,
-                )
-                if matched_stub is not None:
-                    suffix = f"/{matched_stub.__name__}"
-                    effective_path = qualified[:-len(suffix)]
-                    specialization = getattr(matched_stub, "_specialization", "")
-                    typed_suffix = f"[{specialization}]" if specialization else ""
-                    if typed_suffix and effective_path.endswith(typed_suffix):
-                        effective_path = effective_path[:-len(typed_suffix)]
             arguments["path"] = effective_path
+        client_config = (
+            _adaptor_client_config(matched_stub, effective_path)
+            if matched_stub is not None else {})
         for param in scalar_parameters:
-            arguments[param.name] = resolved_config.get(param.name, param.default)
+            configured = resolved_config.get(param.name, inspect.Parameter.empty)
+            client_value = client_config.get(param.name, inspect.Parameter.empty)
+            if configured is not inspect.Parameter.empty:
+                if (client_value is not inspect.Parameter.empty
+                        and client_value != configured):
+                    raise WiringError(
+                        f"implementation '{implementation.__name__}' option "
+                        f"'{param.name}' conflicts with adaptor clients at path "
+                        f"{effective_path!r}")
+                arguments[param.name] = configured
+            elif client_value is not inspect.Parameter.empty:
+                arguments[param.name] = client_value
+            elif param.default is inspect.Parameter.empty:
+                raise WiringError(
+                    f"implementation '{implementation.__name__}' requires scalar "
+                    f"configuration '{param.name}'")
+            else:
+                arguments[param.name] = param.default
         from contextlib import ExitStack
         wiring = _wiring_stack[0] if _wiring_stack else _current_wiring()
         contexts = _SERVICE_BUILD_CONTEXTS.get(wiring, ())

--- a/python/hgraph/_wiring/_services.py
+++ b/python/hgraph/_wiring/_services.py
@@ -3,7 +3,6 @@
 import inspect
 import itertools
 import typing
-import weakref
 
 import _hgraph
 
@@ -26,7 +25,7 @@ from ._node import _PyNode, _warn_deprecated
 _TS_ANNOTATIONS = (_TsExpr, _GenericTsExpr)
 _SERVICE_ADAPTOR_CLIENT_TOKENS = itertools.count()
 _ADAPTOR_CLIENT_CONFIGS = {}
-_ADAPTOR_CLIENT_CONFIG_FINALIZERS = weakref.WeakKeyDictionary()
+_ADAPTOR_CLIENT_CONFIG_CLEANUPS = set()
 
 
 def _is_ts_annotation(annotation):
@@ -62,14 +61,18 @@ def _record_adaptor_client_config(stub, path, bound):
     }
     wiring = _wiring_stack[0] if _wiring_stack else _current_wiring()
     identity = wiring._identity()
-    if wiring not in _ADAPTOR_CLIENT_CONFIG_FINALIZERS:
+    if identity not in _ADAPTOR_CLIENT_CONFIG_CLEANUPS:
         def clear_configs():
             for existing in tuple(_ADAPTOR_CLIENT_CONFIGS):
                 if existing[0] == identity:
                     del _ADAPTOR_CLIENT_CONFIGS[existing]
+            _ADAPTOR_CLIENT_CONFIG_CLEANUPS.discard(identity)
 
-        _ADAPTOR_CLIENT_CONFIG_FINALIZERS[wiring] = weakref.finalize(
-            wiring, clear_configs)
+        # The C++ Wiring owns this callback. A temporary borrowed PyWiring can
+        # disappear before build_services(), but its underlying Wiring retains
+        # both the config and cleanup for its actual lifetime.
+        wiring._retain_cleanup(clear_configs)
+        _ADAPTOR_CLIENT_CONFIG_CLEANUPS.add(identity)
     key = (
         identity, stub.flavour, stub.__name__,
         stub._specialization, path,
@@ -87,10 +90,23 @@ def _record_adaptor_client_config(stub, path, bound):
 
 def _adaptor_client_config(stub, path):
     wiring = _wiring_stack[0] if _wiring_stack else _current_wiring()
-    return _ADAPTOR_CLIENT_CONFIGS.get((
+    key = (
         wiring._identity(), stub.flavour, stub.__name__,
         stub._specialization, path,
-    ), {})
+    )
+    return _ADAPTOR_CLIENT_CONFIGS.get(key, {})
+
+
+def _resolved_adaptor_client_path(stub, path):
+    """Return the config key and concrete native client path."""
+    resolved = stub._resolved_path(path) if path else stub._default_path
+    resolved = resolved or f"{stub.__name__}_default"
+    config_path = resolved
+    specialization = getattr(stub, "_specialization", "")
+    suffix = f"[{specialization}]" if specialization else ""
+    if suffix and config_path.endswith(suffix):
+        config_path = config_path[:-len(suffix)]
+    return config_path, resolved
 
 
 def _resolved_service_path(stub, path):
@@ -629,14 +645,15 @@ class _AdaptorClientStub:
             specialization = _specialization_label(resolution)
             stub = self._specialized_stub(resolution, specialization)
         self._materialize_client_registration(stub)
-        _record_adaptor_client_config(stub, path, bound)
+        config_path, path = _resolved_adaptor_client_path(stub, path)
+        _record_adaptor_client_config(stub, config_path, bound)
         request = (
             None if not requests else requests[0]
             if len(requests) == 1 else WiringPort(_hgraph.tsb_port(
                 stub._request_type,
                 {parameter.name: _unwrap(value)
                  for parameter, value in zip(stub._request_params, requests)})))
-        return stub, stub._resolved_path(path), request
+        return stub, path, request
 
 
 class _AdaptorStub(_AdaptorClientStub):

--- a/python/hgraph/adaptors/perspective/__init__.py
+++ b/python/hgraph/adaptors/perspective/__init__.py
@@ -1,20 +1,29 @@
-"""Optional Perspective table publishing.
+"""Perspective publication without importing the optional client eagerly."""
 
-Importing this package does not import ``perspective``. The client is loaded
-only when a real table or web endpoint is requested; tests and applications
-may inject a compatible client through :class:`PerspectiveTablesManager`.
-"""
-
-from ._perspective import *
-from ._perspective_publish import *
-from ._perspective_adaptor import *
+from ._perspective import (
+    IndexPageHandler,
+    PerspectiveTablesManager,
+    TablePageHandler,
+    perspective_web,
+)
+from ._perspective_publish import TableEdits, defaultdbldict
+from ._perspective_adaptor import (
+    publish_multitable,
+    publish_multitable_impl,
+    publish_table,
+    publish_table_editable,
+    publish_table_editable_impl,
+    publish_table_impl,
+    register_perspective_adaptors,
+)
 
 __all__ = [
-    "PerspectiveTablesManager",
     "perspective_web",
-    "_publish_table",
-    "_receive_table_edits",
+    "PerspectiveTablesManager",
+    "TablePageHandler",
+    "IndexPageHandler",
     "TableEdits",
+    "defaultdbldict",
     "publish_table",
     "publish_table_editable",
     "publish_multitable",

--- a/python/hgraph/adaptors/perspective/_perspective.py
+++ b/python/hgraph/adaptors/perspective/_perspective.py
@@ -18,6 +18,7 @@ from collections import defaultdict
 from datetime import datetime, timezone
 from glob import glob
 from pathlib import Path
+from urllib.parse import unquote
 
 import pyarrow as pa
 import tornado.log
@@ -631,38 +632,81 @@ class IndexPageHandler(BaseHandler):
             })
 
 
+def _workspace_layout_name(url):
+    """Return a single safe layout filename component from a route value."""
+    decoded = str(url)
+    while True:
+        unquoted = unquote(decoded)
+        if unquoted == decoded:
+            break
+        decoded = unquoted
+    if (
+        not decoded
+        or decoded in {".", ".."}
+        or "\x00" in decoded
+        or "/" in decoded
+        or "\\" in decoded
+        or Path(decoded).name != decoded
+    ):
+        raise tornado.web.HTTPError(
+            400, reason="invalid workspace layout name")
+    return decoded
+
+
+def _workspace_layout_target(root, url, suffix=".json"):
+    root = Path(root).resolve()
+    name = _workspace_layout_name(url)
+    target = (root / f"{name}{suffix}").resolve()
+    if target.parent != root:
+        raise tornado.web.HTTPError(
+            400, reason="workspace layout must remain inside the layouts directory")
+    return name, target
+
+
 class WorkspacePageHandler(BaseHandler):
     def initialize(self, path):
-        self.path = Path(path)
+        self.path = Path(path).resolve()
         self.path.mkdir(parents=True, exist_ok=True)
 
     def get(self, url):
-        target = self.path / f"{url}.json"
+        name, target = _workspace_layout_target(self.path, url)
         if target.is_file():
             self.finish(target.read_bytes())
             return
-        versions = sorted(self.path.glob(f"{url}.*.version"))
+        prefix = f"{name}."
+        versions = sorted(
+            resolved
+            for candidate in self.path.iterdir()
+            if candidate.name.startswith(prefix)
+            and candidate.name.endswith(".version")
+            and (resolved := candidate.resolve()).parent == self.path
+            and resolved.is_file()
+        )
         self.finish(versions[-1].read_bytes() if versions else b"{}")
 
     def post(self, url):
-        target = self.path / f"{url}.json"
+        name, target = _workspace_layout_target(self.path, url)
         if target.is_file() and target.read_bytes() == self.request.body:
             self.finish("ok")
             return
         if target.is_file():
             stamp = datetime.now().isoformat(timespec="seconds").replace(":", "-")
-            target.replace(self.path / f"{url}.{stamp}.version")
+            _, version = _workspace_layout_target(
+                self.path, name, f".{stamp}.version")
+            target.replace(version)
         target.write_bytes(self.request.body)
         self.finish("ok")
 
     def delete(self, url):
-        target = self.path / f"{url}.json"
+        name, target = _workspace_layout_target(self.path, url)
         if not target.is_file():
             self.set_status(404)
             self.finish("not found")
             return
         stamp = datetime.now().isoformat(timespec="seconds").replace(":", "-")
-        target.replace(self.path / f"{url}.{stamp}.version")
+        _, version = _workspace_layout_target(
+            self.path, name, f".{stamp}.version")
+        target.replace(version)
         self.finish("ok")
 
 

--- a/python/hgraph/adaptors/perspective/_perspective.py
+++ b/python/hgraph/adaptors/perspective/_perspective.py
@@ -1,45 +1,131 @@
+"""Perspective table ownership and Tornado hosting.
+
+Perspective remains an optional dependency.  The manager accepts an injected
+client for deterministic tests and otherwise creates the current Perspective
+server/client pair lazily when the first table or web transport is required.
+"""
+
+from __future__ import annotations
+
+import base64
+import inspect
+import json
+import logging
+import os
+import tempfile
 import threading
+from collections import defaultdict
+from datetime import datetime, timezone
+from glob import glob
+from pathlib import Path
 
 import pyarrow as pa
+import tornado.log
+import tornado.web
 
-from hgraph import GlobalState, TS, sink_node
+from hgraph import GlobalState, STATE, TS, sink_node
+from hgraph.adaptors.tornado._tornado_web import BaseHandler, TornadoWeb
 
 __all__ = (
     "PerspectiveTablesManager",
+    "TablePageHandler",
+    "IndexPageHandler",
     "perspective_web",
 )
 
+logger = logging.getLogger(__name__)
+
+
+def _sequence(value):
+    if value in (None, ""):
+        return ()
+    return tuple(value) if isinstance(value, (list, tuple)) else (value,)
+
+
+def _decode_update(delta):
+    if delta is None:
+        return []
+    if isinstance(delta, list):
+        return [dict(row) for row in delta]
+    if isinstance(delta, dict):
+        return [dict(delta)]
+    if isinstance(delta, (bytes, bytearray, memoryview, pa.Buffer)):
+        return pa.ipc.open_stream(delta).read_all().to_pylist()
+    to_pylist = getattr(delta, "to_pylist", None)
+    if to_pylist is not None:
+        return to_pylist()
+    raise TypeError(f"unsupported Perspective update payload {type(delta)!r}")
+
 
 class PerspectiveTablesManager:
-    _STATE_KEY = ":adaptors:perspective:manager"
+    """Own Perspective tables, edit subscriptions, configuration and hosting."""
 
-    def __init__(self, client=None, *, host_server_tables=True, **options):
-        self._client = client
-        self._server = None
+    _STATE_KEY = "perspective_manager"
+
+    def __init__(
+        self,
+        host_server_tables=True,
+        table_config_file=(),
+        table_configs=None,
+        view_config_file=(),
+        **kwargs,
+    ):
+        # Preserve the early hg_cpp injected-client spelling while matching
+        # upstream's public positional signature.
+        injected = kwargs.pop("client", None)
+        if not isinstance(host_server_tables, bool):
+            if injected is not None:
+                raise TypeError("Perspective client was supplied twice")
+            injected = host_server_tables
+            host_server_tables = True
+
+        self._client = injected
+        self._server = kwargs.pop("server", None)
         self._host_server_tables = host_server_tables
-        self.options = options
+        self._table_configs = dict(table_configs or {})
+        self._table_config_files = _sequence(table_config_file)
+        self._view_config_files = _sequence(view_config_file)
+        self.options = dict(kwargs)
+
         self._tables = {}
         self._table_options = {}
-        self._subscribers = {}
+        self._subscribers = defaultdict(dict)
+        self._subscription_views = {}
         self._views = {}
+        self._temporary_tables = {}
+        self._stats = defaultdict(int)
+        self._table_stats = []
+        self._callback = lambda fn, *args, **kw: fn(*args, **kw)
+        self._started = False
+        self._system_tables_started = False
         self._web = None
+        self._web_configured = False
         self._lock = threading.RLock()
 
+        self._load_view_configs()
+        # Validate table configuration eagerly, as upstream does, without
+        # importing Perspective or constructing tables.
+        self.read_table_config()
+
+    def is_new_api(self):
+        """hg_cpp supports the current Perspective server/client API."""
+        return True
+
     @classmethod
-    def current(cls, global_state=None):
-        state = global_state or GlobalState.instance()
+    def set_current(cls, self, global_state: GlobalState = None):
+        state = global_state if global_state is not None else GlobalState.instance()
+        if state.get(cls._STATE_KEY) is not None:
+            raise ValueError("a PerspectiveTablesManager is already configured")
+        state[cls._STATE_KEY] = self
+
+    @classmethod
+    def current(cls, global_state: GlobalState = None):
+        state = global_state if global_state is not None else GlobalState.instance()
         manager = state.get(cls._STATE_KEY)
         if manager is None:
             manager = cls()
             state[cls._STATE_KEY] = manager
         return manager
-
-    @classmethod
-    def set_current(cls, manager, global_state=None):
-        state = global_state or GlobalState.instance()
-        if cls._STATE_KEY in state:
-            raise ValueError("a PerspectiveTablesManager is already configured")
-        state[cls._STATE_KEY] = manager
 
     @property
     def server_tables(self):
@@ -51,97 +137,158 @@ class PerspectiveTablesManager:
         try:
             import perspective
         except ModuleNotFoundError as error:
-            raise RuntimeError("Perspective adaptors require the 'perspective' extra") from error
-        self._server = perspective.Server()
+            raise RuntimeError(
+                "Perspective adaptors require the 'perspective' extra") from error
+        self._server = self._server or perspective.Server(
+            on_poll_request=self.schedule_poll)
         new_local_client = getattr(self._server, "new_local_client", None)
-        if new_local_client is not None:
-            self._client = new_local_client()
-        else:
-            self._client = perspective.Client.from_server(self._server)
+        self._client = (
+            new_local_client()
+            if new_local_client is not None
+            else perspective.Client.from_server(self._server)
+        )
         return self._client
+
+    def table(self, *args, **kwargs):
+        return self._ensure_client().table(*args, **kwargs)
 
     def create_table(
         self,
-        data,
-        *,
+        *args,
         name,
-        index=None,
         editable=False,
+        user=True,
         edit_role=None,
         temporary=False,
-        **options,
+        **kwargs,
     ):
         with self._lock:
             if name in self._tables:
                 raise ValueError(f"Perspective table {name!r} already exists")
-            client = self._ensure_client()
-            kwargs = dict(options)
-            if index is not None:
-                kwargs["index"] = index
             try:
-                table = client.table(data, name=name, **kwargs)
+                table = self.table(*args, name=name, **kwargs)
             except TypeError:
-                table = client.table(data, **kwargs)
-            self._tables[name] = table
-            self._table_options[name] = {
-                "editable": editable,
-                "edit_role": edit_role,
-                "temporary": temporary,
-                "index": index,
-            }
-            self._attach_subscribers(name)
+                # Injected test clients and older compatible clients may not
+                # accept Perspective's optional name argument.
+                table = self.table(*args, **kwargs)
+            self.add_table(
+                name,
+                table,
+                editable=editable,
+                user=user,
+                edit_role=edit_role,
+                temporary=temporary,
+            )
             return table
 
-    def add_table(self, name, table, *, editable=False, edit_role=None, **options):
+    def add_table(
+        self,
+        name,
+        table,
+        editable=False,
+        user=True,
+        edit_role=None,
+        temporary=False,
+    ):
         with self._lock:
             if name in self._tables:
                 raise ValueError(f"Perspective table {name!r} already exists")
             self._tables[name] = table
             self._table_options[name] = {
-                "editable": editable,
+                "editable": bool(editable),
+                "user": bool(user),
                 "edit_role": edit_role,
-                **options,
+                "temporary": bool(temporary),
+                "index": (
+                    table.get_index()
+                    if callable(getattr(table, "get_index", None)) else None
+                ),
             }
+            if temporary:
+                self._temporary_tables[name] = 0
             self._attach_subscribers(name)
+            if user:
+                self._publish_index_entry(name)
+            return table
 
-    def update_table(
-        self,
-        name,
-        data,
-        removals=None,
-        *,
-        index=None,
-        editable=False,
-        edit_role=None,
-    ):
-        rows = list(data or ())
+    def _publish_index_entry(self, name):
+        index_table = self._tables.get("index")
+        if index_table is None or name == "index":
+            return
+        table = self._tables[name]
+        options = self._table_options[name]
+        schema_fn = getattr(table, "schema", None)
+        schema = schema_fn() if callable(schema_fn) else {}
+        index_fn = getattr(table, "get_index", None)
+        index = index_fn() if callable(index_fn) else options.get("index")
+        index_table.update([{
+            "name": name,
+            "type": "table" if self.server_tables else "client_table",
+            "editable": options["editable"],
+            "edit_role": options.get("edit_role"),
+            "url": "",
+            "schema": json.dumps({
+                key: value if isinstance(value, str)
+                else getattr(value, "__name__", str(value))
+                for key, value in dict(schema).items()
+            }),
+            "blank": "",
+            "index": index or "",
+            "description": "",
+        }])
+
+    def _ensure_system_tables(self):
+        if self._system_tables_started:
+            return
+        self._system_tables_started = True
+        if "index" not in self._tables:
+            self.create_table(
+                {
+                    "name": str, "type": str, "editable": bool,
+                    "edit_role": str, "url": str, "schema": str,
+                    "blank": str, "index": str, "description": str,
+                },
+                index="name", name="index", user=False,
+            )
+        if "table_stats" not in self._tables:
+            self.create_table(
+                {"table": str, "batch": int, "rows": int, "time": datetime},
+                name="table_stats", user=False,
+            )
+        for name in tuple(self._tables):
+            if self._table_options.get(name, {}).get("user"):
+                self._publish_index_entry(name)
+
+    def update_table(self, name, data, removals=None):
+        rows = _decode_update(data) if data is not None else []
         with self._lock:
-            table = self._tables.get(name)
-            if table is None:
-                if not rows:
-                    return
-                table = self.create_table(
-                    rows,
-                    name=name,
-                    index=index,
-                    editable=editable,
-                    edit_role=edit_role,
-                )
-                rows = []
+            table = self._tables[name]
+            self._stats["updates"] += 1
             if rows:
-                table.update(rows)
+                self._stats["batches"] += 1
+                self._stats["rows"] += len(rows)
+                self._table_stats.append({
+                    "table": name,
+                    "batch": self._stats["batches"],
+                    "rows": len(rows),
+                    "time": datetime.now(timezone.utc),
+                })
+                self.schedule_callback(table.update, rows)
             if removals:
                 remove = getattr(table, "remove", None)
-                if remove is not None:
-                    remove(list(removals))
+                if callable(remove):
+                    self.schedule_callback(remove, list(removals))
 
     def replace_table(self, name, data):
+        rows = _decode_update(data) if data is not None else []
         with self._lock:
             table = self._tables[name]
             replace = getattr(table, "replace", None)
-            if replace is None:
-                raise TypeError("the configured Perspective table does not support replace")
-            replace(data)
+            if not callable(replace):
+                raise TypeError(
+                    "the configured Perspective table does not support replace")
+            self._stats["updates"] += 1
+            self.schedule_callback(replace, rows)
 
     def get_table_names(self):
         with self._lock:
@@ -154,107 +301,398 @@ class PerspectiveTablesManager:
     def is_table_editable(self, name):
         return bool(self._table_options.get(name, {}).get("editable"))
 
-    def subscribe_table_updates(self, name, callback, self_updates=False):
-        token = object()
+    def subscribe_table_updates(self, name, cb, self_updates=False):
         with self._lock:
-            self._subscribers.setdefault(name, {})[token] = callback
+            if name in self._tables and not self.is_table_editable(name):
+                raise ValueError(f"Table {name!r} is not editable")
+            token = object()
+            self._subscribers[name][token] = (cb, bool(self_updates))
             self._attach_subscribers(name)
-        return token
+            return token
 
-    def unsubscribe_table_updates(self, name, token):
+    def unsubscribe_table_updates(self, name, updater):
         with self._lock:
             subscribers = self._subscribers.get(name)
             if subscribers is not None:
-                subscribers.pop(token, None)
+                subscribers.pop(updater, None)
 
-    def publish_edits(self, name, updates=(), removals=()):
-        """Feed edits into graph subscribers; also useful for injected clients."""
+    @staticmethod
+    def _callback_arity(callback):
+        try:
+            signature = inspect.signature(callback)
+        except (TypeError, ValueError):
+            return 2
+        positional = tuple(
+            parameter for parameter in signature.parameters.values()
+            if parameter.kind in (
+                inspect.Parameter.POSITIONAL_ONLY,
+                inspect.Parameter.POSITIONAL_OR_KEYWORD,
+            )
+        )
+        if any(parameter.kind is inspect.Parameter.VAR_POSITIONAL
+               for parameter in signature.parameters.values()):
+            return 2
+        return len(positional)
+
+    def publish_edits(self, name, updates=(), removals=(), *, raw=None):
+        """Deliver an edit batch; injected clients may call this directly."""
+        rows = list(updates)
+        removed = list(removals)
         with self._lock:
-            callbacks = tuple(self._subscribers.get(name, {}).values())
-        for callback in callbacks:
-            callback(list(updates), list(removals))
+            subscribers = tuple(self._subscribers.get(name, {}).values())
+        for callback, _self_updates in subscribers:
+            if self._callback_arity(callback) <= 1:
+                callback(raw if raw is not None else rows)
+            else:
+                callback(rows, removed)
 
     def _attach_subscribers(self, name):
-        if name in self._views or name not in self._tables or name not in self._subscribers:
+        if (name in self._subscription_views or name not in self._tables
+                or not self._subscribers.get(name)):
             return
-        table = self._tables[name]
-        view_factory = getattr(table, "view", None)
-        if view_factory is None:
+        view_factory = getattr(self._tables[name], "view", None)
+        if not callable(view_factory):
             return
         view = view_factory()
         on_update = getattr(view, "on_update", None)
-        if on_update is None:
+        if not callable(on_update):
             return
 
         def updated(*args):
             delta = args[-1] if args else None
-            rows = _decode_update(delta)
-            self.publish_edits(name, rows, ())
+            self.publish_edits(
+                name, _decode_update(delta), (), raw=delta)
 
         on_update(updated, mode="row")
-        self._views[name] = view
+        self._subscription_views[name] = view
 
-    def start_web(self, host, port):
-        self._ensure_client()
+    def start(self):
+        with self._lock:
+            if self._started:
+                return
+            self._ensure_client()
+            self._ensure_system_tables()
+            self._started = True
+            for name in tuple(self._tables):
+                self._attach_subscribers(name)
+
+    def get_table_config_files(self):
+        return list(self._table_config_files)
+
+    def read_table_config(self):
+        config = {}
+        for filename in self._table_config_files:
+            with open(filename, encoding="utf-8") as stream:
+                config.update(json.load(stream))
+        for value in self._table_configs.values():
+            config.update(json.loads(value) if isinstance(value, str) else value)
+        return config
+
+    def add_table_configs(self, table_configs):
+        for value in table_configs.values():
+            if isinstance(value, str):
+                json.loads(value)
+        self._table_configs.update(table_configs)
+
+    def _load_view_configs(self):
+        for filename in self._view_config_files:
+            with open(filename, encoding="utf-8") as stream:
+                self._views.update(json.load(stream))
+
+    def get_view_names(self):
+        return list(self._views)
+
+    def get_view(self, name):
+        return self._views[name]
+
+    def set_loop_callback(self, cb, *args):
+        self._callback = lambda fn, *fn_args, **kwargs: cb(
+            *args, fn, *fn_args, **kwargs)
+
+    def get_loop_callback(self):
+        return self._callback
+
+    def schedule_callback(self, f, *args, **kwargs):
+        return self._callback(f, *args, **kwargs)
+
+    def schedule_poll(self, server):
+        self._stats["polling"] += 1
+        return server.poll()
+
+    def get_stats(self):
+        return self._stats
+
+    def cleanup_temporary_tables(self):
+        for name, previous_views in tuple(self._temporary_tables.items()):
+            table = self._tables.get(name)
+            if table is None:
+                self._temporary_tables.pop(name, None)
+                continue
+            count = getattr(table, "get_num_views", lambda: 0)()
+            if previous_views > 0 and count == 0:
+                delete = getattr(table, "delete", None)
+                if callable(delete):
+                    self.schedule_callback(delete)
+                self._tables.pop(name, None)
+                self._table_options.pop(name, None)
+                self._temporary_tables.pop(name, None)
+            else:
+                self._temporary_tables[name] = count
+
+    def tornado_config(self):
         if self._server is None:
-            raise RuntimeError("an injected Perspective client must provide its own web transport")
+            return []
         try:
             from perspective.handlers.tornado import PerspectiveTornadoHandler
         except (ImportError, ModuleNotFoundError) as error:
-            raise RuntimeError("Perspective web hosting requires the 'perspective' and 'web' extras") from error
-        from hgraph.adaptors.tornado._tornado_web import TornadoWeb
+            raise RuntimeError(
+                "Perspective web hosting requires the 'perspective' extra") from error
+        options = {"perspective_server": self._server}
+        return [
+            (r"/websocket", PerspectiveTornadoHandler, options),
+            (r"/perspective", PerspectiveTornadoHandler, options),
+        ]
 
+    def start_web(
+        self, host, port, *, static=None,
+        table_template="table_template.html",
+        index_template="index_template.html",
+        workspace_template="workspace_template.html",
+        layouts_path=None,
+    ):
+        self.start()
         web = TornadoWeb.instance(port)
-        web.add_handler(
-            r"/perspective",
-            PerspectiveTornadoHandler,
-            {"perspective_server": self._server},
-        )
+        if not self._web_configured:
+            layouts = layouts_path or os.path.join(
+                tempfile.gettempdir(), "psp_layouts")
+            os.makedirs(layouts, exist_ok=True)
+            handlers = [
+                (r"/table/(.*)", TablePageHandler, {
+                    "mgr": self, "template": table_template,
+                    "host": host, "port": port,
+                }),
+                (r"/view/(.*)\.(.*)", ViewPageHandler, {
+                    "mgr": self, "host": host, "port": port,
+                }),
+                (r"/workspace/(.*)", IndexPageHandler, {
+                    "mgr": self, "layouts_path": layouts,
+                    "index_template": workspace_template,
+                    "host": host, "port": port,
+                }),
+                (r"/layout/(.*)", WorkspacePageHandler, {"path": layouts}),
+                (r"/", IndexPageHandler, {
+                    "mgr": self, "layouts_path": layouts,
+                    "index_template": index_template,
+                    "host": host, "port": port,
+                }),
+                (r"/versions/(.*)", IndexPageHandler, {
+                    "mgr": self, "layouts_path": layouts,
+                    "index_template": index_template,
+                    "host": host, "port": port,
+                }),
+            ]
+            handlers.extend(self.tornado_config())
+            handlers.extend(
+                (pattern, tornado.web.StaticFileHandler, options)
+                for pattern, options in (static or {}).items()
+            )
+            web.add_handlers(handlers)
+            self._web_configured = True
         web.start()
         self._web = web
 
     def stop_web(self):
-        if self._web is not None:
-            self._web.stop()
-            self._web = None
+        web, self._web = self._web, None
+        if web is not None:
+            web.stop()
 
     def close(self):
         self.stop_web()
         with self._lock:
-            views = tuple(self._views.values())
-            self._views.clear()
+            views = tuple(self._subscription_views.values())
+            self._subscription_views.clear()
         for view in views:
             delete = getattr(view, "delete", None)
-            if delete is not None:
+            if callable(delete):
                 delete()
 
 
-def _decode_update(delta):
-    if delta is None:
-        return []
-    if isinstance(delta, list):
-        return delta
-    if isinstance(delta, dict):
-        return [delta]
-    if isinstance(delta, (bytes, bytearray, memoryview, pa.Buffer)):
-        return pa.ipc.open_stream(delta).read_all().to_pylist()
-    to_pylist = getattr(delta, "to_pylist", None)
-    if to_pylist is not None:
-        return to_pylist()
-    raise TypeError(f"unsupported Perspective update payload {type(delta)!r}")
+def _resolve_template(template):
+    if not template:
+        return None
+    candidate = Path(template)
+    if not candidate.is_absolute():
+        candidate = Path(__file__).with_name(template)
+    return candidate if candidate.is_file() else None
+
+
+class TablePageHandler(BaseHandler):
+    def initialize(self, mgr, template, host, port):
+        self.mgr = mgr
+        self.template = template
+        self.host = host
+        self.port = port
+
+    def get(self, table_name):
+        if table_name not in self.mgr.get_table_names():
+            self.set_status(404)
+            self.finish("Table not found")
+            return
+        template = _resolve_template(self.template)
+        if template is not None:
+            self.render(
+                str(template), table_name=table_name,
+                is_new_api=self.mgr.is_new_api(),
+                table=self.mgr.get_table(table_name),
+                editable=self.mgr.is_table_editable(table_name),
+                host=self.host, port=self.port,
+            )
+        else:
+            self.write({
+                "table": table_name,
+                "editable": self.mgr.is_table_editable(table_name),
+                "host": self.host,
+                "port": self.port,
+            })
+
+
+class ViewPageHandler(BaseHandler):
+    def initialize(self, mgr, host="localhost", port=8080):
+        self.mgr = mgr
+        self.host = host
+        self.port = port
+
+    def get(self, view_name, output_format):
+        if view_name not in self.mgr.get_view_names():
+            self.set_status(404)
+            self.finish("View not found")
+            return
+        config = dict(self.mgr.get_view(view_name))
+        table_name = config.pop("table")
+        view = self.mgr.get_table(table_name).view(**{
+            key: value for key, value in config.items()
+            if value not in (None, {}, [])
+        })
+        try:
+            if output_format == "json":
+                self.set_header("Content-Type", "application/json")
+                self.write(json.dumps(view.to_json()))
+            elif output_format == "arrow":
+                self.set_header("Content-Type", "application/octet-stream")
+                self.write(view.to_arrow())
+            elif output_format == "csv":
+                self.set_header("Content-Type", "text/csv")
+                self.write(view.to_csv())
+            else:
+                self.set_status(400)
+                self.write("Unsupported format")
+        finally:
+            delete = getattr(view, "delete", None)
+            if callable(delete):
+                delete()
+
+
+class IndexPageHandler(BaseHandler):
+    def initialize(
+        self, mgr, layouts_path, index_template, host, port,
+    ):
+        self.mgr = mgr
+        self.layouts_path = layouts_path
+        self.index_template = index_template
+        self.host = host
+        self.port = port
+
+    def get(self, url=""):
+        layouts = []
+        versions = []
+        if self.layouts_path:
+            layouts = sorted(
+                os.path.basename(filename).removesuffix(".json")
+                for filename in glob(os.path.join(
+                    self.layouts_path, f"{url or '*'}.json")))
+            if url:
+                versions = sorted(
+                    os.path.basename(filename).split(".")[1]
+                    for filename in glob(os.path.join(
+                        self.layouts_path, f"{url}.*.version")))
+        template = _resolve_template(self.index_template)
+        if template is not None:
+            self.render(
+                str(template), url=url, mgr=self.mgr,
+                layouts=layouts, versions=versions,
+                host=self.host, port=self.port,
+            )
+        else:
+            self.write({
+                "tables": self.mgr.get_table_names(),
+                "views": self.mgr.get_view_names(),
+                "layouts": layouts,
+                "versions": versions,
+            })
+
+
+class WorkspacePageHandler(BaseHandler):
+    def initialize(self, path):
+        self.path = Path(path)
+        self.path.mkdir(parents=True, exist_ok=True)
+
+    def get(self, url):
+        target = self.path / f"{url}.json"
+        if target.is_file():
+            self.finish(target.read_bytes())
+            return
+        versions = sorted(self.path.glob(f"{url}.*.version"))
+        self.finish(versions[-1].read_bytes() if versions else b"{}")
+
+    def post(self, url):
+        target = self.path / f"{url}.json"
+        if target.is_file() and target.read_bytes() == self.request.body:
+            self.finish("ok")
+            return
+        if target.is_file():
+            stamp = datetime.now().isoformat(timespec="seconds").replace(":", "-")
+            target.replace(self.path / f"{url}.{stamp}.version")
+        target.write_bytes(self.request.body)
+        self.finish("ok")
+
+    def delete(self, url):
+        target = self.path / f"{url}.json"
+        if not target.is_file():
+            self.set_status(404)
+            self.finish("not found")
+            return
+        stamp = datetime.now().isoformat(timespec="seconds").replace(":", "-")
+        target.replace(self.path / f"{url}.{stamp}.version")
+        self.finish("ok")
 
 
 @sink_node
 def perspective_web(
     host: str,
     port: int,
-    _sig: TS[bool],
-    manager: object,
+    static: dict[str, dict[str, str]] = None,
+    table_template: str = "table_template.html",
+    index_template: str = "index_template.html",
+    workspace_template: str = "workspace_template.html",
+    layouts_path: str = None,
+    _sig: TS[bool] = True,
+    logger: logging.Logger = None,
+    _global_state: GlobalState = None,
 ):
-    if _sig.value:
-        manager.start_web(host, port)
+    manager = PerspectiveTablesManager.current(_global_state)
+    if _sig.value and manager._web is None:
+        manager.start_web(
+            host, port, static=static,
+            table_template=table_template,
+            index_template=index_template,
+            workspace_template=workspace_template,
+            layouts_path=layouts_path,
+        )
+        (logger or globals()["logger"]).info(
+            "Perspective server started at http://%s:%s", host, port)
 
 
 @perspective_web.stop
-def _stop_perspective_web(manager: object):
+def _stop_perspective_web(_global_state: GlobalState = None):
+    manager = PerspectiveTablesManager.current(_global_state)
     manager.stop_web()

--- a/python/hgraph/adaptors/perspective/_perspective_adaptor.py
+++ b/python/hgraph/adaptors/perspective/_perspective_adaptor.py
@@ -1,7 +1,42 @@
-from hgraph import TS, WiringPort, const
+"""Public Perspective adaptor interfaces and their default implementations."""
 
-from ._perspective import PerspectiveTablesManager, perspective_web as _perspective_web_node
-from ._perspective_publish import _publish_table, _receive_table_edits
+from collections import defaultdict
+
+from hgraph import (
+    K,
+    REF,
+    SCALAR,
+    TIME_SERIES_TYPE,
+    TS,
+    TSB,
+    TSD,
+    TSS,
+    TS_SCHEMA,
+    WiringGraphContext,
+    WiringError,
+    adaptor,
+    adaptor_impl,
+    assert_,
+    emit,
+    flip,
+    graph,
+    len_,
+    map_,
+    operator,
+    pass_through,
+    reduce_tsd_of_bundles_with_race,
+    register_adaptor,
+    rekey,
+    service_adaptor,
+    service_adaptor_impl,
+)
+
+from ._perspective import perspective_web
+from ._perspective_publish import (
+    TableEdits,
+    _publish_table,
+    _receive_table_edits,
+)
 
 __all__ = (
     "publish_table",
@@ -15,58 +50,154 @@ __all__ = (
 )
 
 
-def publish_table(path, ts, index_col_name, history=None):
-    manager = PerspectiveTablesManager.current()
+@adaptor
+def publish_table(
+    path: str,
+    ts: TSD[K, TIME_SERIES_TYPE],
+    index_col_name: str,
+    history: int = None,
+) -> None:
+    """Publish a TSD as a read-only Perspective table."""
+
+
+@adaptor_impl(interfaces=publish_table)
+def publish_table_impl(
+    path: str,
+    ts: TSD[K, TIME_SERIES_TYPE],
+    index_col_name: str,
+    history: int = None,
+) -> None:
+    _assert_unique_type_per_path(publish_table)
     _publish_table(
-        ts,
-        name=path,
-        index_col_name=index_col_name,
-        editable=False,
-        edit_role=None,
-        history=history,
-        manager=manager,
-    )
+        path, ts, index_col_name=index_col_name, history=history)
 
 
+@adaptor
 def publish_table_editable(
-    path,
-    ts,
-    index_col_name,
-    history=None,
-    edit_role=None,
-    empty_row=False,
-):
-    if empty_row:
-        raise NotImplementedError("Perspective empty-row creation is not supported")
-    manager = PerspectiveTablesManager.current()
-    _publish_table(
+    path: str,
+    ts: TSD[K, TIME_SERIES_TYPE],
+    index_col_name: str,
+    history: int = None,
+    edit_role: str = None,
+    empty_row: bool = False,
+) -> TSB[TableEdits[K, TIME_SERIES_TYPE]]:
+    """Publish an editable TSD and return its typed edits and removals."""
+
+
+@adaptor_impl(interfaces=publish_table_editable)
+def publish_table_editable_impl(
+    path: str,
+    ts: TSD[K, TIME_SERIES_TYPE],
+    index_col_name: str,
+    history: int = None,
+    edit_role: str = None,
+    empty_row: bool = False,
+) -> TSB[TableEdits[K, TIME_SERIES_TYPE]]:
+    _assert_unique_type_per_path(publish_table_editable)
+    plan = _publish_table(
+        path,
         ts,
-        name=path,
         index_col_name=index_col_name,
+        history=history,
         editable=True,
         edit_role=edit_role,
-        history=history,
-        manager=manager,
+        empty_row=empty_row,
     )
-    return _receive_table_edits(path, ts, index_col_name, manager)
-
-
-def publish_multitable(path, key, ts, unique, index_col_name, history=None):
-    raise NotImplementedError(
-        "Perspective multi-client reduction is not exposed; publish a native TSD with publish_table"
+    return _receive_table_edits(
+        path,
+        ts,
+        index_col_name=index_col_name,
+        empty_row=empty_row,
+        plan=plan,
     )
 
 
-def perspective_web(host="localhost", port=8080, _sig=True, **_):
-    manager = PerspectiveTablesManager.current()
-    signal = _sig if isinstance(_sig, WiringPort) else const(_sig, tp=TS[bool])
-    return _perspective_web_node(host=host, port=port, _sig=signal, manager=manager)
+@service_adaptor
+def publish_multitable(
+    path: str,
+    key: TS[SCALAR],
+    ts: TIME_SERIES_TYPE,
+    unique: bool,
+    index_col_name: str,
+    history: int = None,
+) -> None:
+    """Publish multiple clients into one shared Perspective table."""
+
+
+@operator
+def _merge_multitable_references(
+    keys: TSS[int],
+    ts: TSD[int, REF[TIME_SERIES_TYPE]],
+) -> REF[TIME_SERIES_TYPE]: ...
+
+
+@graph(overloads=_merge_multitable_references)
+def _merge_multitable_bundles(
+    keys: TSS[int],
+    ts: TSD[int, REF[TSB[TS_SCHEMA]]],
+) -> TSB[TS_SCHEMA]:
+    return reduce_tsd_of_bundles_with_race(tsd=ts[keys])
+
+
+@graph(overloads=_merge_multitable_references)
+def _merge_multitable_scalars(
+    keys: TSS[int],
+    ts: TSD[int, REF[TS[SCALAR]]],
+) -> REF[TS[SCALAR]]:
+    assert_(
+        len_(keys),
+        1,
+        "Only bundles may be published as multi-tables with repeating keys",
+    )
+    return ts[emit(keys)]
+
+
+@service_adaptor_impl(interfaces=publish_multitable)
+def publish_multitable_impl(
+    path: str,
+    key: TSD[int, TS[SCALAR]],
+    ts: TSD[int, TIME_SERIES_TYPE],
+    unique: bool,
+    index_col_name: str,
+    history: int = None,
+) -> None:
+    _assert_unique_type_per_path(publish_multitable)
+    if unique:
+        table = rekey(ts, key)
+    else:
+        keys = flip(key, unique=False)
+        table = map_(
+            lambda keys, ts: _merge_multitable_references(keys, ts),
+            keys,
+            pass_through(ts),
+        )
+    _publish_table(
+        path, table, index_col_name=index_col_name, history=history)
+
+
+def _assert_unique_type_per_path(adaptor_type):
+    by_path = defaultdict(lambda: defaultdict(set))
+    for path, type_map, _, receive in \
+            WiringGraphContext.instance().registered_service_clients(adaptor_type):
+        path = path.removesuffix("/from_graph").removesuffix("/to_graph")
+        for variable, concrete in type_map.items():
+            by_path[(path, receive)][variable].add(concrete)
+
+    errors = []
+    for (path, item), variables in by_path.items():
+        for variable, concrete in variables.items():
+            if len(concrete) <= 1:
+                continue
+            errors.append(
+                f"For {adaptor_type.__name__} at path {path!r}, clients "
+                f"provided different {variable} types for {item}:")
+            errors.extend(f"  {value}" for value in concrete)
+    if errors:
+        raise WiringError("\n".join(errors))
 
 
 def register_perspective_adaptors():
-    """Compatibility no-op; publication wires directly to the native graph."""
-
-
-publish_table_impl = publish_table
-publish_table_editable_impl = publish_table_editable
-publish_multitable_impl = publish_multitable
+    """Register the default implementations for the current wiring graph."""
+    register_adaptor(None, publish_table_impl)
+    register_adaptor(None, publish_table_editable_impl)
+    register_adaptor(None, publish_multitable_impl)

--- a/python/hgraph/adaptors/perspective/_perspective_publish.py
+++ b/python/hgraph/adaptors/perspective/_perspective_publish.py
@@ -1,152 +1,535 @@
+"""Typed Perspective row publication and editable-table feedback."""
+
+from collections import defaultdict
 from dataclasses import asdict, dataclass, is_dataclass
 from datetime import datetime
+import threading
+import typing
 
 import pyarrow as pa
-import _hgraph
 
-from hgraph import K, TIME_SERIES_TYPE, TS, TSD, push_queue, sink_node
-from hgraph._types import _TsExpr
-from hgraph._wiring import _unwrap
+from hgraph import (
+    EvaluationClock,
+    GlobalState,
+    K,
+    Removed,
+    STATE,
+    TIME_SERIES_TYPE,
+    TS,
+    TSB,
+    TSD,
+    TSS,
+    TimeSeriesSchema,
+    push_queue,
+    sink_node,
+)
+from hgraph.reflection import (
+    dereference,
+    fields,
+    frame_schema,
+    is_bundle,
+    is_compound_scalar,
+    is_frame,
+    is_ts,
+    key_type,
+    scalar_type,
+    value_type,
+)
 
 from ._perspective import PerspectiveTablesManager
 
-__all__ = ("_publish_table", "_receive_table_edits", "TableEdits")
+__all__ = ("TableEdits", "defaultdbldict")
+
+
+class TableEdits(TimeSeriesSchema, typing.Generic[K, TIME_SERIES_TYPE]):
+    """Typed edits and removals emitted by an editable Perspective table."""
+
+    edits: TSD[K, TIME_SERIES_TYPE]
+    removes: TSS[K]
+
+
+class defaultdbldict(defaultdict):
+    """A one-to-one defaultdict with reverse lookup, used for empty rows."""
+
+    def __init__(self, default_factory):
+        super().__init__(default_factory)
+        self.key_tracker = {}
+
+    def __missing__(self, key):
+        value = super().__missing__(key)
+        self.key_tracker[value] = key
+        return value
+
+    def __setitem__(self, key, value):
+        old_key = self.key_tracker.get(value)
+        if old_key is not None and old_key != key:
+            super().__delitem__(old_key)
+        result = super().__setitem__(key, value)
+        self.key_tracker[value] = key
+        return result
+
+    def __delitem__(self, key):
+        value = self.get(key)
+        result = super().__delitem__(key)
+        self.key_tracker.pop(value, None)
+        return result
+
+    def reverse_get(self, value):
+        return self.key_tracker.get(value)
+
+
+def _cast(value, target):
+    if value is None:
+        return None
+    try:
+        return value if isinstance(value, target) else target(value)
+    except TypeError:
+        return value
+
+
+def _object_dict(value):
+    if is_dataclass(value):
+        return asdict(value)
+    to_dict = getattr(value, "to_dict", None)
+    if callable(to_dict):
+        return dict(to_dict())
+    if isinstance(value, dict):
+        return dict(value)
+    raise TypeError(f"Perspective row value {type(value)!r} is not structured")
+
+
+def _arrow_rows(value):
+    if isinstance(value, (pa.Table, pa.RecordBatch)):
+        return value.to_pylist()
+    to_arrow = getattr(value, "to_arrow", None)
+    if callable(to_arrow):
+        return to_arrow().to_pylist()
+    raise TypeError(f"Perspective Frame value {type(value)!r} is not Arrow-compatible")
 
 
 @dataclass(frozen=True)
-class TableEdits:
-    edits: object
-    removes: object
+class _PerspectiveRowPlan:
+    key_tp: object
+    value_tp: object
+    key_kind: str
+    key_columns: tuple
+    key_column_types: tuple
+    residual_index_columns: tuple
+    index_columns: tuple
+    index: str
+    synthetic_index: bool
+    key_schema: dict
+    value_schema: dict
+    value_kind: str
+    value_fields: tuple
+    value_scalar: object = None
+
+    @property
+    def multi_row(self):
+        return self.value_kind == "frame"
+
+    def process_key(self, key):
+        if self.key_kind == "tuple":
+            values = tuple(key)
+        elif self.key_kind == "compound":
+            source = _object_dict(key)
+            values = tuple(source[name] for name in self.key_columns)
+        else:
+            values = (key,)
+        return dict(zip(self.key_columns, values))
+
+    def parse_key(self, row):
+        values = tuple(
+            _cast(row[name], tp)
+            for name, tp in zip(self.key_columns, self.key_column_types)
+        )
+        if self.key_kind == "tuple":
+            return values
+        if self.key_kind == "compound":
+            return self.key_tp(**dict(zip(self.key_columns, values)))
+        return values[0]
+
+    def add_index(self, row):
+        if self.synthetic_index:
+            row["index"] = ",".join(str(row[name]) for name in self.index_columns)
+        return row
+
+    def row_index(self, row):
+        return row[self.index]
+
+    def rows(self, child):
+        if self.value_kind == "bundle":
+            delta = dict(child.delta_value)
+            for name in self.residual_index_columns:
+                item = child[name]
+                if item.valid:
+                    delta[name] = item.value
+            return [delta]
+        value = child.value
+        if self.value_kind == "compound":
+            return [_object_dict(value)]
+        if self.value_kind == "frame":
+            return _arrow_rows(value)
+        return [{"value": value}]
+
+    def sample_row(self, child, row):
+        if self.value_kind != "bundle":
+            return dict(row)
+        sample = {}
+        for name in self.value_fields:
+            item = child[name]
+            sample[name] = item.value if item.valid else None
+        return sample
+
+    def parse_value(self, row):
+        values = {
+            name: row[name]
+            for name in self.value_fields
+            if name in row and name not in self.key_columns
+        }
+        if self.value_kind == "bundle":
+            return values
+        if self.value_kind == "compound":
+            return self.value_scalar(**{
+                name: _cast(value, self.value_schema[name])
+                for name, value in values.items()
+            })
+        if self.value_kind == "scalar":
+            return _cast(row["value"], self.value_scalar)
+        raise TypeError("editable Perspective tables do not support Frame values")
+
+    def empty_key(self):
+        values = tuple(tp() for tp in self.key_column_types)
+        if self.key_kind == "tuple":
+            return values
+        if self.key_kind == "compound":
+            return self.key_tp(**dict(zip(self.key_columns, values)))
+        return values[0]
+
+
+def _row_plan(ts_type, index_col_name=None):
+    key_tp = key_type(ts_type)
+    value_tp = dereference(value_type(ts_type))
+    requested = tuple(
+        value.strip() for value in (index_col_name or "").split(",")
+        if value.strip()
+    )
+
+    origin = typing.get_origin(key_tp)
+    if origin is tuple:
+        key_kind = "tuple"
+        key_types = tuple(typing.get_args(key_tp))
+        key_columns = requested[:len(key_types)] or tuple(
+            f"index_{index}" for index in range(len(key_types)))
+        if len(key_columns) != len(key_types):
+            raise ValueError("tuple Perspective keys require one index column per element")
+    elif is_compound_scalar(key_tp):
+        key_kind = "compound"
+        key_fields = fields(key_tp)
+        key_columns = tuple(
+            name for name in requested if name in key_fields
+        ) or tuple(key_fields)
+        key_types = tuple(key_fields[name] for name in key_columns)
+    else:
+        key_kind = "scalar"
+        key_columns = (requested[0] if requested else "index",)
+        key_types = (key_tp,)
+
+    residual = requested[len(key_columns):] if requested else ()
+    synthetic = key_kind != "scalar" or bool(residual)
+    index_columns = tuple(key_columns) + tuple(residual)
+    index = "index" if synthetic else key_columns[0]
+    key_schema = dict(zip(key_columns, key_types))
+    if synthetic:
+        key_schema = {"index": str, **key_schema}
+
+    if is_bundle(value_tp):
+        value_kind = "bundle"
+        value_fields = fields(value_tp)
+        value_schema = {
+            name: scalar_type(dereference(field_tp))
+            for name, field_tp in value_fields.items()
+        }
+        value_scalar = None
+    elif is_frame(value_tp):
+        value_kind = "frame"
+        row_schema = frame_schema(value_tp)
+        value_schema = fields(row_schema)
+        value_fields = value_schema
+        value_scalar = scalar_type(value_tp)
+    elif is_ts(value_tp) and is_compound_scalar(value_tp):
+        value_kind = "compound"
+        value_schema = fields(value_tp)
+        value_fields = value_schema
+        value_scalar = scalar_type(value_tp)
+    elif is_ts(value_tp):
+        value_kind = "scalar"
+        value_scalar = scalar_type(value_tp)
+        value_schema = {"value": value_scalar}
+        value_fields = value_schema
+    else:
+        raise TypeError(
+            "Perspective TSD values must be a TSB, scalar TS, compound-scalar TS, or Frame TS")
+
+    missing = tuple(name for name in residual if name not in value_schema)
+    if missing:
+        raise ValueError(
+            f"Perspective index column(s) {missing!r} are not present in the value schema")
+
+    return _PerspectiveRowPlan(
+        key_tp=key_tp,
+        value_tp=value_tp,
+        key_kind=key_kind,
+        key_columns=tuple(key_columns),
+        key_column_types=tuple(key_types),
+        residual_index_columns=tuple(residual),
+        index_columns=index_columns,
+        index=index,
+        synthetic_index=synthetic,
+        key_schema=key_schema,
+        value_schema=dict(value_schema),
+        value_kind=value_kind,
+        value_fields=tuple(value_fields),
+        value_scalar=value_scalar,
+    )
 
 
 @sink_node
-def _publish_table(
+def _publish_table_node(
     ts: TSD[K, TIME_SERIES_TYPE],
     name: str,
-    index_col_name: str,
-    editable: bool,
-    edit_role: str,
-    history: int,
-    manager: object,
+    plan: object,
+    editable: bool = False,
+    edit_role: str = None,
+    empty_row: bool = False,
+    history: int = None,
+    ec: EvaluationClock = None,
+    state: STATE = None,
 ):
-    rows = []
-    history_rows = []
+    data = []
+    history_data = []
+
+    for key in ts.removed_keys():
+        previous = state.key_tracker.pop(key, set() if plan.multi_row else None)
+        if plan.multi_row:
+            state.removed.update(previous)
+        elif previous is not None:
+            state.removed.add(previous)
+
     for key, child in ts.modified_items():
-        child_rows = _value_rows(child.value)
-        for child_row in child_rows:
-            row, index = _with_key(child_row, key, index_col_name)
+        rows = []
+        for value_row in plan.rows(child):
+            row = plan.add_index({**plan.process_key(key), **value_row})
             rows.append(row)
             if history is not None:
-                history_rows.append({**row, "time": child.last_modified_time})
-    removals = list(ts.removed_keys())
-    manager.update_table(
-        name,
-        rows,
-        removals,
-        index=_perspective_index(index_col_name),
-        editable=editable,
-        edit_role=edit_role,
-    )
-    if history is not None and history_rows:
-        manager.update_table(
-            f"{name}_history",
-            history_rows[-history:] if history > 0 else history_rows,
-            index=None,
+                sample = plan.add_index({
+                    **plan.process_key(key),
+                    **plan.sample_row(child, value_row),
+                    "time": ec.now,
+                })
+                history_data.append(sample)
+
+        indices = {plan.row_index(row) for row in rows}
+        previous = state.key_tracker.get(key, set() if plan.multi_row else None)
+        if plan.multi_row:
+            state.removed.update(previous - indices)
+            state.key_tracker[key] = indices
+        elif indices:
+            new_index = next(iter(indices))
+            if previous is not None and previous != new_index:
+                state.removed.add(previous)
+            state.key_tracker[key] = new_index
+        state.removed.difference_update(indices)
+
+        if empty_row:
+            for row in rows:
+                logical = tuple(row[column] for column in plan.index_columns)
+                row["_id"] = state.index_to_id[logical]
+        data.extend(rows)
+
+    if data or state.removed:
+        state.manager.update_table(name, data, state.removed)
+    if history is not None and history_data:
+        if history == 0:
+            state.manager.replace_table(f"{name}_history", history_data)
+        else:
+            state.manager.update_table(f"{name}_history", history_data)
+    state.removed.clear()
+
+
+@_publish_table_node.start
+def _start_publish_table_node(
+    name: str,
+    plan: object,
+    editable: bool,
+    edit_role: str,
+    empty_row: bool,
+    history: int,
+    state: STATE = None,
+    _global_state: GlobalState = None,
+):
+    if history is not None and history < 0:
+        raise ValueError("Perspective history must be None or a non-negative integer")
+    if empty_row and plan.multi_row:
+        raise ValueError("Perspective empty-row editing is not supported for Frame values")
+
+    manager = PerspectiveTablesManager.current(_global_state)
+    if name in manager.get_table_names():
+        raise ValueError(f"Perspective table {name!r} already exists")
+    state.manager = manager
+    state.key_tracker = defaultdict(set) if plan.multi_row else {}
+    state.removed = set()
+
+    schema = {**plan.key_schema, **plan.value_schema}
+    if empty_row:
+        running_id = iter(range(1, 2**63))
+        state.index_to_id = defaultdbldict(lambda: next(running_id))
+        state.index_to_id_lock = threading.Lock()
+        _global_state[f"perspective_table_index_to_id_{name}"] = {
+            "mapping": state.index_to_id,
+            "lock": state.index_to_id_lock,
+        }
+        table = manager.create_table(
+            {"_id": int, **schema}, index="_id", name=name,
+            editable=editable, edit_role=edit_role,
+        )
+        key = plan.empty_key()
+        table.update([{"_id": 0, **plan.process_key(key)}])
+    else:
+        manager.create_table(
+            schema, index=plan.index, name=name,
+            editable=editable, edit_role=edit_role,
+        )
+
+    if history is not None:
+        manager.create_table(
+            {"time": datetime, **schema},
+            limit=history if history > 0 else None,
+            name=f"{name}_history", user=False,
         )
 
 
-def _value_rows(value):
-    if isinstance(value, pa.Table):
-        return value.to_pylist()
-    if isinstance(value, pa.RecordBatch):
-        return value.to_pylist()
-    if is_dataclass(value):
-        return [asdict(value)]
-    if isinstance(value, dict):
-        return [dict(value)]
-    return [{"value": value}]
-
-
-def _with_key(row, key, index_col_name):
-    names = tuple(name.strip() for name in index_col_name.split(",") if name.strip())
-    if not names:
-        names = ("index",)
-    if is_dataclass(key):
-        values = asdict(key)
-        keyed = {name: values[name] for name in names}
-    elif isinstance(key, tuple):
-        if len(names) != len(key):
-            raise ValueError("tuple Perspective keys require one index column name per element")
-        keyed = dict(zip(names, key))
-    else:
-        if len(names) != 1:
-            raise ValueError("scalar Perspective keys require exactly one index column name")
-        keyed = {names[0]: key}
-    if len(keyed) > 1:
-        keyed["index"] = ",".join(str(keyed[name]) for name in names)
-    return {**keyed, **row}, keyed.get("index", next(iter(keyed.values())))
-
-
-def _perspective_index(index_col_name):
-    names = tuple(name.strip() for name in index_col_name.split(",") if name.strip())
-    return names[0] if len(names) == 1 else "index"
-
-
-def _receive_table_edits(name, ts, index_col_name, manager):
-    ts_type = _unwrap(ts).ts_type
-    if not ts_type.is_tsd:
-        raise TypeError("editable Perspective tables require a TSD input")
-    key_type = _hgraph.tsd_key_vt(ts_type)
-    value_type = _hgraph.tsd_element_ts(ts_type)
-    edits_type = _hgraph.tsd(key_type, value_type)
-    removes_type = _hgraph.tss(key_type)
-    output_type = _TsExpr(
-        _hgraph.un_named_tsb_type(
-            [("edits", edits_type), ("removes", removes_type)]
-        ),
-        "TSB[TableEdits]",
+def _publish_table(
+    name,
+    ts,
+    editable=False,
+    edit_role=None,
+    empty_row=False,
+    index_col_name=None,
+    history=None,
+):
+    """Wire the native sink after deriving one immutable public-reflection plan."""
+    plan = _row_plan(ts.output_type, index_col_name)
+    _publish_table_node(
+        ts,
+        name=name,
+        plan=plan,
+        editable=editable,
+        edit_role=edit_role,
+        empty_row=empty_row,
+        history=history,
     )
-    subscription = {}
+    return plan
+
+
+class _SenderHolder:
+    sender = None
+
+
+@sink_node
+def _edit_subscription_lifetime(
+    value: TIME_SERIES_TYPE,
+    name: str,
+    plan: object,
+    empty_row: bool,
+    holder: object,
+):
+    pass
+
+
+@_edit_subscription_lifetime.start
+def _start_edit_subscription_lifetime(
+    name: str,
+    plan: object,
+    empty_row: bool,
+    holder: object,
+    state: STATE = None,
+    _global_state: GlobalState = None,
+):
+    manager = PerspectiveTablesManager.current(_global_state)
+
+    def receive(rows, removals=()):
+        edits = {}
+        removed = set(removals)
+        mapping_state = _global_state.get(
+            f"perspective_table_index_to_id_{name}") if empty_row else None
+
+        for original in rows:
+            row = dict(original)
+            key = plan.parse_key(row)
+            if empty_row:
+                row_id = row.get("_id")
+                if mapping_state:
+                    with mapping_state["lock"]:
+                        previous = mapping_state["mapping"].reverse_get(row_id)
+                    if previous is not None:
+                        previous_key = (
+                            previous[0] if plan.key_kind == "scalar"
+                            else tuple(previous)
+                        )
+                        if previous_key != key:
+                            removed.add(previous_key)
+                            removed.add(Removed(key))
+                if row_id != 0:
+                    edits[key] = plan.parse_value(row)
+                if row_id is not None and row_id < 0:
+                    manager.update_table(name, None, {row_id})
+                    if row_id % 2:
+                        removed.add(Removed(key))
+                    else:
+                        removed.add(key)
+                        edits.pop(key, None)
+            else:
+                edits[key] = plan.parse_value(row)
+
+        update = {}
+        if edits:
+            update["edits"] = edits
+        if removed:
+            update["removes"] = removed
+        if update:
+            holder.sender(update)
+
+    state.manager = manager
+    state.token = manager.subscribe_table_updates(name, receive)
+
+
+@_edit_subscription_lifetime.stop
+def _stop_edit_subscription_lifetime(
+    name: str,
+    state: STATE = None,
+):
+    token = getattr(state, "token", None)
+    if token is not None:
+        state.manager.unsubscribe_table_updates(name, token)
+        state.token = None
+
+
+def _receive_table_edits(name, ts, index_col_name=None, empty_row=False, plan=None):
+    """Wire a typed push source and lifecycle-owned Perspective subscription."""
+    plan = plan or _row_plan(ts.output_type, index_col_name)
+    if plan.multi_row:
+        raise TypeError("editable Perspective tables do not support Frame values")
+    output_type = TSB[TableEdits[plan.key_tp, plan.value_tp]]
+    holder = _SenderHolder()
 
     @push_queue(output_type)
-    def edits(sender):
-        def receive(rows, removals):
-            parsed = {}
-            for row in rows:
-                row = dict(row)
-                key = _edit_key(row, index_col_name)
-                parsed[key] = row["value"] if tuple(row) == ("value",) else row
-            update = {}
-            if parsed:
-                update["edits"] = parsed
-            if removals:
-                update["removes"] = frozenset(removals)
-            if update:
-                sender(update)
+    def edits(sender, sender_holder: object):
+        sender_holder.sender = sender
 
-        subscription["token"] = manager.subscribe_table_updates(name, receive)
-
-    @sink_node
-    def lifetime(value: output_type):
-        pass
-
-    @lifetime.stop
-    def stop():
-        token = subscription.pop("token", None)
-        if token is not None:
-            manager.unsubscribe_table_updates(name, token)
-
-    output = edits()
-    lifetime(output)
+    output = edits(holder)
+    _edit_subscription_lifetime(
+        output, name=name, plan=plan,
+        empty_row=empty_row, holder=holder,
+    )
     return output
-
-
-def _edit_key(row, index_col_name):
-    names = tuple(name.strip() for name in index_col_name.split(",") if name.strip())
-    if not names:
-        names = ("index",)
-    if len(names) == 1:
-        return row.pop(names[0])
-    values = tuple(row.pop(name) for name in names)
-    row.pop("index", None)
-    return values

--- a/python/hgraph/reflection.py
+++ b/python/hgraph/reflection.py
@@ -39,6 +39,9 @@ import _hgraph as _m
 
 from ._types import (
     _TSB_SCHEMA_CLASSES,
+    _TS_SCALAR_TYPES,
+    _VALUE_SCALAR_TYPES,
+    _FrameType,
     _TsExpr,
     _is_python_object_class,
     _structured_specialized_field_types,
@@ -64,6 +67,8 @@ __all__ = (
     "is_tss",
     "is_bundle",
     "is_compound_scalar",
+    "is_frame",
+    "frame_schema",
     "operator_overloads",
 )
 
@@ -123,7 +128,7 @@ def _wrap(handle):
 
 
 def _vt_to_py(vt):
-    py = _VT_TO_PY.get(vt)
+    py = _VALUE_SCALAR_TYPES.get(vt, _VT_TO_PY.get(vt))
     if py is None:
         reflected = _m.python_type_for_value(vt)
         if isinstance(reflected, type):
@@ -146,6 +151,9 @@ def scalar_type(t):
     if h.is_tss:
         return _vt_to_py(_m.vt_element(_m.ts_value_vt(h)))
     if h.is_ts:
+        declared = _TS_SCALAR_TYPES.get(h)
+        if declared is not None:
+            return declared
         structured_schema = getattr(t, "_structured_schema", None)
         if structured_schema is not None:
             return structured_schema
@@ -230,8 +238,20 @@ def fields(t):
     if h.is_tsb:
         return {name: _wrap(field) for name, field in _m.ts_field_types(h)}
     cs = getattr(t, "_cs_class", None)
+    if cs is None and h.is_ts:
+        declared = _TS_SCALAR_TYPES.get(h)
+        declared_origin = typing.get_origin(declared) or declared
+        if isinstance(declared_origin, type) and (
+            (dataclasses.is_dataclass(declared_origin)
+             and issubclass(declared_origin, CompoundScalar))
+            or _is_python_object_class(declared_origin)
+        ):
+            cs = declared_origin
+            t = declared
     if cs is not None:
         schema = getattr(t, "_structured_schema", cs)
+        if not hasattr(t, "_structured_schema"):
+            schema = t
         return dict(_structured_specialized_field_types(schema))
     raise TypeError(f"fields expects a TSB or compound-scalar type, got {t!r}")
 
@@ -295,9 +315,39 @@ def is_bundle(t):
 
 def is_compound_scalar(t):
     """``True`` for a compound-scalar class or a ``TS`` over either structured scalar policy."""
-    if isinstance(t, type):
-        return dataclasses.is_dataclass(t) and issubclass(t, CompoundScalar)
-    return _handle(t).is_ts and getattr(t, "_cs_class", None) is not None
+    import typing
+
+    def structured(value):
+        origin = typing.get_origin(value) or value
+        return isinstance(origin, type) and (
+            (dataclasses.is_dataclass(origin) and issubclass(origin, CompoundScalar))
+            or _is_python_object_class(origin)
+        )
+
+    if structured(t):
+        return True
+    try:
+        return is_ts(t) and structured(scalar_type(t))
+    except TypeError:
+        return False
+
+
+def is_frame(t):
+    """``True`` for ``Frame[Row]`` or ``TS[Frame[Row]]``."""
+    if isinstance(t, _FrameType):
+        return True
+    try:
+        return is_ts(t) and isinstance(scalar_type(t), _FrameType)
+    except TypeError:
+        return False
+
+
+def frame_schema(t):
+    """Return the row schema declared by ``Frame[Row]`` or ``TS[Frame[Row]]``."""
+    scalar = scalar_type(t) if not isinstance(t, _FrameType) else t
+    if not isinstance(scalar, _FrameType):
+        raise TypeError(f"frame_schema expects Frame[Row] or TS[Frame[Row]], got {t!r}")
+    return scalar.schema
 
 
 def operator_overloads(operator):

--- a/python/py_state_services.cpp
+++ b/python/py_state_services.cpp
@@ -309,13 +309,13 @@ namespace hgraph::python_bridge
               }
               else if (flavour == "service_adaptor")
               {
-                  if (!request.has_value() || !output.has_value())
+                  if (!request.has_value())
                   {
-                      throw nb::value_error("service adaptor requires request and output schemas");
+                      throw nb::value_error("service adaptor requires a request schema");
                   }
                   descriptor.flavour      = ServiceFlavour::ServiceAdaptor;
                   descriptor.input_schema = request->meta;
-                  descriptor.output_schema = output->meta;
+                  descriptor.output_schema = output.has_value() ? output->meta : nullptr;
               }
               else { throw nb::value_error("unknown service flavour"); }
               return PyServiceDesc{&intern_service_descriptor(std::move(descriptor))};
@@ -482,8 +482,10 @@ namespace hgraph::python_bridge
           },
           nb::arg("w"), nb::arg("impl"), nb::arg("inputs") = nb::list());
     m.def("service_adaptor_client", [](PyWiring &w, const PyServiceDesc &desc,
-                                        const std::string &path, const PyPort &in) {
-        return PyPort{service_adaptor_client(w.wiring_ref(), *desc.descriptor, path, in.ref)};
+                                        const std::string &path, const PyPort &in) -> nb::object {
+        WiringPortRef out = service_adaptor_client(
+            w.wiring_ref(), *desc.descriptor, path, in.ref);
+        return out.schema != nullptr ? nb::cast(PyPort{std::move(out)}) : nb::none();
     }, nb::arg("w"), nb::arg("desc"), nb::arg("path") = std::string{}, nb::arg("in"));
     m.def("service_adaptor_client_from_graph", [](PyWiring &w, const PyServiceDesc &desc,
                                                     const std::string &path, const PyPort &in,

--- a/python/py_wiring.cpp
+++ b/python/py_wiring.cpp
@@ -1069,9 +1069,9 @@ namespace hgraph::python_bridge
     nb::class_<PyWiring>(m, "Wiring", nb::is_weak_referenceable())
         .def(nb::init<>())
         .def(nb::init<GlobalState &>(), nb::arg("state"))
-        .def("_identity", [](const PyWiring &wiring) {
+        .def("identity", [](const PyWiring &wiring) {
             return wiring.raw->identity();
-        })
+        }, "Return the stable identity of the underlying C++ Wiring.")
         .def("_retain_cleanup", [](PyWiring &wiring, nb::object callback) {
             wiring.raw->retain_extension_state(
                 std::make_shared<PyWiringCleanup>(std::move(callback)));

--- a/python/py_wiring.cpp
+++ b/python/py_wiring.cpp
@@ -1039,6 +1039,9 @@ namespace hgraph::python_bridge
     nb::class_<PyWiring>(m, "Wiring", nb::is_weak_referenceable())
         .def(nb::init<>())
         .def(nb::init<GlobalState &>(), nb::arg("state"))
+        .def("_identity", [](const PyWiring &wiring) {
+            return wiring.raw->identity();
+        })
         .def("exception_time_series", &PyWiring::exception_time_series,
              nb::arg("port"), nb::arg("trace_back_depth") = 1,
              nb::arg("capture_values") = false)

--- a/python/py_wiring.cpp
+++ b/python/py_wiring.cpp
@@ -440,6 +440,36 @@ namespace
         return *registry;
     }
 
+    class PyWiringCleanup final
+    {
+      public:
+        explicit PyWiringCleanup(nb::object callback)
+            : callback_(callback.release().ptr())
+        {
+        }
+
+        PyWiringCleanup(const PyWiringCleanup &) = delete;
+        PyWiringCleanup &operator=(const PyWiringCleanup &) = delete;
+
+        ~PyWiringCleanup() noexcept
+        {
+            if (callback_ == nullptr) { return; }
+            nb::gil_scoped_acquire gil;
+            try
+            {
+                nb::borrow<nb::object>(nb::handle(callback_))();
+            }
+            catch (nb::python_error &error)
+            {
+                error.discard_as_unraisable("Wiring extension cleanup");
+            }
+            Py_DECREF(callback_);
+        }
+
+      private:
+        PyObject *callback_{nullptr};
+    };
+
     [[nodiscard]] WiringPortRef py_graph_fn_wire(const void *context, Wiring &w,
                                                  std::span<const WiringPortRef> args)
     {
@@ -1041,6 +1071,10 @@ namespace hgraph::python_bridge
         .def(nb::init<GlobalState &>(), nb::arg("state"))
         .def("_identity", [](const PyWiring &wiring) {
             return wiring.raw->identity();
+        })
+        .def("_retain_cleanup", [](PyWiring &wiring, nb::object callback) {
+            wiring.raw->retain_extension_state(
+                std::make_shared<PyWiringCleanup>(std::move(callback)));
         })
         .def("exception_time_series", &PyWiring::exception_time_series,
              nb::arg("port"), nb::arg("trace_back_depth") = 1,

--- a/python/tests/adaptors/perspective/test_perspective_adaptor.py
+++ b/python/tests/adaptors/perspective/test_perspective_adaptor.py
@@ -7,6 +7,7 @@ import json
 import pytest
 import threading
 import time
+import tornado.web
 
 import hgraph as hg
 from hgraph.adaptors.perspective import (
@@ -17,6 +18,7 @@ from hgraph.adaptors.perspective import (
     publish_table_editable,
     register_perspective_adaptors,
 )
+from hgraph.adaptors.perspective._perspective import _workspace_layout_target
 
 
 @dataclass(frozen=True)
@@ -172,6 +174,41 @@ def test_perspective_public_surface_matches_the_python_adaptor():
     for name, expected in manager_methods.items():
         assert tuple(inspect.signature(
             getattr(PerspectiveTablesManager, name)).parameters) == expected
+
+
+@pytest.mark.parametrize("url", [
+    "../outside",
+    "/tmp/outside",
+    "nested/layout",
+    r"nested\layout",
+    "%2e%2e%2foutside",
+    "%252e%252e%252foutside",
+])
+def test_workspace_layout_paths_cannot_escape_the_layouts_directory(tmp_path, url):
+    with pytest.raises(tornado.web.HTTPError) as error:
+        _workspace_layout_target(tmp_path, url)
+    assert error.value.status_code == 400
+
+
+def test_workspace_layout_path_resolves_inside_the_layouts_directory(tmp_path):
+    name, target = _workspace_layout_target(tmp_path, "dashboard")
+    assert name == "dashboard"
+    assert target == tmp_path.resolve() / "dashboard.json"
+
+
+def test_workspace_layout_path_rejects_a_symlink_outside_the_layouts_directory(tmp_path):
+    layouts = tmp_path / "layouts"
+    layouts.mkdir()
+    outside = tmp_path / "outside.json"
+    outside.write_text("private")
+    try:
+        (layouts / "dashboard.json").symlink_to(outside)
+    except OSError:
+        pytest.skip("deviation: symlinks are unavailable on this platform")
+
+    with pytest.raises(tornado.web.HTTPError) as error:
+        _workspace_layout_target(layouts, "dashboard")
+    assert error.value.status_code == 400
 
 
 def test_manager_configuration_stats_callbacks_and_temporary_cleanup(tmp_path):

--- a/python/tests/adaptors/perspective/test_perspective_adaptor.py
+++ b/python/tests/adaptors/perspective/test_perspective_adaptor.py
@@ -1,7 +1,22 @@
 from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+
+import pyarrow as pa
+import inspect
+import json
+import pytest
+import threading
+import time
 
 import hgraph as hg
-from hgraph.adaptors.perspective import PerspectiveTablesManager, publish_table
+from hgraph.adaptors.perspective import (
+    PerspectiveTablesManager,
+    TableEdits,
+    publish_multitable,
+    publish_table,
+    publish_table_editable,
+    register_perspective_adaptors,
+)
 
 
 @dataclass(frozen=True)
@@ -11,9 +26,14 @@ class _Row(hg.CompoundScalar):
 
 
 class _Table:
-    def __init__(self, rows):
-        self.updates = [list(rows)]
+    def __init__(self, rows, index=None):
+        self.definition = rows
+        self.index = index
+        self.updates = [] if isinstance(rows, dict) else [list(rows)]
         self.removals = []
+        self.replacements = []
+        self.num_views = 0
+        self.deleted = False
 
     def update(self, rows):
         self.updates.append(list(rows))
@@ -21,13 +41,28 @@ class _Table:
     def remove(self, keys):
         self.removals.append(list(keys))
 
+    def replace(self, rows):
+        self.replacements.append(list(rows))
+
+    def schema(self):
+        return self.definition if isinstance(self.definition, dict) else {}
+
+    def get_index(self):
+        return self.index
+
+    def get_num_views(self):
+        return self.num_views
+
+    def delete(self):
+        self.deleted = True
+
 
 class _Client:
     def __init__(self):
         self.tables = {}
 
     def table(self, rows, *, name, **kwargs):
-        table = _Table(rows)
+        table = _Table(rows, kwargs.get("index"))
         self.tables[name] = (table, kwargs)
         return table
 
@@ -38,6 +73,7 @@ def test_publish_table_applies_tsd_add_modify_and_remove_deltas_with_eval_node()
 
     @hg.graph
     def app(rows: hg.TSD[int, hg.TS[_Row]]):
+        register_perspective_adaptors()
         publish_table("rows", rows, index_col_name="id")
 
     with hg.GlobalContext(hg.GlobalState()):
@@ -63,6 +99,27 @@ def test_publish_table_applies_tsd_add_modify_and_remove_deltas_with_eval_node()
     assert table.removals == [[1]]
 
 
+def test_publish_table_operates_against_the_supported_perspective_client():
+    pytest.importorskip("perspective")
+    manager = PerspectiveTablesManager()
+
+    @hg.graph
+    def app(rows: hg.TSD[int, hg.TS[int]]):
+        register_perspective_adaptors()
+        publish_table("live_rows", rows, index_col_name="id")
+
+    with hg.GlobalContext(hg.GlobalState()):
+        PerspectiveTablesManager.set_current(manager)
+        hg.eval_node(app, [{1: 10}, {1: 11, 2: 20}, {1: hg.REMOVE}])
+
+    view = manager.get_table("live_rows").view()
+    try:
+        assert view.to_records() == [{"id": 2, "value": 20}]
+    finally:
+        view.delete()
+        manager.close()
+
+
 def test_manager_edit_callbacks_do_not_require_perspective_to_be_installed():
     manager = PerspectiveTablesManager(_Client())
     updates = []
@@ -74,3 +131,278 @@ def test_manager_edit_callbacks_do_not_require_perspective_to_be_installed():
     manager.publish_edits("rows", [{"id": 2}], ())
 
     assert updates == [([{"id": 1, "value": 2}], [3])]
+
+
+def test_manager_current_honours_an_empty_injected_global_state():
+    state = hg.GlobalState()
+    manager = PerspectiveTablesManager(_Client())
+
+    PerspectiveTablesManager.set_current(manager, state)
+
+    assert PerspectiveTablesManager.current(state) is manager
+
+
+def test_perspective_public_surface_matches_the_python_adaptor():
+    import hgraph.adaptors.perspective as perspective_api
+
+    assert perspective_api.__all__ == [
+        "perspective_web", "PerspectiveTablesManager", "TablePageHandler",
+        "IndexPageHandler", "TableEdits", "defaultdbldict", "publish_table",
+        "publish_table_editable", "publish_multitable", "publish_table_impl",
+        "publish_table_editable_impl", "publish_multitable_impl",
+        "register_perspective_adaptors",
+    ]
+    assert tuple(inspect.signature(publish_table).parameters) == (
+        "path", "ts", "index_col_name", "history")
+    assert tuple(inspect.signature(perspective_api.publish_table_editable).parameters) == (
+        "path", "ts", "index_col_name", "history", "edit_role", "empty_row")
+    assert tuple(inspect.signature(publish_multitable).parameters) == (
+        "path", "key", "ts", "unique", "index_col_name", "history")
+    assert not hasattr(perspective_api, "_publish_table")
+    assert not hasattr(perspective_api, "_receive_table_edits")
+
+    manager_methods = {
+        "create_table": ("self", "args", "name", "editable", "user",
+                         "edit_role", "temporary", "kwargs"),
+        "add_table": ("self", "name", "table", "editable", "user",
+                      "edit_role", "temporary"),
+        "update_table": ("self", "name", "data", "removals"),
+        "subscribe_table_updates": ("self", "name", "cb", "self_updates"),
+    }
+    for name, expected in manager_methods.items():
+        assert tuple(inspect.signature(
+            getattr(PerspectiveTablesManager, name)).parameters) == expected
+
+
+def test_manager_configuration_stats_callbacks_and_temporary_cleanup(tmp_path):
+    table_config = tmp_path / "tables.json"
+    table_config.write_text(json.dumps({"from_file": {"plugin": "Datagrid"}}))
+    view_config = tmp_path / "views.json"
+    view_config.write_text(json.dumps({"summary": {
+        "table": "rows", "group_by": ["name"],
+    }}))
+    manager = PerspectiveTablesManager(
+        client=_Client(),
+        table_config_file=table_config,
+        table_configs={"inline": json.dumps({
+            "from_inline": {"columns": ["value"]},
+        })},
+        view_config_file=view_config,
+    )
+
+    assert manager.read_table_config() == {
+        "from_file": {"plugin": "Datagrid"},
+        "from_inline": {"columns": ["value"]},
+    }
+    manager.add_table_configs({
+        "second": json.dumps({"second": {"plugin": "X Bar"}}),
+    })
+    assert manager.read_table_config()["second"] == {"plugin": "X Bar"}
+    assert manager.get_view_names() == ["summary"]
+    assert manager.get_view("summary")["table"] == "rows"
+
+    manager.start()
+    assert {"index", "table_stats"} <= set(manager.get_table_names())
+    manager.create_table(
+        {"id": int, "value": int}, name="rows", index="id")
+    manager.update_table("rows", [{"id": 1, "value": 2}])
+    assert manager.get_stats()["updates"] == 1
+    assert manager.get_stats()["rows"] == 1
+
+    callbacks = []
+    manager.set_loop_callback(
+        lambda prefix, fn, *args, **kwargs:
+        (callbacks.append(prefix), fn(*args, **kwargs))[1],
+        "loop",
+    )
+    manager.update_table("rows", [{"id": 1, "value": 3}])
+    assert callbacks == ["loop"]
+
+    temporary = manager.create_table(
+        {"id": int}, name="temporary", index="id", temporary=True)
+    temporary.num_views = 1
+    manager.cleanup_temporary_tables()
+    temporary.num_views = 0
+    manager.cleanup_temporary_tables()
+    assert temporary.deleted
+    assert "temporary" not in manager.get_table_names()
+
+
+@dataclass(frozen=True)
+class _Key(hg.CompoundScalar):
+    desk: str
+    book: int
+
+
+class _Bundle(hg.TimeSeriesSchema):
+    name: hg.TS[str]
+    value: hg.TS[int]
+
+
+def test_publish_table_supports_tuple_and_compound_keys_and_bundle_values():
+    client = _Client()
+    manager = PerspectiveTablesManager(client)
+
+    @hg.graph
+    def tuple_rows(rows: hg.TSD[tuple[int, str], hg.TSB[_Bundle]]):
+        register_perspective_adaptors()
+        publish_table("tuple_rows", rows, index_col_name="number,code")
+
+    with hg.GlobalContext(hg.GlobalState()):
+        PerspectiveTablesManager.set_current(manager)
+        hg.eval_node(tuple_rows, [{(1, "A"): {"name": "one", "value": 10}}])
+
+    table, options = client.tables["tuple_rows"]
+    assert options["index"] == "index"
+    assert table.updates == [[{
+        "index": "1,A", "number": 1, "code": "A",
+        "name": "one", "value": 10,
+    }]]
+
+    client = _Client()
+    manager = PerspectiveTablesManager(client)
+
+    @hg.graph
+    def compound_rows(rows: hg.TSD[_Key, hg.TS[int]]):
+        register_perspective_adaptors()
+        publish_table("compound_rows", rows, index_col_name="desk,book")
+
+    with hg.GlobalContext(hg.GlobalState()):
+        PerspectiveTablesManager.set_current(manager)
+        hg.eval_node(compound_rows, [{_Key("LDN", 7): 42}])
+
+    table, options = client.tables["compound_rows"]
+    assert options["index"] == "index"
+    assert table.updates == [[{
+        "index": "LDN,7", "desk": "LDN", "book": 7, "value": 42,
+    }]]
+
+
+def test_publish_table_supports_frame_rows_and_residual_index_columns():
+    client = _Client()
+    manager = PerspectiveTablesManager(client)
+
+    @hg.graph
+    def app(rows: hg.TSD[int, hg.TS[hg.Frame[_Row]]]):
+        register_perspective_adaptors()
+        publish_table("frame_rows", rows, index_col_name="id,name")
+
+    frame = pa.Table.from_pylist([
+        {"name": "a", "value": 1},
+        {"name": "b", "value": 2},
+    ])
+    with hg.GlobalContext(hg.GlobalState()):
+        PerspectiveTablesManager.set_current(manager)
+        hg.eval_node(app, [{7: frame}, {7: pa.Table.from_pylist([
+            {"name": "b", "value": 3},
+        ])}])
+
+    table, options = client.tables["frame_rows"]
+    assert options["index"] == "index"
+    assert table.updates[0] == [
+        {"index": "7,a", "id": 7, "name": "a", "value": 1},
+        {"index": "7,b", "id": 7, "name": "b", "value": 2},
+    ]
+    assert table.updates[1] == [
+        {"index": "7,b", "id": 7, "name": "b", "value": 3},
+    ]
+    assert table.removals == [["7,a"]]
+
+
+def test_publish_multitable_combines_multiple_clients_without_a_reply_channel():
+    client = _Client()
+    manager = PerspectiveTablesManager(client)
+
+    @hg.graph
+    def app(
+        left_key: hg.TS[int], left: hg.TS[_Row],
+        right_key: hg.TS[int], right: hg.TS[_Row],
+    ) -> hg.TS[int]:
+        register_perspective_adaptors()
+        publish_multitable(
+            "shared", left_key, left, unique=True, index_col_name="id")
+        publish_multitable(
+            "shared", right_key, right, unique=True, index_col_name="id")
+        return left_key
+
+    with hg.GlobalContext(hg.GlobalState()):
+        PerspectiveTablesManager.set_current(manager)
+        assert hg.eval_node(
+            app,
+            [1, 1, 1], [_Row("a", 1), _Row("a", 2), _Row("a", 3)],
+            [2, 2, 2], [_Row("b", 10), _Row("b", 20), _Row("b", 30)],
+        ) == [1, 1, 1]
+
+    table, options = client.tables["shared"]
+    assert options["index"] == "id"
+    assert table.updates == [
+        [
+            {"id": 1, "name": "a", "value": 1},
+            {"id": 2, "name": "b", "value": 10},
+        ],
+        [
+            {"id": 1, "name": "a", "value": 2},
+            {"id": 2, "name": "b", "value": 20},
+        ],
+        [
+            {"id": 1, "name": "a", "value": 3},
+            {"id": 2, "name": "b", "value": 30},
+        ],
+    ]
+
+
+def test_editable_table_emits_typed_feedback_and_unsubscribes_on_stop():
+    client = _Client()
+    manager = PerspectiveTablesManager(client)
+    received = []
+    threads = []
+
+    @hg.push_queue(hg.TSD[int, hg.TS[_Row]])
+    def rows(sender):
+        def feed():
+            deadline = time.monotonic() + 2.0
+            while "editable" not in manager.get_table_names():
+                if time.monotonic() >= deadline:
+                    return
+                time.sleep(0.01)
+            time.sleep(0.05)
+            sender({1: _Row("initial", 1)})
+            manager.publish_edits(
+                "editable",
+                [{"id": 1, "name": "edited", "value": 2}],
+                [3],
+            )
+
+        thread = threading.Thread(target=feed)
+        threads.append(thread)
+        thread.start()
+
+    @hg.sink_node
+    def capture(value: hg.TSB[TableEdits[int, hg.TS[_Row]]]):
+        edits = {
+            key: child.value
+            for key, child in value.edits.modified_items()
+        }
+        removes = set(value.removes.added()) if value.removes.modified else set()
+        if edits or removes:
+            received.append((edits, removes))
+
+    @hg.graph
+    def app():
+        register_perspective_adaptors()
+        capture(publish_table_editable(
+            "editable", rows(), index_col_name="id"))
+
+    with hg.GlobalContext(hg.GlobalState()):
+        PerspectiveTablesManager.set_current(manager)
+        hg.run_graph(
+            app,
+            run_mode=hg.EvaluationMode.REAL_TIME,
+            end_time=datetime.now(timezone.utc).replace(tzinfo=None)
+            + timedelta(seconds=0.5),
+        )
+    for thread in threads:
+        thread.join(timeout=1.0)
+
+    assert received == [({1: _Row("edited", 2)}, {3})]
+    assert not manager._subscribers["editable"]

--- a/python/tests/test_hgraph_api.py
+++ b/python/tests/test_hgraph_api.py
@@ -1450,6 +1450,19 @@ def test_adaptor_client_scalar_options_reach_the_registered_implementation():
     check(observed == [("scaled", 20), ("scaled", 30)],
           f"configured adaptor options: {observed}")
 
+    observed.clear()
+
+    @graph
+    def default_path(value: TS[int]) -> TS[int]:
+        hg.register_adaptor(None, configured_publish_impl)
+        configured_publish(value, multiplier=5, label="default")
+        return value
+
+    check(eval_node(default_path, [2, 3]) == [2, 3],
+          "default-path configured adaptor passthrough")
+    check(observed == [("default", 10), ("default", 15)],
+          f"default-path configured adaptor options: {observed}")
+
     @graph
     def conflicting(value: TS[int]) -> TS[int]:
         hg.register_adaptor("conflicting-publish", configured_publish_impl)
@@ -1462,6 +1475,58 @@ def test_adaptor_client_scalar_options_reach_the_registered_implementation():
         check(False, "expected conflicting client options")
     except hg.WiringError as error:
         check("disagree" in str(error), f"unexpected scalar option error: {error}")
+
+
+def test_adaptor_client_config_follows_cxx_first_wiring_lifetime():
+    # C++-first wiring enters Python through a borrowed wrapper without an
+    # owning Python Wiring at the bottom of the stack. The scalar config must
+    # survive that wrapper and be released with the underlying C++ Wiring.
+    import _hgraph
+    import gc
+    from hgraph._wiring import _wiring_stack
+    from hgraph._wiring._services import _ADAPTOR_CLIENT_CONFIGS
+
+    built_config = []
+
+    @hg.service_adaptor
+    def configured_service(
+        value: TS[int], multiplier: int, label: str = "value",
+    ) -> TS[int]: ...
+
+    @hg.service_adaptor_impl(interfaces=configured_service)
+    def configured_service_impl(
+        value: TSD[int, TS[int]], multiplier: int, label: str = "value",
+    ) -> TSD[int, TS[int]]:
+        built_config.append((multiplier, label))
+        return value
+
+    @hg.operator
+    def cxx_first_client(value: TS[int]) -> TS[int]: ...
+
+    @hg.graph(overloads=cxx_first_client)
+    def cxx_first_client_impl(value: TS[int]) -> TS[int]:
+        return configured_service(
+            value, multiplier=6, label="cxx", path="cxx-first-configured")
+
+    wiring = _hgraph.Wiring()
+    _wiring_stack.append(wiring)
+    try:
+        hg.register_adaptor("cxx-first-configured", configured_service_impl)
+    finally:
+        _wiring_stack.pop()
+    source = wiring.wire("nothing", output_type=TS[int].handle)
+    client = wiring.wire(cxx_first_client._registry_name, (source,), {})
+    wiring_identity = wiring._identity()
+    check(any(key[0] == wiring_identity for key in _ADAPTOR_CLIENT_CONFIGS),
+          "C++-first adaptor config was not retained")
+    wiring.build_services()
+    check(built_config == [(6, "cxx")],
+          f"C++-first adaptor config: {built_config}")
+
+    del client, source, wiring
+    gc.collect()
+    check(not any(key[0] == wiring_identity for key in _ADAPTOR_CLIENT_CONFIGS),
+          "C++-first adaptor config outlived its Wiring")
 
 
 def test_generic_adaptor_specializations_from_python():

--- a/python/tests/test_hgraph_api.py
+++ b/python/tests/test_hgraph_api.py
@@ -1372,6 +1372,98 @@ def test_service_adaptor_explicit_request_id_client_split():
     check(out == [None, 1, None, 2], f"split service adaptor client: {out}")
 
 
+def test_sink_only_service_adaptor_from_python():
+    published = []
+    key_snapshot = {}
+    value_snapshot = {}
+
+    @hg.service_adaptor
+    def publish(key: TS[str], value: TS[int]) -> None: ...
+
+    @hg.sink_node
+    def capture(
+        keys: TSD[int, TS[str]], values: TSD[int, TS[int]]
+    ):
+        if keys.modified or values.modified:
+            key_snapshot.update(
+                (request_id, value.value)
+                for request_id, value in keys.modified_items())
+            value_snapshot.update(
+                (request_id, value.value)
+                for request_id, value in values.modified_items())
+            for request_id in value_snapshot:
+                key_snapshot[request_id] = keys[request_id].value
+            published.append((dict(key_snapshot), dict(value_snapshot)))
+
+    @hg.service_adaptor_impl(interfaces=publish)
+    def publish_impl(
+        key: TSD[int, TS[str]], value: TSD[int, TS[int]]
+    ) -> None:
+        capture(key, value)
+
+    @graph
+    def two_publishers(lhs: TS[int], rhs: TS[int]) -> TS[int]:
+        hg.register_adaptor("publish", publish_impl)
+        publish(hg.const("lhs", tp=TS[str]), lhs, path="publish")
+        publish(hg.const("rhs", tp=TS[str]), rhs, path="publish")
+        return lhs + rhs
+
+    out = eval_node(two_publishers, [1, 2], [10, 20])
+    check(out == [11, 22], f"sink service adaptor passthrough: {out}")
+    check(len(published) == 2, f"sink service adaptor cycles: {published}")
+    check(all(set(keys.values()) == {"lhs", "rhs"}
+              for keys, _ in published),
+          f"sink service adaptor static keys: {published}")
+    check([sorted(values.values()) for _, values in published]
+          == [[1, 10], [2, 20]],
+          f"sink service adaptor values: {published}")
+
+
+def test_adaptor_client_scalar_options_reach_the_registered_implementation():
+    observed = []
+
+    @hg.adaptor
+    def configured_publish(
+        value: TS[int], multiplier: int, label: str = "value",
+    ) -> None: ...
+
+    @hg.sink_node
+    def capture_configured(value: TS[int], multiplier: int, label: str):
+        observed.append((label, value.value * multiplier))
+
+    @hg.adaptor_impl(interfaces=configured_publish)
+    def configured_publish_impl(
+        value: TS[int], multiplier: int, label: str = "value",
+    ) -> None:
+        capture_configured(value, multiplier, label)
+
+    @graph
+    def app(value: TS[int]) -> TS[int]:
+        hg.register_adaptor("configured-publish", configured_publish_impl)
+        configured_publish(
+            value, multiplier=10, label="scaled",
+            path="configured-publish",
+        )
+        return value
+
+    check(eval_node(app, [2, 3]) == [2, 3], "configured adaptor passthrough")
+    check(observed == [("scaled", 20), ("scaled", 30)],
+          f"configured adaptor options: {observed}")
+
+    @graph
+    def conflicting(value: TS[int]) -> TS[int]:
+        hg.register_adaptor("conflicting-publish", configured_publish_impl)
+        configured_publish(value, multiplier=2, path="conflicting-publish")
+        configured_publish(value, multiplier=3, path="conflicting-publish")
+        return value
+
+    try:
+        eval_node(conflicting, [1])
+        check(False, "expected conflicting client options")
+    except hg.WiringError as error:
+        check("disagree" in str(error), f"unexpected scalar option error: {error}")
+
+
 def test_generic_adaptor_specializations_from_python():
     from typing import TypeVar
 

--- a/python/tests/test_hgraph_api.py
+++ b/python/tests/test_hgraph_api.py
@@ -1516,7 +1516,11 @@ def test_adaptor_client_config_follows_cxx_first_wiring_lifetime():
         _wiring_stack.pop()
     source = wiring.wire("nothing", output_type=TS[int].handle)
     client = wiring.wire(cxx_first_client._registry_name, (source,), {})
-    wiring_identity = wiring._identity()
+    wiring_identity = wiring.identity()
+    check(isinstance(wiring_identity, int) and wiring_identity > 0,
+          f"invalid public Wiring identity: {wiring_identity!r}")
+    check(wiring.identity() == wiring_identity,
+          "public Wiring identity changed during its lifetime")
     check(any(key[0] == wiring_identity for key in _ADAPTOR_CLIENT_CONFIGS),
           "C++-first adaptor config was not retained")
     wiring.build_services()

--- a/python/tests/test_reflection.py
+++ b/python/tests/test_reflection.py
@@ -5,18 +5,22 @@ family (see ``docs/source/developer_guide/type_reflection.rst``).
 """
 
 from dataclasses import dataclass
+from typing import Generic
 
 import pytest
 
-from hgraph import (REF, TS, TSB, TSD, TSL, TSS, TS_SCHEMA, CompoundScalar,
-                    TimeSeriesSchema, compute_node, graph, operator)
+from hgraph import (Frame, K, REF, TIME_SERIES_TYPE, TS, TSB, TSD, TSL, TSS,
+                    TS_SCHEMA, CompoundScalar, TimeSeriesSchema, compute_node,
+                    graph, operator)
 from hgraph.reflection import (
     bundle_schema_type,
     dereference,
     element_type,
     fields,
+    frame_schema,
     is_bundle,
     is_compound_scalar,
+    is_frame,
     is_reference,
     is_ts,
     is_tsd,
@@ -83,6 +87,52 @@ def test_fields_tsb():
     f = fields(TSB[MyB])
     assert f == {"a": TS[int], "b": TS[str]}
     assert list(f) == ["a", "b"]  # ordered
+
+
+def test_fields_mixed_scalar_and_time_series_generic_tsb():
+    class Edits(TimeSeriesSchema, Generic[K, TIME_SERIES_TYPE]):
+        edits: TSD[K, TIME_SERIES_TYPE]
+        removes: TSS[K]
+
+    concrete = TSB[Edits[int, TS[str]]]
+
+    assert fields(concrete) == {
+        "edits": TSD[int, TS[str]],
+        "removes": TSS[int],
+    }
+    assert repr(TSB[Edits[K, TIME_SERIES_TYPE]]) == "TSB[Edits]"
+
+
+def test_mixed_generic_tsb_rejects_cross_kind_specialization():
+    class Edits(TimeSeriesSchema, Generic[K, TIME_SERIES_TYPE]):
+        edits: TSD[K, TIME_SERIES_TYPE]
+        removes: TSS[K]
+
+    with pytest.raises(TypeError, match="scalar schema parameter"):
+        TSB[Edits[TS[int], TS[str]]]
+    with pytest.raises(TypeError, match="time-series schema parameter"):
+        TSB[Edits[int, str]]
+
+
+def test_container_key_reflection_preserves_the_declared_python_type():
+    key = tuple[int, str]
+
+    assert key_type(TSD[key, TS[int]]) == key
+    assert scalar_type(TSS[key]) == key
+
+
+def test_frame_reflection_preserves_the_row_schema():
+    @dataclass
+    class Row(CompoundScalar):
+        value: int
+
+    assert is_frame(Frame[Row])
+    assert is_frame(TS[Frame[Row]])
+    assert frame_schema(Frame[Row]) is Row
+    assert frame_schema(TS[Frame[Row]]) is Row
+    assert not is_frame(TS[int])
+    with pytest.raises(TypeError):
+        frame_schema(TS[int])
 
 
 def test_bundle_schema_type_preserves_nominal_schema():

--- a/src/hgraph/runtime/service_node.cpp
+++ b/src/hgraph/runtime/service_node.cpp
@@ -100,6 +100,7 @@ namespace hgraph
         {
             Int   request_id{0};
             Value delta{};
+            DateTime observed_at{};
             bool  remove{false};
         };
 
@@ -334,45 +335,43 @@ namespace hgraph
                 };
             }
 
-            void set(Int request_id, Value delta, DateTime schedule_time) const
+            void set(Int request_id, Value delta, DateTime schedule_time,
+                     DateTime observed_at) const
             {
                 auto &pending = source_storage_of(view_, *context_).pending;
-                const auto existing = std::ranges::find(
-                    pending, request_id, &RequestInputChange::request_id);
-                if (existing != pending.end())
+                if (std::ranges::any_of(pending, [&](const RequestInputChange &change) {
+                        return change.request_id == request_id
+                            && change.observed_at == observed_at;
+                    }))
                 {
-                    existing->delta  = std::move(delta);
-                    existing->remove = false;
+                    return;
                 }
-                else
-                {
-                    pending.push_back(RequestInputChange{
-                        .request_id = request_id,
-                        .delta      = std::move(delta),
-                        .remove     = false,
-                    });
-                }
+                pending.push_back(RequestInputChange{
+                    .request_id = request_id,
+                    .delta      = std::move(delta),
+                    .observed_at = observed_at,
+                    .remove     = false,
+                });
                 schedule(schedule_time);
             }
 
-            void remove(Int request_id, DateTime schedule_time) const
+            void remove(Int request_id, DateTime schedule_time,
+                        DateTime observed_at) const
             {
                 auto &pending = source_storage_of(view_, *context_).pending;
-                const auto existing = std::ranges::find(
-                    pending, request_id, &RequestInputChange::request_id);
-                if (existing != pending.end())
+                if (std::ranges::any_of(pending, [&](const RequestInputChange &change) {
+                        return change.request_id == request_id
+                            && change.observed_at == observed_at;
+                    }))
                 {
-                    existing->delta  = Value{};
-                    existing->remove = true;
+                    return;
                 }
-                else
-                {
-                    pending.push_back(RequestInputChange{
-                        .request_id = request_id,
-                        .delta      = Value{},
-                        .remove     = true,
-                    });
-                }
+                pending.push_back(RequestInputChange{
+                    .request_id = request_id,
+                    .delta      = Value{},
+                    .observed_at = observed_at,
+                    .remove     = true,
+                });
                 schedule(schedule_time);
             }
 
@@ -520,8 +519,18 @@ namespace hgraph
         {
             auto dict     = output.as_dict();
             auto mutation = dict.begin_mutation(evaluation_time);
+            std::vector<Int> applied_request_ids{};
+            std::vector<RequestInputChange> deferred{};
             for (RequestInputChange &change : storage.pending)
             {
+                if (std::ranges::find(applied_request_ids, change.request_id)
+                    != applied_request_ids.end())
+                {
+                    deferred.push_back(std::move(change));
+                    continue;
+                }
+                applied_request_ids.push_back(change.request_id);
+
                 Value request_id{change.request_id};
                 if (change.remove)
                 {
@@ -530,10 +539,12 @@ namespace hgraph
                 }
 
                 auto child = mutation.at(request_id.view());
-                apply_delta(TSOutputView{output.output(), child, evaluation_time}, change.delta.view());
+                apply_delta(
+                    TSOutputView{output.output(), child, evaluation_time},
+                    change.delta.view());
             }
             mutation.touch();
-            storage.pending.clear();
+            storage.pending = std::move(deferred);
         }
 
         bool subscription_key_source_evaluate_impl(const void *, const NodeView &view, DateTime evaluation_time)
@@ -562,6 +573,10 @@ namespace hgraph
             if (storage.pending.empty()) { return true; }
 
             apply_pending_request_input_changes(storage, view.output(evaluation_time), evaluation_time);
+            if (!storage.pending.empty())
+            {
+                view.graph().schedule_node(view.node_index(), evaluation_time + MIN_TD);
+            }
             return true;
         }
 
@@ -645,14 +660,19 @@ namespace hgraph
 
             if (request.valid())
             {
-                source.set(storage.request_id, capture_delta(request), schedule_time);
+                const bool first_value = !storage.live;
+                source.set(
+                    storage.request_id,
+                    first_value ? capture_current_delta(request) : capture_delta(request),
+                    schedule_time,
+                    evaluation_time);
                 storage.live = true;
                 return;
             }
 
             if (storage.live)
             {
-                source.remove(storage.request_id, schedule_time);
+                source.remove(storage.request_id, schedule_time, evaluation_time);
                 storage.live = false;
             }
         }
@@ -710,7 +730,8 @@ namespace hgraph
 
             initialize_request_capture(view, evaluation_time, storage);
             auto source = NodeView{storage.source}.as<RequestInputSourceView>();
-            source.remove(storage.request_id, evaluation_time + MIN_TD);
+            source.remove(
+                storage.request_id, evaluation_time + MIN_TD, evaluation_time);
             storage.live   = false;
             storage.source = NodePtr{};
             storage.input  = TSInputView{};

--- a/src/hgraph/runtime/service_node.cpp
+++ b/src/hgraph/runtime/service_node.cpp
@@ -339,11 +339,16 @@ namespace hgraph
                      DateTime observed_at) const
             {
                 auto &pending = source_storage_of(view_, *context_).pending;
-                if (std::ranges::any_of(pending, [&](const RequestInputChange &change) {
+                auto existing = std::ranges::find_if(
+                    pending, [&](const RequestInputChange &change) {
                         return change.request_id == request_id
                             && change.observed_at == observed_at;
-                    }))
+                    });
+                if (existing != pending.end())
                 {
+                    existing->delta  = std::move(delta);
+                    existing->remove = false;
+                    schedule(schedule_time);
                     return;
                 }
                 pending.push_back(RequestInputChange{
@@ -359,11 +364,16 @@ namespace hgraph
                         DateTime observed_at) const
             {
                 auto &pending = source_storage_of(view_, *context_).pending;
-                if (std::ranges::any_of(pending, [&](const RequestInputChange &change) {
+                auto existing = std::ranges::find_if(
+                    pending, [&](const RequestInputChange &change) {
                         return change.request_id == request_id
                             && change.observed_at == observed_at;
-                    }))
+                    });
+                if (existing != pending.end())
                 {
+                    existing->delta  = Value{};
+                    existing->remove = true;
+                    schedule(schedule_time);
                     return;
                 }
                 pending.push_back(RequestInputChange{

--- a/src/hgraph/types/graph_wiring.cpp
+++ b/src/hgraph/types/graph_wiring.cpp
@@ -1166,6 +1166,7 @@ struct Wiring::Impl {
   std::string service_materialization_path{};
   GlobalState global_state{};  // stateless-wiring fallback (no live context)
   bool live_seeded{false};
+  std::vector<std::shared_ptr<void>> extension_state{};
   std::shared_ptr<WiringObserverRegistry> observers{};
   std::vector<std::string> wiring_path{};
   WiringKind kind{WiringKind::TopLevel};
@@ -1334,6 +1335,13 @@ Wiring::Wiring(Wiring &&) noexcept = default;
 Wiring &Wiring::operator=(Wiring &&) noexcept = default;
 
 std::uint64_t Wiring::identity() const noexcept { return impl_->identity; }
+
+void Wiring::retain_extension_state(std::shared_ptr<void> state) {
+  if (state == nullptr) {
+    throw std::invalid_argument("Wiring extension state must not be null");
+  }
+  impl_->extension_state.push_back(std::move(state));
+}
 
 ErasedDelayedBindingWiringPort::ErasedDelayedBindingWiringPort(
     Wiring &wiring, const TSValueTypeMetaData *schema) {

--- a/src/hgraph/types/graph_wiring.cpp
+++ b/src/hgraph/types/graph_wiring.cpp
@@ -7,6 +7,7 @@
 
 #include <algorithm>
 #include <array>
+#include <atomic>
 #include <cstdint>
 #include <deque>
 #include <stdexcept>
@@ -18,6 +19,8 @@
 
 namespace hgraph {
 namespace {
+std::atomic<std::uint64_t> next_wiring_identity{1};
+
 // Interning key: node definition identity (typeid of the static node type)
 // + input edges by (producing instance, source path, target path) + the scalar
 // configuration values. The output schema is implied by the node + path, so it
@@ -1083,6 +1086,8 @@ struct WiringObserverRegistry {
 };
 
 struct Wiring::Impl {
+  const std::uint64_t identity{next_wiring_identity.fetch_add(
+      1, std::memory_order_relaxed)};
   std::unordered_set<std::string> component_ids; // claimed recordable ids
 
   explicit Impl(WiringKind wiring_kind,
@@ -1327,6 +1332,8 @@ void Wiring::claim_component_id(std::string_view fq_recordable_id) {
 Wiring::~Wiring() = default;
 Wiring::Wiring(Wiring &&) noexcept = default;
 Wiring &Wiring::operator=(Wiring &&) noexcept = default;
+
+std::uint64_t Wiring::identity() const noexcept { return impl_->identity; }
 
 ErasedDelayedBindingWiringPort::ErasedDelayedBindingWiringPort(
     Wiring &wiring, const TSValueTypeMetaData *schema) {

--- a/src/hgraph/types/service_runtime.cpp
+++ b/src/hgraph/types/service_runtime.cpp
@@ -776,7 +776,11 @@ namespace hgraph
                     break;
                 case ServiceFlavour::ServiceAdaptor:
                     required_endpoints.push_back(WiringServiceImplementationEndpoint{base + "/from_graph", {}});
-                    required_endpoints.push_back(WiringServiceImplementationEndpoint{base + "/to_graph", {}});
+                    if (descriptor->output_schema != nullptr)
+                    {
+                        required_endpoints.push_back(
+                            WiringServiceImplementationEndpoint{base + "/to_graph", {}});
+                    }
                     break;
                 case ServiceFlavour::Adaptor:
                     append_adaptor_required_endpoints(
@@ -1210,14 +1214,16 @@ namespace hgraph
                                          std::string_view path,
                                          const WiringPortRef &in)
     {
-        if (descriptor.input_schema == nullptr || descriptor.output_schema == nullptr)
+        if (descriptor.input_schema == nullptr)
         {
             throw std::invalid_argument(
-                "service adaptor '" + descriptor.name + "' requires input and output schemas");
+                "service adaptor '" + descriptor.name + "' requires an input schema");
         }
         WiringPortRef request_id = request_id_source_node(w);
         service_adaptor_client_from_graph(w, descriptor, path, in, request_id);
-        return service_adaptor_client_to_graph(w, descriptor, path, request_id);
+        return descriptor.output_schema != nullptr
+            ? service_adaptor_client_to_graph(w, descriptor, path, request_id)
+            : WiringPortRef{};
     }
 
     namespace
@@ -1232,14 +1238,27 @@ namespace hgraph
         w.register_built_service_path(base, "service adaptor");
         std::vector<WiringServiceImplementationEndpoint> required_endpoints{
             WiringServiceImplementationEndpoint{base + "/from_graph", {}},
-            WiringServiceImplementationEndpoint{base + "/to_graph", {}},
         };
+        if (descriptor.output_schema != nullptr)
+        {
+            required_endpoints.push_back(
+                WiringServiceImplementationEndpoint{base + "/to_graph", {}});
+        }
         auto scope = w.service_implementation_scope(
             "service adaptor " + base, std::move(required_endpoints));
         WiringPortRef requests = service_adaptor_from_graph(w, descriptor, path);
         std::array<WiringPortRef, 1> impl_inputs{requests};
         WiringPortRef replies = wire_impl(w, descriptor, impl, impl_inputs);
-        service_adaptor_to_graph(w, descriptor, path, replies);
+        if (descriptor.output_schema != nullptr)
+        {
+            service_adaptor_to_graph(w, descriptor, path, replies);
+        }
+        else if (replies.schema != nullptr)
+        {
+            throw std::invalid_argument(
+                "sink-only service adaptor '" + descriptor.name +
+                "' implementation returned an output");
+        }
         scope.complete();
     }
     }

--- a/src/hgraph/types/time_series/ts_delta.cpp
+++ b/src/hgraph/types/time_series/ts_delta.cpp
@@ -690,6 +690,126 @@ namespace hgraph
         throw std::logic_error("capture_delta requires a canonical input type record");
     }
 
+    Value capture_current_delta(const TSInputView &in)
+    {
+        const auto &schema = require_schema(in.schema(), "capture_current_delta");
+        if (!in.valid())
+        {
+            throw std::invalid_argument("capture_current_delta requires a valid input");
+        }
+
+        switch (schema.kind)
+        {
+            case TSTypeKind::TS: return Value{in.value()};
+            case TSTypeKind::SIGNAL: return Value{true};
+            case TSTypeKind::TSS:
+            {
+                const ValueTypeRef element = binding_for(
+                    schema.value_schema->element_type, "capture_current_delta");
+                SetBuilder added{element};
+                const auto set = in.as_set();
+                for (const auto &value : set.values())
+                {
+                    static_cast<void>(added.insert_copy(value.data()));
+                }
+                SetBuilder removed{element};
+                BundleBuilder bundle{
+                    binding_for(schema.delta_value_schema, "capture_current_delta")};
+                bundle.set("added", added.build());
+                bundle.set("removed", removed.build());
+                return bundle.build();
+            }
+            case TSTypeKind::TSD:
+            {
+                const auto &data = in.data_view();
+                const auto data_dict = data.as_dict();
+                const auto &layout = data_dict.layout();
+                const ValueTypeRef key_binding = layout.key_binding;
+                const auto *element_schema = schema.element_ts();
+                const ValueTypeRef canonical_delta_binding = binding_for(
+                    element_schema->delta_value_schema, "capture_current_delta");
+                const ValueTypeRef delta_binding =
+                    element_schema->kind == TSTypeKind::TS
+                        ? layout.element_delta_binding
+                        : canonical_delta_binding;
+
+                SetBuilder removed{key_binding};
+                SetBuilder removed_strict{key_binding};
+                MapBuilder modified{key_binding, delta_binding};
+                const auto dict = in.as_dict();
+                for (const auto &[key, child] : dict.valid_items())
+                {
+                    Value child_delta = capture_current_delta(child);
+                    if (child_delta.binding() == delta_binding)
+                    {
+                        modified.set_item_copy(key.data(), child_delta.view().data());
+                        continue;
+                    }
+                    Value stored_delta{delta_binding};
+                    delta_binding.ops_ref().copy_assign_from(
+                        delta_binding,
+                        const_cast<void *>(stored_delta.view().data()),
+                        child_delta.binding(),
+                        child_delta.view().data());
+                    modified.set_item_copy(key.data(), stored_delta.view().data());
+                }
+
+                Value removed_delta = removed.build();
+                Value modified_delta = modified.build();
+                Value removed_strict_delta = removed_strict.build();
+                const std::array field_bindings{
+                    removed_delta.binding(), modified_delta.binding(),
+                    removed_strict_delta.binding()};
+                const auto bundle_binding = ValuePlanFactory::instance().realized_composite_type_for(
+                    schema.delta_value_schema, field_bindings);
+                BundleBuilder bundle{bundle_binding};
+                bundle.set("removed", std::move(removed_delta));
+                bundle.set("modified", std::move(modified_delta));
+                bundle.set("removed_strict", std::move(removed_strict_delta));
+                return bundle.build();
+            }
+            case TSTypeKind::TSL:
+            {
+                const ValueTypeRef key_binding = binding_for(
+                    schema.delta_value_schema->key_type, "capture_current_delta");
+                const ValueTypeRef delta_binding = binding_for(
+                    schema.delta_value_schema->element_type, "capture_current_delta");
+                MapBuilder builder{key_binding, delta_binding};
+                const auto list = in.as_list();
+                for (const auto &[index, child] : list.valid_items())
+                {
+                    const std::int64_t key = static_cast<std::int64_t>(index);
+                    Value child_delta = capture_current_delta(child);
+                    builder.set_item_copy(std::addressof(key), child_delta.view().data());
+                }
+                return builder.build();
+            }
+            case TSTypeKind::TSB:
+            {
+                const auto type = ts_type_for(&schema, "capture_current_delta");
+                BundleBuilder builder{
+                    binding_for(schema.delta_value_schema, "capture_current_delta")};
+                initialize_tsb_delta_defaults(type, builder);
+                auto bundle = in.as_bundle();
+                for (std::size_t index = 0; index < bundle.size(); ++index)
+                {
+                    auto child = bundle.at(index);
+                    if (child.valid())
+                    {
+                        builder.set(index, capture_current_delta(child));
+                    }
+                }
+                return builder.build();
+            }
+            case TSTypeKind::TSW:
+            case TSTypeKind::REF:
+                if (in.modified()) { return capture_delta(in); }
+                throw std::logic_error(
+                    "capture_current_delta cannot reconstruct an unmodified TSW or REF");
+        }
+        throw std::logic_error("capture_current_delta received an unknown time-series kind");
+    }
+
     void apply_delta(const TSOutputView &out, const ValueView &delta)
     {
         const auto type = out.type_ref();

--- a/tests/cpp/test_graph_wiring.cpp
+++ b/tests/cpp/test_graph_wiring.cpp
@@ -2179,3 +2179,19 @@ TEST_CASE("graph wiring: default multi-interface candidates reject exact overlap
             Catch::Matchers::ContainsSubstring("production prices") &&
             Catch::Matchers::ContainsSubstring("ref_svc://prod/prices"));
 }
+
+TEST_CASE("graph wiring: extension state follows the Wiring lifetime")
+{
+    using namespace hgraph;
+
+    auto state = std::make_shared<int>(7);
+    std::weak_ptr<int> retained = state;
+    {
+        Wiring wiring;
+        wiring.retain_extension_state(state);
+        state.reset();
+        CHECK_FALSE(retained.expired());
+        CHECK_THROWS_AS(wiring.retain_extension_state(nullptr), std::invalid_argument);
+    }
+    CHECK(retained.expired());
+}

--- a/tests/cpp/test_service_node.cpp
+++ b/tests/cpp/test_service_node.cpp
@@ -112,3 +112,39 @@ TEST_CASE("service subscription keys are reference counted across captures")
     CHECK(second.contains(Value{std::int32_t{7}}.view()));
     CHECK(second.contains(Value{std::int32_t{8}}.view()));
 }
+
+TEST_CASE("request input teardown supersedes a pending same-time value")
+{
+    using namespace hgraph;
+
+    auto       &registry       = TypeRegistry::instance();
+    const auto *request_schema = registry.ts(
+        registry.register_scalar<std::int32_t>("int32"));
+    const auto  path = std::string{"svc://requests/same-time-teardown"};
+
+    GraphBuilder builder;
+    builder.add_node(NodeBuilder{}.implementation<ConstantKey>());
+    builder.add_node(make_request_input_source_node(path, *request_schema));
+    builder.add_node(make_request_id_source_node());
+    builder.add_node(make_request_input_capture_node(path, *request_schema));
+    builder.add_edge(GraphEdge{.source_node = 0, .target_node = 3, .target_path = {0}});
+    builder.add_edge(GraphEdge{.source_node = 1, .target_node = 3, .target_path = {1}});
+    builder.add_edge(GraphEdge{.source_node = 2, .target_node = 3, .target_path = {2}});
+
+    testing::MockRootGraph graph{builder};
+    auto                   view = graph.graph();
+    const auto             t1   = MIN_ST;
+    const auto             t2   = t1 + MIN_TD;
+
+    view.start(t1);
+    view.evaluate(t1);
+    const Int request_id = view.node_at(2).output(t1).value().checked_as<Int>();
+
+    // Dynamic nested clients can start and stop during one parent evaluation.
+    // Their stop must replace the value captured for the same observed time.
+    view.node_at(3).stop(t1);
+    view.evaluate(t2);
+
+    auto requests = view.node_at(1).output(t2);
+    CHECK_FALSE(requests.as_dict().contains(Value{request_id}.view()));
+}

--- a/tests/cpp/test_service_wiring.cpp
+++ b/tests/cpp/test_service_wiring.cpp
@@ -10,6 +10,8 @@
 
 #include <stdexcept>
 #include <string>
+#include <tuple>
+#include <vector>
 
 namespace
 {
@@ -552,6 +554,35 @@ namespace
         static constexpr std::string_view name{"add_thirty_adaptor"};
         using input_schema  = TS<Int>;
         using output_schema = TS<Int>;
+    };
+
+    struct PublishPairServiceAdaptor : service_adaptor::interface
+    {
+        static constexpr std::string_view name{"publish_pair_adaptor"};
+        using input_schema = PairRequest;
+    };
+
+    inline std::vector<std::tuple<Int, Int, Int>> published_pair_requests;
+
+    struct PublishPairServiceAdaptorImplNode
+    {
+        static constexpr auto name = "publish_pair_service_adaptor_impl_node";
+
+        static void eval(
+            In<"requests", TSD<Int, PairRequest>, InputValidity::Unchecked> requests)
+        {
+            if (!requests.modified()) { return; }
+            for (const auto &[request_id, request] : requests.modified_items())
+            {
+                auto left = request.field<"left">();
+                auto right = request.field<"right">();
+                if (left.valid() && right.valid())
+                {
+                    published_pair_requests.emplace_back(
+                        request_id.checked_as<Int>(), left.value(), right.value());
+                }
+            }
+        }
     };
 
     struct GenericAddOneService
@@ -1573,6 +1604,40 @@ namespace
         }
     };
 
+    struct SinkServiceAdaptorTwoClientGraph
+    {
+        [[maybe_unused]] static constexpr auto name =
+            "sink_service_adaptor_two_client_graph";
+
+        static Port<TS<Int>> compose(
+            Wiring &w, Port<TS<Int>> lhs, Port<TS<Int>> rhs,
+            Port<TS<Int>> other_lhs, Port<TS<Int>> other_rhs)
+        {
+            const auto custom = service_adaptor::path("sink_multi_client");
+            service_adaptor::register_service_adaptor_impl<
+                PublishPairServiceAdaptor, PublishPairServiceAdaptorImplNode>(w, custom);
+            wire<PublishPairServiceAdaptor>(w, custom, lhs, rhs);
+            wire<PublishPairServiceAdaptor>(w, custom, other_lhs, other_rhs);
+            return lhs;
+        }
+    };
+
+    struct SinkServiceAdaptorConstantFieldGraph
+    {
+        [[maybe_unused]] static constexpr auto name =
+            "sink_service_adaptor_constant_field_graph";
+
+        static Port<TS<Int>> compose(Wiring &w, Port<TS<Int>> value)
+        {
+            const auto custom = service_adaptor::path("sink_constant_field");
+            service_adaptor::register_service_adaptor_impl<
+                PublishPairServiceAdaptor, PublishPairServiceAdaptorImplNode>(w, custom);
+            auto constant = wire<stdlib::const_>(w, Int{7}).as<TS<Int>>();
+            wire<PublishPairServiceAdaptor>(w, custom, constant, value);
+            return value;
+        }
+    };
+
     struct MultiServiceAdaptorClientGraph
     {
         [[maybe_unused]] static constexpr auto name = "multi_service_adaptor_client_graph";
@@ -2082,6 +2147,45 @@ TEST_CASE("service wiring: service_adaptor_impl auto-wires single-interface impl
 
     CHECK_OUTPUT(eval_node<ServiceAdaptorImplTwoClientGraph>(values<Int>(1), values<Int>(10)),
                  values<Int>(none, 51));
+}
+
+TEST_CASE("service wiring: sink-only service adaptors collect multiple bundled clients")
+{
+    hgraph::stdlib::register_standard_operators();
+    published_pair_requests.clear();
+
+    CHECK_OUTPUT(
+        eval_node<SinkServiceAdaptorTwoClientGraph>(
+            values<Int>(1, none, 2, none, 3),
+            values<Int>(10, none, 20, none, 30),
+            values<Int>(3, none, 4, none, 5),
+            values<Int>(30, none, 40, none, 50)),
+        values<Int>(1, none, 2, none, 3));
+
+    REQUIRE(published_pair_requests.size() == 6);
+    const auto first_client = std::get<0>(published_pair_requests[0]);
+    const auto second_client = std::get<0>(published_pair_requests[1]);
+    CHECK(first_client != second_client);
+    CHECK(published_pair_requests == std::vector<std::tuple<Int, Int, Int>>{
+        {first_client, 1, 10}, {second_client, 3, 30},
+        {first_client, 2, 20}, {second_client, 4, 40},
+        {first_client, 3, 30}, {second_client, 5, 50}});
+}
+
+TEST_CASE("service wiring: service adaptor first requests snapshot static bundle fields")
+{
+    hgraph::stdlib::register_standard_operators();
+    published_pair_requests.clear();
+
+    CHECK_OUTPUT(
+        eval_node<SinkServiceAdaptorConstantFieldGraph>(
+            values<Int>(10, none, 20)),
+        values<Int>(10, none, 20));
+
+    REQUIRE(published_pair_requests.size() == 2);
+    const auto request_id = std::get<0>(published_pair_requests[0]);
+    CHECK(published_pair_requests == std::vector<std::tuple<Int, Int, Int>>{
+        {request_id, 7, 10}, {request_id, 7, 20}});
 }
 
 TEST_CASE("service wiring: multi-interface service adaptors wire explicit stubs")

--- a/tests/cpp/test_ts_delta.cpp
+++ b/tests/cpp/test_ts_delta.cpp
@@ -68,6 +68,28 @@ template <typename S> struct ProbeRecord {
   }
 };
 
+// Capture a canonical full-state delta on each input tick. This is the
+// transport snapshot form: fields that did not tick in the current cycle are
+// still represented from their current values.
+template <typename S> struct ProbeCurrentRecord {
+  static constexpr auto name = "ts_delta_probe_current_record";
+  static void start(Scalar<"key", Str> key, GlobalStateView gs) {
+    gs.set(key.value(), make_buffer());
+  }
+  static void eval(In<"ts", S> ts, Scalar<"key", Str> key, GlobalStateView gs,
+                   DateTime now) {
+    const std::size_t offset = cycle_offset(now);
+    auto list = gs.get(key.value()).as_list();
+    auto mutation = list.begin_mutation();
+    std::size_t size = list.size();
+    while (size < offset) {
+      mutation.push_back(empty_any().view());
+      ++size;
+    }
+    mutation.push_back(make_any(capture_current_delta(ts.base())).view());
+  }
+};
+
 // A `replay` clone whose eval re-creates ticks with the runtime `apply_delta`
 // instead of `ts_delta<S>::apply`. `out` (an Out<S>) slices to the erased
 // `TSOutputView` the function takes.
@@ -121,6 +143,14 @@ template <typename S> struct RoundTripGraph {
   static void compose(Wiring &w) {
     auto src = wire<ProbeReplay<S>>(w, Str{"in"});
     wire<ProbeRecord<S>>(w, src, Str{"out"});
+  }
+};
+
+template <typename S> struct CurrentCaptureGraph {
+  static constexpr auto name = "ts_delta_current_capture_graph";
+  static void compose(Wiring &w) {
+    auto src = wire<stdlib::replay_impl, S>(w, Str{"in"});
+    wire<ProbeCurrentRecord<S>>(w, src, Str{"out"});
   }
 };
 
@@ -471,6 +501,21 @@ TEST_CASE(
       {tsb_delta<QuoteWithSet>(set_delta<Int>({1, 2}, {}), std::nullopt),
        tsb_delta<QuoteWithSet>(std::nullopt, 5),
        tsb_delta<QuoteWithSet>(set_delta<Int>({3}, {1}), 6)});
+}
+
+TEST_CASE("ts_delta: capture_current_delta includes unchanged scalar and collection fields") {
+  (void)TypeRegistry::instance().register_scalar<Int>("int");
+  const std::vector<std::optional<Value>> deltas{
+      tsb_delta<QuoteWithSet>(set_delta<Int>({1, 2}, {}), 5),
+      tsb_delta<QuoteWithSet>(std::nullopt, 6),
+  };
+
+  auto captured = run_graph<CurrentCaptureGraph<QuoteWithSet>>(
+      [&](const GlobalStateView &gs) { set_replay_deltas(gs, "in", deltas); });
+  CHECK_OUTPUT(
+      get_recorded_deltas(captured.view().graph().global_state(), "out"),
+      {tsb_delta<QuoteWithSet>(set_delta<Int>({1, 2}, {}), 5),
+       tsb_delta<QuoteWithSet>(set_delta<Int>({1, 2}, {}), 6)});
 }
 
 TEST_CASE("ts_delta: capture/apply round-trip a TSW scalar push delta") {

--- a/tests/cpp/test_type_resolution.cpp
+++ b/tests/cpp/test_type_resolution.cpp
@@ -67,6 +67,13 @@ namespace
     using GenericScalarBundle = UnNamedTSB<Field<"p1", TS<ScalarVar<"T">>>>;
     using IntScalarBundle     = UnNamedTSB<Field<"p1", TS<Int>>>;
 
+    using GenericEditsBundle = UnNamedTSB<
+        Field<"edits", TSD<ScalarVar<"K">, TsVar<"V">>>,
+        Field<"removes", TSS<ScalarVar<"K">>>>;
+    using ConcreteEditsBundle = UnNamedTSB<
+        Field<"edits", TSD<Int, TS<Str>>>,
+        Field<"removes", TSS<Int>>>;
+
     struct GenericBundleFromScalar
     {
         static constexpr auto name = "rt_generic_bundle_from_scalar";
@@ -75,6 +82,27 @@ namespace
         {
             const Value delta = capture_delta(p1.base());
             apply_delta(out.field<"p1">(), delta.view());
+        }
+    };
+
+    struct GenericEditsFromInputs
+    {
+        static constexpr auto name = "rt_generic_edits_from_inputs";
+
+        static void eval(In<"edits", TSD<ScalarVar<"K">, TsVar<"V">>> edits,
+                         In<"removes", TSS<ScalarVar<"K">>> removes,
+                         Out<GenericEditsBundle> out)
+        {
+            if (edits.modified())
+            {
+                const Value delta = capture_delta(edits.base());
+                apply_delta(out.field<"edits">().base(), delta.view());
+            }
+            if (removes.modified())
+            {
+                const Value delta = capture_delta(removes.base());
+                apply_delta(out.field<"removes">().base(), delta.view());
+            }
         }
     };
 
@@ -189,6 +217,17 @@ namespace
         }
     };
 
+    struct GenericEditsGraph
+    {
+        static constexpr auto name = "rt_generic_edits_graph";
+
+        static Port<ConcreteEditsBundle> compose(Wiring &w, Port<TSD<Int, TS<Str>>> edits,
+                                                  Port<TSS<Int>> removes)
+        {
+            return wire<GenericEditsFromInputs>(w, edits, removes).as<ConcreteEditsBundle>();
+        }
+    };
+
 }  // namespace
 
 TEST_CASE("type_resolution: a generic node resolves its TS type from the connected input port")
@@ -236,6 +275,24 @@ TEST_CASE("type_resolution: a concrete input resolves a scalar-generic TSB outpu
     CHECK_OUTPUT(eval_node<GenericBundleFromIntGraph>(values<Int>(1, 2)),
                  values<Value>(tsb_delta<IntScalarBundle>(Int{1}),
                                tsb_delta<IntScalarBundle>(Int{2})));
+}
+
+TEST_CASE("type_resolution: scalar and time-series variables resolve together inside a TSB")
+{
+    (void)TypeRegistry::instance().register_scalar<Int>("int");
+    (void)TypeRegistry::instance().register_scalar<Str>("str");
+
+    const auto edits = values<Value>(dict_delta<Int, TS<Str>>({{1, Str{"one"}}}),
+                                     dict_delta<Int, TS<Str>>({{2, Str{"two"}}}, {1}));
+    const auto removes = values<Value>(set_delta<Int>({}, {}), set_delta<Int>({1}, {}));
+
+    CHECK_OUTPUT(
+        eval_node<GenericEditsGraph>(edits, removes),
+        values<Value>(
+            tsb_delta<ConcreteEditsBundle>(dict_delta<Int, TS<Str>>({{1, Str{"one"}}}),
+                                           set_delta<Int>({}, {})),
+            tsb_delta<ConcreteEditsBundle>(dict_delta<Int, TS<Str>>({{2, Str{"two"}}}, {1}),
+                                           set_delta<Int>({1}, {}))));
 }
 
 TEST_CASE("type_resolution: a generic source infers its type from the configured scalar value")

--- a/tools/parity/surface_known.json
+++ b/tools/parity/surface_known.json
@@ -2738,6 +2738,43 @@
       "name": "TornadoWeb.add_handler",
       "kind": "method-signature-mismatch",
       "reason": "TornadoWeb is an internal transport manager excluded by issue #215; the candidate's optional options argument supports the same internal calls"
+    },
+    {
+      "module": "hgraph.adaptors.perspective",
+      "kind": "name-missing",
+      "side": "candidate",
+      "reason": "issue #216 defines hgraph.adaptors.perspective.__all__ as the curated Perspective user API; upstream dependency imports, type variables and implementation helpers are not package API"
+    },
+    {
+      "module": "hgraph.adaptors.perspective._perspective",
+      "kind": "name-missing",
+      "side": "candidate",
+      "reason": "issue #216 makes _perspective.__all__ authoritative; upstream dependency imports, legacy Perspective 2 handlers and implementation helpers are excluded"
+    },
+    {
+      "module": "hgraph.adaptors.perspective._perspetive_publish",
+      "kind": "name-missing",
+      "side": "candidate",
+      "reason": "the misspelled compatibility module mirrors the curated publisher __all__; upstream reflection classes and implementation imports are not user API"
+    },
+    {
+      "module": "hgraph.adaptors.perspective*",
+      "name": "TableEdits.__init__",
+      "kind": "constructor-signature-mismatch",
+      "reason": "TableEdits is a generic TimeSeriesSchema wiring annotation, not a user-constructed scalar; values are produced as a typed TSB by publish_table_editable"
+    },
+    {
+      "module": "hgraph.adaptors.perspective*",
+      "name": "TableEdits.to_scalar_schema",
+      "kind": "method-missing",
+      "side": "candidate",
+      "reason": "TableEdits contains TSD/TSS fields and has no scalar-row analogue; native reflection and the typed TSB contract replace upstream's Python metadata conversion helper"
+    },
+    {
+      "module": "hgraph.adaptors.perspective*",
+      "name": "publish*_impl",
+      "kind": "kind-mismatch",
+      "reason": "C++-first adaptor implementations are passive registration objects rather than directly invoked Python graph callables; registration and publication behaviour are parity-tested"
     }
   ]
 }


### PR DESCRIPTION
## Summary

- implement the released Python hgraph Perspective adaptor surface using the native C++ runtime and wiring contracts
- add general mixed scalar/time-series `TimeSeriesSchema` resolution and public reflection needed by `TableEdits`
- support sink-only service adaptors and preserve complete, repeated client request transport
- add Perspective manager, read-only/editable/multi-table publication, lifecycle-owned edit feedback, current web hosting, and parity documentation

## Why

Issue #216 found that hg_cpp exposed only a partial Perspective surface and that the existing Python-shaped helpers did not provide the released hgraph workflows. The implementation also lacked two general facilities required for correct parity: mixed scalar/time-series schema generics and input-only service adaptors.

The mixed generic pattern is intentional in released hgraph, not a Perspective accident: it is documented on `TimeSeriesSchema` and used by exception-handling and Arrow schemas as well as `TableEdits`.

## Impact

Perspective clients can use the documented Python adaptor workflows while execution, service routing, first-request state capture, and lifecycle remain C++-first. Row planning uses the public reflection API rather than private `_TsExpr` or `_hgraph` layouts. Perspective 2.10's legacy manager branch remains deliberately unsupported; the current server/client API is targeted.

Closes #216.

## Validation

- macOS native: 1,376/1,376
- hg-linux native: 1,376/1,376
- macOS Python 3.14 from cp312-abi3 wheel with Perspective 5.0: 1,807 passed, 10 skipped
- hg-linux Python 3.14 from cp312-abi3 wheel with Perspective 5.0: 1,807 passed, 10 skipped
- hg-linux ASan: 1,807 passed, 10 skipped; no sanitizer reports
- installed C++ SDK consumer: passed
- parity catalogue: 56 recipes validated
- surface audit: zero actionable Perspective findings
- Sphinx warnings-as-errors: passed