### PR TITLE
Align map and mesh TSD input classification

### DIFF
--- a/docs/source/developer_guide/nested_graphs.rst
+++ b/docs/source/developer_guide/nested_graphs.rst
@@ -676,9 +676,14 @@ input(s) — an operator like the rest of the family
   terminals that already require forwarding/non-peered topology are rejected;
   this initial path supports ordinary owned whole-node outputs and sink
   functions.
-- **The variadic tail is classified, Python-style**: every TSD argument is
-  multiplexed alongside the anchor (key types must agree) — the live key set
-  is the **union** of their key sets; a key absent from one dict leaves that
+- **The variadic tail is classified against the child signature**: a TSD is
+  multiplexed when the corresponding child parameter accepts its element. A
+  whole-time-series type variable (for example ``TIME_SERIES_TYPE`` or C++
+  ``Port<void>``), or a parameter accepting the concrete whole TSD, receives
+  it directly. Unresolved operator element variables retain element-wise map
+  behaviour. The first multiplexed TSD establishes the key type; later
+  multiplexed TSDs must agree. The live key set is the **union** of their key
+  sets; a key absent from one dict leaves that
   child input unbound (invalid) until it appears there (the phantom-element
   behaviour), and the output entry is removed only when the key has left
   every multiplexed input. Non-TSD args broadcast whole; in the TSL form a

--- a/docs/source/developer_guide/nested_graphs.rst
+++ b/docs/source/developer_guide/nested_graphs.rst
@@ -776,6 +776,16 @@ another instance requested it.
   ``TSD<K, OUT>`` output; child terminals are forwarding outputs bound to
   real elements in that owned TSD, so branch/map/switch terminals inside the
   instance write through to the mesh element rather than copying values.
+- **TSD argument classification follows ``map_``.** A whole-time-series type
+  variable multiplexes the first TSD argument and establishes the key type;
+  later matching-key TSDs multiplex, while later different-key TSDs and
+  non-TSDs pass through. Concrete whole-TSD parameters pass through and
+  element parameters multiplex. The first multiplexed input drives the
+  signature. ``pass_through`` inputs do not contribute to inferred
+  ``__keys__``; ``no_key`` inputs remain multiplexed but are excluded from the
+  inferred union, so all-``no_key`` inputs require explicit ``__keys__``.
+  TSL-specific ``map_`` rules do not apply because ``mesh_`` has no TSL
+  kernel.
 - **One internal key-slot store is authoritative.** Mesh instance membership
   is a superset of ``__keys__`` because dependency reads may create keys on
   demand. A mesh therefore cannot mirror only the external set's slot ids.
@@ -813,7 +823,8 @@ another instance requested it.
   mirror ``map_`` because the mesh output is an owned TSD whose elements are
   real storage targets.
 
-Tests: ``tests/cpp/test_mesh.cpp``.
+Tests: ``tests/cpp/test_mesh.cpp`` and
+``python/tests/test_mesh_map_classification.py``.
 
 
 ``dispatch_`` — runtime type dispatch (design record)

--- a/docs/source/developer_guide/nested_graphs.rst
+++ b/docs/source/developer_guide/nested_graphs.rst
@@ -679,11 +679,14 @@ input(s) — an operator like the rest of the family
 - **The variadic tail is classified against the child signature**: a TSD is
   multiplexed when the corresponding child parameter accepts its element. A
   whole-time-series type variable (for example ``TIME_SERIES_TYPE`` or C++
-  ``Port<void>``), or a parameter accepting the concrete whole TSD, receives
-  it directly. Unresolved operator element variables retain element-wise map
-  behaviour. The first multiplexed TSD establishes the key type; later
-  multiplexed TSDs must agree. The live key set is the **union** of their key
-  sets; a key absent from one dict leaves that
+  ``Port<void>``) multiplexes the first TSD in the argument list and establishes
+  its key type. A later TSD supplied to such a variable multiplexes when its key
+  type matches, and otherwise passes through whole. A parameter accepting the
+  concrete whole TSD always receives it directly. Non-TSD values supplied to a
+  whole-time-series variable also pass through. Unresolved operator element
+  variables retain element-wise map behaviour. Later multiplexed TSDs must
+  agree with the established key type. The live key set is the **union** of
+  their key sets; a key absent from one dict leaves that
   child input unbound (invalid) until it appears there (the phantom-element
   behaviour), and the output entry is removed only when the key has left
   every multiplexed input. Non-TSD args broadcast whole; in the TSL form a

--- a/include/hgraph/lib/std/operators/higher_order.h
+++ b/include/hgraph/lib/std/operators/higher_order.h
@@ -308,7 +308,7 @@ namespace hgraph::stdlib
      * endpoint shape safely.
      */
     /**
-     * Python's ``pass_through()`` — tag a ``map_`` input so it is NOT
+     * Python's ``pass_through()`` — tag a ``map_`` / ``mesh_`` input so it is NOT
      * demultiplexed: the child binds the input whole (broadcast), whatever
      * its kind. A wiring-time tag on the port; never part of graph structure.
      */
@@ -319,7 +319,7 @@ namespace hgraph::stdlib
     }
 
     /**
-     * Python's ``no_key()`` — tag a multiplexed ``map_`` input so it is
+     * Python's ``no_key()`` — tag a multiplexed ``map_`` / ``mesh_`` input so it is
      * demultiplexed as usual but EXCLUDED from key-set inference (its keys do
      * not contribute to the derived ``__keys__`` union).
      */
@@ -330,7 +330,7 @@ namespace hgraph::stdlib
     }
 
     /**
-     * The ``map_`` call configuration folded into the node's interning
+     * The ``map_`` / ``mesh_`` call configuration folded into the node's interning
      * identity: two calls with equal inputs but different function, key-arg
      * name, or argument tags must NOT dedup to one node.
      */
@@ -370,7 +370,9 @@ namespace hgraph::stdlib
      * create instances on demand, and evaluate in dependency-rank order within a
      * cycle. The instantiation call surface mirrors ``map_``; cross-instance
      * access uses ``mesh_ref<OUT>(w, key)`` inside the mesh body. See the
-     * developer guide *Mesh*.
+     * developer guide *Mesh*. TSD argument classification, including generic
+     * whole-time-series inputs and ``pass_through`` / ``no_key`` tags, follows
+     * ``map_`` exactly; mesh does not implement map's TSL kernels.
      */
     struct mesh_ : Operator<"mesh_",
                             Scalar<"func", WiredFn>,

--- a/include/hgraph/lib/std/operators/higher_order.h
+++ b/include/hgraph/lib/std/operators/higher_order.h
@@ -276,8 +276,10 @@ namespace hgraph::stdlib
      *   in-place child graph slot per observed index). TSD child lifecycle follows
      *   a required ``__keys__`` TSS input; wiring may supply it explicitly or infer
      *   it from the union of multiplexed TSD keys. A TSD multiplexes when the
-     *   corresponding ``func`` parameter accepts its element; a whole-time-series
-     *   type variable or concrete whole-TSD parameter receives it directly.
+     *   corresponding ``func`` parameter accepts its element. A whole-time-series
+     *   type variable multiplexes the first TSD argument and later same-key
+     *   TSDs; later different-key TSDs and all non-TSDs pass through whole. A
+     *   concrete whole-TSD parameter always receives it directly.
      *   Unresolved operator element variables retain element-wise behaviour.
      *   The first multiplexed TSD establishes the key type. Membership changes
      *   only create/destroy children through ``__keys__``. Same-size TSLs in the TSL form

--- a/include/hgraph/lib/std/operators/higher_order.h
+++ b/include/hgraph/lib/std/operators/higher_order.h
@@ -275,9 +275,12 @@ namespace hgraph::stdlib
      *   ``func`` per index), or a grow-only dynamic ``TSL`` (one stable,
      *   in-place child graph slot per observed index). TSD child lifecycle follows
      *   a required ``__keys__`` TSS input; wiring may supply it explicitly or infer
-     *   it from the union of multiplexed TSD keys. EVERY TSD in the tail is
-     *   multiplexed for per-key element binding, but membership changes only
-     *   create/destroy children through ``__keys__``. Same-size TSLs in the TSL form
+     *   it from the union of multiplexed TSD keys. A TSD multiplexes when the
+     *   corresponding ``func`` parameter accepts its element; a whole-time-series
+     *   type variable or concrete whole-TSD parameter receives it directly.
+     *   Unresolved operator element variables retain element-wise behaviour.
+     *   The first multiplexed TSD establishes the key type. Membership changes
+     *   only create/destroy children through ``__keys__``. Same-size TSLs in the TSL form
      *   multiplex per index; non-collection args broadcast whole;
      * - ``func`` may take the key/index as its first argument when that
      *   parameter is named ``key`` for TSD maps or ``ndx`` for TSL maps.

--- a/include/hgraph/lib/std/operators/impl/higher_order_impl.h
+++ b/include/hgraph/lib/std/operators/impl/higher_order_impl.h
@@ -2766,15 +2766,17 @@ namespace hgraph::stdlib
             std::span<const std::uint8_t> arg_tags,
             const ValueTypeMetaData *fallback_key_meta = nullptr)
         {
-            return fallback_on_exception<std::optional<const TSValueTypeMetaData *>>(std::nullopt, [&] {
-                const TSValueTypeMetaData *output_schema = nullptr;
-                std::vector<WiringPortRef> captured;
-                std::vector<NestedServiceInput> external_services;
-                (void)compile_map_child(func, ts_schemas, arg_tags, output_schema, &captured,
-                                        fallback_key_meta, &external_services);
-                if (output_schema == nullptr) { return std::optional<const TSValueTypeMetaData *>{}; }
-                return std::optional<const TSValueTypeMetaData *>{output_schema};
-            });
+            // OperatorRegistry already probes each overload behind an exception
+            // boundary and records what() as that candidate's rejection reason.
+            // Let classification/compilation failures reach that boundary so an
+            // invalid map call retains its actionable diagnostic.
+            const TSValueTypeMetaData *output_schema = nullptr;
+            std::vector<WiringPortRef> captured;
+            std::vector<NestedServiceInput> external_services;
+            (void)compile_map_child(func, ts_schemas, arg_tags, output_schema, &captured,
+                                    fallback_key_meta, &external_services);
+            if (output_schema == nullptr) { return std::optional<const TSValueTypeMetaData *>{}; }
+            return std::optional<const TSValueTypeMetaData *>{output_schema};
         }
 
         [[nodiscard]] inline std::optional<bool> try_resolve_map_output_mode(
@@ -2783,14 +2785,12 @@ namespace hgraph::stdlib
             std::span<const std::uint8_t> arg_tags,
             const ValueTypeMetaData *fallback_key_meta = nullptr)
         {
-            return fallback_on_exception<std::optional<bool>>(std::nullopt, [&] {
-                const TSValueTypeMetaData *output_schema = nullptr;
-                std::vector<WiringPortRef> captured;
-                std::vector<NestedServiceInput> external_services;
-                (void)compile_map_child(func, ts_schemas, arg_tags, output_schema, &captured,
-                                        fallback_key_meta, &external_services);
-                return std::optional<bool>{output_schema != nullptr};
-            });
+            const TSValueTypeMetaData *output_schema = nullptr;
+            std::vector<WiringPortRef> captured;
+            std::vector<NestedServiceInput> external_services;
+            (void)compile_map_child(func, ts_schemas, arg_tags, output_schema, &captured,
+                                    fallback_key_meta, &external_services);
+            return std::optional<bool>{output_schema != nullptr};
         }
 
         /**
@@ -3314,32 +3314,23 @@ namespace hgraph::stdlib
 
             if (const TSValueTypeMetaData *element = func->output_schema())
             {
-                const auto output_schema = fallback_on_exception(
-                    static_cast<const TSValueTypeMetaData *>(nullptr), [&] {
-                        const MapArgClassification classified = classify_map_args(
-                            {ordered->schemas.data(), ordered->schemas.size()},
-                            {ordered->arg_tags.data(), ordered->arg_tags.size()},
-                            keys_kwarg_element(context));
-                        std::size_t parameter = 0;
-                        const auto accepts = [&](const TSValueTypeMetaData *actual) {
-                            const TSValueTypeMetaData *expected = func->input_schema(parameter++);
-                            return expected == nullptr ||
-                                   graph_wiring_detail::input_accepts_output_schema(expected, actual);
-                        };
-                        if (ordered->takes_key &&
-                            !accepts(TypeRegistry::instance().ts(classified.key_meta)))
-                        {
-                            return static_cast<const TSValueTypeMetaData *>(nullptr);
-                        }
-                        for (const TSValueTypeMetaData *child : classified.child_schemas)
-                        {
-                            if (!accepts(child))
-                            {
-                                return static_cast<const TSValueTypeMetaData *>(nullptr);
-                            }
-                        }
-                        return TypeRegistry::instance().tsd(classified.key_meta, element);
-                    });
+                const MapArgClassification classified = classify_map_args(
+                    {ordered->schemas.data(), ordered->schemas.size()},
+                    {ordered->arg_tags.data(), ordered->arg_tags.size()},
+                    keys_kwarg_element(context));
+                std::size_t parameter = 0;
+                const auto accepts = [&](const TSValueTypeMetaData *actual) {
+                    const TSValueTypeMetaData *expected = func->input_schema(parameter++);
+                    return expected == nullptr ||
+                           graph_wiring_detail::input_accepts_output_schema(expected, actual);
+                };
+                const bool key_accepted =
+                    !ordered->takes_key || accepts(TypeRegistry::instance().ts(classified.key_meta));
+                const bool inputs_accepted = key_accepted &&
+                    std::ranges::all_of(classified.child_schemas, accepts);
+                const auto *output_schema = inputs_accepted
+                                                ? TypeRegistry::instance().tsd(classified.key_meta, element)
+                                                : nullptr;
                 if (output_schema != nullptr)
                 {
                     bind_graph_output(resolution, output_schema, "O");

--- a/include/hgraph/lib/std/operators/impl/higher_order_impl.h
+++ b/include/hgraph/lib/std/operators/impl/higher_order_impl.h
@@ -2448,12 +2448,12 @@ namespace hgraph::stdlib
         {};
 
         /**
-         * Classify the ``map_`` time-series arguments, Python-style: every
-         * TSD argument is **multiplexed** (the key types must all agree —
-         * the live key set is their union); everything else broadcasts whole.
-         * The argument list has already been resolved onto ``func``'s
-         * parameter order, so argument ``i`` feeds ``func`` parameter ``i``
-         * (after the optional key).
+         * Classify the ``map_`` time-series arguments against ``func``'s
+         * ordered parameters. An unmarked TSD binds whole when the parameter
+         * is a whole-time-series type variable or accepts that concrete TSD;
+         * it multiplexes only when the parameter instead accepts the TSD
+         * element. The first multiplexed TSD establishes the key type and
+         * later multiplexed TSDs must agree.
          */
         struct MapArgClassification
         {
@@ -2463,15 +2463,63 @@ namespace hgraph::stdlib
             const ValueTypeMetaData                 *key_meta{nullptr};
         };
 
