### PR TITLE
Fix service adaptor and subscription timing parity

### DIFF
--- a/docs/source/developer_guide/parity_testing.rst
+++ b/docs/source/developer_guide/parity_testing.rst
@@ -120,14 +120,14 @@ Generated discovery targets the agreed compatibility contract, not accepted
 deviations.  The fixed corpus permanently retains the latter, but unrestricted
 generation works around them: every reduction supplies its explicit identity
 zero; collection and nested scalar outputs use ``dedup`` to normalize equal
-re-ticks; subscription keys are not repeated and use a non-zero multiplier;
-nested service-backed invalid windows remain fixed-corpus cases while
-standalone service generators cover their agreed behavior; and the designed
-one-cycle service-adaptor round trip is available only by explicit template
-selection; reference-unsupported temporal method-call spellings and cyclic
-adaptor/outer-switch composition remain ordinary compatibility or fixed
-coverage.  This keeps churn, branch lifecycle, service, and reduction coverage
-while reserving random examples for previously unruled behavior.
+re-ticks; subscription keys include replacements and re-subscriptions while
+using a non-zero multiplier; nested service-backed invalid windows remain
+fixed-corpus cases while standalone service and service-adaptor generators
+cover their agreed behavior; reference-unsupported temporal method-call
+spellings and cyclic adaptor/outer-switch composition remain ordinary
+compatibility or fixed coverage.  This keeps churn, branch lifecycle, service,
+and reduction coverage while reserving random examples for previously unruled
+behavior.
 
 Coverage is semantic rather than only line-based.  Reports count templates,
 time-series shapes, scalar types, operator families, topology, lifecycle
@@ -166,9 +166,9 @@ production triage has actually produced (the 2026-07 batch, issues #74-#92):
   restricted to upstream-supported space (a per-key adaptor client cycles
   released hgraph's toposort, so the adaptor consumes the reduced pipeline
   output; subscriptions subscribe per key outside the flipping switch), and
-  the subscription variant stays out of the ruled re-subscription timing
-  space (no key re-adds, no outer switch). Its first differential replays
-  surfaced issues #94 and #95.
+  the subscription variant avoids key re-adds inside this already-complex
+  composition; standalone subscription generation covers that lifecycle.
+  Its first differential replays surfaced issues #94 and #95.
 
 When a new compatibility issue is fixed, extend this list: either an
 existing template's generated space must provably contain the issue's
@@ -224,15 +224,8 @@ way:
 
 * ``trace-value`` accepts only a trace value difference, used by the
   non-identity reduce-zero deviation;
-* ``service-adaptor-one-cycle`` requires the candidate trace to equal one
-  leading no-tick cycle followed by the complete reference trace;
 * ``key-set-size-no-retick`` removes only ``size`` fields and then requires
   every remaining field to compare within the template's float tolerance;
-* ``subscription-resample-one-cycle`` requires repeated non-null subscription
-  keys and proves that delaying the **subset** of repeats that actually emit
-  an existing value — a repeat that emits nothing shifts nothing — makes the
-  complete payload traces equal, with at least one repeat accounting for the
-  mismatch; and
 * ``switch-flip-map-removal`` requires the candidate to remove exactly every
   currently-live mapped output, opposite the reference's canonical empty-map
   delta, on the exact ``beta``-to-request/reply-``alpha`` switch flip. Later

--- a/docs/source/developer_guide/roadmap.rst
+++ b/docs/source/developer_guide/roadmap.rst
@@ -630,15 +630,6 @@ The following are intentional unless separately re-opened:
   TSS/TSD delta that nets to no change does not tick. Explicit writes are
   unaffected and match upstream exactly: a python node returning the same
   scalar each evaluation ticks each time, as do repeated TSD entry writes.
-- **Service-boundary timing** (design record: the scheduling matrix in
-  :doc:`services`): request stubs forward next cycle by design, so a
-  ``service_adaptor`` round trip observably lands one cycle after released
-  hgraph's same-cycle adaptor wiring; conversely a late or duplicate
-  subscription samples the existing shared output in the same cycle, one
-  cycle earlier than released hgraph's re-delivery. Both are pinned by
-  ``tests/cpp/test_service_wiring.cpp`` (the service-adaptor collection cases
-  and "late duplicate subscription samples the existing value"). First
-  subscriptions and request/reply match the Python timing model exactly.
 - **Reduce over partially-valid mapped keys** (issue #95; design record:
   :doc:`nested_graphs`): reduction is over currently-valid values. A keyed
   value can be invalid while its slot is live — a map child existing before

--- a/docs/source/developer_guide/services.rst
+++ b/docs/source/developer_guide/services.rst
@@ -34,7 +34,7 @@ source/capture pair** — applied with different payloads:
       cons["consumers bind here and are woken by<br/>ordinary output notification"]
 
       client --> cap
-      cap -->|"write state; schedule_node<br/>(relays: same cycle / request stubs: +MIN_TD)"| src
+      cap -->|"write state; schedule_node<br/>(ranked adaptors: same cycle / deferred services: +MIN_TD)"| src
       src -->|"applies state in one mutation<br/>of its own output"| out
       out --> cons
 
@@ -53,19 +53,34 @@ source/capture pair** — applied with different payloads:
 - **Scheduling matrix** (see *Lifecycle Teardown* in :doc:`architecture` for
   the invariant statement):
 
-  - **Shared-output relays** (reference and subscription outputs, adaptor
-    ``from_graph``/``to_graph``, contexts) are **rank-correct and
-    same-cycle**: pairs are declared with ``Wiring::add_same_cycle_pair``
+  - **Ranked boundaries in their owning graph** (reference and subscription
+    outputs, adaptor ``from_graph``/``to_graph``, service-adaptor requests,
+    contexts) are **rank-correct and same-cycle**: pairs are declared with
+    ``Wiring::add_same_cycle_pair``
     (source rank-constrained after every capture); ``Wiring::finish`` re-ranks
     once all captures are known — which is what keeps chains of multiple
     adaptors/services correct — and **validates** every pair's final order.
     The runtime trusts the wiring-time proof: a capture always schedules the
     source for the **current** evaluation time with no hot-path checks (debug
-    asserts only) — never a silent next-cycle deferral.
-  - **Request stubs** (subscription keys, request/reply requests) forward
-    **next cycle** by design: the pairing is rank-free (no rank dependency),
-    and the capture schedules the service source for
-    ``evaluation_time + MIN_TD`` (current time during ``start``). The temporal
+    asserts only) — never a silent next-cycle deferral. A dynamically-started
+    child service-adaptor client cannot precede an outer source whose rank has
+    already passed, so its boundary hand-off occurs on the following cycle;
+    the implementation and reply then remain rank-ordered in that owning
+    graph. This is the released Python lifecycle behavior, not the old
+    top-level adaptor delay.
+  - **Subscription keys** in the owning graph are ranked before their source
+    and publish in the capture cycle. A dynamically-started nested client hands
+    off to the outer source on the following cycle because the outer rank may
+    already have passed. Changes are queued by observed engine time so rapid
+    replacements cannot coalesce. When a key becomes globally live, the
+    response boundary invalidates an old keyed value immediately and publishes
+    the first fresh implementation value one cycle after it arrives, matching
+    Python's keyed-child lifecycle and preventing cached values from leaking on
+    re-add. A client joining a key that another client has kept live samples the
+    existing value immediately.
+  - **Request/reply requests** forward **next cycle** by design: the pairing is
+    rank-free (no rank dependency), and the capture schedules the service source
+    for ``evaluation_time + MIN_TD`` (current time during ``start``). The temporal
     request mutation does not run the implementation in the capture cycle.
     A request/reply input source retains its earliest outstanding publication
     time, so a later request cannot postpone work that is already due.
@@ -103,8 +118,9 @@ The per-flavour payloads:
 - **Subscription service**: the source owns a ``TSS<K>`` output and graph-local
   reference counts; capture sinks enqueue key add/remove intents and schedule
   the source (``make_subscription_key_source_node`` /
-  ``make_subscription_key_capture_node``). Keys published by the source appear
-  the cycle after capture; releases are reference-counted across captures
+  ``make_subscription_key_capture_node``). Keys publish in the owning graph's
+  capture cycle; a dynamically-started nested client hands off on the next
+  cycle. Releases are reference-counted across captures
   (``tests/cpp/test_service_node.cpp``).
 - **Request/reply service**: the source owns ``TSD<int, request_schema>``.
   Each live client instance has a stable runtime request id; capture sinks
@@ -486,10 +502,11 @@ second implementation for the same service kind + path throws
 
 **Semantics proven by tests** (``test_service_wiring.cpp``): a reference client
 reads the implementation output by reference (no copy); paths keep shared
-outputs separate; a subscription client's keys reach the implementation on the
-next cycle and the response flows back keyed; request/reply replies cross the
-outer feedback edge and remain keyed by the client's request id; two clients'
-requests reach the implementation as one cumulative delta.
+outputs separate; a subscription client's key transitions reach the
+implementation in order and the response flows back keyed with Python timing;
+request/reply replies cross the outer feedback edge and remain keyed by the
+client's request id; two clients' requests reach the implementation as one
+cumulative delta.
 
 
 How a client expression lowers

--- a/include/hgraph/runtime/service_node.h
+++ b/include/hgraph/runtime/service_node.h
@@ -48,6 +48,19 @@ namespace hgraph
         const ValueTypeMetaData &key_schema);
 
     /**
+     * Build the response boundary for one subscription client.
+     *
+     * A newly-live service key immediately invalidates any response sampled
+     * through the shared dictionary. The first fresh implementation value is
+     * published one cycle after it arrives, matching Python's keyed-child
+     * lifecycle and preventing cached values from leaking on re-add. A client
+     * joining a key already kept live by another client samples it immediately.
+     */
+    [[nodiscard]] HGRAPH_EXPORT NodeBuilder make_subscription_response_gate_node(
+        const ValueTypeMetaData &key_schema,
+        const TSValueTypeMetaData &response_schema);
+
+    /**
      * Build a source node that owns a request/reply service request dictionary.
      *
      * The output schema is ``TSD<int, request_schema>``. Paired capture nodes
@@ -59,17 +72,23 @@ namespace hgraph
         const TSValueTypeMetaData &request_schema);
 
     /**
-     * Build a sink node that captures one request/reply client's request.
+     * Build a sink node that captures one request/reply or service-adaptor
+     * client's request.
      *
      * Input field ``request`` is ``request_schema`` and field ``requests`` is
      * the paired source node's ``TSD<int, request_schema>`` output. Only
      * ``request`` is active; ``requests`` is a passive binding used to locate
-     * the source node. Captures schedule the source for the current engine time
-     * during start, and the next engine tick during normal evaluation.
+     * the source node. Deferred request/reply captures schedule the next engine
+     * tick during normal evaluation. Rank-correct service-adaptor captures set
+     * ``same_cycle`` and schedule the paired source for the current engine time
+     * when both live in the owning graph. Dynamically started child graphs hand
+     * work to the enclosing source on the following engine cycle because its
+     * outer rank may already have passed.
      */
     [[nodiscard]] HGRAPH_EXPORT NodeBuilder make_request_input_capture_node(
         std::string path,
-        const TSValueTypeMetaData &request_schema);
+        const TSValueTypeMetaData &request_schema,
+        bool same_cycle = false);
 }  // namespace hgraph
 
 #endif  // HGRAPH_RUNTIME_SERVICE_NODE_H

