### PR TITLE
Expose Python runtime time-series ownership metadata

### DIFF
--- a/docs/source/developer_guide/python_integration.rst
+++ b/docs/source/developer_guide/python_integration.rst
@@ -528,11 +528,17 @@ Recorded divergences / gaps (the morning-summary list):
   kinds, strictly lazy): user nodes receive a C++-bound ``TimeSeries``
   view over the LIVE input — nothing converts unless accessed.
   Universal: ``.value`` / ``.delta_value`` / ``.modified`` / ``.valid`` /
-  ``.all_valid`` / ``.last_modified_time``. Kind-dispatched: TSS
+  ``.all_valid`` / ``.last_modified_time`` / ``.owning_node`` /
+  ``.owning_graph`` / ``.is_reference()``. Mutable ``_output`` views expose
+  the same generic interrogation properties while retaining their native
+  mutation API. Kind-dispatched: TSS
   ``added()``/``removed()``; TSD ``[]``/``keys()``/``modified_keys()``/
   ``modified_items()``/``removed_keys()``/``in``; TSL ``[i]``/``len``;
   TSB ``.field`` / ``[]``. Child access returns child views sharing the
   parent's lifetime guard: a view stored past its node's evaluation
   raises rather than dangling. ``delta_value`` builds hgraph's friendly
   shapes natively from the dict/set views (no canonical-delta
-  intermediate).
+  intermediate). Python does not reproduce the old engine's endpoint topology
+  mutation hooks: ``bind_output`` / ``un_bind_output``, their ``do_*``
+  implementation hooks, ``re_parent``, direct parent/bound-output traversal,
+  and subscription management remain native runtime responsibilities.

--- a/docs/source/developer_guide/roadmap.rst
+++ b/docs/source/developer_guide/roadmap.rst
@@ -604,6 +604,14 @@ Accepted Deviations
 
 The following are intentional unless separately re-opened:
 