+        struct MapParameterAcceptance
+        {
+            bool whole{false};
+            bool element{false};
+        };
+
+        /** Determine whether one mapped parameter accepts a TSD whole or its
+            element. A bare pattern variable on a user callable denotes a
+            whole-time-series parameter; abstract operator markers retain the
+            established element-wise default because their variables are
+            resolved by overload selection after map has chosen its boundary. */
+        [[nodiscard]] inline MapParameterAcceptance map_parameter_acceptance(
+            const WiredFn &func, std::size_t parameter,
+            const TSValueTypeMetaData *whole, const TSValueTypeMetaData *element)
+        {
+            MapParameterAcceptance result;
+            if (const auto *expected = func.input_schema(parameter))
+            {
+                result.whole = graph_wiring_detail::input_accepts_output_schema(expected, whole);
+                result.element = graph_wiring_detail::input_accepts_output_schema(expected, element);
+            }
+
+            if (auto pattern = func.input_pattern(parameter))
+            {
+                ResolutionMap whole_resolution;
+                ResolutionMap element_resolution;
+                const bool pattern_accepts_whole =
+                    input_ts_pattern_match(*pattern, whole, whole_resolution);
+                const bool pattern_accepts_element =
+                    input_ts_pattern_match(*pattern, element, element_resolution);
+                result.element = result.element || pattern_accepts_element;
+                result.whole = result.whole ||
+                    (pattern_accepts_whole &&
+                     (!pattern_accepts_element ||
+                      pattern->kind == TypePattern::Kind::TSD ||
+                      (pattern->kind == TypePattern::Kind::Var && func.operator_name.empty())));
+            }
+            else if (func.input_schema(parameter) == nullptr)
+            {
+                // Unreflective runtime operators and unannotated lambdas keep
+                // map_'s long-standing element-wise default.
+                result.element = true;
+            }
+            return result;
+        }
+
         /**
-         * Classification honours the wiring-time argument tags (Python's
-         * wrappers): ``pass_through`` forces broadcast whatever the kind;
-         * ``no_key`` keeps the TSD multiplexed but excludes it from key-set
-         * inference.
+         * Classification honours the wiring-time argument tags:
+         * ``pass_through`` forces broadcast whatever the kind; ``no_key``
+         * forces a TSD to multiplex but excludes it from key-set inference.
          */
-        [[nodiscard]] inline MapArgClassification classify_map_args(std::span<const TSValueTypeMetaData *const> ts_schemas,
-                                                                    std::span<const std::uint8_t>               arg_tags,
-                                                                    const ValueTypeMetaData *fallback_key_meta = nullptr) {
+        [[nodiscard]] inline MapArgClassification classify_map_args(
+            const WiredFn &func,
+            bool takes_leading_key,
+            std::span<const TSValueTypeMetaData *const> ts_schemas,
+            std::span<const std::uint8_t> arg_tags,
+            const ValueTypeMetaData *fallback_key_meta = nullptr) {
             MapArgClassification result;
             result.is_multiplexed.reserve(ts_schemas.size());
             result.exclude_from_keys.reserve(ts_schemas.size());
@@ -2481,8 +2529,22 @@ namespace hgraph::stdlib
                 const auto tag = i < arg_tags.size() ? static_cast<WiringPortRef::ArgTag>(arg_tags[i])
                                                      : WiringPortRef::ArgTag::None;
                 const auto *tsd = time_series_schema_as<AnyTSD>(ts_schemas[i]);
-                if (tag != WiringPortRef::ArgTag::PassThrough && tsd != nullptr)
+                const auto parameter = i + (takes_leading_key ? 1 : 0);
+                const auto acceptance = tsd != nullptr
+                                            ? map_parameter_acceptance(
+                                                  func, parameter, ts_schemas[i], tsd->element_ts())
+                                            : MapParameterAcceptance{};
+                const bool force_multiplex = tag == WiringPortRef::ArgTag::NoKey;
+                const bool is_multiplexed =
+                    tsd != nullptr && tag != WiringPortRef::ArgTag::PassThrough &&
+                    (force_multiplex || !acceptance.whole);
+                if (is_multiplexed)
                 {
+                    if (!acceptance.element)
+                    {
+                        throw std::invalid_argument(
+                            "map_: a multiplexed TSD value is incompatible with the mapped function parameter");
+                    }
                     if (result.key_meta == nullptr) { result.key_meta = tsd->key_type(); }
                     else if (tsd->key_type() != result.key_meta)
                     {
@@ -2490,7 +2552,7 @@ namespace hgraph::stdlib
                             "map_: every multiplexed TSD must share the same key type");
                     }
                     result.is_multiplexed.push_back(true);
-                    result.exclude_from_keys.push_back(tag == WiringPortRef::ArgTag::NoKey);
+                    result.exclude_from_keys.push_back(force_multiplex);
                     result.child_schemas.push_back(tsd->element_ts());
                 }
                 else
@@ -2540,10 +2602,6 @@ namespace hgraph::stdlib
                 throw std::invalid_argument("map_: 'func' must be a wirable function (fn<X>())");
             }
 
-            auto &registry = TypeRegistry::instance();
-
-            const MapArgClassification classified = classify_map_args(ts_schemas, arg_tags, fallback_key_meta);
-
             const std::size_t base_arity = ts_schemas.size();
             const bool        takes_key  = !func.variadic && func.arity == base_arity + 1;
             if (!takes_key && (func.variadic ? base_arity < func.arity : func.arity != base_arity))
@@ -2552,6 +2610,10 @@ namespace hgraph::stdlib
                     "map_: 'func' must take one parameter per time-series argument, with an optional key "
                     "already resolved by name");
             }
+
+            auto &registry = TypeRegistry::instance();
+            const MapArgClassification classified = classify_map_args(
+                func, takes_key, ts_schemas, arg_tags, fallback_key_meta);
 
             const auto *key_ts = registry.ts(classified.key_meta);
 
@@ -2824,7 +2886,10 @@ namespace hgraph::stdlib
                     explicit_key_meta = keys_schema->value_schema->element_type;
                 }
             }
+            const bool takes_key =
+                !func.value().variadic && func.value().arity == ts_schemas.size() + 1;
             const MapArgClassification classified = classify_map_args(
+                func.value(), takes_key,
                 {ts_schemas.data(), ts_schemas.size()}, {arg_tags.data(), arg_tags.size()},
                 explicit_key_meta);
             std::vector<WiringPortRef> captured;
@@ -3000,7 +3065,10 @@ namespace hgraph::stdlib
                     explicit_key_meta = keys_schema->value_schema->element_type;
                 }
             }
+            const bool takes_key =
+                !func.value().variadic && func.value().arity == ts_schemas.size() + 1;
             const MapArgClassification classified = classify_map_args(
+                func.value(), takes_key,
                 {ts_schemas.data(), ts_schemas.size()}, {arg_tags.data(), arg_tags.size()},
                 explicit_key_meta);
 
@@ -3315,6 +3383,7 @@ namespace hgraph::stdlib
             if (const TSValueTypeMetaData *element = func->output_schema())
             {
                 const MapArgClassification classified = classify_map_args(
+                    *func, ordered->takes_key,
                     {ordered->schemas.data(), ordered->schemas.size()},
                     {ordered->arg_tags.data(), ordered->arg_tags.size()},
                     keys_kwarg_element(context));
@@ -3345,22 +3414,32 @@ namespace hgraph::stdlib
             bind_graph_output(resolution, *output_schema, "O");
         }
 
