### PR TITLE
Verify push sources inside service implementations

### DIFF
--- a/docs/source/developer_guide/nested_graphs.rst
+++ b/docs/source/developer_guide/nested_graphs.rst
@@ -944,7 +944,12 @@ Roadmap (this milestone)
 
 Non-goals for the milestone: services/contexts (since landed as their own
 milestone — see :doc:`services`),
-push sources inside nested graphs. (Non-associative reduction and dynamic-TSL
+push sources inside nested graphs — a graph carrying a push prefix never gets a
+nested graph type interned, so ``GraphBuilder::nested_type()`` rejects it. Note
+this bounds nested *children* only: service and adaptor implementations are
+inlined into the top-level graph, so an implementation may own a push source
+(:doc:`services`, "Implementations are inlined, not nested").
+(Non-associative reduction and dynamic-TSL
 reduction have since landed. Explicit ``__keys__`` and the ``pass_through`` /
 ``no_key`` wrappers, originally deferred, landed within the milestone —
 see the ``map_`` section. ``try_except_`` landed as its own follow-on

--- a/docs/source/developer_guide/roadmap.rst
+++ b/docs/source/developer_guide/roadmap.rst
@@ -440,11 +440,16 @@ Dynamic-TSL mesh is not a Python parity target: the upstream Python mesh
 contract is TSD-only and :doc:`mesh` records the same accepted restriction.
 Dynamic TSL mapping and reduction remain fully supported independently.
 
-**Remaining boundary mode:** push sources inside nested graphs if a concrete
-adaptor requires them. Service clients inside compiled ``map_``/``mesh_``
-children use the explicit parent-service endpoint import; the current audit
-found Python context-specialization residue around this landed path rather
-than a missing nested-service runtime.
+**Remaining boundary mode:** push sources inside genuine nested children
+(``map_``/``mesh_``/``switch_``/``reduce``/``nested_``/``try_except_``/component)
+if a concrete adaptor requires them. This does **not** affect service or adaptor
+implementations: those are inlined into the top-level graph rather than compiled
+as nested children, so an implementation may own a push source today — see
+:doc:`services` ("Implementations are inlined, not nested") and
+``tests/cpp/test_service_push_sources.cpp``. Service clients inside compiled
+``map_``/``mesh_`` children use the explicit parent-service endpoint import; the
+current audit found Python context-specialization residue around this landed
+path rather than a missing nested-service runtime.
 
 **Completed: Tornado web adaptors (2026-07-17).**  The upstream Python HTTP,
 WebSocket, and REST adaptor family has been ported onto the C++ service/adaptor

--- a/docs/source/developer_guide/services.rst
+++ b/docs/source/developer_guide/services.rst
@@ -309,10 +309,12 @@ Implementations are inlined, not nested (and may own push sources)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Registration does **not** wire anything. It records a *materializer candidate*
-(``Wiring::register_service_implementation_candidate``), and
-``Wiring::build_services()`` — reached only from ``Wiring::finish_top_level``,
-never from ``finish_subgraph`` — runs the candidates that some client actually
-requested. Each materializer calls ``WiredFn::wire(target, …)``, the **inline**
+(``Wiring::register_service_implementation_candidate``).
+``Wiring::finish_top_level`` calls ``Wiring::build_services()`` automatically;
+authors may also call ``build_services()`` explicitly to materialize current
+demand, and finishing calls it again for any later demand. ``finish_subgraph``
+does not perform this automatic materialization. Each requested materializer
+calls ``WiredFn::wire(target, …)``, the **inline**
 verb, not ``WiredFn::compile``, which is what produces a ``CompiledSubGraph``
 for ``map_``/``switch_``. An implementation's nodes are therefore ordinary nodes
 of the registering (top-level) graph.

--- a/docs/source/developer_guide/services.rst
+++ b/docs/source/developer_guide/services.rst
@@ -305,6 +305,46 @@ output). The implementation graph is wired once per registration; clients then
 consume each interface with the ordinary ``wire<Service>`` calls.
 
 
+Implementations are inlined, not nested (and may own push sources)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Registration does **not** wire anything. It records a *materializer candidate*
+(``Wiring::register_service_implementation_candidate``), and
+``Wiring::build_services()`` — reached only from ``Wiring::finish_top_level``,
+never from ``finish_subgraph`` — runs the candidates that some client actually
+requested. Each materializer calls ``WiredFn::wire(target, …)``, the **inline**
+verb, not ``WiredFn::compile``, which is what produces a ``CompiledSubGraph``
+for ``map_``/``switch_``. An implementation's nodes are therefore ordinary nodes
+of the registering (top-level) graph.
+
+Two consequences worth stating explicitly, because they are the opposite of the
+upstream Python reference:
+
+* **An implementation may own a push source.** ``@push_queue`` / a
+  ``make_push_source_node`` builder inside an implementation body is legal and
+  supported: the node lands in the root graph's push prefix
+  (``build_ranked_graph`` ranks push sources first) and is drained by the
+  real-time executor's push phase like any other root push source. This is the
+  intended way to feed a service from an external, thread-driven source — no
+  adaptor is required to get a push queue into a service. Upstream instead
+  compiles a ``@service_impl`` into a nested graph node
+  (``create_graph_builder(sink_nodes, False)``) and rejects push sources there.
+  Coverage: ``tests/cpp/test_service_push_sources.cpp`` and
+  ``python/tests/test_service_push_sources.py`` (reference, subscription,
+  request/reply and adaptor implementations, plus the two-implementations case).
+  The usual real-time rule still applies — a graph carrying a push source needs
+  a real-time executor.
+* **An implementation cannot be registered inside a sub-graph.** Registration
+  from a ``WiringKind::SubGraph`` wiring throws (*"service/adaptor
+  implementations cannot be registered inside an isolated sub-graph"*), which is
+  what keeps the inlining target unambiguous.
+
+Genuine nested children are unaffected: a push source inside a
+``map_``/``mesh_``/``switch_``/``reduce``/``nested_``/``try_except_``/component
+child is still rejected, because a graph with a push prefix never gets a nested
+graph type interned (``GraphBuilder::nested_type()``). See :doc:`nested_graphs`.
+
+
 Adaptors
 --------
 

--- a/python/tests/test_service_push_sources.py
+++ b/python/tests/test_service_push_sources.py
@@ -1,10 +1,12 @@
 """Push queues inside service implementations.
 
 A service/adaptor implementation is not a nested graph in hg_cpp: registration
-records a materializer candidate, and ``Wiring::build_services()`` — reached only
-from ``finish_top_level`` — runs it with ``WiredFn::wire(target, ...)``, which
-inlines the implementation into the top-level wiring. An implementation's
-``@push_queue`` is therefore an ordinary root-graph push-prefix node.
+records a materializer candidate. ``finish_top_level`` calls
+``Wiring::build_services()`` automatically, while an explicit ``build_services``
+call provides the same supported materialization boundary. Materialization uses
+``WiredFn::wire(target, ...)``, which inlines the implementation into the
+top-level wiring. An implementation's ``@push_queue`` is therefore an ordinary
+root-graph push-prefix node.
 
 Upstream Python compiles a ``@service_impl`` into a nested graph node built with
 ``create_graph_builder(sink_nodes, False)`` and rejects push sources inside it;

--- a/python/tests/test_service_push_sources.py
+++ b/python/tests/test_service_push_sources.py
@@ -1,0 +1,168 @@
+"""Push queues inside service implementations.
+
+A service/adaptor implementation is not a nested graph in hg_cpp: registration
+records a materializer candidate, and ``Wiring::build_services()`` — reached only
+from ``finish_top_level`` — runs it with ``WiredFn::wire(target, ...)``, which
+inlines the implementation into the top-level wiring. An implementation's
+``@push_queue`` is therefore an ordinary root-graph push-prefix node.
+
+Upstream Python compiles a ``@service_impl`` into a nested graph node built with
+``create_graph_builder(sink_nodes, False)`` and rejects push sources inside it;
+genuine nested children here still reject them, which the last test pins.
+
+The C++ counterpart is ``tests/cpp/test_service_push_sources.cpp``. These tests
+deliberately use no external resources — the only other Python coverage of
+push-inside-implementation lives in the tornado/sql/json/delta adaptor suites,
+and the one ``@service_impl`` case (kafka) needs a broker.
+"""
+
+import datetime
+import threading
+import time
+
+import pytest
+
+import hgraph as hg
+from hgraph import TS, TSD, TSS, graph
+
+
+def _run(g, seconds=2.0):
+    end = datetime.datetime.now(datetime.UTC).replace(tzinfo=None) + datetime.timedelta(
+        seconds=seconds)
+    hg.run_graph(g, end_time=end, run_mode=hg.EvaluationMode.REAL_TIME)
+
+
+def _feeder(*values, delay=0.15):
+    """A ``@push_queue`` start hook that feeds ``values`` from a side thread.
+
+    Returns ``(hook, threads)``; ``threads`` is populated when the graph starts
+    the push node, so tests join it after the run rather than before.
+    """
+    threads = []
+
+    def hook(sender):
+        def feed():
+            time.sleep(delay)
+            for value in values:
+                sender(value)
+                time.sleep(0.02)
+
+        thread = threading.Thread(target=feed)
+        threads.append(thread)
+        thread.start()
+
+    return hook, threads
+
+
+def test_reference_service_impl_may_own_a_push_queue():
+    collected = []
+    hook, threads = _feeder(42)
+
+    @hg.reference_service
+    def live_ticks(path: str = "ticks") -> TS[int]: ...
+
+    @hg.service_impl(interfaces=live_ticks)
+    def live_ticks_impl(path: str = "ticks") -> TS[int]:
+        @hg.push_queue(TS[int])
+        def source(sender):
+            hook(sender)
+
+        return source()
+
+    @hg.sink_node
+    def collect(value: TS[int]) -> None:
+        collected.append(value.value)
+
+    @graph
+    def live() -> None:
+        hg.register_service("ticks", live_ticks_impl)
+        collect(live_ticks(path="ticks"))
+
+    _run(live)
+    for thread in threads:
+        thread.join()
+    assert collected == [42]
+
+
+def test_subscription_service_impl_may_own_a_push_queue():
+    collected = []
+    hook, threads = _feeder(99)
+
+    @hg.subscription_service
+    def quotes(key: TS[str], path: str = "quotes") -> TS[int]: ...
+
+    @hg.service_impl(interfaces=quotes)
+    def quotes_impl(keys: TSS[str], path: str = "quotes") -> TSD[str, TS[int]]:
+        @hg.push_queue(TS[int])
+        def source(sender):
+            hook(sender)
+
+        tick = source()
+        # Broadcast each pushed value to every live subscription key.
+        return hg.map_(lambda t: t, __keys__=keys, t=tick)
+
+    @hg.sink_node
+    def collect(value: TS[int]) -> None:
+        collected.append(value.value)
+
+    @graph
+    def live() -> None:
+        hg.register_service("quotes", quotes_impl)
+        collect(quotes(hg.const("instrument"), path="quotes"))
+
+    _run(live)
+    for thread in threads:
+        thread.join()
+    assert collected == [99]
+
+
+def test_request_reply_service_impl_may_own_a_push_queue():
+    collected = []
+    hook, threads = _feeder(55)
+
+    @hg.request_reply_service
+    def echo(value: TS[int], path: str = "echo") -> TS[int]: ...
+
+    @hg.service_impl(interfaces=echo)
+    def echo_impl(value: TSD[int, TS[int]], path: str = "echo") -> TSD[int, TS[int]]:
+        @hg.push_queue(TS[int])
+        def source(sender):
+            hook(sender)
+
+        tick = source()
+        # Reply to every outstanding request with the latest pushed value.
+        return hg.map_(lambda v, t: t, value, t=tick)
+
+    @hg.sink_node
+    def collect(value: TS[int]) -> None:
+        collected.append(value.value)
+
+    @graph
+    def live() -> None:
+        hg.register_service("echo", echo_impl)
+        collect(echo(hg.const(1), path="echo"))
+
+    _run(live)
+    for thread in threads:
+        thread.join()
+    assert collected == [55]
+
+
+def test_push_queue_inside_a_nested_graph_is_still_rejected():
+    """The complementary edge: inlining is what makes the impl case legal."""
+
+    @hg.push_queue(TS[int])
+    def source(sender):
+        pass
+
+    @graph
+    def child(key: TS[str]) -> TS[int]:
+        return source()
+
+    @graph
+    def live() -> None:
+        keys = hg.convert[TSS](hg.const("a"))
+        hg.debug_print("out", hg.map_(child, __keys__=keys))
+
+    with pytest.raises(Exception, match="[Nn]ested graphs do not support push source"):
+        _run(live, seconds=0.5)

--- a/tests/cpp/CMakeLists.txt
+++ b/tests/cpp/CMakeLists.txt
@@ -170,6 +170,7 @@ hgraph_add_test_objects(hgraph_wiring_test_objects
     test_nested_wiring.cpp
     test_operators.cpp
     test_race_semantics.cpp
+    test_service_push_sources.cpp
     test_service_runtime.cpp
     test_service_wiring.cpp
     test_static_node.cpp

--- a/tests/cpp/test_service_push_sources.cpp
+++ b/tests/cpp/test_service_push_sources.cpp
@@ -8,10 +8,12 @@
 
 #include <array>
 #include <chrono>
+#include <condition_variable>
 #include <cstddef>
+#include <mutex>
+#include <optional>
 #include <span>
 #include <stdexcept>
-#include <thread>
 #include <typeindex>
 #include <vector>
 
@@ -19,8 +21,9 @@
  * Push sources inside service implementations.
  *
  * A service/adaptor implementation is NOT a nested graph in hg_cpp: registration
- * only records a materializer candidate, and ``Wiring::build_services()`` — called
- * solely from ``finish_top_level`` — runs each materializer with
+ * only records a materializer candidate. ``finish_top_level`` calls
+ * ``Wiring::build_services()`` automatically, while the supported explicit
+ * ``build_services()`` boundary runs the same materializers with
  * ``WiredFn::wire(target, …)``, which INLINES the implementation into the
  * registering (top-level) wiring. An implementation's push source is therefore an
  * ordinary root-graph node and lands in the push prefix.
@@ -38,14 +41,52 @@ namespace
     using namespace hgraph;
     using namespace hgraph::testing;
 
-    // A static ``compose`` has nowhere to capture test state, so the senders the
-    // implementations' push sources hand out at start live at namespace scope —
-    // the same pattern as ``lazy_reference_compositions`` in test_service_wiring.cpp.
-    inline PushSourceSender ticks_sender{};
-    inline PushSourceSender alt_ticks_sender{};
-    inline PushSourceSender quotes_sender{};
-    inline PushSourceSender replies_sender{};
-    inline PushSourceSender adaptor_sender{};
+    /** Synchronize publication of the sender from the executor's start thread.
+     *
+     *  ``PushSourceSender`` is safe to use from another thread after publication,
+     *  but assigning and inspecting the multi-field handle concurrently would be
+     *  a data race. The latch supplies the required happens-before edge. */
+    class SenderLatch
+    {
+      public:
+        void reset()
+        {
+            std::lock_guard lock{mutex_};
+            sender_.reset();
+        }
+
+        void publish(PushSourceSender sender)
+        {
+            {
+                std::lock_guard lock{mutex_};
+                sender_ = std::move(sender);
+            }
+            ready_.notify_all();
+        }
+
+        [[nodiscard]] std::optional<PushSourceSender> await()
+        {
+            std::unique_lock lock{mutex_};
+            if (!ready_.wait_for(lock, std::chrono::seconds{2}, [this] { return sender_.has_value(); }))
+            {
+                return std::nullopt;
+            }
+            return sender_;
+        }
+
+      private:
+        std::mutex                      mutex_{};
+        std::condition_variable         ready_{};
+        std::optional<PushSourceSender> sender_{};
+    };
+
+    // A static ``compose`` has nowhere to capture test state, so the latches that
+    // receive implementation senders at start live at namespace scope.
+    inline SenderLatch ticks_sender{};
+    inline SenderLatch alt_ticks_sender{};
+    inline SenderLatch quotes_sender{};
+    inline SenderLatch replies_sender{};
+    inline SenderLatch adaptor_sender{};
 
     inline std::vector<Int> observed{};
 
@@ -75,11 +116,15 @@ namespace
      *  two push sources that differ only in their ``on_start`` callback, because
      *  the callback lives in the builder context and not in the scalars. */
     template <typename S>
-    [[nodiscard]] Port<S> push_source_port(Wiring &w, std::type_index def, PushSourceSender &sender)
+    [[nodiscard]] Port<S> push_source_port(Wiring &w, std::type_index def, SenderLatch &sender)
     {
         return Port<S>{w,
                        w.add_unique_node(def,
-                                         capturing_push_source(*ts_type<S>(), sender),
+                                         make_push_source_node(
+                                             *ts_type<S>(),
+                                             [&sender](PushSourceSender started_sender) {
+                                                 sender.publish(std::move(started_sender));
+                                             }),
                                          std::span<const WiringPortRef>{},
                                          Value{})};
     }
@@ -316,11 +361,11 @@ namespace
     {
         hgraph::stdlib::register_standard_operators();
         observed.clear();
-        ticks_sender     = PushSourceSender{};
-        alt_ticks_sender = PushSourceSender{};
-        quotes_sender    = PushSourceSender{};
-        replies_sender   = PushSourceSender{};
-        adaptor_sender   = PushSourceSender{};
+        ticks_sender.reset();
+        alt_ticks_sender.reset();
+        quotes_sender.reset();
+        replies_sender.reset();
+        adaptor_sender.reset();
     }
 
     /** Count the push-source prefix the runtime will drain. */
@@ -340,15 +385,6 @@ namespace
         return executor_builder.make_executor();
     }
 
-    /** The sender only becomes valid once the push node starts on the runner thread. */
-    [[nodiscard]] bool await_sender(const PushSourceSender &sender)
-    {
-        for (int attempt = 0; attempt < 400 && !sender.valid(); ++attempt)
-        {
-            std::this_thread::sleep_for(std::chrono::milliseconds{5});
-        }
-        return sender.valid();
-    }
 }   // namespace
 
 TEST_CASE("service push sources: a reference service implementation owns a root push source")
@@ -368,8 +404,9 @@ TEST_CASE("service push sources: a reference service implementation owns a root 
     auto               view     = executor.view();
 
     AsyncGraphExecutorRun runner{view};
-    REQUIRE(await_sender(ticks_sender));
-    ticks_sender.send(Int{42});
+    auto sender = ticks_sender.await();
+    REQUIRE(sender.has_value());
+    sender->send(Int{42});
     runner.join();
 
     CHECK(observed == std::vector<Int>{Int{42}});
@@ -391,10 +428,12 @@ TEST_CASE("service push sources: two implementations contribute two push sources
     auto               view     = executor.view();
 
     AsyncGraphExecutorRun runner{view};
-    REQUIRE(await_sender(ticks_sender));
-    REQUIRE(await_sender(alt_ticks_sender));
-    ticks_sender.send(Int{40});
-    alt_ticks_sender.send(Int{2});
+    auto ticks     = ticks_sender.await();
+    auto alt_ticks = alt_ticks_sender.await();
+    REQUIRE(ticks.has_value());
+    REQUIRE(alt_ticks.has_value());
+    ticks->send(Int{40});
+    alt_ticks->send(Int{2});
     runner.join();
 
     REQUIRE(observed.size() == 1);
@@ -412,8 +451,9 @@ TEST_CASE("service push sources: a subscription service implementation owns a ro
     auto               view     = executor.view();
 
     AsyncGraphExecutorRun runner{view};
-    REQUIRE(await_sender(quotes_sender));
-    quotes_sender.send(Int{99});
+    auto sender = quotes_sender.await();
+    REQUIRE(sender.has_value());
+    sender->send(Int{99});
     runner.join();
 
     CHECK(observed == std::vector<Int>{Int{99}});
@@ -430,8 +470,9 @@ TEST_CASE("service push sources: a request/reply service implementation owns a r
     auto               view     = executor.view();
 
     AsyncGraphExecutorRun runner{view};
-    REQUIRE(await_sender(replies_sender));
-    replies_sender.send(Int{55});
+    auto sender = replies_sender.await();
+    REQUIRE(sender.has_value());
+    sender->send(Int{55});
     runner.join();
 
     CHECK(observed == std::vector<Int>{Int{55}});
@@ -448,8 +489,9 @@ TEST_CASE("service push sources: an adaptor implementation owns a root push sour
     auto               view     = executor.view();
 
     AsyncGraphExecutorRun runner{view};
-    REQUIRE(await_sender(adaptor_sender));
-    adaptor_sender.send(Int{13});
+    auto sender = adaptor_sender.await();
+    REQUIRE(sender.has_value());
+    sender->send(Int{13});
     runner.join();
 
     CHECK(observed == std::vector<Int>{Int{13}});

--- a/tests/cpp/test_service_push_sources.cpp
+++ b/tests/cpp/test_service_push_sources.cpp
@@ -1,0 +1,481 @@
+#include <catch2/catch_test_macros.hpp>
+
+#include <hgraph/lib/std/std_operators.h>
+#include <hgraph/lib/testing/runtime_support.h>
+#include <hgraph/types/adaptor_wiring.h>
+#include <hgraph/types/service_wiring.h>
+#include <hgraph/types/static_node.h>
+
+#include <array>
+#include <chrono>
+#include <cstddef>
+#include <span>
+#include <stdexcept>
+#include <thread>
+#include <typeindex>
+#include <vector>
+
+/**
+ * Push sources inside service implementations.
+ *
+ * A service/adaptor implementation is NOT a nested graph in hg_cpp: registration
+ * only records a materializer candidate, and ``Wiring::build_services()`` — called
+ * solely from ``finish_top_level`` — runs each materializer with
+ * ``WiredFn::wire(target, …)``, which INLINES the implementation into the
+ * registering (top-level) wiring. An implementation's push source is therefore an
+ * ordinary root-graph node and lands in the push prefix.
+ *
+ * That is what these tests pin. The upstream Python reference instead compiles a
+ * service impl into a nested graph node (``create_graph_builder(sink_nodes, False)``)
+ * and rejects push sources there; genuine nested children here still reject them
+ * (``GraphBuilder::nested_type()``), so the two edges are asserted side by side.
+ *
+ * See ``docs/source/developer_guide/services.rst`` ("Implementations are inlined").
+ */
+
+namespace
+{
+    using namespace hgraph;
+    using namespace hgraph::testing;
+
+    // A static ``compose`` has nowhere to capture test state, so the senders the
+    // implementations' push sources hand out at start live at namespace scope —
+    // the same pattern as ``lazy_reference_compositions`` in test_service_wiring.cpp.
+    inline PushSourceSender ticks_sender{};
+    inline PushSourceSender alt_ticks_sender{};
+    inline PushSourceSender quotes_sender{};
+    inline PushSourceSender replies_sender{};
+    inline PushSourceSender adaptor_sender{};
+
+    inline std::vector<Int> observed{};
+
+    struct TicksTag
+    {
+    };
+    struct AltTicksTag
+    {
+    };
+    struct QuotesTag
+    {
+    };
+    struct RepliesTag
+    {
+    };
+    struct AdaptorTicksTag
+    {
+    };
+    struct SinkTag
+    {
+    };
+
+    /** Wire a push source of ``S`` into ``w`` and return its port.
+     *
+     *  ``add_unique_node`` (not ``add_node``) matches ``PyWiring::push_source``:
+     *  a push source's identity is its allocation site. Interning would collapse
+     *  two push sources that differ only in their ``on_start`` callback, because
+     *  the callback lives in the builder context and not in the scalars. */
+    template <typename S>
+    [[nodiscard]] Port<S> push_source_port(Wiring &w, std::type_index def, PushSourceSender &sender)
+    {
+        return Port<S>{w,
+                       w.add_unique_node(def,
+                                         capturing_push_source(*ts_type<S>(), sender),
+                                         std::span<const WiringPortRef>{},
+                                         Value{})};
+    }
+
+    /** Collect the scalar values reaching ``port``, stopping the executor once
+     *  ``stop_after`` have arrived so the test never waits out its end time. */
+    void collect(Wiring &w, Port<TS<Int>> port, std::size_t stop_after)
+    {
+        const auto      *ts_int = ts_type<TS<Int>>();
+        const std::array inputs{port.erased()};
+        w.add_unique_node(std::type_index(typeid(SinkTag)),
+                          collecting_scalar_sink<Int>(*single_input_schema(*ts_int), *ts_int, observed, stop_after),
+                          std::span<const WiringPortRef>{inputs},
+                          Value{});
+    }
+
+    // ---------------------------------------------------------------------
+    // Reference service
+    // ---------------------------------------------------------------------
+
+    struct LiveTicksService
+    {
+        static constexpr std::string_view name{"live_ticks"};
+        using output_schema = TS<Int>;
+    };
+
+    struct LiveTicksImpl
+    {
+        [[maybe_unused]] static constexpr auto name = "live_ticks_impl";
+
+        static Port<TS<Int>> compose(Wiring &w)
+        {
+            return push_source_port<TS<Int>>(w, std::type_index(typeid(TicksTag)), ticks_sender);
+        }
+    };
+
+    struct ReferencePushGraph
+    {
+        [[maybe_unused]] static constexpr auto name = "reference_push_graph";
+
+        static void compose(Wiring &w)
+        {
+            service::register_reference_service<LiveTicksService, LiveTicksImpl>(w);
+            collect(w, wire<LiveTicksService>(w), 1);
+        }
+    };
+
+    // A second, independent reference service — two implementations, two push
+    // sources, both hoisted into the same root prefix.
+    struct AltTicksService
+    {
+        static constexpr std::string_view name{"alt_ticks"};
+        using output_schema = TS<Int>;
+    };
+
+    struct AltTicksImpl
+    {
+        [[maybe_unused]] static constexpr auto name = "alt_ticks_impl";
+
+        static Port<TS<Int>> compose(Wiring &w)
+        {
+            return push_source_port<TS<Int>>(w, std::type_index(typeid(AltTicksTag)), alt_ticks_sender);
+        }
+    };
+
+    struct TwoPushServicesGraph
+    {
+        [[maybe_unused]] static constexpr auto name = "two_push_services_graph";
+
+        static void compose(Wiring &w)
+        {
+            service::register_reference_service<LiveTicksService, LiveTicksImpl>(w);
+            service::register_reference_service<AltTicksService, AltTicksImpl>(w);
+            collect(w, wire<stdlib::add_>(w, wire<LiveTicksService>(w), wire<AltTicksService>(w)).as<TS<Int>>(), 1);
+        }
+    };
+
+    // ---------------------------------------------------------------------
+    // Subscription service
+    // ---------------------------------------------------------------------
+
+    struct QuotesService
+    {
+        static constexpr std::string_view name{"push_quotes"};
+        using key_type     = Int;
+        using value_schema = TS<Int>;
+    };
+
+    /** Broadcast each pushed value to every live subscription key. The push
+     *  source carries the external feed; the keys arrive from clients. */
+    struct QuotesFanOutNode
+    {
+        static constexpr auto name = "quotes_fan_out_node";
+
+        static void eval(In<"keys", TSS<Int>, InputValidity::Unchecked> keys,
+                         In<"tick", TS<Int>>                           tick,
+                         Out<TSD<Int, TS<Int>>>                        out)
+        {
+            if (!keys.valid() || !tick.valid()) { return; }
+
+            auto mutation = out.begin_mutation(out.evaluation_time());
+            for (Int removed : keys.removed()) { static_cast<void>(mutation.erase(Value{removed}.view())); }
+            for (Int key : keys.values()) { mutation.set(Value{key}.view(), Value{tick.value()}.view()); }
+        }
+    };
+
+    struct QuotesImpl
+    {
+        [[maybe_unused]] static constexpr auto name = "push_quotes_impl";
+
+        static Port<TSD<Int, TS<Int>>> compose(Wiring &w, Port<TSS<Int>> keys)
+        {
+            auto tick = push_source_port<TS<Int>>(w, std::type_index(typeid(QuotesTag)), quotes_sender);
+            return wire<QuotesFanOutNode>(w, keys, tick).as<TSD<Int, TS<Int>>>();
+        }
+    };
+
+    struct SubscriptionPushGraph
+    {
+        [[maybe_unused]] static constexpr auto name = "subscription_push_graph";
+
+        static void compose(Wiring &w)
+        {
+            service::register_subscription_service<QuotesService, QuotesImpl>(w);
+            collect(w, wire<QuotesService>(w, wire<stdlib::const_>(w, Int{7}).as<TS<Int>>()), 1);
+        }
+    };
+
+    // ---------------------------------------------------------------------
+    // Request/reply service
+    // ---------------------------------------------------------------------
+
+    struct PushEchoService
+    {
+        static constexpr std::string_view name{"push_echo"};
+        using request_schema  = TS<Int>;
+        using response_schema = TS<Int>;
+    };
+
+    /** Reply to each outstanding request with the latest pushed value. */
+    struct PushEchoImplNode
+    {
+        static constexpr auto name = "push_echo_impl_node";
+
+        static void eval(In<"requests", TSD<Int, TS<Int>>, InputValidity::Unchecked> requests,
+                         In<"tick", TS<Int>>                                         tick,
+                         Out<TSD<Int, TS<Int>>>                                      out)
+        {
+            if (!requests.valid() || !tick.valid()) { return; }
+
+            auto mutation = out.begin_mutation(out.evaluation_time());
+            for (const auto &[request_id, request] : requests.removed_items())
+            {
+                static_cast<void>(request);
+                static_cast<void>(mutation.erase(Value{request_id}.view()));
+            }
+            for (const auto &[request_id, request] : requests.items())
+            {
+                if (!request.valid()) { continue; }
+                mutation.set(Value{request_id}.view(), Value{tick.value()}.view());
+            }
+        }
+    };
+
+    struct PushEchoImpl
+    {
+        [[maybe_unused]] static constexpr auto name = "push_echo_impl";
+
+        static Port<TSD<Int, TS<Int>>> compose(Wiring &w, Port<TSD<Int, TS<Int>>> requests)
+        {
+            auto tick = push_source_port<TS<Int>>(w, std::type_index(typeid(RepliesTag)), replies_sender);
+            return wire<PushEchoImplNode>(w, requests, tick).as<TSD<Int, TS<Int>>>();
+        }
+    };
+
+    struct RequestReplyPushGraph
+    {
+        [[maybe_unused]] static constexpr auto name = "request_reply_push_graph";
+
+        static void compose(Wiring &w)
+        {
+            service::register_request_reply_service<PushEchoService, PushEchoImpl>(w);
+            collect(w, wire<PushEchoService>(w, wire<stdlib::const_>(w, Int{1}).as<TS<Int>>()), 1);
+        }
+    };
+
+    // ---------------------------------------------------------------------
+    // Adaptor (confirmatory — adaptors were designed for exactly this)
+    // ---------------------------------------------------------------------
+
+    // Deliberately DUPLEX. A source-only adaptor (``adaptor::interface`` with only
+    // ``output_schema``) also satisfies ``service::detail::reference_service_interface``,
+    // so ``wire<Interface>`` is an ambiguous partial specialization in any
+    // translation unit that includes both service_wiring.h and adaptor_wiring.h.
+    // Declaring ``input_schema`` excludes the service concept and keeps this test
+    // about push sources rather than about that overlap.
+    struct TickAdaptor : adaptor::interface
+    {
+        static constexpr std::string_view name{"tick_adaptor"};
+        using input_schema  = TS<Int>;
+        using output_schema = TS<Int>;
+    };
+
+    struct TickAdaptorImpl
+    {
+        [[maybe_unused]] static constexpr auto name = "tick_adaptor_impl";
+
+        static void compose(Wiring &w)
+        {
+            // The client input exists only to keep the adaptor duplex; the output
+            // is driven entirely by the implementation-owned push source.
+            static_cast<void>(wire<stdlib::null_sink>(w, adaptor::from_graph<TickAdaptor>(w)));
+            adaptor::to_graph<TickAdaptor>(
+                w, push_source_port<TS<Int>>(w, std::type_index(typeid(AdaptorTicksTag)), adaptor_sender));
+        }
+    };
+
+    struct AdaptorPushGraph
+    {
+        [[maybe_unused]] static constexpr auto name = "adaptor_push_graph";
+
+        static void compose(Wiring &w)
+        {
+            adaptor::register_adaptor<TickAdaptor, TickAdaptorImpl>(w);
+            collect(w, wire<TickAdaptor>(w, wire<stdlib::const_>(w, Int{0}).as<TS<Int>>()), 1);
+        }
+    };
+
+    // ---------------------------------------------------------------------
+    // Harness
+    // ---------------------------------------------------------------------
+
+    void reset_case()
+    {
+        hgraph::stdlib::register_standard_operators();
+        observed.clear();
+        ticks_sender     = PushSourceSender{};
+        alt_ticks_sender = PushSourceSender{};
+        quotes_sender    = PushSourceSender{};
+        replies_sender   = PushSourceSender{};
+        adaptor_sender   = PushSourceSender{};
+    }
+
+    /** Count the push-source prefix the runtime will drain. */
+    [[nodiscard]] std::size_t push_prefix(const GraphBuilder &builder)
+    {
+        return builder.root_type().schema()->push_source_nodes_end;
+    }
+
+    [[nodiscard]] GraphExecutorValue start_realtime(GraphBuilder builder)
+    {
+        const DateTime       start = wall_now();
+        GraphExecutorBuilder executor_builder;
+        executor_builder.graph_builder(std::move(builder))
+            .mode(GraphExecutorMode::RealTime)
+            .start_time(start)
+            .end_time(start + TimeDelta{5'000'000});   // generous: the sink stops the run
+        return executor_builder.make_executor();
+    }
+
+    /** The sender only becomes valid once the push node starts on the runner thread. */
+    [[nodiscard]] bool await_sender(const PushSourceSender &sender)
+    {
+        for (int attempt = 0; attempt < 400 && !sender.valid(); ++attempt)
+        {
+            std::this_thread::sleep_for(std::chrono::milliseconds{5});
+        }
+        return sender.valid();
+    }
+}   // namespace
+
+TEST_CASE("service push sources: a reference service implementation owns a root push source")
+{
+    reset_case();
+
+    GraphBuilder graph_builder = build_graph<ReferencePushGraph>();
+
+    // The implementation was INLINED, so its push source is a node of the root
+    // graph and occupies the push prefix the real-time drain loop walks. A
+    // nested-graph implementation could not produce this shape at all.
+    REQUIRE(graph_builder.node_count() > 1);
+    CHECK(graph_builder.nodes()[0].type().schema()->node_kind == NodeKind::PushSource);
+    CHECK(push_prefix(graph_builder) == 1);
+
+    GraphExecutorValue executor = start_realtime(std::move(graph_builder));
+    auto               view     = executor.view();
+
+    AsyncGraphExecutorRun runner{view};
+    REQUIRE(await_sender(ticks_sender));
+    ticks_sender.send(Int{42});
+    runner.join();
+
+    CHECK(observed == std::vector<Int>{Int{42}});
+}
+
+TEST_CASE("service push sources: two implementations contribute two push sources to one prefix")
+{
+    reset_case();
+
+    GraphBuilder graph_builder = build_graph<TwoPushServicesGraph>();
+
+    // Distinct nodes: ``add_unique_node`` keeps them apart even though both
+    // builders carry identical schemas and empty scalars.
+    REQUIRE(push_prefix(graph_builder) == 2);
+    CHECK(graph_builder.nodes()[0].type().schema()->node_kind == NodeKind::PushSource);
+    CHECK(graph_builder.nodes()[1].type().schema()->node_kind == NodeKind::PushSource);
+
+    GraphExecutorValue executor = start_realtime(std::move(graph_builder));
+    auto               view     = executor.view();
+
+    AsyncGraphExecutorRun runner{view};
+    REQUIRE(await_sender(ticks_sender));
+    REQUIRE(await_sender(alt_ticks_sender));
+    ticks_sender.send(Int{40});
+    alt_ticks_sender.send(Int{2});
+    runner.join();
+
+    REQUIRE(observed.size() == 1);
+    CHECK(observed.front() == Int{42});
+}
+
+TEST_CASE("service push sources: a subscription service implementation owns a root push source")
+{
+    reset_case();
+
+    GraphBuilder graph_builder = build_graph<SubscriptionPushGraph>();
+    REQUIRE(push_prefix(graph_builder) == 1);
+
+    GraphExecutorValue executor = start_realtime(std::move(graph_builder));
+    auto               view     = executor.view();
+
+    AsyncGraphExecutorRun runner{view};
+    REQUIRE(await_sender(quotes_sender));
+    quotes_sender.send(Int{99});
+    runner.join();
+
+    CHECK(observed == std::vector<Int>{Int{99}});
+}
+
+TEST_CASE("service push sources: a request/reply service implementation owns a root push source")
+{
+    reset_case();
+
+    GraphBuilder graph_builder = build_graph<RequestReplyPushGraph>();
+    REQUIRE(push_prefix(graph_builder) == 1);
+
+    GraphExecutorValue executor = start_realtime(std::move(graph_builder));
+    auto               view     = executor.view();
+
+    AsyncGraphExecutorRun runner{view};
+    REQUIRE(await_sender(replies_sender));
+    replies_sender.send(Int{55});
+    runner.join();
+
+    CHECK(observed == std::vector<Int>{Int{55}});
+}
+
+TEST_CASE("service push sources: an adaptor implementation owns a root push source")
+{
+    reset_case();
+
+    GraphBuilder graph_builder = build_graph<AdaptorPushGraph>();
+    REQUIRE(push_prefix(graph_builder) == 1);
+
+    GraphExecutorValue executor = start_realtime(std::move(graph_builder));
+    auto               view     = executor.view();
+
+    AsyncGraphExecutorRun runner{view};
+    REQUIRE(await_sender(adaptor_sender));
+    adaptor_sender.send(Int{13});
+    runner.join();
+
+    CHECK(observed == std::vector<Int>{Int{13}});
+}
+
+TEST_CASE("service push sources: an implementation push source still requires a real-time executor")
+{
+    reset_case();
+
+    GraphExecutorBuilder executor_builder;
+    executor_builder.graph_builder(build_graph<ReferencePushGraph>())
+        .mode(GraphExecutorMode::Simulation)
+        .start_time(MIN_ST)
+        .end_time(MIN_ST + TimeDelta{1});
+
+    CHECK_THROWS_AS(executor_builder.make_executor(), std::invalid_argument);
+}
+
+TEST_CASE("service push sources: a graph carrying an implementation push source has no nested type")
+{
+    reset_case();
+
+    // The complementary edge: inlining is what makes the implementation's push
+    // source legal. The same builder used as a CHILD graph is still rejected,
+    // because the nested graph type is never interned when a push prefix exists.
+    GraphBuilder graph_builder = build_graph<ReferencePushGraph>();
+    REQUIRE(push_prefix(graph_builder) == 1);
+    CHECK_THROWS_AS((void)graph_builder.nested_type(), std::invalid_argument);
+}


### PR DESCRIPTION
## Why

The starting question was how to support push nodes inside nested graphs by hoisting them to the root, restricted to service impls, so a simple push queue no longer forces you to mix adaptor and service wiring.

Investigation showed **hg_cpp does not need that for service impls — they are already flat**, a deliberate divergence from upstream:

| | upstream `ext/main` | hg_cpp |
|---|---|---|
| `@service_impl` | nested graph node, inner builder from `create_graph_builder(sink_nodes, False)` → push rejected | **inlined into the registering (root) wiring** |
| `@adaptor_impl` | `GraphWiringNodeClass`, inlined → push allowed | inlined |

Registration only records a materializer candidate. `Wiring::finish_top_level` calls `build_services()` automatically; authors may also call it explicitly to materialize current demand, and finishing calls it again for later demand. `finish_subgraph` does not perform automatic materialization. Materializers run with `WiredFn::wire(target, …)`, the **inline** verb rather than `WiredFn::compile` (`src/hgraph/types/service_runtime.cpp:180-188`). An implementation's push source is therefore an ordinary root-graph node, ranked into the push prefix by `build_ranked_graph` and drained by the root-only push phase.

So the capability existed — the gap was proof. No C++ test wired a push source inside any service or adaptor implementation, and the only Python coverage was the tornado/sql/json/delta adaptor suites (live external resources) plus kafka's `@service_impl` (needs a broker).

## What this adds

**`tests/cpp/test_service_push_sources.cpp`** (7 cases, registered in `tests/cpp/CMakeLists.txt`)

- Push sources inside **reference**, **subscription** and **request/reply** service implementations — each asserted both structurally (`push_source_nodes_end == 1`, node 0 is `NodeKind::PushSource`) and behaviourally: send from the test thread, value reaches a client sink under a real-time executor.
- Two implementations contributing two **distinct** push sources to one prefix — a regression guard, since `add_unique_node` is what keeps them apart (their `on_start` callbacks live in the builder context, not the scalars, so interning would collapse them).
- The simulation-executor rejection still fires.
- The complementary edge: the same builder used as a *child* still has no nested type.
- Adaptor implementation covered as confirmatory — adaptors were designed for this.

**`python/tests/test_service_push_sources.py`** (4 cases) — `@push_queue` inside `@service_impl` for all three flavours under `REAL_TIME` with a feeder thread and **no external resources**, plus a negative pinning that a push queue inside a `map_` child is still rejected.

**Docs** — `services.rst` gains "Implementations are inlined, not nested (and may own push sources)", recording the contract, the upstream divergence, and that implementations cannot be registered inside a sub-graph. `roadmap.rst:443` and `nested_graphs.rst` both narrowed: the remaining gap is genuine nested *children* (`map_`/`mesh_`/`switch_`/`reduce`/`nested_`/`try_except_`/component), not implementations.

No runtime code changed.

## Note — a latent overlap this surfaced

A **source-only adaptor** (`adaptor::interface` with only `output_schema`) satisfies *both* `adaptor::detail::adaptor_interface` and `service::detail::reference_service_interface`, so `wire<Interface>` is an **ambiguous partial specialization** in any translation unit that includes both `service_wiring.h` and `adaptor_wiring.h`:

```
error: ambiguous partial specializations of 'wire_customization<TickAdaptor, void>'
  note: adaptor_wiring.h:696 matches [with Interface = TickAdaptor, ...]
  note: service_wiring.h:2073 matches [with Service  = TickAdaptor, ...]
```

`test_adaptor_wiring.cpp` never hits it because it does not include `service_wiring.h`. `reference_service_interface` excludes a *duplex* adaptor via `!has_adaptor_input_schema`, but nothing excludes a source-only one.

This PR sidesteps it with a duplex adaptor and a comment explaining why, rather than changing the concepts. The fix is a design call — and the deeper observation is that, now that implementations are inlined, a source-only adaptor and a reference service are arguably the same construct and could collapse to one implementation. That is being taken up separately.

## Verification

- Fresh native gate: **1405/1405 pass**; new suite 24 assertions / 7 cases; no compiler warnings
- Stable-ABI wheel built with Python 3.12 and installed into fresh Python 3.14: **1842 passed, 11 skipped**
- Sphinx builds all 72 sources cleanly with warnings treated as errors
- The pre-review head (`3d44fb1e`) completed its full GitHub Actions run successfully before the review update was pushed

Review follow-up in `bc6c26d5` synchronizes cross-thread publication of each C++ test sender with a mutex/condition-variable latch and corrects the explicit `build_services()` materialization contract in the docs and test commentary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