+- Runtime time-series views expose native value/state interrogation, ownership
+  (``owning_node`` / ``owning_graph``), reference-kind inspection, input
+  activity control, and mutable ``_output`` operations. They do not reproduce
+  the old Python engine's endpoint-topology object model: ``bind_output`` /
+  ``un_bind_output``, their ``do_*`` hooks, ``re_parent``, direct parent and
+  bound-output traversal, peer/bound topology inspection, and output
+  subscription hooks remain C++ runtime responsibilities. Python graph authors
+  express those relationships through wiring and ``REF`` values.
 - A set delta's ``added`` and ``removed`` **must be disjoint** (ruling
   2026-07-28): an element listed in both is incorrect data, rejected at
   construction (``set_delta`` raises; the parity recipe decoder rejects

--- a/docs/source/user_guide/python_compatibility.rst
+++ b/docs/source/user_guide/python_compatibility.rst
@@ -20,6 +20,21 @@ Python-authored compute, sink, generator, graph, service, adaptor, component,
 and push-source code executes in the C++ runtime. Python adapts values and
 callables; it does not implement a second graph engine.
 
+Runtime time-series views expose the authoring and interrogation surface backed
+by the native endpoints. Input and mutable ``_output`` views provide
+``owning_node``, ``owning_graph``, and ``is_reference()`` in addition to their
+value, validity, delta, and modification properties. Input views also provide
+``active``, ``make_active()``, and ``make_passive()``; mutable outputs provide
+``all_valid`` and ``last_modified_time``.
+
+The old Python engine's endpoint-topology object model is intentionally not
+part of this API. Python views do not expose ``bind_output()``,
+``un_bind_output()``, ``do_bind_output()``, ``do_un_bind_output()``, or
+``re_parent()``. Direct bound-output and parent-input/output traversal,
+peer/bound topology inspection, and output subscription hooks are likewise
+native runtime responsibilities. Graph authors express topology through wiring
+and ``REF`` values instead of mutating live endpoint ownership from Python.
+
 Upstream's ``hgraph.nodes`` wildcard also exposes several private transport
 helpers: ``capture_output_node_to_global_state``,
 ``capture_output_to_global_state``, ``get_shared_reference_output``,

--- a/include/hgraph/types/time_series/ts_input/base_view.h
+++ b/include/hgraph/types/time_series/ts_input/base_view.h
@@ -85,6 +85,12 @@ namespace hgraph
         /** Canonical type record and schema for the input-side projection. */
         [[nodiscard]] TSInputTypeRef type_ref() const;
         [[nodiscard]] const TSValueTypeMetaData *schema() const noexcept;
+        /** True when this input carries REF values rather than ordinary time-series values. */
+        [[nodiscard]] bool is_reference() const noexcept
+        {
+            const auto *value_schema = schema();
+            return value_schema != nullptr && value_schema->kind == TSTypeKind::REF;
+        }
         /** Underlying TSData projection; empty for unbound peered terminals. */
         [[nodiscard]] const TSDataView &data_view() const noexcept;
 

--- a/include/hgraph/types/time_series/ts_output/base_view.h
+++ b/include/hgraph/types/time_series/ts_output/base_view.h
@@ -118,6 +118,12 @@ namespace hgraph
         [[nodiscard]] TSRoleTypeRef storage_type() const noexcept { return data_.storage_type(); }
         [[nodiscard]] TSOutputTypeRef type_ref() const;
         [[nodiscard]] const TSValueTypeMetaData *schema() const noexcept { return data_.schema(); }
+        /** True when this output carries REF values rather than ordinary time-series values. */
+        [[nodiscard]] bool is_reference() const noexcept
+        {
+            const auto *value_schema = schema();
+            return value_schema != nullptr && value_schema->kind == TSTypeKind::REF;
+        }
 
         /** Current and delta value projections. */
         [[nodiscard]] ValueView value() const;

--- a/python/py_nodes.cpp
+++ b/python/py_nodes.cpp
@@ -407,6 +407,7 @@ struct PyFastComputeStateRef {
 };
 
 [[nodiscard]] bool py_make_ts_arg(char kind, TSInputView child,
+                                  NodeScheduler scheduler,
                                   const PyTsLease &lease, nb::object &result) {
   const auto &evaluation_data = child.data_view();
   const bool has_current_value =
@@ -425,14 +426,15 @@ struct PyFastComputeStateRef {
   const auto evaluation_storage = evaluation_data.valid()
                                       ? evaluation_data.storage_ref()
                                       : TSDataStorageRef<>{};
-  PyTimeSeries wrapped{std::move(child), lease, evaluation_storage};
+  PyTimeSeries wrapped{std::move(child), scheduler, lease, evaluation_storage};
   wrapped.refresh_evaluation_data(evaluation_storage, has_current_value);
   result = nb::cast(std::move(wrapped));
   return true;
 }
 
 [[nodiscard]] bool py_make_direct_ts_arg(PyFastComputeCache &cache,
-                                         DateTime now, const PyTsLease &lease,
+                                         DateTime now, NodeScheduler scheduler,
+                                         const PyTsLease &lease,
                                          nb::object &result) {
   TSInputView child = cache.input.borrowed_ref(now);
   const auto &evaluation_data = child.data_view();
@@ -455,6 +457,7 @@ struct PyFastComputeStateRef {
   // the cache entry with a fresh wrapper.
   if (cache.input_object != nullptr && Py_REFCNT(cache.input_object) == 1) {
     cache.input_wrapper->view = std::move(child);
+    cache.input_wrapper->scheduler = scheduler;
     cache.input_wrapper->lease.generation = lease.generation;
     cache.input_wrapper->refresh_evaluation_data(evaluation_storage,
                                                  has_current_value);
@@ -467,7 +470,7 @@ struct PyFastComputeStateRef {
     cache.input_object = nullptr;
     cache.input_wrapper = nullptr;
   }
-  PyTimeSeries wrapped{std::move(child), lease, evaluation_storage};
+  PyTimeSeries wrapped{std::move(child), scheduler, lease, evaluation_storage};
   wrapped.refresh_evaluation_data(evaluation_storage, has_current_value);
   result = nb::cast(std::move(wrapped));
   cache.input_object = result.ptr();
@@ -479,6 +482,7 @@ struct PyFastComputeStateRef {
 [[nodiscard]] bool py_make_cached_pair_ts_arg(PyFastComputeCache &cache,
                                               std::size_t slot, char kind,
                                               TSInputView child,
+                                              NodeScheduler scheduler,
                                               const PyTsLease &lease,
                                               nb::object &result) {
   const auto &evaluation_data = child.data_view();
@@ -499,6 +503,7 @@ struct PyFastComputeStateRef {
   PyTimeSeries *&cached_wrapper = cache.pair_wrappers.at(slot);
   if (cached_object != nullptr && Py_REFCNT(cached_object) == 1) {
     cached_wrapper->view = std::move(child);
+    cached_wrapper->scheduler = scheduler;
     cached_wrapper->lease.generation = lease.generation;
     cached_wrapper->refresh_evaluation_data(evaluation_storage,
                                             has_current_value);
@@ -511,7 +516,7 @@ struct PyFastComputeStateRef {
     cached_object = nullptr;
     cached_wrapper = nullptr;
   }
-  PyTimeSeries wrapped{std::move(child), lease, evaluation_storage};
+  PyTimeSeries wrapped{std::move(child), scheduler, lease, evaluation_storage};
   wrapped.refresh_evaluation_data(evaluation_storage, has_current_value);
   result = nb::cast(std::move(wrapped));
   cached_object = result.ptr();
@@ -547,7 +552,7 @@ struct PyFastComputeStateRef {
     case 'P': {
       auto child = bundle[ts_index++];
       nb::object ts_obj;
-      if (!py_make_ts_arg(kind, std::move(child), lease, ts_obj)) {
+      if (!py_make_ts_arg(kind, std::move(child), scheduler, lease, ts_obj)) {
         return false;
       }
       call_args.append(ts_obj);
@@ -598,7 +603,8 @@ struct PyFastComputeStateRef {
       if (output == nullptr) {
         throw std::logic_error("_output injection requires a compute node");
       }
-      call_args.append(nb::cast(PyOutput{output->handle(), now, lease}));
+      call_args.append(
+          nb::cast(PyOutput{output->handle(), now, scheduler, lease}));
       break;
     }
     case 'c':
@@ -652,6 +658,7 @@ struct PyFastComputeStateRef {
                                          std::string_view layout,
                                          const TSInputView &args,
                                          const ValueView &scalars,
+                                         NodeScheduler scheduler,
                                          const PyTsLease &lease,
                                          nb::list &call_args) {
   auto bundle = args.as_bundle();
@@ -668,8 +675,8 @@ struct PyFastComputeStateRef {
     case 'a':
     case 'A': {
       nb::object ts_obj;
-      if (!py_make_ts_arg(kind, cache.arg_at(args, bundle, ts_index++), lease,
-                          ts_obj)) {
+      if (!py_make_ts_arg(kind, cache.arg_at(args, bundle, ts_index++),
+                          scheduler, lease, ts_obj)) {
         return false;
       }
       call_args.append(ts_obj);
@@ -720,7 +727,7 @@ void py_assemble_lifecycle_args(std::string_view layout,
       }
       nb::object ts_object;
       static_cast<void>(py_make_ts_arg(
-          'U', bundle[index], lease, ts_object));
+          'U', bundle[index], scheduler, lease, ts_object));
       call_args.append(ts_object);
       break;
     }
@@ -993,7 +1000,7 @@ struct py_fast_compute_node {
       Scalar<"start_scalars", ScalarVar<"SSV">>, Scalar<"stop_fn", PyNodeRef>,
       Scalar<"stop_enabled", Bool>, Scalar<"stop_config", Str>,
       Scalar<"stop_scalars", ScalarVar<"XSV">>, State<PyFastComputeStateRef>,
-      Out<TsVar<"O">>>;
+      NodeScheduler, Out<TsVar<"O">>>;
 
   static bool requires_(const ResolutionMap &, OperatorCallContext context) {
     return py_fast_compute_eligible(context);
@@ -1046,7 +1053,8 @@ struct py_fast_compute_node {
     static_cast<void>(cache.release());
   }
 
-  static void eval(State<PyFastComputeStateRef> state, DateTime now) {
+  static void eval(State<PyFastComputeStateRef> state, NodeScheduler scheduler,
+                   DateTime now) {
     PyFastComputeCache *cache = state.get().cache;
     if (cache == nullptr) {
       throw std::logic_error("fast python node has no runtime cache");
@@ -1059,7 +1067,7 @@ struct py_fast_compute_node {
       nb::object result;
       if (cache->direct()) {
         nb::object ts_obj;
-        if (!py_make_direct_ts_arg(*cache, now, lease, ts_obj)) {
+        if (!py_make_direct_ts_arg(*cache, now, scheduler, lease, ts_obj)) {
           return;
         }
         result = cache->record->fn(ts_obj);
@@ -1069,11 +1077,11 @@ struct py_fast_compute_node {
         nb::object lhs;
         nb::object rhs;
         if (!py_make_cached_pair_ts_arg(*cache, 0, cache->shape.layout[0],
-                                        cache->arg_at(input, bundle, 0), lease,
-                                        lhs) ||
+                                        cache->arg_at(input, bundle, 0),
+                                        scheduler, lease, lhs) ||
             !py_make_cached_pair_ts_arg(*cache, 1, cache->shape.layout[1],
-                                        cache->arg_at(input, bundle, 1), lease,
-                                        rhs)) {
+                                        cache->arg_at(input, bundle, 1),
+                                        scheduler, lease, rhs)) {
           return;
         }
         result = cache->record->fn(lhs, rhs);
@@ -1081,7 +1089,8 @@ struct py_fast_compute_node {
         TSInputView input = cache->input.borrowed_ref(now);
         nb::list call_args;
         if (!py_assemble_fast_args(*cache, cache->shape.layout, input,
-                                   cache->scalars, lease, call_args)) {
+                                   cache->scalars, scheduler, lease,
+                                   call_args)) {
           return;
         }
         auto call_kwargs = py_peel_kwargs(call_args, cache->shape.kw_names);

--- a/python/py_runtime.h
+++ b/python/py_runtime.h
@@ -433,6 +433,29 @@ namespace hgraph::python_bridge
             return view.valid() && view.data_view().has_current_value();
         }
 
+        [[nodiscard]] bool all_valid() const { return checked().all_valid(); }
+
+        [[nodiscard]] DateTime last_modified_time() const
+        {
+            return checked().last_modified_time();
+        }
+
+        [[nodiscard]] bool is_reference() const { return checked().is_reference(); }
+
+        [[nodiscard]] nb::object owning_node() const
+        {
+            const NodeView owner = checked().owner_node();
+            return owner.valid()
+                       ? nb::cast(PyNode{owner.pointer(), NodeScheduler{}, lease})
+                       : nb::none();
+        }
+
+        [[nodiscard]] nb::object owning_graph() const
+        {
+            const GraphView owner = checked().owner_graph();
+            return owner.valid() ? nb::cast(PyGraph{owner.pointer(), lease}) : nb::none();
+        }
+
         [[nodiscard]] nb::object value() const
         {
             auto view = checked();
@@ -719,6 +742,22 @@ namespace hgraph::python_bridge
         }
 
         [[nodiscard]] TSTypeKind kind() const { return checked().schema()->kind; }
+
+        [[nodiscard]] bool is_reference() const { return checked().is_reference(); }
+
+        [[nodiscard]] nb::object owning_node() const
+        {
+            const NodeView owner = checked().consumer_node();
+            return owner.valid()
+                       ? nb::cast(PyNode{owner.pointer(), NodeScheduler{}, lease})
+                       : nb::none();
+        }
+
+        [[nodiscard]] nb::object owning_graph() const
+        {
+            const GraphView owner = checked().consumer_graph();
+            return owner.valid() ? nb::cast(PyGraph{owner.pointer(), lease}) : nb::none();
+        }
 
         [[nodiscard]] nb::object value() const
         {

--- a/python/py_runtime.h
+++ b/python/py_runtime.h
@@ -419,6 +419,7 @@ namespace hgraph::python_bridge
     {
         TSOutputHandle handle;
         DateTime       now{};
+        NodeScheduler  scheduler;
         PyTsLease      lease;
 
         [[nodiscard]] TSOutputView checked() const
@@ -446,7 +447,7 @@ namespace hgraph::python_bridge
         {
             const NodeView owner = checked().owner_node();
             return owner.valid()
-                       ? nb::cast(PyNode{owner.pointer(), NodeScheduler{}, lease})
+                       ? nb::cast(PyNode{owner.pointer(), scheduler, lease})
                        : nb::none();
         }
 
@@ -469,7 +470,7 @@ namespace hgraph::python_bridge
                     const auto &field = view.schema()->fields()[index];
                     auto child = bundle.at(index);
                     value[nb::str{field.name}] =
-                        PyOutput{TSOutputHandle{child}, now, lease}.value();
+                        PyOutput{TSOutputHandle{child}, now, scheduler, lease}.value();
                 }
                 return materialize_tsb_value(view.schema(), std::move(value));
             }
@@ -516,18 +517,19 @@ namespace hgraph::python_bridge
                     {
                         throw nb::key_error("output key not found");
                     }
-                    return PyOutput{dict.at(key_value.view()).handle(), now, lease};
+                    return PyOutput{dict.at(key_value.view()).handle(), now, scheduler, lease};
                 }
                 case TSTypeKind::TSL: {
                     auto list = view.as_list();
-                    return PyOutput{list.at(nb::cast<std::size_t>(key)).handle(), now, lease};
+                    return PyOutput{
+                        list.at(nb::cast<std::size_t>(key)).handle(), now, scheduler, lease};
                 }
                 case TSTypeKind::TSB: {
                     auto bundle = view.as_bundle();
                     TSOutputView result = nb::isinstance<nb::str>(key)
                                               ? bundle.field(nb::cast<std::string>(key))
                                               : bundle.at(nb::cast<std::size_t>(key));
-                    return PyOutput{result.handle(), now, lease};
+                    return PyOutput{result.handle(), now, scheduler, lease};
                 }
                 default: throw nb::type_error("this output kind has no children");
             }
@@ -543,7 +545,8 @@ namespace hgraph::python_bridge
             Value key_value = py_to_value_as(key, view.schema()->key_type());
             auto  mutation  = view.as_dict().begin_mutation(now);
             auto  child     = mutation.at(key_value.view());
-            return PyOutput{TSOutputHandle{view.output(), child}, now, lease};
+            return PyOutput{
+                TSOutputHandle{view.output(), child}, now, scheduler, lease};
         }
 
         void erase(nb::handle key) const
@@ -712,6 +715,7 @@ namespace hgraph::python_bridge
     struct PyTimeSeries
     {
         TSInputView       view;
+        NodeScheduler     scheduler;
         PyTsLease         lease;
         TSDataStorageRef<> evaluation_data{};
         const TSDataOps   *python_value_ops{nullptr};
@@ -749,7 +753,7 @@ namespace hgraph::python_bridge
         {
             const NodeView owner = checked().consumer_node();
             return owner.valid()
-                       ? nb::cast(PyNode{owner.pointer(), NodeScheduler{}, lease})
+                       ? nb::cast(PyNode{owner.pointer(), scheduler, lease})
                        : nb::none();
         }
 
@@ -833,7 +837,7 @@ namespace hgraph::python_bridge
                     const auto &field = schema->fields()[index];
                     auto child = bundle.at(index);
                     result[nb::str{field.name}] =
-                        PyTimeSeries{std::move(child), lease}.value();
+                        PyTimeSeries{std::move(child), scheduler, lease}.value();
                 }
                 return materialize_tsb_value(schema, std::move(result));
             }
@@ -892,19 +896,23 @@ namespace hgraph::python_bridge
             {
                 case TSTypeKind::TSD: {
                     Value key_value = py_to_value_as(key, ts.schema()->key_type());
-                    return PyTimeSeries{ts.as_dict().at(key_value.view()), lease};
+                    return PyTimeSeries{
+                        ts.as_dict().at(key_value.view()), scheduler, lease};
                 }
                 case TSTypeKind::TSL: {
                     auto list = ts.as_list();
-                    return PyTimeSeries{list[nb::cast<std::size_t>(key)], lease};
+                    return PyTimeSeries{
+                        list[nb::cast<std::size_t>(key)], scheduler, lease};
                 }
                 case TSTypeKind::TSB: {
                     auto bundle = ts.as_bundle();
                     if (nb::isinstance<nb::str>(key))
                     {
-                        return PyTimeSeries{bundle.field(nb::cast<std::string>(key)), lease};
+                        return PyTimeSeries{
+                            bundle.field(nb::cast<std::string>(key)), scheduler, lease};
                     }
-                    return PyTimeSeries{bundle[nb::cast<std::size_t>(key)], lease};
+                    return PyTimeSeries{
+                        bundle[nb::cast<std::size_t>(key)], scheduler, lease};
                 }
                 default: throw nb::type_error("this time-series kind has no children");
             }
@@ -945,7 +953,8 @@ namespace hgraph::python_bridge
             auto dict = checked().as_dict();
             for (auto &&[key, child] : dict.modified_items())
             {
-                result.append(nb::make_tuple(value_to_py(key), PyTimeSeries{std::move(child), lease}));
+                result.append(nb::make_tuple(
+                    value_to_py(key), PyTimeSeries{std::move(child), scheduler, lease}));
             }
             return result;
         }
@@ -957,7 +966,7 @@ namespace hgraph::python_bridge
             for (auto &&[key, child] : dict.modified_items())
             {
                 static_cast<void>(key);
-                result.append(PyTimeSeries{std::move(child), lease});
+                result.append(PyTimeSeries{std::move(child), scheduler, lease});
             }
             return result;
         }
@@ -973,7 +982,8 @@ namespace hgraph::python_bridge
                     auto dict = ts.as_dict();
                     for (const ValueView &key : dict.keys())
                     {
-                        result.append(nb::cast(PyTimeSeries{dict.at(key), lease}));
+                        result.append(
+                            nb::cast(PyTimeSeries{dict.at(key), scheduler, lease}));
                     }
                     return result;
                 }
@@ -981,7 +991,8 @@ namespace hgraph::python_bridge
                     auto bundle = ts.as_bundle();
                     for (std::size_t index = 0; index < bundle.size(); ++index)
                     {
-                        result.append(nb::cast(PyTimeSeries{bundle[index], lease}));
+                        result.append(
+                            nb::cast(PyTimeSeries{bundle[index], scheduler, lease}));
                     }
                     return result;
                 }
@@ -989,7 +1000,8 @@ namespace hgraph::python_bridge
                     auto list = ts.as_list();
                     for (std::size_t index = 0; index < list.size(); ++index)
                     {
-                        result.append(nb::cast(PyTimeSeries{list[index], lease}));
+                        result.append(
+                            nb::cast(PyTimeSeries{list[index], scheduler, lease}));
                     }
                     return result;
                 }

--- a/python/py_state_services.cpp
+++ b/python/py_state_services.cpp
@@ -537,9 +537,14 @@ namespace hgraph::python_bridge
     m.attr("MAX_ET")     = nb::cast(MAX_ET);
 
     nb::class_<PyOutput>(m, "OutputView")
+        .def_prop_ro("owning_node", &PyOutput::owning_node)
+        .def_prop_ro("owning_graph", &PyOutput::owning_graph)
         .def_prop_ro("valid", &PyOutput::valid)
+        .def_prop_ro("all_valid", &PyOutput::all_valid)
         .def_prop_ro("modified", &PyOutput::modified)
+        .def_prop_ro("last_modified_time", &PyOutput::last_modified_time)
         .def_prop_ro("delta_value", &PyOutput::delta_value)
+        .def("is_reference", &PyOutput::is_reference)
         .def_prop_rw("value", &PyOutput::value, &PyOutput::set_value,
                      nb::for_setter(nb::arg("value").none()))
         .def("can_apply_result", &PyOutput::can_apply_result)
@@ -554,8 +559,19 @@ namespace hgraph::python_bridge
         .def("__contains__", &PyOutput::contains)
         .def("__len__", &PyOutput::size)
         .def("__getattr__",
-             [](const PyOutput &self, const std::string &name) {
-                 return self.child(nb::str(name.c_str()));
+             [](const PyOutput &self, const std::string &name) -> PyOutput {
+                 if (self.checked().schema()->kind != TSTypeKind::TSB)
+                 {
+                     throw nb::attribute_error(name.c_str());
+                 }
+                 try
+                 {
+                     return self.child(nb::str(name.c_str()));
+                 }
+                 catch (const std::out_of_range &)
+                 {
+                     throw nb::attribute_error(name.c_str());
+                 }
              });
     nb::class_<PyRecordableState>(m, "RecordableStateView")
         .def_prop_ro("valid", &PyRecordableState::valid)
@@ -673,6 +689,9 @@ namespace hgraph::python_bridge
     };
     nb::class_<PyTimeSeries>(m, "TimeSeries", nb::type_slots(py_ts_slots))
         .def_prop_ro("_kind", [](const PyTimeSeries &self) { return static_cast<int>(self.kind()); })
+        .def_prop_ro("owning_node", &PyTimeSeries::owning_node)
+        .def_prop_ro("owning_graph", &PyTimeSeries::owning_graph)
+        .def("is_reference", &PyTimeSeries::is_reference)
         // hgraph's runtime activity control: a node may passivate/reactivate
         // its own input subscription (the C++ In views expose the same).
         .def("make_passive",

--- a/python/tests/test_time_series_runtime_api.py
+++ b/python/tests/test_time_series_runtime_api.py
@@ -5,6 +5,7 @@ import pytest
 from hgraph import (
     MIN_DT,
     MIN_ST,
+    MIN_TD,
     NODE,
     REF,
     TS,
@@ -68,6 +69,43 @@ def test_input_and_output_views_expose_generic_time_series_interrogation():
     for owner in retained[1::4] + retained[3::4]:
         with pytest.raises(RuntimeError, match="outside its lifecycle callback"):
             _ = owner.graph_id
+
+
+def test_input_and_output_owners_keep_the_callback_scheduler():
+    evaluations = []
+
+    @compute_node
+    def reschedule(value: TS[int], _output: TS_OUT[int] = None) -> TS[int]:
+        evaluations.append(value.value)
+        if len(evaluations) == 1:
+            value.owning_node.notify_next_cycle()
+            _output.owning_node.notify()
+        return value.value
+
+    eval_node(
+        reschedule,
+        value=[1],
+        __end_time__=MIN_ST + 2 * MIN_TD,
+    )
+    assert evaluations == [1, 1]
+
+
+def test_fast_compute_input_owner_keeps_the_callback_scheduler():
+    evaluations = []
+
+    @compute_node
+    def reschedule(value: TS[int]) -> TS[int]:
+        evaluations.append(value.value)
+        if len(evaluations) == 1:
+            value.owning_node.notify_next_cycle()
+        return value.value
+
+    eval_node(
+        reschedule,
+        value=[1],
+        __end_time__=MIN_ST + 2 * MIN_TD,
+    )
+    assert evaluations == [1, 1]
 
 
 def test_reference_input_and_output_views_identify_their_runtime_schema():

--- a/python/tests/test_time_series_runtime_api.py
+++ b/python/tests/test_time_series_runtime_api.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+import pytest
+
+from hgraph import (
+    MIN_DT,
+    MIN_ST,
+    NODE,
+    REF,
+    TS,
+    TSB,
+    TSB_OUT,
+    TS_OUT,
+    TimeSeriesSchema,
+    compute_node,
+)
+from hgraph.test import eval_node
+
+
+def test_input_and_output_views_expose_generic_time_series_interrogation():
+    observations = []
+    retained = []
+
+    @compute_node
+    def inspect(value: TS[int], node: NODE = None, _output: TS_OUT[int] = None) -> TS[int]:
+        observations.append(
+            (
+                value.owning_node.node_id,
+                value.owning_graph.graph_id,
+                value.is_reference(),
+                _output.owning_node.node_id,
+                _output.owning_graph.graph_id,
+                _output.is_reference(),
+                _output.valid,
+                _output.all_valid,
+                _output.last_modified_time,
+                node.node_id,
+            )
+        )
+        retained.extend(
+            (
+                value.owning_node,
+                value.owning_graph,
+                _output.owning_node,
+                _output.owning_graph,
+            )
+        )
+
+        # Binding and ownership mutation are native engine responsibilities,
+        # not Python runtime-view APIs.
+        assert not hasattr(value, "bind_output")
+        assert not hasattr(value, "un_bind_output")
+        assert not hasattr(value, "do_bind_output")
+        assert not hasattr(value, "do_un_bind_output")
+        assert not hasattr(value, "re_parent")
+        assert not hasattr(_output, "re_parent")
+        return value.value
+
+    assert eval_node(inspect, value=[1, 2]) == [1, 2]
+    assert observations == [
+        ((1,), (), False, (1,), (), False, False, False, MIN_DT, (1,)),
+        ((1,), (), False, (1,), (), False, True, True, MIN_ST, (1,)),
+    ]
+
+    for owner in retained[::4] + retained[2::4]:
+        with pytest.raises(RuntimeError, match="outside its node's evaluation"):
+            _ = owner.node_id
+    for owner in retained[1::4] + retained[3::4]:
+        with pytest.raises(RuntimeError, match="outside its lifecycle callback"):
+            _ = owner.graph_id
+
+
+def test_reference_input_and_output_views_identify_their_runtime_schema():
+    observations = []
+
+    @compute_node
+    def inspect(value: REF[TS[int]], _output: REF[TS[int]] = None) -> REF[TS[int]]:
+        observations.append((value.is_reference(), _output.is_reference()))
+        return value.value
+
+    assert eval_node(inspect, value=[1]) == [1]
+    assert observations == [(True, True)]
+
+
+class RuntimeApiPair(TimeSeriesSchema):
+    left: TS[int]
+    right: TS[str]
+
+
+def test_structural_child_views_keep_their_node_and_graph_owners():
+    observations = []
+
+    @compute_node
+    def inspect(
+        value: TSB[RuntimeApiPair],
+        node: NODE = None,
+        _output: TSB_OUT[RuntimeApiPair] = None,
+    ) -> TSB[RuntimeApiPair]:
+        observations.append(
+            (
+                value.left.owning_node.node_id,
+                value.left.owning_graph.graph_id,
+                _output.left.owning_node.node_id,
+                _output.left.owning_graph.graph_id,
+                node.node_id,
+            )
+        )
+        assert not hasattr(_output, "not_a_field")
+        return value.delta_value
+
+    assert eval_node(inspect, value=[{"left": 1, "right": "a"}]) == [
+        {"left": 1, "right": "a"}
+    ]
+    assert observations == [((1,), (), (1,), (), (1,))]

--- a/tests/cpp/test_endpoint_owner.cpp
+++ b/tests/cpp/test_endpoint_owner.cpp
@@ -66,6 +66,7 @@ TEST_CASE("node output TSData can recover its owning node")
     REQUIRE(output_owner.valid());
     CHECK(output_owner.node_index() == 0);
     CHECK(output_owner.graph_value() == source.graph_value());
+    CHECK(output.owner_graph().data() == graph_view.data());
 
     auto root_owner = output.data_view().owner_node();
     REQUIRE(root_owner.valid());
@@ -103,11 +104,34 @@ TEST_CASE("node input TSData can recover its consuming node")
     REQUIRE(consumer_owner.valid());
     CHECK(consumer_owner.node_index() == 0);
     CHECK(consumer_owner.graph_value() == consumer.graph_value());
+    CHECK(input.consumer_graph().data() == graph_view.data());
 
     auto root_owner = input.data_view().owner_node();
     REQUIRE(root_owner.valid());
     CHECK(root_owner.node_index() == 0);
     CHECK(input.data_view().root_endpoint_owner().port() == TSEndpointOwnerPort::Input);
+}
+
+TEST_CASE("time-series endpoint views report whether their schema is a reference")
+{
+    using namespace hgraph;
+
+    auto       &registry = TypeRegistry::instance();
+    const auto *int_meta = registry.register_scalar<std::int32_t>("int32");
+    const auto *ts_int   = registry.ts(int_meta);
+    const auto *ref_int  = registry.ref(ts_int);
+
+    TSOutput value_output{*ts_int};
+    TSOutput reference_output{*ref_int};
+    CHECK_FALSE(value_output.view().is_reference());
+    CHECK(reference_output.view().is_reference());
+
+    TSInput value_input{
+        TSInputBuilderFactory::checked_builder_for(*ts_int, TSEndpointSchema::peered(ts_int))};
+    TSInput reference_input{
+        TSInputBuilderFactory::checked_builder_for(*ref_int, TSEndpointSchema::peered(ref_int))};
+    CHECK_FALSE(value_input.view().is_reference());
+    CHECK(reference_input.view().is_reference());
 }
 
 TEST_CASE("bound input output owner remains the producer node")


### PR DESCRIPTION
## Summary

- expose `owning_node`, `owning_graph`, and `is_reference()` on Python runtime input and mutable output views
- expose generic output `all_valid` and `last_modified_time`, while preserving callback-scoped lifetime checks for returned owners
- preserve the callback's live scheduler on returned owners, including cached fast-compute wrappers, so node notification remains callable during evaluation
- add the corresponding first-class C++ `is_reference()` view contract and native/Python regression coverage
- document binding, topology surgery, re-parenting, and subscription hooks as intentional engine-only deviations

This is the standalone runtime time-series API correction identified while reviewing #219. The broader surface inventory remains separate and this PR does not close that issue.

## Validation

- focused Python runtime time-series API tests: 5/5 passed
- macOS fresh native build: 1,399/1,399 tests passed
- macOS cp312 stable-ABI wheel installed under Python 3.14: 1,843 passed, 11 skipped
- installed CMake SDK consumer: passed
- Sphinx HTML build with warnings as errors: passed
- `hg-linux` fresh native build: 1,399/1,399 tests passed
- `hg-linux` cp312 stable-ABI wheel under Python 3.14: 1,841 passed, 11 skipped
- `hg-linux` ASan build: focused runtime API tests and full non-WIP Python suite passed