-        /** The first NON-pass-through collection decides the map kernel. */
+        /** The first genuinely multiplexed collection decides the map kernel. */
         [[nodiscard]] inline const TSValueTypeMetaData *first_map_collection(OperatorCallContext context)
         {
+            const WiredFn *func = context.scalar_as<WiredFn>("func");
+            if (func == nullptr) { return nullptr; }
             auto ordered = ordered_map_schemas(context, "key");
             if (!ordered.has_value()) { ordered = ordered_map_schemas(context, "ndx"); }
             if (!ordered.has_value()) { return nullptr; }
             for (std::size_t i = 0; i < ordered->schemas.size(); ++i)
             {
-                if (i < ordered->arg_tags.size() &&
-                    static_cast<WiringPortRef::ArgTag>(ordered->arg_tags[i]) ==
-                        WiringPortRef::ArgTag::PassThrough)
+                const auto tag = i < ordered->arg_tags.size()
+                                     ? static_cast<WiringPortRef::ArgTag>(ordered->arg_tags[i])
+                                     : WiringPortRef::ArgTag::None;
+                if (tag == WiringPortRef::ArgTag::PassThrough)
                 {
                     continue;   // pass_through never selects the kernel
                 }
                 if (const auto *schema = time_series_schema_as<AnyTSD>(ordered->schemas[i]))
                 {
+                    if (tag != WiringPortRef::ArgTag::NoKey &&
+                        map_parameter_acceptance(
+                            *func, i + (ordered->takes_key ? 1 : 0),
+                            ordered->schemas[i], schema->element_ts()).whole)
+                    {
+                        continue;   // whole-time-series parameter: direct input
+                    }
                     return schema;
                 }
                 if (const auto *schema = time_series_schema_as<AnyTSL>(ordered->schemas[i]))
@@ -3374,8 +3453,10 @@ namespace hgraph::stdlib
         /**
          * ``map_(func, *args, **kwargs)`` over TSDs — keyed runtime children,
          * the Python shape: no fixed anchor parameter; positional + keyword
-         * arguments resolve onto ``func``'s parameters, every TSD multiplexes
-         * (union key set), everything else broadcasts.
+         * arguments resolve onto ``func``'s parameters. TSDs whose parameters
+         * accept their elements multiplex (union key set); whole-time-series
+         * type variables and concrete whole-TSD parameters bind directly, and
+         * everything else broadcasts.
          */
         /**
          * Split the ``__keys__`` special out of the collected kwargs — it is
@@ -3508,7 +3589,8 @@ namespace hgraph::stdlib
             try
             {
                 const MapArgClassification classified =
-                    classify_map_args({ordered->schemas.data(), ordered->schemas.size()},
+                    classify_map_args(*func, ordered->takes_key,
+                                      {ordered->schemas.data(), ordered->schemas.size()},
                                       {ordered->arg_tags.data(), ordered->arg_tags.size()},
                                       keys_kwarg_element(context));
                 const auto *output_schema = TypeRegistry::instance().tsd(classified.key_meta, element);

--- a/include/hgraph/lib/std/operators/impl/higher_order_impl.h
+++ b/include/hgraph/lib/std/operators/impl/higher_order_impl.h
@@ -2449,11 +2449,12 @@ namespace hgraph::stdlib
 
         /**
          * Classify the ``map_`` time-series arguments against ``func``'s
-         * ordered parameters. An unmarked TSD binds whole when the parameter
-         * is a whole-time-series type variable or accepts that concrete TSD;
-         * it multiplexes only when the parameter instead accepts the TSD
-         * element. The first multiplexed TSD establishes the key type and
-         * later multiplexed TSDs must agree.
+         * ordered parameters. A whole-time-series type variable multiplexes
+         * the first TSD argument and later TSDs with the established key type;
+         * a later TSD with a different key type binds whole. A parameter that
+         * accepts the concrete TSD always binds it whole, while a parameter
+         * accepting only the element multiplexes it. The first multiplexed
+         * TSD establishes the key type and later multiplexed TSDs must agree.
          */
         struct MapArgClassification
         {
@@ -2467,6 +2468,7 @@ namespace hgraph::stdlib
         {
             bool whole{false};
             bool element{false};
+            bool whole_variable{false};
         };
 
         /** Determine whether one mapped parameter accepts a TSD whole or its
@@ -2493,12 +2495,15 @@ namespace hgraph::stdlib
                     input_ts_pattern_match(*pattern, whole, whole_resolution);
                 const bool pattern_accepts_element =
                     input_ts_pattern_match(*pattern, element, element_resolution);
+                result.whole_variable =
+                    pattern_accepts_whole && pattern_accepts_element &&
+                    pattern->kind == TypePattern::Kind::Var && func.operator_name.empty();
                 result.element = result.element || pattern_accepts_element;
                 result.whole = result.whole ||
                     (pattern_accepts_whole &&
                      (!pattern_accepts_element ||
                       pattern->kind == TypePattern::Kind::TSD ||
-                      (pattern->kind == TypePattern::Kind::Var && func.operator_name.empty())));
+                      result.whole_variable));
             }
             else if (func.input_schema(parameter) == nullptr)
             {
@@ -2519,25 +2524,33 @@ namespace hgraph::stdlib
             bool takes_leading_key,
             std::span<const TSValueTypeMetaData *const> ts_schemas,
             std::span<const std::uint8_t> arg_tags,
-            const ValueTypeMetaData *fallback_key_meta = nullptr) {
+            const ValueTypeMetaData *fallback_key_meta = nullptr,
+            bool require_multiplexed_tsd = true) {
             MapArgClassification result;
             result.is_multiplexed.reserve(ts_schemas.size());
             result.exclude_from_keys.reserve(ts_schemas.size());
             result.child_schemas.reserve(ts_schemas.size());
+            bool seen_tsd = false;
             for (std::size_t i = 0; i < ts_schemas.size(); ++i)
             {
                 const auto tag = i < arg_tags.size() ? static_cast<WiringPortRef::ArgTag>(arg_tags[i])
                                                      : WiringPortRef::ArgTag::None;
                 const auto *tsd = time_series_schema_as<AnyTSD>(ts_schemas[i]);
+                const bool first_tsd = tsd != nullptr && !seen_tsd;
+                seen_tsd = seen_tsd || tsd != nullptr;
                 const auto parameter = i + (takes_leading_key ? 1 : 0);
                 const auto acceptance = tsd != nullptr
                                             ? map_parameter_acceptance(
                                                   func, parameter, ts_schemas[i], tsd->element_ts())
                                             : MapParameterAcceptance{};
                 const bool force_multiplex = tag == WiringPortRef::ArgTag::NoKey;
+                const bool generic_multiplex =
+                    acceptance.whole_variable &&
+                    (first_tsd ||
+                     (result.key_meta != nullptr && tsd->key_type() == result.key_meta));
                 const bool is_multiplexed =
                     tsd != nullptr && tag != WiringPortRef::ArgTag::PassThrough &&
-                    (force_multiplex || !acceptance.whole);
+                    (force_multiplex || generic_multiplex || !acceptance.whole);
                 if (is_multiplexed)
                 {
                     if (!acceptance.element)
@@ -2557,7 +2570,7 @@ namespace hgraph::stdlib
                 }
                 else
                 {
-                    if (tag == WiringPortRef::ArgTag::NoKey)
+                    if (tag == WiringPortRef::ArgTag::NoKey && require_multiplexed_tsd)
                     {
                         throw std::invalid_argument("map_: 'no_key' applies to multiplexed TSD inputs only");
                     }
@@ -2572,7 +2585,7 @@ namespace hgraph::stdlib
                 // dictionaries) takes its key type from the key set.
                 result.key_meta = fallback_key_meta;
             }
-            if (result.key_meta == nullptr)
+            if (result.key_meta == nullptr && require_multiplexed_tsd)
             {
                 throw std::invalid_argument(
                     "map_: at least one input must be a multiplexed TSD (or supply an explicit '__keys__')");
@@ -3422,6 +3435,11 @@ namespace hgraph::stdlib
             auto ordered = ordered_map_schemas(context, "key");
             if (!ordered.has_value()) { ordered = ordered_map_schemas(context, "ndx"); }
             if (!ordered.has_value()) { return nullptr; }
+            const MapArgClassification classified = classify_map_args(
+                *func, ordered->takes_key,
+                {ordered->schemas.data(), ordered->schemas.size()},
+                {ordered->arg_tags.data(), ordered->arg_tags.size()},
+                keys_kwarg_element(context), false);
             for (std::size_t i = 0; i < ordered->schemas.size(); ++i)
             {
                 const auto tag = i < ordered->arg_tags.size()
@@ -3433,13 +3451,7 @@ namespace hgraph::stdlib
                 }
                 if (const auto *schema = time_series_schema_as<AnyTSD>(ordered->schemas[i]))
                 {
-                    if (tag != WiringPortRef::ArgTag::NoKey &&
-                        map_parameter_acceptance(
-                            *func, i + (ordered->takes_key ? 1 : 0),
-                            ordered->schemas[i], schema->element_ts()).whole)
-                    {
-                        continue;   // whole-time-series parameter: direct input
-                    }
+                    if (!classified.is_multiplexed[i]) { continue; }
                     return schema;
                 }
                 if (const auto *schema = time_series_schema_as<AnyTSL>(ordered->schemas[i]))
@@ -3454,9 +3466,10 @@ namespace hgraph::stdlib
          * ``map_(func, *args, **kwargs)`` over TSDs — keyed runtime children,
          * the Python shape: no fixed anchor parameter; positional + keyword
          * arguments resolve onto ``func``'s parameters. TSDs whose parameters
-         * accept their elements multiplex (union key set); whole-time-series
-         * type variables and concrete whole-TSD parameters bind directly, and
-         * everything else broadcasts.
+         * accept their elements multiplex (union key set). A whole-time-series
+         * type variable multiplexes the first TSD or a later same-key TSD and
+         * binds a later different-key TSD directly. Concrete whole-TSD
+         * parameters and all other time-series shapes bind directly.
          */
         /**
          * Split the ``__keys__`` special out of the collected kwargs — it is

--- a/include/hgraph/lib/std/operators/impl/higher_order_impl.h
+++ b/include/hgraph/lib/std/operators/impl/higher_order_impl.h
@@ -2525,7 +2525,8 @@ namespace hgraph::stdlib
             std::span<const TSValueTypeMetaData *const> ts_schemas,
             std::span<const std::uint8_t> arg_tags,
             const ValueTypeMetaData *fallback_key_meta = nullptr,
-            bool require_multiplexed_tsd = true) {
+            bool require_multiplexed_tsd = true,
+            std::string_view operation_name = "map_") {
             MapArgClassification result;
             result.is_multiplexed.reserve(ts_schemas.size());
             result.exclude_from_keys.reserve(ts_schemas.size());
@@ -2555,14 +2556,16 @@ namespace hgraph::stdlib
                 {
                     if (!acceptance.element)
                     {
-                        throw std::invalid_argument(
-                            "map_: a multiplexed TSD value is incompatible with the mapped function parameter");
+                        throw std::invalid_argument(fmt::format(
+                            "{}: a multiplexed TSD value is incompatible with the mapped function parameter",
+                            operation_name));
                     }
                     if (result.key_meta == nullptr) { result.key_meta = tsd->key_type(); }
                     else if (tsd->key_type() != result.key_meta)
                     {
-                        throw std::invalid_argument(
-                            "map_: every multiplexed TSD must share the same key type");
+                        throw std::invalid_argument(fmt::format(
+                            "{}: every multiplexed TSD must share the same key type",
+                            operation_name));
                     }
                     result.is_multiplexed.push_back(true);
                     result.exclude_from_keys.push_back(force_multiplex);
@@ -2572,7 +2575,9 @@ namespace hgraph::stdlib
                 {
                     if (tag == WiringPortRef::ArgTag::NoKey && require_multiplexed_tsd)
                     {
-                        throw std::invalid_argument("map_: 'no_key' applies to multiplexed TSD inputs only");
+                        throw std::invalid_argument(fmt::format(
+                            "{}: 'no_key' applies to multiplexed TSD inputs only",
+                            operation_name));
                     }
                     result.is_multiplexed.push_back(false);
                     result.exclude_from_keys.push_back(false);
@@ -2587,10 +2592,70 @@ namespace hgraph::stdlib
             }
             if (result.key_meta == nullptr && require_multiplexed_tsd)
             {
-                throw std::invalid_argument(
-                    "map_: at least one input must be a multiplexed TSD (or supply an explicit '__keys__')");
+                throw std::invalid_argument(fmt::format(
+                    "{}: at least one input must be a multiplexed TSD (or supply an explicit '__keys__')",
+                    operation_name));
             }
             return result;
+        }
+
+        /** Resolve and validate the lifecycle key set shared by keyed map and
+            mesh nodes. An explicit ``__keys__`` wins; otherwise only the
+            classified multiplexed inputs participate. ``pass_through`` inputs
+            are absent from that list, while ``no_key`` inputs carry the
+            classifier's ``exclude_from_keys`` bit and are skipped here. */
+        [[nodiscard]] inline WiringPortRef wire_keyed_lifecycle_keys(
+            Wiring &w,
+            std::optional<WiringPortRef> explicit_keys,
+            std::span<const std::size_t> multiplexed_inputs,
+            const MapArgClassification &classified,
+            std::span<const WiringPortRef> ordered,
+            std::string_view operation_name)
+        {
+            WiringPortRef keys;
+            if (explicit_keys.has_value())
+            {
+                keys = std::move(*explicit_keys);
+            }
+            else
+            {
+                std::vector<WiringArg> key_set_args;
+                key_set_args.reserve(multiplexed_inputs.size());
+                for (const std::size_t mux_index : multiplexed_inputs)
+                {
+                    if (classified.exclude_from_keys[mux_index]) { continue; }
+                    WiringArg key_set_arg;
+                    key_set_arg.kind = WiringArg::Kind::TimeSeries;
+                    key_set_arg.port = subgraph_wiring_detail::tsd_key_set_ref(ordered[mux_index]);
+                    key_set_args.push_back(std::move(key_set_arg));
+                }
+                if (key_set_args.empty())
+                {
+                    throw std::invalid_argument(fmt::format(
+                        "{}: every multiplexed input is no_key — supply an explicit '__keys__'",
+                        operation_name));
+                }
+                keys = key_set_args.size() == 1
+                           ? key_set_args.front().port
+                           : wire_operator(
+                                 w, "union", {key_set_args.data(), key_set_args.size()}, true)
+                                 .output.erased();
+            }
+
+            auto &registry = TypeRegistry::instance();
+            const auto *actual_keys_schema = registry.dereference(keys.schema);
+            const auto *expected_keys_schema = registry.tss(classified.key_meta);
+            if (actual_keys_schema != expected_keys_schema)
+            {
+                throw std::invalid_argument(fmt::format(
+                    "{}: '__keys__' must be a TSS of the mapped key type (got '{}', expected '{}')",
+                    operation_name,
+                    actual_keys_schema != nullptr ? actual_keys_schema->name()
+                                                  : std::string_view{"<unbound>"},
+                    expected_keys_schema != nullptr ? expected_keys_schema->name()
+                                                    : std::string_view{"<unbound>"}));
+            }
+            return keys;
         }
 
         /**
@@ -2608,25 +2673,29 @@ namespace hgraph::stdlib
                                                            std::vector<WiringPortRef> *captured = nullptr,
                                                            const ValueTypeMetaData *fallback_key_meta = nullptr,
                                                            std::vector<NestedServiceInput> *external_services = nullptr,
-                                                           Wiring *parent = nullptr)
+                                                           Wiring *parent = nullptr,
+                                                           std::string_view operation_name = "map_")
         {
             if (!func.valid())
             {
-                throw std::invalid_argument("map_: 'func' must be a wirable function (fn<X>())");
+                throw std::invalid_argument(fmt::format(
+                    "{}: 'func' must be a wirable function (fn<X>())", operation_name));
             }
 
             const std::size_t base_arity = ts_schemas.size();
             const bool        takes_key  = !func.variadic && func.arity == base_arity + 1;
             if (!takes_key && (func.variadic ? base_arity < func.arity : func.arity != base_arity))
             {
-                throw std::invalid_argument(
-                    "map_: 'func' must take one parameter per time-series argument, with an optional key "
-                    "already resolved by name");
+                throw std::invalid_argument(fmt::format(
+                    "{}: 'func' must take one parameter per time-series argument, with an optional key "
+                    "already resolved by name",
+                    operation_name));
             }
 
             auto &registry = TypeRegistry::instance();
             const MapArgClassification classified = classify_map_args(
-                func, takes_key, ts_schemas, arg_tags, fallback_key_meta);
+                func, takes_key, ts_schemas, arg_tags, fallback_key_meta, true,
+                operation_name);
 
             const auto *key_ts = registry.ts(classified.key_meta);
 
@@ -2643,8 +2712,9 @@ namespace hgraph::stdlib
             const bool child_has_output = compiled.output_schema != nullptr;
             if (compiled.output_binding.has_value() != child_has_output)
             {
-                throw std::invalid_argument(
-                    "map_: the function output schema and nested output binding must agree");
+                throw std::invalid_argument(fmt::format(
+                    "{}: the function output schema and nested output binding must agree",
+                    operation_name));
             }
             if (child_has_output)
             {
@@ -2668,8 +2738,9 @@ namespace hgraph::stdlib
                             registry.dereference(compiled.output_schema));
                     if (!exact_match && !ref_transparent_match)
                     {
-                        throw std::invalid_argument(
-                            "map_: the function's wired output is incompatible with its declared output schema");
+                        throw std::invalid_argument(fmt::format(
+                            "{}: the function's wired output is incompatible with its declared output schema",
+                            operation_name));
                     }
                     if (exact_match || declared->kind == TSTypeKind::REF ||
                         compiled.output_is_structural_reference)
@@ -2737,8 +2808,9 @@ namespace hgraph::stdlib
                         !time_series_schema_equivalent(
                             registry.dereference(terminal_schema), registry.dereference(out)))
                     {
-                        throw std::invalid_argument(
-                            "map_: child terminal schema is incompatible with its declared output");
+                        throw std::invalid_argument(fmt::format(
+                            "{}: child terminal schema is incompatible with its declared output",
+                            operation_name));
                     }
                     // A declared forwarding terminal already owns its link, and a
                     // non-peered terminal has required child endpoint topology
@@ -2839,7 +2911,8 @@ namespace hgraph::stdlib
             const WiredFn &func,
             std::span<const TSValueTypeMetaData *const> ts_schemas,
             std::span<const std::uint8_t> arg_tags,
-            const ValueTypeMetaData *fallback_key_meta = nullptr)
+            const ValueTypeMetaData *fallback_key_meta = nullptr,
+            std::string_view operation_name = "map_")
         {
             // OperatorRegistry already probes each overload behind an exception
             // boundary and records what() as that candidate's rejection reason.
@@ -2849,7 +2922,8 @@ namespace hgraph::stdlib
             std::vector<WiringPortRef> captured;
             std::vector<NestedServiceInput> external_services;
             (void)compile_map_child(func, ts_schemas, arg_tags, output_schema, &captured,
-                                    fallback_key_meta, &external_services);
+                                    fallback_key_meta, &external_services, nullptr,
+                                    operation_name);
             if (output_schema == nullptr) { return std::optional<const TSValueTypeMetaData *>{}; }
             return std::optional<const TSValueTypeMetaData *>{output_schema};
         }
@@ -2935,46 +3009,10 @@ namespace hgraph::stdlib
             // excluded from the inference. The runtime is always keys-driven;
             // there is no in-node union scan.
             auto &registry = TypeRegistry::instance();
-            if (!keys.has_value())
-            {
-                // Each multiplexed dict contributes its ZERO-COPY key-set
-                // projection (no node); several union through the union
-                // operator — the Python wiring ``__keys__ = union(*key_sets)``.
-                std::vector<WiringArg> key_set_args;
-                key_set_args.reserve(spec.multiplexed_inputs.size());
-                for (const std::size_t mux_index : spec.multiplexed_inputs)
-                {
-                    if (static_cast<WiringPortRef::ArgTag>(arg_tags[mux_index]) ==
-                        WiringPortRef::ArgTag::NoKey)
-                    {
-                        continue;
-                    }
-                    WiringArg key_set_arg;
-                    key_set_arg.kind = WiringArg::Kind::TimeSeries;
-                    key_set_arg.port = subgraph_wiring_detail::tsd_key_set_ref(ordered[mux_index]);
-                    key_set_args.push_back(std::move(key_set_arg));
-                }
-                if (key_set_args.empty())
-                {
-                    throw std::invalid_argument(
-                        "map_: every multiplexed input is no_key — supply an explicit '__keys__'");
-                }
-                if (key_set_args.size() == 1) { keys = key_set_args.front().port; }
-                else
-                {
-                    keys = wire_operator(w, "union", {key_set_args.data(), key_set_args.size()}, true)
-                               .output.erased();
-                }
-            }
-            const auto *actual_keys_schema = registry.dereference(keys->schema);
-            const auto *expected_keys_schema = registry.tss(classified.key_meta);
-            if (actual_keys_schema != expected_keys_schema)
-            {
-                throw std::invalid_argument(fmt::format(
-                    "map_: '__keys__' must be a TSS of the mapped key type (got '{}', expected '{}')",
-                    actual_keys_schema != nullptr ? actual_keys_schema->name() : std::string_view{"<unbound>"},
-                    expected_keys_schema != nullptr ? expected_keys_schema->name() : std::string_view{"<unbound>"}));
-            }
+            WiringPortRef lifecycle_keys = wire_keyed_lifecycle_keys(
+                w, std::move(keys),
+                {spec.multiplexed_inputs.data(), spec.multiplexed_inputs.size()},
+                classified, {ordered.data(), ordered.size()}, "map_");
             spec.keys_input_index = ordered.size();
 
             std::vector<std::pair<std::string, const TSValueTypeMetaData *>> fields;
@@ -2987,11 +3025,11 @@ namespace hgraph::stdlib
                         : ts_schemas[i];
                 fields.emplace_back(std::to_string(i), input_schema);
             }
-            fields.emplace_back("__keys__", keys->schema);
+            fields.emplace_back("__keys__", lifecycle_keys.schema);
             const auto *input_schema = TypeRegistry::instance().un_named_tsb(fields);
 
             std::vector<WiringPortRef> inputs = std::move(ordered);
-            inputs.push_back(std::move(*keys));
+            inputs.push_back(std::move(lifecycle_keys));
 
             WiringNodeSchema node_schema;
             node_schema.input  = input_schema;
@@ -3083,7 +3121,7 @@ namespace hgraph::stdlib
             const MapArgClassification classified = classify_map_args(
                 func.value(), takes_key,
                 {ts_schemas.data(), ts_schemas.size()}, {arg_tags.data(), arg_tags.size()},
-                explicit_key_meta);
+                explicit_key_meta, true, "mesh_");
 
             const TSValueTypeMetaData *output_schema = nullptr;
             MapNodeSpec                map_spec;
@@ -3096,13 +3134,13 @@ namespace hgraph::stdlib
                 auto pop = make_scope_exit([] noexcept { OperatorRegistry::instance().pop_mesh_scope(); });
                 map_spec = compile_map_child(func.value(), {ts_schemas.data(), ts_schemas.size()},
                                              {arg_tags.data(), arg_tags.size()}, output_schema, &captured,
-                                             explicit_key_meta, &external_services, &w);
+                                             explicit_key_meta, &external_services, &w, "mesh_");
             }
             else
             {
                 map_spec = compile_map_child(func.value(), {ts_schemas.data(), ts_schemas.size()},
                                              {arg_tags.data(), arg_tags.size()}, output_schema, &captured,
-                                             explicit_key_meta, &external_services, &w);
+                                             explicit_key_meta, &external_services, &w, "mesh_");
                 const auto *inferred = time_series_schema_as<AnyTSD>(output_schema);
                 if (inferred == nullptr)
                 {
@@ -3123,44 +3161,10 @@ namespace hgraph::stdlib
 
             auto &registry = TypeRegistry::instance();
 
-            // Key-set derivation — identical to map_ (explicit __keys__, else the
-            // union of the multiplexed dict key sets).
-            if (!keys.has_value())
-            {
-                std::vector<WiringArg> key_set_args;
-                key_set_args.reserve(map_spec.multiplexed_inputs.size());
-                for (const std::size_t mux_index : map_spec.multiplexed_inputs)
-                {
-                    if (static_cast<WiringPortRef::ArgTag>(arg_tags[mux_index]) == WiringPortRef::ArgTag::NoKey)
-                    {
-                        continue;
-                    }
-                    WiringArg key_set_arg;
-                    key_set_arg.kind = WiringArg::Kind::TimeSeries;
-                    key_set_arg.port = subgraph_wiring_detail::tsd_key_set_ref(ordered[mux_index]);
-                    key_set_args.push_back(std::move(key_set_arg));
-                }
-                if (key_set_args.empty())
-                {
-                    throw std::invalid_argument(
-                        "mesh_: every multiplexed input is no_key — supply an explicit '__keys__'");
-                }
-                if (key_set_args.size() == 1) { keys = key_set_args.front().port; }
-                else
-                {
-                    keys = wire_operator(w, "union", {key_set_args.data(), key_set_args.size()}, true)
-                               .output.erased();
-                }
-            }
-            const auto *actual_keys_schema = registry.dereference(keys->schema);
-            const auto *expected_keys_schema = registry.tss(output_schema->key_type());
-            if (actual_keys_schema != expected_keys_schema)
-            {
-                throw std::invalid_argument(fmt::format(
-                    "mesh_: '__keys__' must be a TSS of the mapped key type (got '{}', expected '{}')",
-                    actual_keys_schema != nullptr ? actual_keys_schema->name() : std::string_view{"<unbound>"},
-                    expected_keys_schema != nullptr ? expected_keys_schema->name() : std::string_view{"<unbound>"}));
-            }
+            WiringPortRef lifecycle_keys = wire_keyed_lifecycle_keys(
+                w, std::move(keys),
+                {map_spec.multiplexed_inputs.data(), map_spec.multiplexed_inputs.size()},
+                classified, {ordered.data(), ordered.size()}, "mesh_");
 
             // Transcribe the map child spec into a mesh spec (a superset).
             MeshNodeSpec spec;
@@ -3184,11 +3188,11 @@ namespace hgraph::stdlib
                         : ts_schemas[i];
                 fields.emplace_back(std::to_string(i), input_schema);
             }
-            fields.emplace_back("__keys__", keys->schema);
+            fields.emplace_back("__keys__", lifecycle_keys.schema);
             const auto *input_schema = registry.un_named_tsb(fields);
 
             std::vector<WiringPortRef> inputs = std::move(ordered);
-            inputs.push_back(std::move(*keys));
+            inputs.push_back(std::move(lifecycle_keys));
 
             WiringNodeSchema node_schema;
             node_schema.input  = input_schema;
@@ -3428,7 +3432,8 @@ namespace hgraph::stdlib
         }
 
         /** The first genuinely multiplexed collection decides the map kernel. */
-        [[nodiscard]] inline const TSValueTypeMetaData *first_map_collection(OperatorCallContext context)
+        [[nodiscard]] inline const TSValueTypeMetaData *first_map_collection(
+            OperatorCallContext context, std::string_view operation_name = "map_")
         {
             const WiredFn *func = context.scalar_as<WiredFn>("func");
             if (func == nullptr) { return nullptr; }
@@ -3439,7 +3444,7 @@ namespace hgraph::stdlib
                 *func, ordered->takes_key,
                 {ordered->schemas.data(), ordered->schemas.size()},
                 {ordered->arg_tags.data(), ordered->arg_tags.size()},
-                keys_kwarg_element(context), false);
+                keys_kwarg_element(context), false, operation_name);
             for (std::size_t i = 0; i < ordered->schemas.size(); ++i)
             {
                 const auto tag = i < ordered->arg_tags.size()
@@ -3595,24 +3600,17 @@ namespace hgraph::stdlib
                 const auto inferred = try_resolve_map_output_schema(
                     *func, {ordered->schemas.data(), ordered->schemas.size()},
                     {ordered->arg_tags.data(), ordered->arg_tags.size()},
-                    keys_kwarg_element(context));
+                    keys_kwarg_element(context), "mesh_");
                 if (inferred.has_value()) { bind_graph_output(resolution, *inferred, "O"); }
                 return;
             }
-            try
-            {
-                const MapArgClassification classified =
-                    classify_map_args(*func, ordered->takes_key,
-                                      {ordered->schemas.data(), ordered->schemas.size()},
-                                      {ordered->arg_tags.data(), ordered->arg_tags.size()},
-                                      keys_kwarg_element(context));
-                const auto *output_schema = TypeRegistry::instance().tsd(classified.key_meta, element);
-                bind_graph_output(resolution, output_schema, "O");
-            }
-            catch (...)
-            {
-                // Leave unresolved; the real wiring path reports the error.
-            }
+            const MapArgClassification classified =
+                classify_map_args(*func, ordered->takes_key,
+                                  {ordered->schemas.data(), ordered->schemas.size()},
+                                  {ordered->arg_tags.data(), ordered->arg_tags.size()},
+                                  keys_kwarg_element(context), true, "mesh_");
+            const auto *output_schema = TypeRegistry::instance().tsd(classified.key_meta, element);
+            bind_graph_output(resolution, output_schema, "O");
         }
 
         struct mesh_impl_tsd