--- a/include/hgraph/types/service_wiring.h
+++ b/include/hgraph/types/service_wiring.h
@@ -615,6 +615,10 @@ namespace hgraph::service
         {
         };
 
+        struct subscription_response_gate_marker
+        {
+        };
+
         struct shared_output_source_marker
         {
         };
@@ -831,11 +835,10 @@ namespace hgraph::service
                                                std::move(builder),
                                                std::span<const WiringInputRef>{inputs.data(), inputs.size()},
                                                Value{});
-            // The capture schedules the source for the next cycle. Service
-            // rank application places the first client before that source and
-            // later clients after it. Repeated first-client ticks therefore
-            // conflate, while a later client first ticking on the source cycle
-            // is published on the following cycle, matching Python ordering.
+            // Root captures rank before the shared key source and publish in
+            // the same cycle. A dynamically-started nested capture defers its
+            // outer hand-off one cycle; observed-time batches keep successive
+            // transitions distinct.
             return capture.peered_node();
         }
 
@@ -867,8 +870,8 @@ namespace hgraph::service
                                                std::move(builder),
                                                std::span<const WiringInputRef>{inputs.data(), inputs.size()},
                                                Value{});
-            // Request stubs forward on the next cycle; see
-            // capture_subscription_key above for the ordering contract.
+            // Request/reply alone forwards on the next cycle; the temporal
+            // break is what permits recursive request/reply implementations.
             return capture.peered_node();
         }
 
@@ -905,8 +908,8 @@ namespace hgraph::service
             // dependency places the paired source after this capture (and
             // Wiring::finish's topological sort re-ranks once ALL captures are
             // known), so the capture schedules the source for the CURRENT
-            // evaluation time — no next-cycle workaround. Request stubs above
-            // still schedule their transport sources for the next cycle.
+            // evaluation time — no next-cycle workaround. Request/reply stubs
+            // above still schedule their transport sources for the next cycle.
             // The same rule applies at every add_rank_dependency site below
             // and in adaptor_wiring.h.
             w.add_same_cycle_pair(capture.peered_node(), shared_output.node());
@@ -1237,8 +1240,30 @@ namespace hgraph::service
                 detail::capture_subscription_key<Service>(*wiring_, key, subscriptions_, path_);
             wiring_->register_service_client_rank(
                 detail::subscriptions_path<Service>(path_), "subscription service", capture, false);
-            return wire<stdlib::getitem_>(*wiring_, output_.template as<output_schema>(), key)
+            auto sampled = wire<stdlib::getitem_>(
+                *wiring_, output_.template as<output_schema>(), key)
                 .template as<value_schema>();
+            std::array<WiringPortRef, 3> sources{
+                sampled.erased(), key.erased(), subscriptions_.erased()};
+            std::array<WiringInputRef, 3> inputs{{
+                WiringInputRef{.source = sources[0]},
+                WiringInputRef{.source = sources[1]},
+                WiringInputRef{.source = sources[2]},
+            }};
+            const auto *key_meta = detail::resolved_scalar_meta<key_type>(
+                path_.resolution, "subscription service key");
+            const auto *response_meta = detail::resolved_schema_meta<value_schema>(
+                path_.resolution, "subscription service response");
+            NodeBuilder builder = make_subscription_response_gate_node(
+                *key_meta, *response_meta);
+            builder.input_endpoint(graph_wiring_detail::input_endpoint_for_sources(
+                builder.type().schema()->input_schema,
+                std::span<const WiringPortRef>{sources.data(), sources.size()}));
+            WiringPortRef gated = wiring_->add_node(
+                std::type_index(typeid(detail::subscription_response_gate_marker)),
+                std::move(builder),
+                std::span<const WiringInputRef>{inputs.data(), inputs.size()}, Value{});
+            return Port<value_schema>{*wiring_, std::move(gated)};
         }
 
       private:
@@ -1714,7 +1739,8 @@ namespace hgraph::service_adaptor
             }
             NodeBuilder builder = make_request_input_capture_node(
                 adaptor_from_graph_path<Interface>(user_path),
-                *input_meta);
+                *input_meta,
+                true);
             builder.input_endpoint(graph_wiring_detail::input_endpoint_for_sources(
                 builder.type().schema()->input_schema,
                 std::span<const WiringPortRef>{sources.data(), sources.size()}));
@@ -1723,8 +1749,11 @@ namespace hgraph::service_adaptor
                                                std::move(builder),
                                                std::span<const WiringInputRef>{inputs.data(), inputs.size()},
                                                Value{});
-            // Service adaptor requests use the same next-cycle transport and
-            // same-time capture ordering as request/reply services.
+            // Service-adaptor sends are rank-correct and same-cycle in their
+            // owning graph. A dynamically-started child hands off to its outer
+            // source on the following cycle because that outer rank may already
+            // have passed. Only request/reply is unconditionally deferred to
+            // permit recursion.
             return capture.peered_node();
         }
 

--- a/python/tests/test_hgraph_api.py
+++ b/python/tests/test_hgraph_api.py
@@ -1347,7 +1347,7 @@ def test_service_adaptor_from_python():
         return echo(lhs, path="echo") + echo(rhs, path="echo")
 
     out = eval_node(two_clients, [1, None, 2], [10, None, 20])
-    check(out == [None, 11, None, 22], f"service adaptor clients: {out}")
+    check(out == [11, None, 22], f"service adaptor clients: {out}")
 
     @hg.service_adaptor
     def routed(path: str, request: TS[int]) -> TS[int]: ...
@@ -1367,7 +1367,7 @@ def test_service_adaptor_from_python():
         return routed("small", request=value) + routed(value, path="large")
 
     out = eval_node(separated_paths, [1, None, 2])
-    check(out == [None, 13, None, 15], f"service adaptor paths: {out}")
+    check(out == [13, None, 15], f"service adaptor paths: {out}")
 
     @hg.service_adaptor
     def left(request: TS[int]) -> TS[int]: ...
@@ -1388,7 +1388,7 @@ def test_service_adaptor_from_python():
         return left(value, path="both") + right(value, path="both")
 
     out = eval_node(two_interfaces, [3, None, 4])
-    check(out == [None, 6, None, 8], f"service adaptor interfaces: {out}")
+    check(out == [6, None, 8], f"service adaptor interfaces: {out}")
 
     class ArithmeticResult(hg.TimeSeriesSchema):
         total: TS[int]
@@ -1417,7 +1417,7 @@ def test_service_adaptor_from_python():
         return arithmetic(lhs, rhs, path="arithmetic")
 
     out = eval_node(arithmetic_client, [7], [2])
-    check(out == [None, {"total": 9, "difference": 5}], f"multi-field service adaptor: {out}")
+    check(out == [{"total": 9, "difference": 5}], f"multi-field service adaptor: {out}")
 
     try:
         @hg.service_adaptor_impl(interfaces=echo)
@@ -1454,7 +1454,7 @@ def test_service_adaptor_explicit_request_id_client_split():
             path="echo-split", __request_id__=rid, __no_ts_inputs__=True)
 
     out = eval_node(split_client, [1, None, 2])
-    check(out == [None, 1, None, 2], f"split service adaptor client: {out}")
+    check(out == [1, None, 2], f"split service adaptor client: {out}")
 
 
 def test_sink_only_service_adaptor_from_python():
@@ -1666,7 +1666,7 @@ def test_generic_adaptor_specializations_from_python():
         return generic_service_adaptor(adapted, path="generic_service")
 
     out = eval_node(app, [2, None, 4])
-    check(out == [None, 3, None, 5], f"generic adaptors: {out}")
+    check(out == [3, None, 5], f"generic adaptors: {out}")
 
     try:
         generic_adaptor[payload:float]

--- a/python/tests/test_parity_harness.py
+++ b/python/tests/test_parity_harness.py
@@ -1332,17 +1332,41 @@ def test_generator_covers_the_2026_07_compat_issue_classes():
     # the 2026-07 compatibility issues lived: temporal accessors (#82),
     # collection sizes (#81), lifecycle signature spellings (#79), the
     # recorded-frame surface (PR #92), and postponed annotations (#83).
-    from tools.parity.generate import generate_recipes
+    from hypothesis import find, settings
 
-    templates = set()
-    postponed = False
-    for recipe in generate_recipes(480, seed=29):
-        templates.add(recipe.template)
-        postponed = postponed or recipe.parameters.get(
-            "postponed_annotations", False)
-    assert {"temporal_expression", "collection_size", "lifecycle_state",
-            "data_frame_recording", "nested_higher_order"} <= templates
-    assert postponed
+    from tools.parity.generate import (
+        generate_recipes,
+        recipe_payload_strategy,
+    )
+
+    required_templates = {
+        "temporal_expression",
+        "collection_size",
+        "lifecycle_state",
+        "data_frame_recording",
+        "nested_higher_order",
+    }
+    generated_templates = {
+        recipe.template
+        for template in required_templates
+        for recipe in generate_recipes(
+            1, seed=29, templates=(template,)
+        )
+    }
+    assert generated_templates == required_templates
+
+    postponed = find(
+        recipe_payload_strategy(
+            min_ticks=8,
+            max_ticks=32,
+            templates=("scalar_expression",),
+        ),
+        lambda payload: payload["parameters"].get(
+            "postponed_annotations", False
+        ),
+        settings=settings(database=None, deadline=None),
+    )
+    assert postponed["parameters"]["postponed_annotations"]
 
 
 def test_coverage_corpus_recipes_execute_on_the_candidate():

--- a/python/tests/test_parity_harness.py
+++ b/python/tests/test_parity_harness.py
@@ -176,13 +176,13 @@ def test_generated_framework_recipes_prioritize_ref_and_non_peered_paths():
         "service_reference",
         "service_request_reply",
         "service_subscription",
+        "service_adaptor_roundtrip",
         "adaptor_loopback",
         "context_switch",
         "operator_pipeline",
         "tsd_key_set_pipeline",
         "mesh_key_set",
     } <= templates