@@ -3621,7 +3619,7 @@ namespace hgraph::stdlib
 
             static bool requires_(const ResolutionMap &, OperatorCallContext context)
             {
-                const auto *collection = first_map_collection(context);
+                const auto *collection = first_map_collection(context, "mesh_");
                 return collection != nullptr
                            ? time_series_schema_as<AnyTSD>(collection) != nullptr
                            : keys_kwarg_element(context) != nullptr;

--- a/include/hgraph/types/lift.h
+++ b/include/hgraph/types/lift.h
@@ -583,6 +583,7 @@ namespace hgraph
                 [](const void *) { return lift_detail::param_names<F>(); },
                 nullptr,
                 nullptr,
+                nullptr,
                 [](const void *) -> std::string_view {
                     const char *name = lift_detail::kernel<F, Identity>().name;
                     return name != nullptr ? std::string_view{name}

--- a/include/hgraph/types/wired_fn.h
+++ b/include/hgraph/types/wired_fn.h
@@ -3,6 +3,7 @@
 
 #include <hgraph/types/graph_wiring.h>
 #include <hgraph/types/subgraph_wiring.h>
+#include <hgraph/types/type_pattern.h>
 #include <hgraph/types/value/value_view.h>
 
 #include <cstddef>
@@ -124,6 +125,7 @@ namespace hgraph
                                     std::span<const TSValueTypeMetaData *const>){nullptr};
         std::span<const std::string_view> (*param_names)(const void *context){nullptr};
         const TSValueTypeMetaData *(*input_schema)(const void *context, std::size_t index){nullptr};
+        std::optional<TypePattern> (*input_pattern)(const void *context, std::size_t index){nullptr};
         const TSValueTypeMetaData *(*output_schema)(const void *context){nullptr};
         std::string_view (*diagnostic_label)(const void *context){nullptr};
     };
@@ -167,6 +169,23 @@ namespace hgraph
             return ops != nullptr && ops->input_schema != nullptr
                        ? ops->input_schema(context, index)
                        : nullptr;
+        }
+
+        /** The declared input type pattern, including generic structure.
+
+            Unlike ``input_schema()``, this distinguishes a whole-time-series
+            variable from a structured generic such as ``TS<ScalarVar>``.
+            Runtime callables which cannot expose a pattern return nullopt. */
+        [[nodiscard]] std::optional<TypePattern> input_pattern(std::size_t index) const
+        {
+            if (index >= arity) { return std::nullopt; }
+            if (lifted != nullptr)
+            {
+                return TypePattern::concrete(lifted->input_schema(index));
+            }
+            return ops != nullptr && ops->input_pattern != nullptr
+                       ? ops->input_pattern(context, index)
+                       : std::nullopt;
         }
 
         /**
@@ -738,6 +757,63 @@ namespace hgraph
         }
 
         template <typename X>
+        [[nodiscard]] std::optional<TypePattern> input_pattern_thunk(std::size_t index)
+        {
+            std::optional<TypePattern> out;
+            if constexpr (std::is_base_of_v<operator_tag, X>)
+            {
+                using params = typename X::param_types;
+                std::size_t next = 0;
+                [&]<std::size_t... I>(std::index_sequence<I...>) {
+                    (
+                        [&] {
+                            using P = std::tuple_element_t<I, params>;
+                            if constexpr (static_node_detail::is_input_selector<P>::value)
+                            {
+                                if (next == index) { out = to_pattern<typename P::schema>(); }
+                                ++next;
+                            }
+                        }(),
+                        ...);
+                }(std::make_index_sequence<std::tuple_size_v<params>>{});
+            }
+            else if constexpr (graph_wiring_detail::is_graph_def<X>)
+            {
+                using params = typename StaticGraphSignature<X>::param_types;
+                std::size_t next = 0;
+                [&]<std::size_t... I>(std::index_sequence<I...>) {
+                    (
+                        [&] {
+                            using P = std::tuple_element_t<I, params>;
+                            if constexpr (graph_wiring_detail::is_port<P>::value)
+                            {
+                                if (next == index)
+                                {
+                                    using S = typename graph_wiring_detail::port_static_schema<P>::type;
+                                    if constexpr (std::is_void_v<S>)
+                                    {
+                                        out = TypePattern::var(
+                                            std::string{"__erased_input_"} + std::to_string(index));
+                                    }
+                                    else { out = to_pattern<S>(); }
+                                }
+                                ++next;
+                            }
+                        }(),
+                        ...);
+                }(std::make_index_sequence<std::tuple_size_v<params>>{});
+            }
+            else
+            {
+                using inputs = typename StaticNodeSignature<X>::input_schema_types;
+                [&]<std::size_t... I>(std::index_sequence<I...>) {
+                    ((index == I ? void(out = to_pattern<std::tuple_element_t<I, inputs>>()) : void()), ...);
+                }(std::make_index_sequence<std::tuple_size_v<inputs>>{});
+            }
+            return out;
+        }
+
+        template <typename X>
         [[nodiscard]] const TSValueTypeMetaData *output_schema_thunk()
         {
             if constexpr (!has_output_of<X>()) { return nullptr; }
@@ -773,6 +849,7 @@ namespace hgraph
                 },
                 [](const void *) { return param_names_thunk<X>(); },
                 [](const void *, std::size_t index) { return input_schema_thunk<X>(index); },
+                [](const void *, std::size_t index) { return input_pattern_thunk<X>(index); },
                 [](const void *) { return output_schema_thunk<X>(); },
                 [](const void *) -> std::string_view {
                     if constexpr (static_node_detail::has_name<X>) {

--- a/python/hgraph/_wiring/_compose.py
+++ b/python/hgraph/_wiring/_compose.py
@@ -191,13 +191,13 @@ def passive(ts):
 
 
 def pass_through(tsd):
-    """map_'s pass-through marker: do NOT demultiplex this argument."""
+    """map_/mesh_ pass-through marker: do NOT demultiplex this argument."""
     ts = tsd
     return WiringPort(_hgraph.pass_through_tag(_unwrap(ts)))
 
 
 def no_key(tsd):
-    """map_'s no-key marker: demultiplex, but exclude from key inference."""
+    """map_/mesh_ no-key marker: demultiplex, but exclude from key inference."""
     ts = tsd
     return WiringPort(_hgraph.no_key_tag(_unwrap(ts)))
 

--- a/python/hgraph/_wiring/_graph.py
+++ b/python/hgraph/_wiring/_graph.py
@@ -5,7 +5,7 @@ import inspect
 import _hgraph
 
 from .._types import (_ContextExpr, _GenericTsExpr, _TsExpr,
-                      _TypeVarSentinel, _type_var_name)
+                      _TypeVarSentinel, _pattern_of, _type_var_name)
 from ._core import (ParseError, WiringError, WiringPort, _current_wiring,
                     _resolve_context, _unwrap, _wiring_stack, wire)
 from ._markers import _INJECTABLE_MARKERS
@@ -97,14 +97,20 @@ def _wrap_graph_fn(gfn, *, input_names=None, scalar_bindings=None):
     out_tp = sig.return_annotation
     out_handle = out_tp.handle if isinstance(out_tp, _TsExpr) else None
     input_handles = []
+    input_patterns = []
     for name in names:
         annotation = sig.parameters[name].annotation
         input_handles.append(
             annotation.handle if isinstance(annotation, _TsExpr) else None)
+        try:
+            input_patterns.append(_pattern_of(annotation))
+        except TypeError:
+            input_patterns.append(None)
     identity = wrapper if input_names is not None or scalar_bindings else gfn
     return _hgraph.graph_fn(
         wrapper, identity, names, has_output, output_type=out_handle,
-        input_types=input_handles, user_callable=gfn)
+        input_types=input_handles, input_patterns=input_patterns,
+        user_callable=gfn)
 
 
 def _prepare_higher_order_call(func, args, kwargs, *, default_key_arg):

--- a/python/py_carriers.h
+++ b/python/py_carriers.h
@@ -180,6 +180,7 @@ namespace hgraph::python_bridge
         std::vector<std::string>      name_storage;
         std::vector<std::string_view> names;
         std::vector<const TSValueTypeMetaData *> input_schemas;
+        std::vector<std::optional<TypePattern>> input_patterns;
         std::size_t                   arity{0};
         bool                          has_output{true};
         /** The annotated output schema, when known (mesh_ needs the element

--- a/python/py_wiring.cpp
+++ b/python/py_wiring.cpp
@@ -359,6 +359,7 @@ namespace
                     record.name_views.data(), record.name_views.size()};
             },
             [](const void *, std::size_t) -> const TSValueTypeMetaData * { return nullptr; },
+            nullptr,
             [](const void *context) -> const TSValueTypeMetaData * {
                 return static_cast<const RuntimeOperatorRecord *>(context)->expected_output;
             },
@@ -533,6 +534,11 @@ namespace
             [](const void *context, std::size_t index) -> const TSValueTypeMetaData * {
                 const auto &record = *static_cast<const PyGraphFnRecord *>(context);
                 return index < record.input_schemas.size() ? record.input_schemas[index] : nullptr;
+            },
+            [](const void *context, std::size_t index) -> std::optional<TypePattern> {
+                const auto &record = *static_cast<const PyGraphFnRecord *>(context);
+                return index < record.input_patterns.size() ? record.input_patterns[index]
+                                                            : std::nullopt;
             },
             [](const void *context) {
                 // Known when the python fn carries a TS return annotation
@@ -928,6 +934,7 @@ namespace hgraph::python_bridge
 
     m.def("graph_fn", [](nb::object wrapper, nb::object identity, nb::list param_names, bool has_output,
                          std::optional<PyTsType> output_type, nb::list input_types,
+                         nb::list input_patterns,
                          nb::object user_callable) {
         auto &registry = py_graph_fn_registry();
         auto  found    = registry.find(identity.ptr());
@@ -953,6 +960,14 @@ namespace hgraph::python_bridge
                 record->input_schemas.push_back(
                     input_type.is_none() ? nullptr : nb::cast<PyTsType &>(input_type).meta);
             }
+            record->input_patterns.reserve(record->arity);
+            for (nb::handle input_pattern : input_patterns)
+            {
+                record->input_patterns.push_back(
+                    input_pattern.is_none()
+                        ? std::nullopt
+                        : std::optional<TypePattern>{nb::cast<PyTypePattern &>(input_pattern).pattern});
+            }
             record->name_storage.reserve(record->arity);
             for (nb::handle name : param_names) { record->name_storage.push_back(nb::cast<std::string>(name)); }
             for (const auto &name : record->name_storage) { record->names.emplace_back(name); }
@@ -968,6 +983,7 @@ namespace hgraph::python_bridge
         }};
     }, nb::arg("wrapper"), nb::arg("identity"), nb::arg("param_names"), nb::arg("has_output"),
        nb::arg("output_type") = nb::none(), nb::arg("input_types") = nb::list(),
+       nb::arg("input_patterns") = nb::list(),
        nb::arg("user_callable") = nb::none());
 
     nb::class_<PySwitchCases>(m, "SwitchCases");

--- a/python/tests/test_map_upstream_kwargs.py
+++ b/python/tests/test_map_upstream_kwargs.py
@@ -12,6 +12,8 @@ from hgraph import (
     graph,
     len_,
     map_,
+    no_key,
+    pass_through,
 )
 from hgraph.test import eval_node
 
@@ -57,6 +59,18 @@ def _add_concrete_dict_size(
     whole: TSD[int, TS[int]], value: TS[int]
 ) -> TS[int]:
     return value + len_(whole)
+
+
+@graph
+def _return_rhs(_lhs: TS[int], rhs: TS[int]) -> TS[int]:
+    return rhs
+
+
+@graph
+def _whole_dict_size(
+    _value: TS[int], whole: TSD[str, TS[int]]
+) -> TS[int]:
+    return len_(whole)
 
 
 def test_map_explicit_keys_restrict_children():
@@ -163,3 +177,35 @@ def test_map_concrete_tsd_before_first_multiplexed_input_is_direct():
         [{1: 10, 2: 20}, {3: 30}],
         [{"a": 1, "b": 2}, None],
     ) == [{"a": 3, "b": 4}, {"a": 4, "b": 5}]
+
+
+def test_map_no_key_input_is_excluded_from_inferred_key_union():
+    @graph
+    def g(
+        keys_source: TSD[str, TS[int]], values: TSD[str, TS[int]]
+    ) -> TSD[str, TS[int]]:
+        return map_(_return_rhs, keys_source, no_key(values))
+
+    # If values contributed to the inferred union, its independently usable
+    # "z" value would produce an observable output child.
+    assert eval_node(
+        g,
+        [{"x": 1, "y": 2}],
+        [{"x": 10, "z": 30}],
+    ) == [{"x": 10}]
+
+
+def test_map_pass_through_input_is_excluded_from_inferred_key_union():
+    @graph
+    def g(
+        keys_source: TSD[str, TS[int]], whole: TSD[str, TS[int]]
+    ) -> TSD[str, TS[int]]:
+        return map_(_whole_dict_size, keys_source, pass_through(whole))
+
+    # The mapped output does not depend on keys_source's values, so any key
+    # incorrectly inferred from whole would be visible in the output.
+    assert eval_node(
+        g,
+        [{"a": 1, "b": 2}],
+        [{"p": 10, "q": 20, "r": 30}],
+    ) == [{"a": 3, "b": 3}]

--- a/python/tests/test_map_upstream_kwargs.py
+++ b/python/tests/test_map_upstream_kwargs.py
@@ -1,13 +1,20 @@
 """map_'s upstream-parity kwargs (theme-F ruling 2026-08-01): __keys__,
 __key_arg__, __label__."""
 
-from hgraph import TS, TSD, TSS, compute_node, graph, map_
+import pytest
+
+from hgraph import TS, TSD, TSS, WiringError, compute_node, graph, map_
 from hgraph.test import eval_node
 
 
 @compute_node
 def _add1(v: TS[int]) -> TS[int]:
     return v.value + 1
+
+
+@compute_node
+def _add_pair(lhs: TS[int], rhs: TS[int]) -> TS[int]:
+    return lhs.value + rhs.value
 
 
 def test_map_explicit_keys_restrict_children():
@@ -36,3 +43,17 @@ def test_map_label_is_accepted_and_traces():
         return map_(_add1, tsd, __label__="my_map")
 
     assert eval_node(g, [{"a": 1}]) == [{"a": 2}]
+
+
+def test_map_mismatched_key_types_retain_the_classifier_diagnostic():
+    @graph
+    def g(
+        lhs: TSD[str, TS[int]], rhs: TSD[int, TS[int]]
+    ) -> TSD[str, TS[int]]:
+        return map_(_add_pair, lhs, rhs)
+
+    with pytest.raises(
+        WiringError,
+        match="map_: every multiplexed TSD must share the same key type",
+    ):
+        eval_node(g, [{"a": 1}], [{1: 2}])

--- a/python/tests/test_map_upstream_kwargs.py
+++ b/python/tests/test_map_upstream_kwargs.py
@@ -34,6 +34,25 @@ def _add_generic_dict_size(
 
 
 @graph
+def _add_one_generic(value: TIME_SERIES_TYPE) -> TS[int]:
+    return value + 1
+
+
+@graph
+def _add_two_generics(
+    lhs: TIME_SERIES_TYPE, rhs: TIME_SERIES_TYPE
+) -> TS[int]:
+    return lhs + rhs
+
+
+@graph
+def _add_generic_offset(
+    value: TS[int], offset: TIME_SERIES_TYPE
+) -> TS[int]:
+    return value + offset
+
+
+@graph
 def _add_concrete_dict_size(
     whole: TSD[int, TS[int]], value: TS[int]
 ) -> TS[int]:
@@ -82,7 +101,29 @@ def test_map_mismatched_key_types_retain_the_classifier_diagnostic():
         eval_node(g, [{"a": 1}], [{1: 2}])
 
 
-def test_map_generic_parameter_receives_later_tsd_whole():
+def test_map_first_generic_tsd_is_multiplexed():
+    @graph
+    def g(tsd: TSD[str, TS[int]]) -> TSD[str, TS[int]]:
+        return map_(_add_one_generic, tsd)
+
+    assert eval_node(g, [{"a": 1, "b": 2}]) == [{"a": 2, "b": 3}]
+
+
+def test_map_later_same_key_generic_tsd_is_multiplexed():
+    @graph
+    def g(
+        lhs: TSD[str, TS[int]], rhs: TSD[str, TS[int]]
+    ) -> TSD[str, TS[int]]:
+        return map_(_add_two_generics, lhs, rhs)
+
+    assert eval_node(
+        g,
+        [{"a": 1, "b": 2}],
+        [{"a": 10, "b": 20}],
+    ) == [{"a": 11, "b": 22}]
+
+
+def test_map_later_different_key_generic_tsd_is_direct():
     @graph
     def g(
         mux: TSD[str, TS[int]], whole: TSD[int, TS[int]]
@@ -94,6 +135,20 @@ def test_map_generic_parameter_receives_later_tsd_whole():
         [{"a": 1, "b": 2}, None],
         [{1: 10, 2: 20}, {3: 30}],
     ) == [{"a": 3, "b": 4}, {"a": 4, "b": 5}]
+
+
+def test_map_non_tsd_generic_input_is_direct():
+    @graph
+    def g(
+        mux: TSD[str, TS[int]], offset: TS[int]
+    ) -> TSD[str, TS[int]]:
+        return map_(_add_generic_offset, mux, offset)
+
+    assert eval_node(
+        g,
+        [{"a": 1, "b": 2}, None],
+        [10, 20],
+    ) == [{"a": 11, "b": 12}, {"a": 21, "b": 22}]
 
 
 def test_map_concrete_tsd_before_first_multiplexed_input_is_direct():

--- a/python/tests/test_map_upstream_kwargs.py
+++ b/python/tests/test_map_upstream_kwargs.py
@@ -1,9 +1,18 @@
-"""map_'s upstream-parity kwargs (theme-F ruling 2026-08-01): __keys__,
-__key_arg__, __label__."""
+"""map_ argument classification and upstream-compatible kwargs."""
 
 import pytest
 
-from hgraph import TS, TSD, TSS, WiringError, compute_node, graph, map_
+from hgraph import (
+    TIME_SERIES_TYPE,
+    TS,
+    TSD,
+    TSS,
+    WiringError,
+    compute_node,
+    graph,
+    len_,
+    map_,
+)
 from hgraph.test import eval_node
 
 
@@ -15,6 +24,20 @@ def _add1(v: TS[int]) -> TS[int]:
 @compute_node
 def _add_pair(lhs: TS[int], rhs: TS[int]) -> TS[int]:
     return lhs.value + rhs.value
+
+
+@graph
+def _add_generic_dict_size(
+    value: TS[int], whole: TIME_SERIES_TYPE
+) -> TS[int]:
+    return value + len_(whole)
+
+
+@graph
+def _add_concrete_dict_size(
+    whole: TSD[int, TS[int]], value: TS[int]
+) -> TS[int]:
+    return value + len_(whole)
 
 
 def test_map_explicit_keys_restrict_children():
@@ -57,3 +80,31 @@ def test_map_mismatched_key_types_retain_the_classifier_diagnostic():
         match="map_: every multiplexed TSD must share the same key type",
     ):
         eval_node(g, [{"a": 1}], [{1: 2}])
+
+
+def test_map_generic_parameter_receives_later_tsd_whole():
+    @graph
+    def g(
+        mux: TSD[str, TS[int]], whole: TSD[int, TS[int]]
+    ) -> TSD[str, TS[int]]:
+        return map_(_add_generic_dict_size, mux, whole)
+
+    assert eval_node(
+        g,
+        [{"a": 1, "b": 2}, None],
+        [{1: 10, 2: 20}, {3: 30}],
+    ) == [{"a": 3, "b": 4}, {"a": 4, "b": 5}]
+
+
+def test_map_concrete_tsd_before_first_multiplexed_input_is_direct():
+    @graph
+    def g(
+        whole: TSD[int, TS[int]], mux: TSD[str, TS[int]]
+    ) -> TSD[str, TS[int]]:
+        return map_(_add_concrete_dict_size, whole, mux)
+
+    assert eval_node(
+        g,
+        [{1: 10, 2: 20}, {3: 30}],
+        [{"a": 1, "b": 2}, None],
+    ) == [{"a": 3, "b": 4}, {"a": 4, "b": 5}]

--- a/python/tests/test_mesh_map_classification.py
+++ b/python/tests/test_mesh_map_classification.py
@@ -1,0 +1,209 @@
+"""mesh_ follows map_'s applicable TSD argument-classification rules."""
+
+import pytest
+
+from hgraph import (
+    TIME_SERIES_TYPE,
+    TS,
+    TSD,
+    TSS,
+    WiringError,
+    compute_node,
+    graph,
+    len_,
+    mesh_,
+    no_key,
+    pass_through,
+)
+from hgraph.test import eval_node
+
+
+@compute_node
+def _add_pair(lhs: TS[int], rhs: TS[int]) -> TS[int]:
+    return lhs.value + rhs.value
+
+
+@graph
+def _add_one_generic(value: TIME_SERIES_TYPE) -> TS[int]:
+    return value + 1
+
+
+@graph
+def _add_two_generics(
+    lhs: TIME_SERIES_TYPE, rhs: TIME_SERIES_TYPE
+) -> TS[int]:
+    return lhs + rhs
+
+
+@graph
+def _add_generic_dict_size(
+    value: TS[int], whole: TIME_SERIES_TYPE
+) -> TS[int]:
+    return value + len_(whole)
+
+
+@graph
+def _add_generic_offset(
+    value: TS[int], offset: TIME_SERIES_TYPE
+) -> TS[int]:
+    return value + offset
+
+
+@graph
+def _add_concrete_dict_size(
+    whole: TSD[int, TS[int]], value: TS[int]
+) -> TS[int]:
+    return value + len_(whole)
+
+
+@graph
+def _return_rhs(_lhs: TS[int], rhs: TS[int]) -> TS[int]:
+    return rhs
+
+
+@graph
+def _whole_dict_size(
+    _value: TS[int], whole: TSD[str, TS[int]]
+) -> TS[int]:
+    return len_(whole)
+
+
+@compute_node
+def _add_one(value: TS[int]) -> TS[int]:
+    return value.value + 1
+
+
+def test_mesh_first_generic_tsd_is_multiplexed():
+    @graph
+    def g(tsd: TSD[str, TS[int]]) -> TSD[str, TS[int]]:
+        return mesh_(_add_one_generic, tsd)
+
+    assert eval_node(g, [{"a": 1, "b": 2}]) == [{"a": 2, "b": 3}]
+
+
+def test_mesh_later_same_key_generic_tsd_is_multiplexed():
+    @graph
+    def g(
+        lhs: TSD[str, TS[int]], rhs: TSD[str, TS[int]]
+    ) -> TSD[str, TS[int]]:
+        return mesh_(_add_two_generics, lhs, rhs)
+
+    assert eval_node(
+        g,
+        [{"a": 1, "b": 2}],
+        [{"a": 10, "b": 20}],
+    ) == [{"a": 11, "b": 22}]
+
+
+def test_mesh_later_different_key_generic_tsd_is_direct():
+    @graph
+    def g(
+        mux: TSD[str, TS[int]], whole: TSD[int, TS[int]]
+    ) -> TSD[str, TS[int]]:
+        return mesh_(_add_generic_dict_size, mux, whole)
+
+    assert eval_node(
+        g,
+        [{"a": 1, "b": 2}, None],
+        [{1: 10, 2: 20}, {3: 30}],
+    ) == [{"a": 3, "b": 4}, {"a": 4, "b": 5}]
+
+
+def test_mesh_non_tsd_generic_input_is_direct():
+    @graph
+    def g(
+        mux: TSD[str, TS[int]], offset: TS[int]
+    ) -> TSD[str, TS[int]]:
+        return mesh_(_add_generic_offset, mux, offset)
+
+    assert eval_node(
+        g,
+        [{"a": 1, "b": 2}, None],
+        [10, 20],
+    ) == [{"a": 11, "b": 12}, {"a": 21, "b": 22}]
+
+
+def test_mesh_concrete_tsd_before_first_multiplexed_input_is_direct():
+    @graph
+    def g(
+        whole: TSD[int, TS[int]], mux: TSD[str, TS[int]]
+    ) -> TSD[str, TS[int]]:
+        return mesh_(_add_concrete_dict_size, whole, mux)
+
+    assert eval_node(
+        g,
+        [{1: 10, 2: 20}, {3: 30}],
+        [{"a": 1, "b": 2}, None],
+    ) == [{"a": 3, "b": 4}, {"a": 4, "b": 5}]
+
+
+def test_mesh_mismatched_multiplexed_key_types_keep_the_diagnostic():
+    @graph
+    def g(
+        lhs: TSD[str, TS[int]], rhs: TSD[int, TS[int]]
+    ) -> TSD[str, TS[int]]:
+        return mesh_(_add_pair, lhs, rhs)
+
+    with pytest.raises(
+        WiringError,
+        match="every multiplexed TSD must share the same key type",
+    ):
+        eval_node(g, [{"a": 1}], [{1: 2}])
+
+
+def test_mesh_no_key_input_is_excluded_from_inferred_key_union():
+    @graph
+    def g(
+        keys_source: TSD[str, TS[int]], values: TSD[str, TS[int]]
+    ) -> TSD[str, TS[int]]:
+        return mesh_(_return_rhs, keys_source, no_key(values))
+
+    # If values contributed to the inferred union, its independently usable
+    # "z" value would produce an observable output child.
+    assert eval_node(
+        g,
+        [{"x": 1, "y": 2}],
+        [{"x": 10, "z": 30}],
+    ) == [{"x": 10}]
+
+
+def test_mesh_pass_through_input_is_excluded_from_inferred_key_union():
+    @graph
+    def g(
+        keys_source: TSD[str, TS[int]], whole: TSD[str, TS[int]]
+    ) -> TSD[str, TS[int]]:
+        return mesh_(_whole_dict_size, keys_source, pass_through(whole))
+
+    # The mapped output does not depend on keys_source's values, so any key
+    # incorrectly inferred from whole would be visible in the output.
+    assert eval_node(
+        g,
+        [{"a": 1, "b": 2}],
+        [{"p": 10, "q": 20, "r": 30}],
+    ) == [{"a": 3, "b": 3}]
+
+
+def test_mesh_all_no_key_inputs_require_explicit_keys():
+    @graph
+    def g(values: TSD[str, TS[int]]) -> TSD[str, TS[int]]:
+        return mesh_(_add_one, no_key(values))
+
+    with pytest.raises(
+        WiringError,
+        match="every multiplexed input is no_key",
+    ):
+        eval_node(g, [{"a": 1}])
+
+
+def test_mesh_no_key_with_explicit_keys_uses_that_lifecycle():
+    @graph
+    def g(
+        values: TSD[str, TS[int]], keys: TSS[str]
+    ) -> TSD[str, TS[int]]:
+        return mesh_(_add_one, no_key(values), __keys__=keys)
+
+    assert eval_node(
+        g,
+        [{"a": 1, "b": 2, "c": 3}],
+        [{"a", "c"}],
+    ) == [{"a": 2, "c": 4}]

--- a/tests/cpp/test_map.cpp
+++ b/tests/cpp/test_map.cpp
@@ -28,6 +28,7 @@
 #include "nested_lifecycle_test_support.h"
 
 #include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_string.hpp>
 
 #include <optional>
 #include <span>
@@ -1625,6 +1626,18 @@ namespace
         }
     };
 
+    struct MapMismatchedKeyTypesG
+    {
+        static constexpr auto name = "map_mismatched_key_types_g";
+        static Port<TSD<Str, TS<Int>>> compose(Wiring &w,
+                                                Port<TSD<Str, TS<Int>>> lhs,
+                                                Port<TSD<Int, TS<Int>>> rhs)
+        {
+            return wire<stdlib::map_>(w, fn<AddPairG>(), lhs, rhs)
+                .as<TSD<Str, TS<Int>>>();
+        }
+    };
+
     struct MapAllNoKeyG
     {
         static constexpr auto             name = "map_all_no_key_g";
@@ -2047,6 +2060,19 @@ TEST_CASE("map_: no_key demultiplexes but is excluded from key inference")
                      values<Value>(dict_delta<Str, TS<Int>>({{"x"s, 1}, {"y"s, 2}})),
                      values<Value>(dict_delta<Str, TS<Int>>({{"x"s, 10}, {"z"s, 30}})))),
                  values<Value>(dict_delta<Str, TS<Int>>({{"x"s, 11}})));
+}
+
+TEST_CASE("map_: mismatched multiplexed key types retain the classifier diagnostic")
+{
+    using namespace hgraph;
+    stdlib::register_standard_operators();
+
+    REQUIRE_THROWS_WITH(
+        (eval_node<MapMismatchedKeyTypesG>(
+            values<Value>(dict_delta<Str, TS<Int>>({{"a"s, 1}})),
+            values<Value>(dict_delta<Int, TS<Int>>({{1, 2}})))),
+        Catch::Matchers::ContainsSubstring(
+            "map_: every multiplexed TSD must share the same key type"));
 }
 
 TEST_CASE("map_: every multiplexed input no_key requires an explicit __keys__")

--- a/tests/cpp/test_map.cpp
+++ b/tests/cpp/test_map.cpp
@@ -7,8 +7,9 @@
 // element. func is a WiredFn (graph, node, or operator) and may take the key
 // when its first parameter is named "key" (or the configured __key_arg__). TSD
 // inputs multiplex when the child parameter accepts their element;
-// whole-time-series type variables and concrete whole-TSD parameters receive
-// the collection directly. See *Nested Graphs*.
+// whole-time-series type variables multiplex the first TSD and later same-key
+// TSDs, while concrete whole-TSD parameters receive the collection directly.
+// See *Nested Graphs*.
 
 #include <hgraph/lib/std/std_operators.h>
 #include <hgraph/lib/std/std_nodes.h>
@@ -1626,6 +1627,70 @@ namespace
         }
     };
 
+    struct AddOneGenericG
+    {
+        static constexpr auto name = "add_one_generic_g";
+        static Port<TS<Int>> compose(Wiring &, Port<void> value)
+        {
+            using namespace hgraph::stdlib::syntax;
+            return (value.as<TS<Int>>() + Int{1}).as<TS<Int>>();
+        }
+    };
+
+    struct MapFirstGenericTsdG
+    {
+        static constexpr auto name = "map_first_generic_tsd_g";
+        static Port<TSD<Str, TS<Int>>> compose(Wiring &w, Port<TSD<Str, TS<Int>>> tsd)
+        {
+            return wire<stdlib::map_>(w, fn<AddOneGenericG>(), tsd)
+                .as<TSD<Str, TS<Int>>>();
+        }
+    };
+
+    struct AddTwoGenericsG
+    {
+        static constexpr auto name = "add_two_generics_g";
+        static Port<TS<Int>> compose(Wiring &, Port<void> lhs, Port<void> rhs)
+        {
+            using namespace hgraph::stdlib::syntax;
+            return (lhs.as<TS<Int>>() + rhs.as<TS<Int>>()).as<TS<Int>>();
+        }
+    };
+
+    struct MapSameKeyGenericsG
+    {
+        static constexpr auto name = "map_same_key_generics_g";
+        static Port<TSD<Str, TS<Int>>> compose(Wiring &w,
+                                               Port<TSD<Str, TS<Int>>> lhs,
+                                               Port<TSD<Str, TS<Int>>> rhs)
+        {
+            return wire<stdlib::map_>(w, fn<AddTwoGenericsG>(), lhs, rhs)
+                .as<TSD<Str, TS<Int>>>();
+        }
+    };
+
+    struct AddGenericOffsetG
+    {
+        static constexpr auto name = "add_generic_offset_g";
+        static Port<TS<Int>> compose(Wiring &, Port<TS<Int>> value, Port<void> offset)
+        {
+            using namespace hgraph::stdlib::syntax;
+            return (value + offset.as<TS<Int>>()).as<TS<Int>>();
+        }
+    };
+
+    struct MapGenericOffsetG
+    {
+        static constexpr auto name = "map_generic_offset_g";
+        static Port<TSD<Str, TS<Int>>> compose(Wiring &w,
+                                               Port<TSD<Str, TS<Int>>> mux,
+                                               Port<TS<Int>> offset)
+        {
+            return wire<stdlib::map_>(w, fn<AddGenericOffsetG>(), mux, offset)
+                .as<TSD<Str, TS<Int>>>();
+        }
+    };
+
     struct MapGenericDictAfterMuxG
     {
         static constexpr auto name = "map_generic_dict_after_mux_g";
@@ -2095,7 +2160,28 @@ TEST_CASE("map_: a broadcast TSD update reaches every existing child")
                                dict_delta<Str, TS<Int>>({{"a"s, 5}, {"b"s, 6}})));
 }
 
-TEST_CASE("map_: a generic child parameter receives a later TSD whole")
+TEST_CASE("map_: the first TSD passed to a generic child parameter multiplexes")
+{
+    using namespace hgraph;
+    stdlib::register_standard_operators();
+
+    CHECK_OUTPUT((eval_node<MapFirstGenericTsdG>(
+                     values<Value>(dict_delta<Str, TS<Int>>({{"a"s, 1}, {"b"s, 2}})))),
+                 values<Value>(dict_delta<Str, TS<Int>>({{"a"s, 2}, {"b"s, 3}})));
+}
+
+TEST_CASE("map_: a later same-key TSD passed to a generic child parameter multiplexes")
+{
+    using namespace hgraph;
+    stdlib::register_standard_operators();
+
+    CHECK_OUTPUT((eval_node<MapSameKeyGenericsG>(
+                     values<Value>(dict_delta<Str, TS<Int>>({{"a"s, 1}, {"b"s, 2}})),
+                     values<Value>(dict_delta<Str, TS<Int>>({{"a"s, 10}, {"b"s, 20}})))),
+                 values<Value>(dict_delta<Str, TS<Int>>({{"a"s, 11}, {"b"s, 22}})));
+}
+
+TEST_CASE("map_: a later different-key TSD passed to a generic child parameter is direct")
 {
     using namespace hgraph;
     stdlib::register_standard_operators();
@@ -2106,6 +2192,18 @@ TEST_CASE("map_: a generic child parameter receives a later TSD whole")
                                    dict_delta<Int, TS<Int>>({{3, 30}})))),
                  values<Value>(dict_delta<Str, TS<Int>>({{"a"s, 3}, {"b"s, 4}}),
                                dict_delta<Str, TS<Int>>({{"a"s, 4}, {"b"s, 5}})));
+}
+
+TEST_CASE("map_: a non-TSD passed to a generic child parameter is direct")
+{
+    using namespace hgraph;
+    stdlib::register_standard_operators();
+
+    CHECK_OUTPUT((eval_node<MapGenericOffsetG>(
+                     values<Value>(dict_delta<Str, TS<Int>>({{"a"s, 1}, {"b"s, 2}}), none),
+                     values<Int>(10, 20))),
+                 values<Value>(dict_delta<Str, TS<Int>>({{"a"s, 11}, {"b"s, 12}}),
+                               dict_delta<Str, TS<Int>>({{"a"s, 21}, {"b"s, 22}})));
 }
 
 TEST_CASE("map_: a whole-TSD child parameter before the first multiplexed input is direct")

--- a/tests/cpp/test_map.cpp
+++ b/tests/cpp/test_map.cpp
@@ -1737,6 +1737,51 @@ namespace
         }
     };
 
+    struct ReturnRightG
+    {
+        static constexpr auto name = "return_right_g";
+        static Port<TS<Int>> compose(Wiring &, Port<TS<Int>>, Port<TS<Int>> rhs)
+        {
+            return rhs;
+        }
+    };
+
+    struct MapNoKeyUnionG
+    {
+        static constexpr auto name = "map_no_key_union_g";
+        static Port<TSD<Str, TS<Int>>> compose(Wiring &w,
+                                               Port<TSD<Str, TS<Int>>> keys_source,
+                                               Port<TSD<Str, TS<Int>>> values)
+        {
+            return wire<stdlib::map_>(w, fn<ReturnRightG>(), keys_source,
+                                      stdlib::no_key(values))
+                .as<TSD<Str, TS<Int>>>();
+        }
+    };
+
+    struct WholeDictSizeG
+    {
+        static constexpr auto name = "whole_dict_size_g";
+        static Port<TS<Int>> compose(Wiring &w, Port<TS<Int>>,
+                                     Port<TSD<Str, TS<Int>>> whole)
+        {
+            return wire<stdlib::len_>(w, whole).as<TS<Int>>();
+        }
+    };
+
+    struct MapPassThroughUnionG
+    {
+        static constexpr auto name = "map_pass_through_union_g";
+        static Port<TSD<Str, TS<Int>>> compose(Wiring &w,
+                                               Port<TSD<Str, TS<Int>>> keys_source,
+                                               Port<TSD<Str, TS<Int>>> whole)
+        {
+            return wire<stdlib::map_>(w, fn<WholeDictSizeG>(), keys_source,
+                                      stdlib::pass_through(whole))
+                .as<TSD<Str, TS<Int>>>();
+        }
+    };
+
     struct MapMismatchedKeyTypesG
     {
         static constexpr auto name = "map_mismatched_key_types_g";
@@ -2230,6 +2275,33 @@ TEST_CASE("map_: no_key demultiplexes but is excluded from key inference")
                      values<Value>(dict_delta<Str, TS<Int>>({{"x"s, 1}, {"y"s, 2}})),
                      values<Value>(dict_delta<Str, TS<Int>>({{"x"s, 10}, {"z"s, 30}})))),
                  values<Value>(dict_delta<Str, TS<Int>>({{"x"s, 11}})));
+}
+
+TEST_CASE("map_: no_key keys are observably excluded from the inferred union")
+{
+    using namespace hgraph;
+    stdlib::register_standard_operators();
+
+    // ReturnRightG can publish rhs independently of lhs. If the no_key input
+    // contributed to the inferred union, its z key would therefore emit.
+    CHECK_OUTPUT((eval_node<MapNoKeyUnionG>(
+                     values<Value>(dict_delta<Str, TS<Int>>({{"x"s, 1}, {"y"s, 2}})),
+                     values<Value>(dict_delta<Str, TS<Int>>({{"x"s, 10}, {"z"s, 30}})))),
+                 values<Value>(dict_delta<Str, TS<Int>>({{"x"s, 10}})));
+}
+
+TEST_CASE("map_: pass_through keys are observably excluded from the inferred union")
+{
+    using namespace hgraph;
+    stdlib::register_standard_operators();
+
+    // WholeDictSizeG does not depend on keys_source's value. If the
+    // pass-through input contributed keys, p/q/r would therefore emit.
+    CHECK_OUTPUT((eval_node<MapPassThroughUnionG>(
+                     values<Value>(dict_delta<Str, TS<Int>>({{"a"s, 1}, {"b"s, 2}})),
+                     values<Value>(dict_delta<Str, TS<Int>>(
+                         {{"p"s, 10}, {"q"s, 20}, {"r"s, 30}})))),
+                 values<Value>(dict_delta<Str, TS<Int>>({{"a"s, 3}, {"b"s, 3}})));
 }
 
 TEST_CASE("map_: mismatched multiplexed key types retain the classifier diagnostic")

--- a/tests/cpp/test_map.cpp
+++ b/tests/cpp/test_map.cpp
@@ -6,8 +6,9 @@
 // element directly (no copy); removed keys destroy the child and remove the
 // element. func is a WiredFn (graph, node, or operator) and may take the key
 // when its first parameter is named "key" (or the configured __key_arg__). TSD
-// inputs multiplex; other time-series inputs broadcast whole. See *Nested
-// Graphs*.
+// inputs multiplex when the child parameter accepts their element;
+// whole-time-series type variables and concrete whole-TSD parameters receive
+// the collection directly. See *Nested Graphs*.
 
 #include <hgraph/lib/std/std_operators.h>
 #include <hgraph/lib/std/std_nodes.h>
@@ -940,10 +941,10 @@ TEST_CASE("map_ over TSL: ndx key plus broadcast")
 }
 
 // ---------------------------------------------------------------------------
-// Multi-multiplexed inputs (Python parity): every TSD in *args demultiplexes
-// by key — the live key set is the UNION; a key absent from one TSD leaves
-// that child input invalid until it appears. Same-size TSLs multiplex per
-// index in the TSL form.
+// Multi-multiplexed inputs: each TSD whose child parameter accepts its element
+// demultiplexes by key — the live key set is the UNION; a key absent from one
+// TSD leaves that child input invalid until it appears. Same-size TSLs
+// multiplex per index in the TSL form.
 // ---------------------------------------------------------------------------
 
 namespace
@@ -1583,8 +1584,8 @@ TEST_CASE("map_: __key_arg__ is keyword-only")
 
 namespace
 {
-    // Reads a whole TSD: only reachable through pass_through (an untagged TSD
-    // argument is always multiplexed).
+    // Reads a whole TSD. pass_through explicitly forces the direct binding;
+    // signature-directed classification also binds a matching TSD parameter whole.
     struct ElemPlusDictSizeNode
     {
         static constexpr auto name = "elem_plus_dict_size";
@@ -1611,6 +1612,51 @@ namespace
         {
             return wire<stdlib::map_>(w, fn<ElemPlusDictSizeG>(), mux,
                                       stdlib::pass_through(whole))
+                .as<TSD<Str, TS<Int>>>();
+        }
+    };
+
+    struct ElemPlusGenericDictSizeG
+    {
+        static constexpr auto name = "elem_plus_generic_dict_size_g";
+        static Port<TS<Int>> compose(Wiring &w, Port<TS<Int>> value, Port<void> whole)
+        {
+            using namespace hgraph::stdlib::syntax;
+            return (value + wire<stdlib::len_>(w, whole).as<TS<Int>>()).as<TS<Int>>();
+        }
+    };
+
+    struct MapGenericDictAfterMuxG
+    {
+        static constexpr auto name = "map_generic_dict_after_mux_g";
+        static Port<TSD<Str, TS<Int>>> compose(Wiring &w,
+                                               Port<TSD<Str, TS<Int>>> mux,
+                                               Port<TSD<Int, TS<Int>>> whole)
+        {
+            return wire<stdlib::map_>(w, fn<ElemPlusGenericDictSizeG>(), mux, whole)
+                .as<TSD<Str, TS<Int>>>();
+        }
+    };
+
+    struct ElemPlusConcreteDictSizeG
+    {
+        static constexpr auto name = "elem_plus_concrete_dict_size_g";
+        static Port<TS<Int>> compose(Wiring &w, Port<TSD<Int, TS<Int>>> whole,
+                                     Port<TS<Int>> value)
+        {
+            using namespace hgraph::stdlib::syntax;
+            return (value + wire<stdlib::len_>(w, whole).as<TS<Int>>()).as<TS<Int>>();
+        }
+    };
+
+    struct MapConcreteDictBeforeMuxG
+    {
+        static constexpr auto name = "map_concrete_dict_before_mux_g";
+        static Port<TSD<Str, TS<Int>>> compose(Wiring &w,
+                                               Port<TSD<Int, TS<Int>>> whole,
+                                               Port<TSD<Str, TS<Int>>> mux)
+        {
+            return wire<stdlib::map_>(w, fn<ElemPlusConcreteDictSizeG>(), whole, mux)
                 .as<TSD<Str, TS<Int>>>();
         }
     };
@@ -2047,6 +2093,32 @@ TEST_CASE("map_: a broadcast TSD update reaches every existing child")
                                    dict_delta<Str, TS<Int>>({{"s"s, 40}})))),
                  values<Value>(dict_delta<Str, TS<Int>>({{"a"s, 4}, {"b"s, 5}}),
                                dict_delta<Str, TS<Int>>({{"a"s, 5}, {"b"s, 6}})));
+}
+
+TEST_CASE("map_: a generic child parameter receives a later TSD whole")
+{
+    using namespace hgraph;
+    stdlib::register_standard_operators();
+
+    CHECK_OUTPUT((eval_node<MapGenericDictAfterMuxG>(
+                     values<Value>(dict_delta<Str, TS<Int>>({{"a"s, 1}, {"b"s, 2}}), none),
+                     values<Value>(dict_delta<Int, TS<Int>>({{1, 10}, {2, 20}}),
+                                   dict_delta<Int, TS<Int>>({{3, 30}})))),
+                 values<Value>(dict_delta<Str, TS<Int>>({{"a"s, 3}, {"b"s, 4}}),
+                               dict_delta<Str, TS<Int>>({{"a"s, 4}, {"b"s, 5}})));
+}
+
+TEST_CASE("map_: a whole-TSD child parameter before the first multiplexed input is direct")
+{
+    using namespace hgraph;
+    stdlib::register_standard_operators();
+
+    CHECK_OUTPUT((eval_node<MapConcreteDictBeforeMuxG>(
+                     values<Value>(dict_delta<Int, TS<Int>>({{1, 10}, {2, 20}}),
+                                   dict_delta<Int, TS<Int>>({{3, 30}})),
+                     values<Value>(dict_delta<Str, TS<Int>>({{"a"s, 1}, {"b"s, 2}}), none))),
+                 values<Value>(dict_delta<Str, TS<Int>>({{"a"s, 3}, {"b"s, 4}}),
+                               dict_delta<Str, TS<Int>>({{"a"s, 4}, {"b"s, 5}})));
 }
 
 TEST_CASE("map_: no_key demultiplexes but is excluded from key inference")

--- a/tests/cpp/test_mesh.cpp
+++ b/tests/cpp/test_mesh.cpp
@@ -19,6 +19,7 @@
 #include "nested_lifecycle_test_support.h"
 
 #include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_string.hpp>
 
 #include <array>
 #include <span>
@@ -86,6 +87,176 @@ struct KeyIdentityG {
   static constexpr auto name = "mesh_key_identity_g";
   static Port<TS<Int>> compose(Wiring &, NamedPort<"key", TS<Int>> key) {
     return key;
+  }
+};
+
+struct AddPairG {
+  static constexpr auto name = "mesh_add_pair_g";
+  static Port<TS<Int>> compose(Wiring &, Port<TS<Int>> lhs,
+                               Port<TS<Int>> rhs) {
+    using namespace hgraph::stdlib::syntax;
+    return (lhs + rhs).as<TS<Int>>();
+  }
+};
+
+struct AddOneGenericG {
+  static constexpr auto name = "mesh_add_one_generic_g";
+  static Port<TS<Int>> compose(Wiring &, Port<void> value) {
+    using namespace hgraph::stdlib::syntax;
+    return (value.as<TS<Int>>() + Int{1}).as<TS<Int>>();
+  }
+};
+
+struct MeshFirstGenericTsdG {
+  static constexpr auto name = "mesh_first_generic_tsd_g";
+  static Port<TSD<Str, TS<Int>>>
+  compose(Wiring &w, Port<TSD<Str, TS<Int>>> values) {
+    return wire<stdlib::mesh_>(w, fn<AddOneGenericG>(), values)
+        .as<TSD<Str, TS<Int>>>();
+  }
+};
+
+struct AddTwoGenericsG {
+  static constexpr auto name = "mesh_add_two_generics_g";
+  static Port<TS<Int>> compose(Wiring &, Port<void> lhs, Port<void> rhs) {
+    using namespace hgraph::stdlib::syntax;
+    return (lhs.as<TS<Int>>() + rhs.as<TS<Int>>()).as<TS<Int>>();
+  }
+};
+
+struct MeshSameKeyGenericsG {
+  static constexpr auto name = "mesh_same_key_generics_g";
+  static Port<TSD<Str, TS<Int>>>
+  compose(Wiring &w, Port<TSD<Str, TS<Int>>> lhs,
+          Port<TSD<Str, TS<Int>>> rhs) {
+    return wire<stdlib::mesh_>(w, fn<AddTwoGenericsG>(), lhs, rhs)
+        .as<TSD<Str, TS<Int>>>();
+  }
+};
+
+struct GenericDictSizeG {
+  static constexpr auto name = "mesh_generic_dict_size_g";
+  static Port<TS<Int>> compose(Wiring &w, Port<TS<Int>> value,
+                               Port<void> whole) {
+    using namespace hgraph::stdlib::syntax;
+    return (value + wire<stdlib::len_>(w, whole).as<TS<Int>>())
+        .as<TS<Int>>();
+  }
+};
+
+struct MeshGenericDictAfterMuxG {
+  static constexpr auto name = "mesh_generic_dict_after_mux_g";
+  static Port<TSD<Str, TS<Int>>>
+  compose(Wiring &w, Port<TSD<Str, TS<Int>>> mux,
+          Port<TSD<Int, TS<Int>>> whole) {
+    return wire<stdlib::mesh_>(w, fn<GenericDictSizeG>(), mux, whole)
+        .as<TSD<Str, TS<Int>>>();
+  }
+};
+
+struct GenericOffsetG {
+  static constexpr auto name = "mesh_generic_offset_g";
+  static Port<TS<Int>> compose(Wiring &, Port<TS<Int>> value,
+                               Port<void> offset) {
+    using namespace hgraph::stdlib::syntax;
+    return (value + offset.as<TS<Int>>()).as<TS<Int>>();
+  }
+};
+
+struct MeshGenericOffsetG {
+  static constexpr auto name = "mesh_generic_offset_wrapper_g";
+  static Port<TSD<Str, TS<Int>>>
+  compose(Wiring &w, Port<TSD<Str, TS<Int>>> mux, Port<TS<Int>> offset) {
+    return wire<stdlib::mesh_>(w, fn<GenericOffsetG>(), mux, offset)
+        .as<TSD<Str, TS<Int>>>();
+  }
+};
+
+struct ConcreteDictSizeG {
+  static constexpr auto name = "mesh_concrete_dict_size_g";
+  static Port<TS<Int>> compose(Wiring &w,
+                               Port<TSD<Int, TS<Int>>> whole,
+                               Port<TS<Int>> value) {
+    using namespace hgraph::stdlib::syntax;
+    return (value + wire<stdlib::len_>(w, whole).as<TS<Int>>())
+        .as<TS<Int>>();
+  }
+};
+
+struct MeshConcreteDictBeforeMuxG {
+  static constexpr auto name = "mesh_concrete_dict_before_mux_g";
+  static Port<TSD<Str, TS<Int>>>
+  compose(Wiring &w, Port<TSD<Int, TS<Int>>> whole,
+          Port<TSD<Str, TS<Int>>> mux) {
+    return wire<stdlib::mesh_>(w, fn<ConcreteDictSizeG>(), whole, mux)
+        .as<TSD<Str, TS<Int>>>();
+  }
+};
+
+struct MeshMismatchedKeyTypesG {
+  static constexpr auto name = "mesh_mismatched_key_types_g";
+  static Port<TSD<Str, TS<Int>>>
+  compose(Wiring &w, Port<TSD<Str, TS<Int>>> lhs,
+          Port<TSD<Int, TS<Int>>> rhs) {
+    return wire<stdlib::mesh_>(w, fn<AddPairG>(), lhs, rhs)
+        .as<TSD<Str, TS<Int>>>();
+  }
+};
+
+struct ReturnRightG {
+  static constexpr auto name = "mesh_return_right_g";
+  static Port<TS<Int>> compose(Wiring &, Port<TS<Int>>, Port<TS<Int>> rhs) {
+    return rhs;
+  }
+};
+
+struct MeshNoKeyUnionG {
+  static constexpr auto name = "mesh_no_key_union_g";
+  static Port<TSD<Str, TS<Int>>>
+  compose(Wiring &w, Port<TSD<Str, TS<Int>>> keys_source,
+          Port<TSD<Str, TS<Int>>> values) {
+    return wire<stdlib::mesh_>(w, fn<ReturnRightG>(), keys_source,
+                               stdlib::no_key(values))
+        .as<TSD<Str, TS<Int>>>();
+  }
+};
+
+struct WholeDictSizeG {
+  static constexpr auto name = "mesh_whole_dict_size_g";
+  static Port<TS<Int>> compose(Wiring &w, Port<TS<Int>>,
+                               Port<TSD<Str, TS<Int>>> whole) {
+    return wire<stdlib::len_>(w, whole).as<TS<Int>>();
+  }
+};
+
+struct MeshPassThroughUnionG {
+  static constexpr auto name = "mesh_pass_through_union_g";
+  static Port<TSD<Str, TS<Int>>>
+  compose(Wiring &w, Port<TSD<Str, TS<Int>>> keys_source,
+          Port<TSD<Str, TS<Int>>> whole) {
+    return wire<stdlib::mesh_>(w, fn<WholeDictSizeG>(), keys_source,
+                               stdlib::pass_through(whole))
+        .as<TSD<Str, TS<Int>>>();
+  }
+};
+
+struct MeshAllNoKeyG {
+  static constexpr auto name = "mesh_all_no_key_g";
+  static Port<TSD<Str, TS<Int>>>
+  compose(Wiring &w, Port<TSD<Str, TS<Int>>> values) {
+    return wire<stdlib::mesh_>(w, fn<AddOneG>(), stdlib::no_key(values))
+        .as<TSD<Str, TS<Int>>>();
+  }
+};
+
+struct MeshAllNoKeyExplicitKeysG {
+  static constexpr auto name = "mesh_all_no_key_explicit_keys_g";
+  static Port<TSD<Str, TS<Int>>>
+  compose(Wiring &w, Port<TSD<Str, TS<Int>>> values,
+          Port<TSS<Str>> keys) {
+    return wire<stdlib::mesh_>(w, fn<AddOneG>(), stdlib::no_key(values),
+                               arg<"__keys__">(keys))
+        .as<TSD<Str, TS<Int>>>();
   }
 };
 
@@ -417,6 +588,136 @@ TEST_CASE("mesh_: with no cross-instance access a mesh is observably map_") {
       values<Value>(dict_delta<Str, TS<Int>>({{"a"s, 2}, {"b"s, 3}}),
                     dict_delta<Str, TS<Int>>({{"a"s, 11}}),
                     dict_delta<Str, TS<Int>>({}, {"b"s})));
+}
+
+TEST_CASE("mesh_: the first TSD passed to a generic child parameter multiplexes") {
+  using namespace hgraph;
+  stdlib::register_standard_operators();
+
+  CHECK_OUTPUT(
+      (eval_node<MeshFirstGenericTsdG>(values<Value>(
+          dict_delta<Str, TS<Int>>({{"a"s, 1}, {"b"s, 2}})))),
+      values<Value>(dict_delta<Str, TS<Int>>({{"a"s, 2}, {"b"s, 3}})));
+}
+
+TEST_CASE(
+    "mesh_: a later same-key TSD passed to a generic child parameter multiplexes") {
+  using namespace hgraph;
+  stdlib::register_standard_operators();
+
+  CHECK_OUTPUT(
+      (eval_node<MeshSameKeyGenericsG>(
+          values<Value>(dict_delta<Str, TS<Int>>({{"a"s, 1}, {"b"s, 2}})),
+          values<Value>(
+              dict_delta<Str, TS<Int>>({{"a"s, 10}, {"b"s, 20}})))),
+      values<Value>(dict_delta<Str, TS<Int>>({{"a"s, 11}, {"b"s, 22}})));
+}
+
+TEST_CASE(
+    "mesh_: a later different-key TSD passed to a generic child parameter is direct") {
+  using namespace hgraph;
+  stdlib::register_standard_operators();
+
+  CHECK_OUTPUT(
+      (eval_node<MeshGenericDictAfterMuxG>(
+          values<Value>(
+              dict_delta<Str, TS<Int>>({{"a"s, 1}, {"b"s, 2}}), none),
+          values<Value>(dict_delta<Int, TS<Int>>({{1, 10}, {2, 20}}),
+                        dict_delta<Int, TS<Int>>({{3, 30}})))),
+      values<Value>(dict_delta<Str, TS<Int>>({{"a"s, 3}, {"b"s, 4}}),
+                    dict_delta<Str, TS<Int>>({{"a"s, 4}, {"b"s, 5}})));
+}
+
+TEST_CASE("mesh_: a non-TSD passed to a generic child parameter is direct") {
+  using namespace hgraph;
+  stdlib::register_standard_operators();
+
+  CHECK_OUTPUT(
+      (eval_node<MeshGenericOffsetG>(
+          values<Value>(
+              dict_delta<Str, TS<Int>>({{"a"s, 1}, {"b"s, 2}}), none),
+          values<Int>(10, 20))),
+      values<Value>(dict_delta<Str, TS<Int>>({{"a"s, 11}, {"b"s, 12}}),
+                    dict_delta<Str, TS<Int>>({{"a"s, 21}, {"b"s, 22}})));
+}
+
+TEST_CASE(
+    "mesh_: a whole-TSD child parameter before the first multiplexed input is direct") {
+  using namespace hgraph;
+  stdlib::register_standard_operators();
+
+  CHECK_OUTPUT(
+      (eval_node<MeshConcreteDictBeforeMuxG>(
+          values<Value>(dict_delta<Int, TS<Int>>({{1, 10}, {2, 20}}),
+                        dict_delta<Int, TS<Int>>({{3, 30}})),
+          values<Value>(
+              dict_delta<Str, TS<Int>>({{"a"s, 1}, {"b"s, 2}}), none))),
+      values<Value>(dict_delta<Str, TS<Int>>({{"a"s, 3}, {"b"s, 4}}),
+                    dict_delta<Str, TS<Int>>({{"a"s, 4}, {"b"s, 5}})));
+}
+
+TEST_CASE(
+    "mesh_: mismatched multiplexed key types retain the classifier diagnostic") {
+  using namespace hgraph;
+  stdlib::register_standard_operators();
+
+  REQUIRE_THROWS_WITH(
+      (eval_node<MeshMismatchedKeyTypesG>(
+          values<Value>(dict_delta<Str, TS<Int>>({{"a"s, 1}})),
+          values<Value>(dict_delta<Int, TS<Int>>({{1, 2}})))),
+      Catch::Matchers::ContainsSubstring(
+          "mesh_: every multiplexed TSD must share the same key type"));
+}
+
+TEST_CASE("mesh_: no_key keys are observably excluded from the inferred union") {
+  using namespace hgraph;
+  stdlib::register_standard_operators();
+
+  // ReturnRightG can publish values independently of keys_source. If the
+  // no_key input contributed to the inferred union, its z key would emit.
+  CHECK_OUTPUT(
+      (eval_node<MeshNoKeyUnionG>(
+          values<Value>(dict_delta<Str, TS<Int>>({{"x"s, 1}, {"y"s, 2}})),
+          values<Value>(dict_delta<Str, TS<Int>>({{"x"s, 10}, {"z"s, 30}})))),
+      values<Value>(dict_delta<Str, TS<Int>>({{"x"s, 10}})));
+}
+
+TEST_CASE(
+    "mesh_: pass_through keys are observably excluded from the inferred union") {
+  using namespace hgraph;
+  stdlib::register_standard_operators();
+
+  // WholeDictSizeG does not depend on keys_source's value. If the
+  // pass-through input contributed keys, p/q/r would therefore emit.
+  CHECK_OUTPUT(
+      (eval_node<MeshPassThroughUnionG>(
+          values<Value>(dict_delta<Str, TS<Int>>({{"a"s, 1}, {"b"s, 2}})),
+          values<Value>(dict_delta<Str, TS<Int>>(
+              {{"p"s, 10}, {"q"s, 20}, {"r"s, 30}})))),
+      values<Value>(dict_delta<Str, TS<Int>>({{"a"s, 3}, {"b"s, 3}})));
+}
+
+TEST_CASE("mesh_: every multiplexed input no_key requires explicit __keys__") {
+  using namespace hgraph;
+  stdlib::register_standard_operators();
+
+  REQUIRE_THROWS_WITH(
+      (eval_node<MeshAllNoKeyG>(
+          values<Value>(dict_delta<Str, TS<Int>>({{"a"s, 1}})))),
+      Catch::Matchers::ContainsSubstring(
+          "mesh_: every multiplexed input is no_key"));
+}
+
+TEST_CASE("mesh_: no_key with explicit __keys__ uses that lifecycle") {
+  using namespace hgraph;
+  stdlib::register_standard_operators();
+
+  CHECK_OUTPUT(
+      (eval_node<MeshAllNoKeyExplicitKeysG>(
+          values<Value>(
+              dict_delta<Str, TS<Int>>({{"a"s, 1}, {"b"s, 2}, {"c"s, 3}})),
+          values<Value>(set_delta<Str>({"a"s, "c"s}, {})))),
+      values<Value>(dict_delta<Str, TS<Int>>({{"a"s, 2}, {"c"s, 4}})));
 }
 
 TEST_CASE("mesh_: a peer-instantiation func may consume the key") {


### PR DESCRIPTION
## Summary

- expose public `WiredFn::input_pattern()` reflection so higher-order wiring can distinguish a whole time-series type variable from a structured/concrete input
- carry Python graph annotation patterns across the bridge to that C++-first reflection path
- apply the same TSD input-classification rules to `map_` and `mesh_`
- share argument classification, child compilation, kernel selection, and lifecycle-key construction so the two adaptors cannot drift
- preserve explicit `pass_through` / `no_key` behavior and actionable adaptor-specific diagnostics
- document the contract and cover it through equivalent public C++ and Python wiring tests

## `TIME_SERIES_TYPE` resolution

For a mapped-function parameter that is a whole time-series variable (`TIME_SERIES_TYPE` in Python or `Port<void>` in C++):

1. The first TSD in argument order multiplexes and establishes the key type.
2. A later TSD with the same key type multiplexes.
3. A later TSD with a different key type passes through whole.
4. A non-TSD passes through whole.

A parameter that explicitly accepts a concrete whole TSD passes through. A parameter that accepts the TSD element multiplexes. The first genuinely multiplexed input continues to drive the multiplexed signature/kernel.

These rules now apply to both `map_` and `mesh_` where applicable. `mesh_` remains TSD-only; the TSL-specific `map_` kernels are intentionally not added to mesh.

## Shared implementation

The overlapping wiring-time behavior is centralized:

- `classify_map_args` classifies ordered arguments and retains marker/key metadata
- `compile_map_child` compiles the child boundary from that classification
- `first_map_collection` selects the first genuinely multiplexed kernel input
- `wire_keyed_lifecycle_keys` handles explicit keys, inferred zero-copy key projections, `no_key` exclusion, pass-through exclusion, unions, and key-schema validation

Map and mesh retain separate node construction because mesh adds cross-instance scope, subscription, and key-output semantics. The shared work is wiring-time only and adds no per-tick policy branch or runtime storage.

The mesh output resolver also now lets classifier/compile failures reach the operator rejection boundary, preserving specific `mesh_:` diagnostics instead of collapsing them to a generic unresolved-output error.

## Inferred lifecycle keys

When `__keys__` is not supplied, only classified multiplexed inputs eligible for key inference contribute their zero-copy key-set projections:

- `no_key(tsd)` remains multiplexed but is skipped in the inferred union
- `pass_through(tsd)` is not multiplexed and cannot contribute
- if every multiplexed input is marked `no_key`, wiring requires explicit `__keys__`

The regression tests make exclusion observable: their child output does not depend on the ordinary key-source value, so an incorrectly included marker-only key would emit an extra output entry.

## Validation

macOS:

- fresh native configure/build: 1,396/1,396 tests passed
- stable-ABI wheel built with Python 3.12 and installed under fresh Python 3.14: 1,835 passed, 11 skipped
- focused mesh classification/marker suite: 10/10 Python tests passed
- focused existing map regression suite: 11/11 Python tests passed
- combined focused native map/mesh classification tests: 19/19 passed
- installed-SDK consumer for the public reflection surface: 1/1 passed

`hg-linux`:

- fresh native configure/build with GCC 14: 1,396/1,396 tests passed
- stable-ABI wheel built with Python 3.12 and installed under fresh Python 3.14 with `polars[rtcompat]`: 1,835 passed, 11 skipped
- focused mesh classification/marker suite: 10/10 Python tests passed
- focused existing map regression suite: 11/11 Python tests passed

Parity recipe validation: 56 recipes validated.

Closes #254.