-    assert "service_adaptor_roundtrip" not in templates
     assert {
         recipe.template
         for recipe in generate_recipes(
@@ -511,17 +511,11 @@ def test_family_suppression_covers_only_the_documented_difference(
     assert report["summary"]["known_failures"] == 0
 
 
-def test_generated_recipes_avoid_accepted_deviation_spaces():
+def test_generated_recipes_avoid_remaining_accepted_deviation_spaces():
     # Generated discovery must test the agreed contract rather than consume
     # examples rediscovering accepted deviations. Fixed corpus recipes retain
     # each ruled behavior as a permanent regression.
     from tools.parity.generate import generate_recipes
-
-    unrestricted = generate_recipes(400, seed=7)
-    assert all(
-        recipe.template != "service_adaptor_roundtrip"
-        for recipe in unrestricted
-    )
 
     def generated(template):
         recipes = generate_recipes(
@@ -545,10 +539,13 @@ def test_generated_recipes_avoid_accepted_deviation_spaces():
     )
 
     subscriptions = generated("service_subscription")
-    for recipe in subscriptions:
-        symbols = [tick for tick in recipe.inputs["symbol"] if tick is not None]
-        assert len(symbols) == len(set(symbols))
-        assert recipe.parameters["multiplier"] != 0
+    assert all(recipe.parameters["multiplier"] != 0 for recipe in subscriptions)
+    assert any(
+        len(symbols := [
+            tick for tick in recipe.inputs["symbol"] if tick is not None
+        ]) != len(set(symbols))
+        for recipe in subscriptions
+    )
 
     nested = generated("nested_higher_order")
     for recipe in nested:
@@ -830,28 +827,7 @@ def test_family_gate_requires_the_documented_trace_relation():
     _fingerprints, families = load_known_divergences()
     ok = lambda trace: {"status": "ok", "trace": trace}
 
-    # 1. service_adaptor_roundtrip: ref [2] vs cand [None, 2].
-    adaptor_recipe = {
-        "template": "service_adaptor_roundtrip",
-        "inputs": {"value": [0]},
-        "parameters": {"increment": 2},
-    }
-    difference = compare_outcomes(ok([2]), ok([None, 2]))
-    assert difference.to_dict()["classification"] == "length"
-    assert is_known_family_failure(
-        adaptor_recipe, difference.to_dict(), ok([2]), ok([None, 2]), families
-    )
-    corrupted = ok([None, 3])
-    difference = compare_outcomes(ok([2]), corrupted)
-    assert not is_known_family_failure(
-        adaptor_recipe,
-        difference.to_dict(),
-        ok([2]),
-        corrupted,
-        families,
-    )
-
-    # 2. tsd_key_set_pipeline dedup_size=false: the unchanged size field is
+    # tsd_key_set_pipeline dedup_size=false: the unchanged size field is
     # republished by the reference and omitted by the candidate. The float
     # difference is inside the template tolerance and is not a second defect.
     pipeline_recipe = {
@@ -892,46 +868,7 @@ def test_family_gate_requires_the_documented_trace_relation():
         families,
     )
 
-    # 3. A different subscription key samples normally; a repeated key is
-    # same-cycle in hg_cpp and delayed one cycle in released hgraph. Payload
-    # values and every other tick must remain equal.
-    subscription_recipe = {
-        "template": "service_subscription",
-        "inputs": {"symbol": ["rates", None, "long_symbol", "rates"]},
-        "parameters": {"multiplier": 10, "path": "live"},
-    }
-    reference = ok([None, 50, None, None, 50])
-    candidate = ok([None, 50, None, 50])
-    difference = compare_outcomes(reference, candidate)
-    assert is_known_family_failure(
-        subscription_recipe,
-        difference.to_dict(),
-        reference,
-        candidate,
-        families,
-    )
-    corrupted = ok([None, 50, None, 51])
-    difference = compare_outcomes(reference, corrupted)
-    assert not is_known_family_failure(
-        subscription_recipe,
-        difference.to_dict(),
-        reference,
-        corrupted,
-        families,
-    )
-    first_subscriptions_only = {
-        **subscription_recipe,
-        "inputs": {"symbol": ["rates", None, "long_symbol"]},
-    }
-    assert not is_known_family_failure(
-        first_subscriptions_only,
-        difference.to_dict(),
-        reference,
-        corrupted,
-        families,
-    )
-
-    # 4. The non-identity reduce ruling covers a value difference only. A
+    # The non-identity reduce ruling covers a value difference only. A
     # length difference in the same parameter space remains reportable.
     reduce_recipe = {
         "template": "tsd_map_reduce",
@@ -959,169 +896,7 @@ def test_family_gate_requires_the_documented_trace_relation():
     crash = {"status": "error", "phase": "runtime"}
     difference = compare_outcomes(ok([2]), crash)
     assert not is_known_family_failure(
-        adaptor_recipe, difference.to_dict(), ok([2]), crash, families
-    )
-
-
-def test_publisher_suppresses_stale_resubscription_variants(monkeypatch):
-    # Symbols and path deliberately differ from the exact issue-66 corpus
-    # fingerprint. The input-aware relation must still prevent a stale report
-    # from creating or reopening the documented deviation.
-    recipe = {
-        "schema_version": 1,
-        "id": "stale-resubscription-variant",
-        "description": "Stale report with a different repeated symbol.",
-        "template": "service_subscription",
-        "inputs": {"symbol": ["fx", None, "long_symbol", "fx"]},
-        "parameters": {"multiplier": 0, "path": "quotes"},
-        "features": [],
-    }
-    reference = {"status": "ok", "trace": [None, 0, None, None, 0]}
-    candidate = {"status": "ok", "trace": [None, 0, None, 0]}
-    failure = {
-        "minimized_recipe": recipe,
-        "difference": compare_outcomes(reference, candidate).to_dict(),
-        "reference": reference,
-        "candidate": candidate,
-        "reduction": {"attempts": 0, "accepted": 0},
-    }
-    failure["failure_fingerprint"] = failure_fingerprint(failure)
-    assert failure["failure_fingerprint"] != (
-        "6d05f5590cc2ff1d6ff45fa63f5189771924d30b9df7d754569979a3d2718b0b"
-    )
-
-    calls = []
-    monkeypatch.setattr(
-        "tools.parity.issues._existing_issues", lambda _repo: []
-    )
-
-    def fake_gh(arguments, *, repo, capture=False):
-        calls.append(arguments)
-        return SimpleNamespace(stdout="")
-
-    monkeypatch.setattr("tools.parity.issues._gh", fake_gh)
-    actions = publish_failures([failure], repo="hhenson/hg_cpp", publish=True)
-    assert actions == [
-        {
-            "action": "known-divergence",
-            "fingerprint": failure["failure_fingerprint"],
-        }
-    ]
-    assert not any(
-        arguments[:2] in (["issue", "create"], ["issue", "reopen"])
-        for arguments in calls
-    )
-
-
-def test_resample_relation_permits_subset_delays(monkeypatch):
-    # Issue #71: only the repeats that actually sample an existing value
-    # delay; inserting a cycle for EVERY repeat is too rigid. Uses the
-    # committed known_divergences.json family records.
-    from tools.parity.known import (
-        is_known_family_failure,
-        load_known_divergences,
-    )
-
-    _fingerprints, families = load_known_divergences()
-    ok = lambda trace: {"status": "ok", "trace": trace}
-
-    def classify(symbols, reference_trace, candidate_trace):
-        recipe = {
-            "template": "service_subscription",
-            "inputs": {"symbol": symbols},
-            "parameters": {"multiplier": 7, "path": "live"},
-        }
-        reference, candidate = ok(reference_trace), ok(candidate_trace)
-        difference = compare_outcomes(reference, candidate)
-        assert difference is not None
-        return is_known_family_failure(
-            recipe, difference.to_dict(), reference, candidate, families
-        )
-
-    # The representative stale case: fx and long_symbol both repeat, but
-    # only the final long_symbol repeat emits the existing value.
-    representative_symbols = [
-        "rates", None, "fx", None, None, "long_symbol", None, "fx", "long_symbol",
-    ]
-    representative_reference = [None, 35, None, 14, None, None, 77, None, None, 77]
-    representative_candidate = [None, 35, None, 14, None, None, 77, None, 77]
-    assert classify(
-        representative_symbols,
-        representative_reference,
-        representative_candidate,
-    )
-
-    # More than one emitting repeat aligns.
-    assert classify(
-        ["fx", None, "fx", None, "fx"],
-        [None, 14, None, 14, None, 14],
-        [None, 14, 14, None, 14],
-    )
-
-    # A first-subscription difference remains reportable (no repeats).
-    assert not classify(
-        ["rates", None, "fx"],
-        [None, 35, None, 14],
-        [None, 35, None, 15],
-    )
-
-    # Payload corruption at the aligned repeat remains reportable.
-    assert not classify(
-        representative_symbols,
-        representative_reference,
-        [None, 35, None, 14, None, None, 77, None, 78],
-    )
-
-    # An unrelated missing tick (not at an emitting repeat) remains
-    # reportable.
-    assert not classify(
-        representative_symbols,
-        representative_reference,
-        [None, 35, None, None, None, 77, None, 77],
-    )
-
-    # The representative case flows through the publisher as a known
-    # mismatch: no create, no reopen.
-    recipe = {
-        "schema_version": 1,
-        "id": "stale-partial-delay-variant",
-        "description": "Stale report where only one of two repeats emits.",
-        "template": "service_subscription",
-        "inputs": {"symbol": representative_symbols},
-        "parameters": {"multiplier": 7, "path": "live"},
-        "features": [],
-    }
-    reference = ok(representative_reference)
-    candidate = ok(representative_candidate)
-    failure = {
-        "minimized_recipe": recipe,
-        "difference": compare_outcomes(reference, candidate).to_dict(),
-        "reference": reference,
-        "candidate": candidate,
-        "reduction": {"attempts": 0, "accepted": 0},
-    }
-    failure["failure_fingerprint"] = failure_fingerprint(failure)
-
-    calls = []
-    monkeypatch.setattr(
-        "tools.parity.issues._existing_issues", lambda _repo: []
-    )
-
-    def fake_gh(arguments, *, repo, capture=False):
-        calls.append(arguments)
-        return SimpleNamespace(stdout="")
-
-    monkeypatch.setattr("tools.parity.issues._gh", fake_gh)
-    actions = publish_failures([failure], repo="hhenson/hg_cpp", publish=True)
-    assert actions == [
-        {
-            "action": "known-divergence",
-            "fingerprint": failure["failure_fingerprint"],
-        }
-    ]
-    assert not any(
-        arguments[:2] in (["issue", "create"], ["issue", "reopen"])
-        for arguments in calls
+        reduce_recipe, difference.to_dict(), ok([2]), crash, families
     )
 
 
@@ -1511,18 +1286,20 @@ def test_nested_no_change_retick_family_is_elision_only():
     assert not classify([0, 0], [0, 1])
 
 
-def test_generated_subscription_recipes_never_resubscribe():
-    # Re-subscribing a previously computed symbol is the designed same-cycle
-    # sampling deviation (issue #66): the generator must not explore it.
+def test_generated_subscription_recipes_include_resubscriptions():
+    # Re-subscribing a previously computed symbol is part of the parity
+    # contract and must remain in randomized discovery.
     pytest.importorskip("hypothesis")
     from tools.parity.generate import generate_recipes
 
     recipes = generate_recipes(240, seed=29)
     subs = [r for r in recipes if r.template == "service_subscription"]
     assert subs, "expected generated service_subscription recipes"
-    for recipe in subs:
-        symbols = [s for s in recipe.inputs["symbol"] if s is not None]
-        assert len(symbols) == len(set(symbols))
+    assert any(
+        len(symbols := [s for s in recipe.inputs["symbol"] if s is not None])
+        != len(set(symbols))
+        for recipe in subs
+    )
 
 
 def test_coverage_reports_operator_frontier_and_semantic_pairs():

--- a/python/tests/test_service_timing_semantics.py
+++ b/python/tests/test_service_timing_semantics.py
@@ -1,11 +1,8 @@
 """Service-boundary and mapped-service reduction timing semantics.
 
 The scheduling matrix in ``docs/source/developer_guide/services.rst`` is the
-design record: request stubs forward next cycle by design, and a late or
-duplicate subscription samples the existing shared output in the same cycle.
-Released hgraph observably differs on both edges (same-cycle adaptor round
-trips; one-cycle re-subscription re-delivery). See the Accepted Deviations
-list in ``roadmap.rst`` and parity issues #64 / #66.
+design record: adaptors are rank-correct and same-cycle, subscription changes
+are delivered in order, and request/reply alone retains its temporal break.
 
 Issue #95 is a separate reduce boundary: released hgraph waits when a keyed
 mapped slot is live but not yet valid, whereas hg_cpp reduces the currently
@@ -21,10 +18,9 @@ from hgraph import TS, TSD, TSS, graph
 from hgraph.test import eval_node
 
 
-def test_service_adaptor_roundtrip_takes_one_transport_cycle():
-    # Issue #64: released hgraph completes the adaptor round trip in the
-    # same engine cycle ([1]); hg_cpp's request stub forwards next cycle by
-    # design, so the reply lands one cycle later.
+def test_service_adaptor_roundtrip_is_same_cycle():
+    # Issue #64: service adaptors rank the client before the implementation
+    # and the reply after it, completing the round trip in one engine cycle.
     @hg.service_adaptor
     def echo(request: TS[int]) -> TS[int]: ...
 
@@ -38,23 +34,36 @@ def test_service_adaptor_roundtrip_takes_one_transport_cycle():
         return echo(value)
 
     out = eval_node(roundtrip, [1, 2, 3], __end_time__=hg.MIN_ST + 5 * hg.MIN_TD)
-    assert out == [None, 1, 2, 3]
+    assert out == [1, 2, 3]
 
 
-def test_resubscription_samples_existing_value_in_the_same_cycle():
-    # Issue #66: re-subscribing a previously computed symbol samples the
-    # existing shared-output entry in the same cycle; released hgraph takes
-    # the usual one-cycle transport hop again. First subscriptions match
-    # upstream exactly (value one cycle after subscribe).
+def test_subscription_replacement_waits_for_fresh_value_and_preserves_transitions():
+    # Issue #66: a fast rates -> fx -> rates sequence must reach the
+    # implementation as three distinct transitions. The second rates child is
+    # fresh; a cached first-generation value must not leak during replacement.
+    calls = {}
+    transitions = []
+
     @hg.subscription_service
     def quote(path: str, symbol: TS[str]) -> TS[int]: ...
 
+    @hg.compute_node
+    def generation(symbol: TS[str]) -> TS[int]:
+        key = symbol.value
+        calls[key] = calls.get(key, 0) + 1
+        return calls[key]
+
     @graph
     def quote_value(symbol: TS[str]) -> TS[int]:
-        return hg.len_(symbol) * 7
+        return generation(symbol)
+
+    @hg.sink_node
+    def observe(symbols: TSS[str]):
+        transitions.append((sorted(symbols.added()), sorted(symbols.removed())))
 
     @hg.service_impl(interfaces=quote)
     def quote_values(symbol: TSS[str]) -> TSD[str, TS[int]]:
+        observe(symbol)
         return hg.map_(quote_value, __keys__=symbol, __key_arg__="symbol")
 
     @graph
@@ -67,7 +76,9 @@ def test_resubscription_samples_existing_value_in_the_same_cycle():
         ["rates", None, "fx", "rates"],
         __end_time__=hg.MIN_ST + 7 * hg.MIN_TD,
     )
-    assert out == [None, 35, None, 35]
+    assert out == [None, 1, None, None, 2]
+    assert transitions == [(["rates"], []), (["fx"], ["rates"]), (["rates"], ["fx"])]
+    assert calls == {"rates": 2, "fx": 1}
 
 
 def test_request_reply_inside_a_mapped_switch_keeps_late_keys():

--- a/python/tests/test_signature_compatibility.py
+++ b/python/tests/test_signature_compatibility.py
@@ -310,7 +310,7 @@ def test_service_resolvers_and_registration_resolution_dict():
     assert hg.eval_node(resolved_app, [1], __end_time__=end_time) == [None, None, 1]
     assert hg.eval_node(registered_app, [2], __end_time__=end_time) == [None, None, 2]
     assert hg.eval_node(
-        registered_adaptor_app, [3], __end_time__=end_time) == [None, 3]
+        registered_adaptor_app, [3], __end_time__=end_time) == [3]
 
 
 def test_push_queue_options_feedback_keyword_and_eval_node_trace_defaults(capfd):

--- a/src/hgraph/runtime/service_node.cpp
+++ b/src/hgraph/runtime/service_node.cpp
@@ -1,6 +1,7 @@
 #include <hgraph/runtime/service_node.h>
 
 #include <hgraph/runtime/graph.h>
+#include <hgraph/runtime/node_scheduler.h>
 #include <hgraph/types/metadata/type_registry.h>
 #include <hgraph/types/time_series/ts_delta.h>
 #include <hgraph/types/time_series/ts_input/bundle_view.h>
@@ -34,6 +35,7 @@ namespace hgraph
     {
         constexpr std::string_view subscription_key_source_storage_field{"subscription_key_source"};
         constexpr std::string_view subscription_key_capture_storage_field{"subscription_key_capture"};
+        constexpr std::string_view subscription_response_gate_storage_field{"subscription_response_gate"};
         constexpr std::string_view request_input_source_storage_field{"request_input_source"};
         constexpr std::string_view request_input_capture_storage_field{"request_input_capture"};
 
@@ -60,8 +62,9 @@ namespace hgraph
 
         struct SubscriptionKeyChange
         {
-            Value key{};
-            bool  add{true};
+            Value    key{};
+            DateTime observed_at{};
+            bool     add{true};
         };
 
         struct SubscriptionKeySourceStorage
@@ -88,6 +91,14 @@ namespace hgraph
         {
             std::string path{};
             std::size_t storage_offset{0};
+        };
+
+        struct SubscriptionResponseGateStorage
+        {
+            Value previous_key{};
+            Value pending_response{};
+            bool  has_previous{false};
+            bool  awaiting_fresh_response{false};
         };
 
         struct RequestInputSourceContext
@@ -122,6 +133,7 @@ namespace hgraph
         {
             std::string path{};
             std::size_t storage_offset{0};
+            bool        same_cycle{false};
         };
 
         [[nodiscard]] std::vector<std::unique_ptr<SubscriptionKeySourceContext>> &
@@ -194,6 +206,14 @@ namespace hgraph
                 MemoryUtils::advance(view.data(), context.storage_offset));
         }
 
+        [[nodiscard]] SubscriptionResponseGateStorage &response_gate_storage_of(
+            const NodeView &view,
+            std::size_t storage_offset)
+        {
+            return *MemoryUtils::cast<SubscriptionResponseGateStorage>(
+                MemoryUtils::advance(view.data(), storage_offset));
+        }
+
         [[nodiscard]] std::vector<std::unique_ptr<RequestInputSourceContext>> &
         request_input_source_contexts() noexcept
         {
@@ -238,18 +258,21 @@ namespace hgraph
 
         [[nodiscard]] const RequestInputCaptureContext &register_request_input_capture_context(
             std::string path,
-            std::size_t storage_offset)
+            std::size_t storage_offset,
+            bool same_cycle)
         {
             auto &contexts = request_input_capture_contexts();
             const auto existing = std::ranges::find_if(
                 contexts,
                 [&](const auto &context) {
-                    return context->path == path && context->storage_offset == storage_offset;
+                    return context->path == path && context->storage_offset == storage_offset
+                        && context->same_cycle == same_cycle;
                 });
             if (existing != contexts.end()) { return **existing; }
             auto context = std::make_unique<RequestInputCaptureContext>(RequestInputCaptureContext{
                 .path           = std::move(path),
                 .storage_offset = storage_offset,
+                .same_cycle     = same_cycle,
             });
             const auto *result = context.get();
             contexts.push_back(std::move(context));
@@ -285,13 +308,14 @@ namespace hgraph
                 };
             }
 
-            void enqueue(Value key, bool add, DateTime schedule_time) const
+            void enqueue(Value key, bool add, DateTime schedule_time, DateTime observed_at) const
             {
                 if (!key.has_value()) { return; }
                 auto &pending = source_storage_of(view_, *context_).pending;
                 pending.push_back(SubscriptionKeyChange{
-                    .key = std::move(key),
-                    .add = add,
+                    .key         = std::move(key),
+                    .observed_at = observed_at,
+                    .add         = add,
                 });
 
                 GraphValue *graph = view_.graph_value();
@@ -470,16 +494,13 @@ namespace hgraph
         }
 
         /**
-         * Request stubs (subscription keys, request/reply requests) are
-         * NEXT-cycle forwarders. Wiring rank places the first sending client
-         * before the source and later clients after it when they have work at
-         * the same engine time; this function provides the temporal break by
-         * scheduling newly captured work later.
+         * Request/reply inputs publish on the next cycle and intentionally omit
+         * service ranking because that temporal break permits recursive graphs.
          * Root capture during ``start`` can schedule for the current engine
          * time because evaluation has not begun. A dynamically started nested
          * capture schedules the next cycle because the outer source rank may
-         * already have passed. (Shared-output relays are the opposite:
-         * rank-correct and same-cycle — see shared_output_node.cpp.)
+         * already have passed. Subscription and service-adaptor sends are the
+         * rank-correct same-cycle cases and do not use this helper.
          */
         [[nodiscard]] DateTime request_stub_forward_time(
             const NodeView &view,
@@ -500,8 +521,15 @@ namespace hgraph
             SubscriptionKeySourceStorage &storage,
             TSSDataMutationView &mutation)
         {
+            const DateTime publication = storage.pending.front().observed_at;
+            std::vector<SubscriptionKeyChange> deferred;
             for (SubscriptionKeyChange &change : storage.pending)
             {
+                if (change.observed_at != publication)
+                {
+                    deferred.push_back(std::move(change));
+                    continue;
+                }
                 if (!change.key.has_value()) { continue; }
 
                 if (change.add)
@@ -524,7 +552,7 @@ namespace hgraph
                 storage.counts.erase(it);
                 static_cast<void>(mutation.remove(removed_key.view()));
             }
-            storage.pending.clear();
+            storage.pending = std::move(deferred);
         }
 
         void apply_pending_request_input_changes(
@@ -575,6 +603,10 @@ namespace hgraph
             auto set      = output.as_set();
             auto mutation = set.begin_mutation(evaluation_time);
             apply_pending_subscription_key_changes(storage, mutation);
+            if (!storage.pending.empty())
+            {
+                view.graph().schedule_node(view.node_index(), evaluation_time + MIN_TD);
+            }
             return true;
         }
 
@@ -630,11 +662,15 @@ namespace hgraph
             const SubscriptionKeySourceView &source,
             SubscriptionKeyCaptureStorage &storage,
             const TSInputView &key_input,
-            DateTime schedule_time)
+            DateTime schedule_time,
+            DateTime observed_at)
         {
             if (!key_input.valid())
             {
-                if (storage.has_previous) { source.enqueue(std::move(storage.previous_key), false, schedule_time); }
+                if (storage.has_previous)
+                {
+                    source.enqueue(std::move(storage.previous_key), false, schedule_time, observed_at);
+                }
                 storage.previous_key = Value{};
                 storage.has_previous = false;
                 return;
@@ -643,8 +679,11 @@ namespace hgraph
             Value key{key_input.value()};
             if (storage.has_previous && storage.previous_key.equals(key)) { return; }
 
-            if (storage.has_previous) { source.enqueue(std::move(storage.previous_key), false, schedule_time); }
-            source.enqueue(key, true, schedule_time);
+            if (storage.has_previous)
+            {
+                source.enqueue(std::move(storage.previous_key), false, schedule_time, observed_at);
+            }
+            source.enqueue(key, true, schedule_time, observed_at);
             storage.previous_key = std::move(key);
             storage.has_previous = true;
         }
@@ -659,9 +698,118 @@ namespace hgraph
             initialize_subscription_capture(view, evaluation_time, storage);
             auto key    = storage.input.borrowed_ref(evaluation_time);
             auto source = NodeView{storage.source}.as<SubscriptionKeySourceView>();
-            const DateTime schedule_time = request_stub_forward_time(
-                view, evaluation_time, start_phase);
-            record_subscription_key(source, storage, key, schedule_time);
+            static_cast<void>(start_phase);
+            const DateTime schedule_time = view.graph().is_nested()
+                                               ? evaluation_time + MIN_TD
+                                               : evaluation_time;
+            record_subscription_key(source, storage, key, schedule_time, evaluation_time);
+        }
+
+        [[nodiscard]] bool response_key_changed(
+            SubscriptionResponseGateStorage &storage,
+            const TSInputView &key)
+        {
+            if (!key.valid())
+            {
+                const bool changed = storage.has_previous;
+                storage.previous_key = Value{};
+                storage.has_previous = false;
+                return changed;
+            }
+
+            Value current{key.value()};
+            if (storage.has_previous && storage.previous_key.equals(current)) { return false; }
+            storage.previous_key = std::move(current);
+            storage.has_previous = true;
+            return true;
+        }
+
+        void evaluate_subscription_response_gate(
+            std::size_t storage_offset,
+            const NodeView &view,
+            DateTime evaluation_time)
+        {
+            auto input_root = view.input(evaluation_time);
+            auto input = input_root.as_bundle();
+            auto value = input.at(0);
+            auto key   = input.at(1);
+            auto subscriptions_input = input.at(2);
+            auto subscriptions = subscriptions_input.as_set();
+            auto &storage = response_gate_storage_of(view, storage_offset);
+            NodeScheduler scheduler{
+                view.scheduler_state(), view.graph_value(), view.node_index(), evaluation_time};
+            auto output = view.output(evaluation_time);
+
+            const auto key_was_added = [&]() {
+                if (!key.valid()) { return false; }
+                return std::ranges::any_of(
+                    subscriptions.added(),
+                    [&](const ValueView &added) { return added.equals(key.value()); });
+            };
+
+            const auto stage_fresh_response = [&]() {
+                if (!value.valid() || !value.modified()) { return; }
+                storage.pending_response = Value{value.value()};
+                scheduler.schedule(MIN_TD);
+            };
+
+            if (response_key_changed(storage, key))
+            {
+                storage.pending_response = Value{};
+                storage.awaiting_fresh_response = key_was_added();
+                auto mutation = output.begin_mutation(evaluation_time);
+                static_cast<void>(mutation.invalidate());
+                if (!key.valid()) { return; }
+                if (storage.awaiting_fresh_response)
+                {
+                    stage_fresh_response();
+                    return;
+                }
+            }
+
+            if (storage.awaiting_fresh_response)
+            {
+                if (scheduler.is_scheduled_now() && storage.pending_response.has_value())
+                {
+                    if (!value.valid())
+                    {
+                        storage.pending_response = Value{};
+                        return;
+                    }
+                    // A newer first-generation value in the release cycle wins;
+                    // Python exposes the child's current value at this boundary.
+                    if (value.modified())
+                    {
+                        storage.pending_response = Value{value.value()};
+                    }
+                    apply_current_value(output, storage.pending_response.view());
+                    storage.pending_response = Value{};
+                    storage.awaiting_fresh_response = false;
+                    return;
+                }
+                stage_fresh_response();
+                return;
+            }
+
+            if (!value.valid())
+            {
+                auto mutation = output.begin_mutation(evaluation_time);
+                static_cast<void>(mutation.invalidate());
+                return;
+            }
+
+            if (!output.valid()) { apply_current_value(output, value.value()); }
+            else if (value.modified()) { apply_delta(output, capture_delta(value).view()); }
+        }
+
+        bool subscription_key_capture_evaluate_impl(
+            const void *, const NodeView &view, DateTime evaluation_time)
+        {
+            if (!view.started()) { return true; }
+            const auto *context = static_cast<const SubscriptionKeyCaptureContext *>(
+                view.type().ops_ref().extended_view_context);
+            capture_subscription_key(*context, view, evaluation_time, false);
+            return true;
         }
 
         void capture_request_input(
@@ -674,8 +822,11 @@ namespace hgraph
             initialize_request_capture(view, evaluation_time, storage);
             auto request = storage.input.borrowed_ref(evaluation_time);
             auto source  = NodeView{storage.source}.as<RequestInputSourceView>();
-            const DateTime schedule_time = request_stub_forward_time(
-                view, evaluation_time, start_phase);
+            const DateTime schedule_time = context.same_cycle
+                                               ? (view.graph().is_nested()
+                                                      ? evaluation_time + MIN_TD
+                                                      : evaluation_time)
+                                               : request_stub_forward_time(view, evaluation_time, start_phase);
 
             if (request.valid())
             {
@@ -694,15 +845,6 @@ namespace hgraph
                 source.remove(storage.request_id, schedule_time, evaluation_time);
                 storage.live = false;
             }
-        }
-
-        bool subscription_key_capture_evaluate_impl(const void *, const NodeView &view, DateTime evaluation_time)
-        {
-            if (!view.started()) { return true; }
-            const auto *context = static_cast<const SubscriptionKeyCaptureContext *>(
-                view.type().ops_ref().extended_view_context);
-            capture_subscription_key(*context, view, evaluation_time, false);
-            return true;
         }
 
         bool request_input_capture_evaluate_impl(const void *, const NodeView &view, DateTime evaluation_time)
@@ -728,7 +870,10 @@ namespace hgraph
 
             initialize_subscription_capture(view, evaluation_time, storage);
             auto source = NodeView{storage.source}.as<SubscriptionKeySourceView>();
-            source.enqueue(std::move(storage.previous_key), false, evaluation_time + MIN_TD);
+            source.enqueue(
+                std::move(storage.previous_key), false,
+                view.graph().is_nested() ? evaluation_time + MIN_TD : evaluation_time,
+                evaluation_time);
             storage.previous_key = Value{};
             storage.has_previous = false;
             storage.source       = NodePtr{};
@@ -750,7 +895,11 @@ namespace hgraph
             initialize_request_capture(view, evaluation_time, storage);
             auto source = NodeView{storage.source}.as<RequestInputSourceView>();
             source.remove(
-                storage.request_id, evaluation_time + MIN_TD, evaluation_time);
+                storage.request_id,
+                context->same_cycle && !view.graph().is_nested()
+                    ? evaluation_time
+                    : evaluation_time + MIN_TD,
+                evaluation_time);
             storage.live   = false;
             storage.source = NodePtr{};
             storage.input  = TSInputView{};
@@ -841,7 +990,7 @@ namespace hgraph
             {"key", key_ts_schema},
             {"subscriptions", subscription_schema},
         });
-        descriptor.schema.node_kind    = NodeKind::Sink;
+        descriptor.schema.node_kind     = NodeKind::Sink;
         descriptor.schema.active_inputs = std::vector<std::size_t>{0};
         descriptor.schema.valid_inputs  = std::vector<std::size_t>{};
 
@@ -857,13 +1006,53 @@ namespace hgraph
         descriptor.callbacks.start = [context](const NodeView &view, DateTime evaluation_time) {
             capture_subscription_key(*context, view, evaluation_time, true);
         };
-        descriptor.callbacks.stop             = &subscription_key_capture_stop;
-        descriptor.ops.evaluate_impl          = &subscription_key_capture_evaluate_impl;
-        descriptor.ops.extended_view_context  = context;
+        descriptor.callbacks.stop            = &subscription_key_capture_stop;
+        descriptor.ops.evaluate_impl         = &subscription_key_capture_evaluate_impl;
+        descriptor.ops.extended_view_context = context;
 
         NodeBuilder builder = NodeBuilder::from_canonical_descriptor(
             std::move(descriptor), context);
         builder.label(std::string{"subscription_key_capture:"} + context->path);
+        return builder;
+    }
+
+    NodeBuilder make_subscription_response_gate_node(
+        const ValueTypeMetaData &key_schema,
+        const TSValueTypeMetaData &response_schema)
+    {
+        auto &registry = TypeRegistry::instance();
+        const auto *key_ts_schema = registry.ts(&key_schema);
+
+        NodeTypeDescriptor descriptor;
+        descriptor.schema.display_name = "subscription_response_gate";
+        descriptor.schema.input_schema = registry.un_named_tsb({
+            {"value", &response_schema},
+            {"key", key_ts_schema},
+            {"subscriptions", registry.tss(&key_schema)},
+        });
+        descriptor.schema.output_schema = &response_schema;
+        descriptor.schema.node_kind = NodeKind::Compute;
+        descriptor.schema.uses_scheduler = true;
+        descriptor.schema.active_inputs = std::vector<std::size_t>{0, 1};
+        descriptor.schema.valid_inputs = std::vector<std::size_t>{};
+
+        const std::array fields{NodeStorageField{
+            .name = subscription_response_gate_storage_field,
+            .plan = &MemoryUtils::plan_for<SubscriptionResponseGateStorage>(),
+        }};
+        descriptor.storage_plan = &node_storage_plan_for(descriptor.schema, fields);
+        const std::size_t storage_offset =
+            descriptor.storage_plan->component(subscription_response_gate_storage_field).offset;
+        const auto *canonical_context = descriptor.storage_plan;
+
+        descriptor.callbacks.evaluate = [storage_offset](
+            const NodeView &view, DateTime evaluation_time) {
+            evaluate_subscription_response_gate(storage_offset, view, evaluation_time);
+        };
+
+        NodeBuilder builder = NodeBuilder::from_canonical_descriptor(
+            std::move(descriptor), canonical_context);
+        builder.label("subscription_response_gate");
         return builder;
     }
 
@@ -902,7 +1091,8 @@ namespace hgraph
 
     NodeBuilder make_request_input_capture_node(
         std::string path,
-        const TSValueTypeMetaData &request_schema)
+        const TSValueTypeMetaData &request_schema,
+        bool same_cycle)
     {
         path = request_input_path(std::move(path));
 
@@ -928,7 +1118,9 @@ namespace hgraph
         descriptor.storage_plan = &node_storage_plan_for(descriptor.schema, fields);
 
         const auto *context = &register_request_input_capture_context(
-            path, descriptor.storage_plan->component(request_input_capture_storage_field).offset);
+            path,
+            descriptor.storage_plan->component(request_input_capture_storage_field).offset,
+            same_cycle);
 
         descriptor.callbacks.start = [context](const NodeView &view, DateTime evaluation_time) {
             // A request_id operator publishes during evaluation rather than

--- a/src/hgraph/types/graph_wiring.cpp
+++ b/src/hgraph/types/graph_wiring.cpp
@@ -2382,7 +2382,6 @@ GlobalStateView Wiring::operator_state() noexcept {
 }
 
 void Wiring::apply_service_rank_dependencies() {
-  std::unordered_set<std::string> ranked_senders;
   for (const auto &client : impl_->service_client_ranks) {
     auto anchor_it = impl_->service_rank_anchors.find(client.path);
     if (anchor_it == impl_->service_rank_anchors.end() ||
@@ -2397,10 +2396,8 @@ void Wiring::apply_service_rank_dependencies() {
 
     if (client.receive) {
       add_rank_dependency(client.node, anchor);
-    } else if (ranked_senders.insert(client.path).second) {
-      add_rank_dependency(anchor, client.node);
     } else {
-      add_rank_dependency(client.node, anchor);
+      add_rank_dependency(anchor, client.node);
     }
   }
 }

--- a/src/hgraph/types/service_runtime.cpp
+++ b/src/hgraph/types/service_runtime.cpp
@@ -342,7 +342,8 @@ namespace hgraph
         // the service interface's closed base union before capture.
         WiringPortRef adapted_key = graph_wiring_detail::adapt_source_for_input(
             w, TypeRegistry::instance().ts(descriptor.key_type), key);
-        // The subscription capture schedules the source for the next cycle.
+        // Root captures rank before the shared key source and publish in the
+        // same cycle. Nested hand-offs retain their one-cycle temporal boundary.
         std::array<WiringPortRef, 2>  sources{adapted_key, subscriptions};
         std::array<WiringInputRef, 2> inputs{{
             WiringInputRef{.source = sources[0]},
@@ -373,7 +374,24 @@ namespace hgraph
         WiringPortRef output =
             resolved.impl->wire(w, resolved.map, resolved.args, resolved.kwargs).output;
         output.schema = descriptor.value_schema;
-        return output;
+        std::array<WiringPortRef, 3> gate_sources{
+            output, adapted_key, subscriptions};
+        std::array<WiringInputRef, 3> gate_inputs{{
+            WiringInputRef{.source = gate_sources[0]},
+            WiringInputRef{.source = gate_sources[1]},
+            WiringInputRef{.source = gate_sources[2]},
+        }};
+        NodeBuilder gate_builder = make_subscription_response_gate_node(
+            *descriptor.key_type, *descriptor.value_schema);
+        gate_builder.input_endpoint(graph_wiring_detail::input_endpoint_for_sources(
+            gate_builder.type().schema()->input_schema,
+            std::span<const WiringPortRef>{gate_sources.data(), gate_sources.size()}));
+        WiringPortRef gated = w.add_node(
+            std::type_index(typeid(service::detail::subscription_response_gate_marker)),
+            std::move(gate_builder),
+            std::span<const WiringInputRef>{gate_inputs.data(), gate_inputs.size()}, Value{});
+        gated.schema = descriptor.value_schema;
+        return gated;
     }
 
     void register_subscription_service_impl(Wiring &w, const RuntimeServiceDescriptor &descriptor,
@@ -1160,7 +1178,7 @@ namespace hgraph
             WiringInputRef{.source = sources[2]},
         }};
         NodeBuilder builder = make_request_input_capture_node(
-            request_path, *descriptor.input_schema);
+            request_path, *descriptor.input_schema, true);
         builder.input_endpoint(graph_wiring_detail::input_endpoint_for_sources(
             builder.type().schema()->input_schema,
             std::span<const WiringPortRef>{sources.data(), sources.size()}));

--- a/tests/cpp/test_service_node.cpp
+++ b/tests/cpp/test_service_node.cpp
@@ -39,7 +39,7 @@ namespace
     };
 }  // namespace
 
-TEST_CASE("service subscription keys publish captured keys on the next cycle")
+TEST_CASE("service subscription keys publish after ranked captures in the same cycle")
 {
     using namespace hgraph;
 
@@ -49,22 +49,18 @@ TEST_CASE("service subscription keys publish captured keys on the next cycle")
 
     GraphBuilder builder;
     builder.add_node(NodeBuilder{}.implementation<ConstantKey>());
-    builder.add_node(make_subscription_key_source_node(path, *int_meta));
     builder.add_node(make_subscription_key_capture_node(path, *int_meta));
-    builder.add_edge(GraphEdge{.source_node = 0, .target_node = 2, .target_path = {0}});
-    builder.add_edge(GraphEdge{.source_node = 1, .target_node = 2, .target_path = {1}});
+    builder.add_node(make_subscription_key_source_node(path, *int_meta));
+    builder.add_edge(GraphEdge{.source_node = 0, .target_node = 1, .target_path = {0}});
+    builder.add_edge(GraphEdge{.source_node = 2, .target_node = 1, .target_path = {1}});
 
     testing::MockRootGraph graph{builder};
     auto                   view = graph.graph();
     const auto             t1   = MIN_ST;
-    const auto             t2   = t1 + MIN_TD;
 
     view.start(t1);
     view.evaluate(t1);
-    CHECK_FALSE(view.node_at(1).output(t1).modified());
-
-    view.evaluate(t2);
-    auto output_view = view.node_at(1).output(t2);
+    auto output_view = view.node_at(2).output(t1);
     auto output      = output_view.as_set();
     REQUIRE(output.modified());
     CHECK(output.contains(Value{std::int32_t{7}}.view()));
@@ -81,32 +77,29 @@ TEST_CASE("service subscription keys are reference counted across captures")
     GraphBuilder builder;
     builder.add_node(NodeBuilder{}.implementation<SwitchingKey>());
     builder.add_node(NodeBuilder{}.implementation<ConstantKey>());
+    builder.add_node(make_subscription_key_capture_node(path, *int_meta));
+    builder.add_node(make_subscription_key_capture_node(path, *int_meta));
     builder.add_node(make_subscription_key_source_node(path, *int_meta));
-    builder.add_node(make_subscription_key_capture_node(path, *int_meta));
-    builder.add_node(make_subscription_key_capture_node(path, *int_meta));
-    builder.add_edge(GraphEdge{.source_node = 0, .target_node = 3, .target_path = {0}});
-    builder.add_edge(GraphEdge{.source_node = 2, .target_node = 3, .target_path = {1}});
-    builder.add_edge(GraphEdge{.source_node = 1, .target_node = 4, .target_path = {0}});
-    builder.add_edge(GraphEdge{.source_node = 2, .target_node = 4, .target_path = {1}});
+    builder.add_edge(GraphEdge{.source_node = 0, .target_node = 2, .target_path = {0}});
+    builder.add_edge(GraphEdge{.source_node = 4, .target_node = 2, .target_path = {1}});
+    builder.add_edge(GraphEdge{.source_node = 1, .target_node = 3, .target_path = {0}});
+    builder.add_edge(GraphEdge{.source_node = 4, .target_node = 3, .target_path = {1}});
 
     testing::MockRootGraph graph{builder};
     auto                   view = graph.graph();
     const auto             t1   = MIN_ST;
     const auto             t2   = t1 + MIN_TD;
-    const auto             t3   = t2 + MIN_TD;
 
     view.start(t1);
     view.evaluate(t1);
-
-    view.evaluate(t2);
-    auto first_view = view.node_at(2).output(t2);
+    auto first_view = view.node_at(4).output(t1);
     auto first      = first_view.as_set();
     REQUIRE(first.modified());
     CHECK(first.contains(Value{std::int32_t{7}}.view()));
     CHECK_FALSE(first.contains(Value{std::int32_t{8}}.view()));
 
-    view.evaluate(t3);
-    auto second_view = view.node_at(2).output(t3);
+    view.evaluate(t2);
+    auto second_view = view.node_at(4).output(t2);
     auto second      = second_view.as_set();
     REQUIRE(second.modified());
     CHECK(second.contains(Value{std::int32_t{7}}.view()));

--- a/tests/cpp/test_service_runtime.cpp
+++ b/tests/cpp/test_service_runtime.cpp
@@ -290,7 +290,7 @@ TEST_CASE("service runtime: erased service-adaptor registration serves typed cli
     stdlib::register_standard_operators();
     CHECK_OUTPUT(eval_node<ErasedServiceAdaptorRegisterTemplateClients>(
                      values<Int>(1, none, 2), values<Int>(10, none, 20)),
-                 values<Int>(none, 11, none, 22));
+                 values<Int>(11, none, 22));
 }
 
 TEST_CASE("service runtime: C++ service adaptors carry multi-field requests and responses")
@@ -298,7 +298,7 @@ TEST_CASE("service runtime: C++ service adaptors carry multi-field requests and 
     stdlib::register_standard_operators();
     CHECK_OUTPUT(eval_node<RuntimeMultiFieldServiceAdaptorGraph>(
                      values<Int>(1, none, 2), values<Int>(10, none, 20)),
-                 values<Int>(none, 11, none, 22));
+                 values<Int>(11, none, 22));
 }
 
 TEST_CASE("service runtime: erased automatic adaptor registration serves a typed client")

--- a/tests/cpp/test_service_wiring.cpp
+++ b/tests/cpp/test_service_wiring.cpp
@@ -785,6 +785,34 @@ namespace
         }
     };
 
+    inline std::vector<std::pair<std::vector<Int>, std::vector<Int>>> observed_subscription_keys;
+
+    struct ObserveSubscriptionKeysNode
+    {
+        static constexpr auto name = "observe_subscription_keys_node";
+
+        static void eval(In<"keys", TSS<Int>> keys)
+        {
+            std::vector<Int> added;
+            std::vector<Int> removed;
+            for (Int key : keys.added()) { added.push_back(key); }
+            for (Int key : keys.removed()) { removed.push_back(key); }
+            observed_subscription_keys.emplace_back(
+                std::move(added), std::move(removed));
+        }
+    };
+
+    struct ObservedPricesImpl
+    {
+        [[maybe_unused]] static constexpr auto name = "observed_prices_impl";
+
+        static Port<TSD<Int, TS<Int>>> compose(Wiring &w, Port<TSS<Int>> keys)
+        {
+            static_cast<void>(wire<ObserveSubscriptionKeysNode>(w, keys));
+            return wire<PricesImplNode>(w, keys).as<TSD<Int, TS<Int>>>();
+        }
+    };
+
     struct BundlePricesImpl
     {
         [[maybe_unused]] static constexpr auto name = "bundle_prices_impl";
@@ -907,6 +935,17 @@ namespace
         static Port<TS<Int>> compose(Wiring &w, Port<TS<Int>> instrument)
         {
             service::register_subscription_service<PricesService, PricesImpl>(w);
+            return wire<PricesService>(w, instrument);
+        }
+    };
+
+    struct ObservedPriceClientGraph
+    {
+        [[maybe_unused]] static constexpr auto name = "observed_price_client_graph";
+
+        static Port<TS<Int>> compose(Wiring &w, Port<TS<Int>> instrument)
+        {
+            service::register_subscription_service<PricesService, ObservedPricesImpl>(w);
             return wire<PricesService>(w, instrument);
         }
     };
@@ -1602,6 +1641,37 @@ namespace
         }
     };
 
+    struct ServiceAdaptorSwitchBranch
+    {
+        [[maybe_unused]] static constexpr auto name = "service_adaptor_switch_branch";
+
+        static Port<TS<Int>> compose(Wiring &w, Port<TS<Int>> request)
+        {
+            return wire<AddTwentyServiceAdaptor>(
+                w, service_adaptor::path("switch_adaptor"), request);
+        }
+    };
+
+    struct ServiceAdaptorSwitchGraph
+    {
+        [[maybe_unused]] static constexpr auto name = "service_adaptor_switch_graph";
+
+        static Port<TS<Int>> compose(
+            Wiring &w, Port<TS<Str>> selector, Port<TS<Int>> request)
+        {
+            service_adaptor::register_service_adaptor<
+                AddTwentyServiceAdaptor, AddTwentyServiceAdaptorImpl>(
+                    w, service_adaptor::path("switch_adaptor"));
+            return wire<stdlib::switch_>(
+                       w, selector,
+                       stdlib::switch_cases({
+                           {Value{Str{"adaptor"}}, fn<ServiceAdaptorSwitchBranch>()},
+                       }),
+                       request)
+                .as<TS<Int>>();
+        }
+    };
+
     struct ServiceAdaptorImplTwoClientGraph
     {
         [[maybe_unused]] static constexpr auto name = "service_adaptor_impl_two_client_graph";
@@ -1824,6 +1894,18 @@ TEST_CASE("service wiring: subscription client reads implementation output by re
                  values<Int>(none, 70, none, 80));
 }
 
+TEST_CASE("service wiring: successive subscription keys are published in order")
+{
+    hgraph::stdlib::register_standard_operators();
+    observed_subscription_keys.clear();
+
+    CHECK_OUTPUT(eval_node<ObservedPriceClientGraph>(values<Int>(7, none, 8, 7)),
+                 values<Int>(none, 70, none, none, 70));
+    CHECK(observed_subscription_keys ==
+          std::vector<std::pair<std::vector<Int>, std::vector<Int>>>{
+              {{7}, {}}, {{8}, {7}}, {{7}, {8}}});
+}
+
 TEST_CASE("service wiring: subscription keys preserve registered derived Bundles")
 {
     hgraph::stdlib::register_standard_operators();
@@ -1864,7 +1946,7 @@ TEST_CASE("service wiring: mapped subscription results retain their declared val
                  values<Int>(0, 70));
 }
 
-TEST_CASE("service wiring: late duplicate subscription samples the existing value")
+TEST_CASE("service wiring: a late client samples a key kept live by another client")
 {
     hgraph::stdlib::register_standard_operators();
 
@@ -2151,7 +2233,17 @@ TEST_CASE("service wiring: service adaptors collect multiple client requests")
     hgraph::stdlib::register_standard_operators();
 
     CHECK_OUTPUT(eval_node<ServiceAdaptorTwoClientGraph>(values<Int>(1), values<Int>(10)),
-                 values<Int>(none, 51));
+                 values<Int>(51));
+}
+
+TEST_CASE("service wiring: a dynamically started adaptor branch hands off on the next cycle")
+{
+    hgraph::stdlib::register_standard_operators();
+
+    CHECK_OUTPUT(
+        eval_node<ServiceAdaptorSwitchGraph>(
+            values<Str>(Str{"adaptor"}), values<Int>(1)),
+        values<Int>(none, 21));
 }
 
 TEST_CASE("service wiring: service adaptors preserve successive requests from one client")
@@ -2159,7 +2251,7 @@ TEST_CASE("service wiring: service adaptors preserve successive requests from on
     hgraph::stdlib::register_standard_operators();
 
     CHECK_OUTPUT(eval_node<ServiceAdaptorSingleClientGraph>(values<Int>(1, 2, 3)),
-                 values<Int>(none, 21, 22, 23));
+                 values<Int>(21, 22, 23));
 }
 
 TEST_CASE("service wiring: service_adaptor_impl auto-wires single-interface implementations")
@@ -2167,7 +2259,7 @@ TEST_CASE("service wiring: service_adaptor_impl auto-wires single-interface impl
     hgraph::stdlib::register_standard_operators();
 
     CHECK_OUTPUT(eval_node<ServiceAdaptorImplTwoClientGraph>(values<Int>(1), values<Int>(10)),
-                 values<Int>(none, 51));
+                 values<Int>(51));
 }
 
 TEST_CASE("service wiring: sink-only service adaptors collect multiple bundled clients")
@@ -2213,7 +2305,7 @@ TEST_CASE("service wiring: multi-interface service adaptors wire explicit stubs"
 {
     hgraph::stdlib::register_standard_operators();
 
-    CHECK_OUTPUT(eval_node<MultiServiceAdaptorClientGraph>(values<Int>(1)), values<Int>(none, 52));
+    CHECK_OUTPUT(eval_node<MultiServiceAdaptorClientGraph>(values<Int>(1)), values<Int>(52));
 }
 
 TEST_CASE("service wiring: service adaptors validate requested implementations and ignore unused candidates")
@@ -2239,7 +2331,7 @@ TEST_CASE("service wiring: generic service descriptors resolve from client input
     CHECK_OUTPUT(eval_node<GenericServiceClientGraph>(values<Int>(3)), values<Int>(none, none, 4));
     CHECK_OUTPUT(eval_node<GenericFloatServiceClientGraph>(values<Float>(1.5)),
                  values<Float>(none, none, 2.0));
-    CHECK_OUTPUT(eval_node<GenericServiceAdaptorClientGraph>(values<Int>(3)), values<Int>(none, 23));
+    CHECK_OUTPUT(eval_node<GenericServiceAdaptorClientGraph>(values<Int>(3)), values<Int>(23));
     CHECK_THROWS_AS((void)eval_node<GenericStringServiceClientGraph>(values<Str>("not numeric")),
                     std::invalid_argument);
 }

--- a/tools/parity/catalog.py
+++ b/tools/parity/catalog.py
@@ -1474,7 +1474,7 @@ CATALOG = {
             "adaptor:service",
             "adaptor:multi-client",
             "implementation:path-injection",
-            "lifecycle:transport-delay",
+            "lifecycle:same-cycle",
             "shape:TSL",
             "reference:REF",
             "binding:non-peered",

--- a/tools/parity/corpus/issue-64-service-adaptor-cycle.json
+++ b/tools/parity/corpus/issue-64-service-adaptor-cycle.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
   "id": "issue-64-service-adaptor-cycle",
-  "description": "Track the designed service_adaptor transport timing: the round trip lands one cycle after released hgraph's same-cycle adaptor wiring (known deviation, services.rst scheduling matrix).",
+  "description": "Pin same-cycle service-adaptor transport parity: ranked client input, implementation, and reply complete in one engine cycle.",
   "template": "service_adaptor_roundtrip",
   "inputs": {
     "value": [
@@ -17,7 +17,7 @@
     "binding:non-peered",
     "framework:adaptor",
     "implementation:path-injection",
-    "lifecycle:transport-delay",
+    "lifecycle:same-cycle",
     "reference:REF",
     "shape:TS",
     "shape:TSD",

--- a/tools/parity/corpus/issue-66-resubscribe-sampling.json
+++ b/tools/parity/corpus/issue-66-resubscribe-sampling.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
   "id": "issue-66-resubscribe-sampling",
-  "description": "Track the designed late-subscription sampling timing: re-subscribing a previously computed symbol delivers the existing value in the same cycle, one cycle earlier than released hgraph (known deviation, services.rst scheduling matrix).",
+  "description": "Pin subscription replacement parity: rapid key transitions publish in order and re-subscription waits for the fresh implementation value.",
   "template": "service_subscription",
   "inputs": {
     "symbol": [

--- a/tools/parity/generate.py
+++ b/tools/parity/generate.py
@@ -243,22 +243,10 @@ def recipe_payload_strategy(*, min_ticks: int = 8, max_ticks: int = 32,
     @st.composite
     def service_subscription(draw):
         count = draw(st.integers(min_value=min_ticks, max_value=max_ticks))
-        # Each symbol subscribes at most once: re-subscribing a previously
-        # computed symbol is the designed same-cycle sampling deviation
-        # (services.rst scheduling matrix; issue #66), so differential
-        # exploration there measures the deviation, not candidate defects.
-        # The corpus tracks the re-subscription case explicitly.
-        pool = list(
-            draw(
-                st.permutations(("a", "fx", "rates", "EURUSD", "long_symbol"))
-            )
-        )
-        ticks = [pool.pop(0)]
+        symbols = st.sampled_from(("a", "fx", "rates", "EURUSD", "long_symbol"))
+        ticks = [draw(symbols)]
         for _ in range(count - 1):
-            if pool and draw(st.booleans()):
-                ticks.append(pool.pop(0))
-            else:
-                ticks.append(None)
+            ticks.append(draw(st.one_of(st.none(), symbols)))
         return {
             "template": "service_subscription",
             "inputs": {"symbol": ticks},
@@ -686,9 +674,9 @@ def recipe_payload_strategy(*, min_ticks: int = 8, max_ticks: int = 32,
             "features": [*CATALOG["data_frame_recording"].features],
         }
 
-    # (name, factory) pairs for discovery. Families whose every differential
-    # is already an accepted deviation stay in the fixed corpus rather than
-    # consuming random examples here.
+    # (name, factory) pairs for discovery. The service strategies exercise
+    # the Python parity contract directly; only still-accepted divergences are
+    # constrained within their individual generators.
     discovery_weighted = (
         ("scalar_expression", scalar_expression),
         ("feedback_accumulate", feedback_accumulate),
@@ -698,6 +686,7 @@ def recipe_payload_strategy(*, min_ticks: int = 8, max_ticks: int = 32,
         ("service_request_reply", service_request_reply),
         ("service_subscription", service_subscription),
         ("adaptor_loopback", adaptor_loopback),
+        ("service_adaptor_roundtrip", service_adaptor_roundtrip),
         ("context_switch", context_switch),
         ("operator_pipeline", operator_pipeline),
         ("tsd_key_set_pipeline", tsd_key_set_pipeline),
@@ -709,13 +698,7 @@ def recipe_payload_strategy(*, min_ticks: int = 8, max_ticks: int = 32,
         ("nested_higher_order", nested_higher_order),
         ("nested_higher_order", nested_higher_order),
     )
-    selectable = (
-        *discovery_weighted,
-        # Explicit selection remains available for controller tests and
-        # reproductions; unrestricted discovery excludes its designed
-        # one-cycle transport difference.
-        ("service_adaptor_roundtrip", service_adaptor_roundtrip),
-    )
+    selectable = discovery_weighted
     if templates is None:
         return st.one_of(*(factory() for _, factory in discovery_weighted))
     # A restricted profile draws ONLY the allowed strategies — selecting at

--- a/tools/parity/known.py
+++ b/tools/parity/known.py
@@ -26,9 +26,7 @@ from .compare import compare_outcomes
 
 DEFAULT_PATH = Path(__file__).with_name("known_divergences.json")
 TRACE_VALUE = "trace-value"
-SERVICE_ADAPTOR_ONE_CYCLE = "service-adaptor-one-cycle"
 KEY_SET_SIZE_NO_RETICK = "key-set-size-no-retick"
-SUBSCRIPTION_RESAMPLE_ONE_CYCLE = "subscription-resample-one-cycle"
 NO_CHANGE_ELISION = "no-change-elision"
 VALID_SUBSET_REDUCE = "valid-subset-reduce"
 SWITCH_FLIP_MAP_REMOVAL = "switch-flip-map-removal"
@@ -92,22 +90,6 @@ def _trace_value_relation(
     return difference.get("classification") == "value"
 
 
-def _service_adaptor_one_cycle_relation(
-    _recipe: dict[str, Any],
-    _difference: dict[str, Any],
-    reference: dict[str, Any],
-    candidate: dict[str, Any],
-    _family: dict[str, Any],
-) -> bool:
-    reference_trace = reference.get("trace")
-    candidate_trace = candidate.get("trace")
-    return (
-        isinstance(reference_trace, list)
-        and isinstance(candidate_trace, list)
-        and candidate_trace == [None, *reference_trace]
-    )
-
-
 def _without_map_field(trace: Any, field: str) -> Any:
     if not isinstance(trace, list):
         return trace
@@ -163,73 +145,6 @@ def _key_set_size_no_retick_relation(
         )
         is None
     )
-
-
-def _repeated_non_null_positions(values: Any) -> list[int]:
-    if not isinstance(values, list):
-        return []
-    seen = set()
-    repeated = []
-    for index, value in enumerate(values):
-        if value is None:
-            continue
-        if value in seen:
-            repeated.append(index)
-        else:
-            seen.add(value)
-    return repeated
-
-
-def _subscription_resample_one_cycle_relation(
-    recipe: dict[str, Any],
-    _difference: dict[str, Any],
-    reference: dict[str, Any],
-    candidate: dict[str, Any],
-    _family: dict[str, Any],
-) -> bool:
-    """Issue #66/#71: only the repeats that actually sample delay.
-
-    The documented deviation inserts one no-tick cycle immediately before
-    the payload of an EMITTING repeated subscription — a repeat that emits
-    nothing (e.g. its value never arrived) shifts nothing. Align the traces
-    with a two-pointer walk that may consume one reference ``None`` before
-    the candidate payload at any emitting repeat position; the walk is
-    deterministic because the delay branch only opens where the direct
-    comparison fails. At least one repeat must account for the mismatch and
-    the complete payload traces must be equal after alignment, so corrupt
-    values, unrelated missing ticks, and first-subscription differences
-    remain reportable.
-    """
-    repeated = set(
-        _repeated_non_null_positions((recipe.get("inputs") or {}).get("symbol"))
-    )
-    reference_trace = reference.get("trace")
-    candidate_trace = candidate.get("trace")
-    if (
-        not repeated
-        or not isinstance(reference_trace, list)
-        or not isinstance(candidate_trace, list)
-    ):
-        return False
-
-    inserted = 0
-    j = 0
-    for i, item in enumerate(candidate_trace):
-        if j < len(reference_trace) and reference_trace[j] == item:
-            j += 1
-            continue
-        if (
-            i in repeated
-            and item is not None
-            and j + 1 < len(reference_trace)
-            and reference_trace[j] is None
-            and reference_trace[j + 1] == item
-        ):
-            j += 2
-            inserted += 1
-            continue
-        return False
-    return j == len(reference_trace) and inserted >= 1
 
 
 def _no_change_elision_relation(
@@ -495,11 +410,7 @@ RELATIONS = {
     VALID_SUBSET_REDUCE: _valid_subset_reduce_relation,
     SWITCH_FLIP_VALID_SUBSET: _switch_flip_valid_subset_relation,
     SWITCH_FLIP_MAP_REMOVAL: _switch_flip_map_removal_relation,
-    SERVICE_ADAPTOR_ONE_CYCLE: _service_adaptor_one_cycle_relation,
     KEY_SET_SIZE_NO_RETICK: _key_set_size_no_retick_relation,
-    SUBSCRIPTION_RESAMPLE_ONE_CYCLE: (
-        _subscription_resample_one_cycle_relation
-    ),
 }
 
 

--- a/tools/parity/known_divergences.json
+++ b/tools/parity/known_divergences.json
@@ -14,18 +14,6 @@
       "review_after": "2027-07-26"
     },
     {
-      "fingerprint": "e64b8a5662c389c92396ef0805a60bb97e109ee943222ed1e22fadbae88eb28e",
-      "issue": "https://github.com/hhenson/hg_cpp/issues/64",
-      "reason": "Designed service-boundary timing (services.rst scheduling matrix): a service_adaptor request forwards next cycle by design, so the round trip lands one cycle after released hgraph's same-cycle adaptor wiring. Pinned by test_service_wiring.cpp service-adaptor cases.",
-      "review_after": "2027-07-26"
-    },
-    {
-      "fingerprint": "6d05f5590cc2ff1d6ff45fa63f5189771924d30b9df7d754569979a3d2718b0b",
-      "issue": "https://github.com/hhenson/hg_cpp/issues/66",
-      "reason": "Designed service-boundary timing (services.rst scheduling matrix): a late/duplicate subscription samples the existing shared output in the same cycle, one cycle earlier than released hgraph's re-delivery. Pinned by test_service_wiring.cpp 'late duplicate subscription samples the existing value'.",
-      "review_after": "2027-07-26"
-    },
-    {
       "fingerprint": "7834fe8ecb1c87ca79cd6ef4229a20376622857e8b1b7b56b6a76d02e4613182",
       "issue": "https://github.com/hhenson/hg_cpp/pull/67",
       "reason": "No-change-means-no-tick ruling (2026-07-17, roadmap.rst): a mesh over an initially empty key set emits no tick in hg_cpp where released hgraph ticks an empty map. Fingerprint pinned by test_parity_harness.py against the corpus recipe mesh-empty-initial-no-tick.",
@@ -33,15 +21,6 @@
     }
   ],
   "families": [
-    {
-      "family": "service-adaptor-transport-cycle",
-      "template": "service_adaptor_roundtrip",
-      "parameters_not_equal": {},
-      "relation": "service-adaptor-one-cycle",
-      "issue": "https://github.com/hhenson/hg_cpp/issues/64",
-      "reason": "The designed service_adaptor request hop adds exactly one leading no-tick cycle to the hg_cpp trace. Suppress only when removing that cycle makes the complete payload trace equal to released hgraph.",
-      "review_after": "2027-07-26"
-    },
     {
       "family": "key-set-size-no-retick",
       "template": "tsd_key_set_pipeline",
@@ -52,15 +31,6 @@
       "float_abs_tolerance": 1e-12,
       "issue": "https://github.com/hhenson/hg_cpp/issues/65",
       "reason": "No-change-means-no-tick ruling (2026-07-17, roadmap.rst): suppress only when removing size fields from both dedup_size=false traces makes every other field equal within the template tolerance.",
-      "review_after": "2027-07-26"
-    },
-    {
-      "family": "service-resubscription-sampling",
-      "template": "service_subscription",
-      "parameters_not_equal": {},
-      "relation": "subscription-resample-one-cycle",
-      "issue": "https://github.com/hhenson/hg_cpp/issues/66",
-      "reason": "Designed service-boundary timing: a repeated non-null subscription key that samples an existing value emits in the repeat cycle while released hgraph re-delivers one cycle later; repeats that emit nothing shift nothing. Suppress only when delaying the subset of emitting repeats makes the complete payload traces equal (issue #71).",
       "review_after": "2027-07-26"
     },
     {


### PR DESCRIPTION
## Summary

- restore graph-ranked service adaptor transport so top-level client, implementation, and reply processing completes in the same engine cycle
- preserve successive requests from one client while retaining Python-compatible nested-graph handoff
- leave request/reply services deliberately deferred
- preserve observed subscription-key transition order and wait for a fresh implementation generation after a globally new subscription
- immediately sample a key that another client already keeps live
- remove the accepted #64 and #66 parity divergences and update the related documentation, corpus, and coverage

## Root cause

The adaptor transport scheduled work across engine cycles and only ranked the first sender against the service implementation. Subscription transitions could also be coalesced, and re-subscription could expose a stale cached value instead of respecting the implementation generation boundary.

Released Python hgraph and the legacy C++ implementation use service graph ranks to order adaptor senders, implementation nodes, and receivers. Subscription replacement additionally distinguishes globally new keys from keys that are already live.

## Implementation notes

The branch is rebased onto current `main` and incorporates its successive-request queueing fix with same-tick adaptor expectations.

The subscription response gate uses graph-owned planned node storage. This change does not add thread-local storage or a process-lifetime runtime registry.

## Validation

- macOS native suite: 1,382/1,382 passed
- macOS Python 3.14 non-WIP suite: 1,818 passed, 11 skipped
- physical `hg-linux`, fresh clean GCC 14.3 build: 1,382/1,382 native tests passed
- physical `hg-linux`, Python 3.14 non-WIP suite: 1,818 passed, 11 skipped
- exact differential replay against Python hgraph 0.5.34:
  - #64: no difference, trace `[1]`
  - #66: no difference, trace `[null, 35, null, null, 35]`
- all 56 parity corpus recipes validate
- `git diff --check` passes

Closes #64
Closes #66