### PR TITLE
Support concurrent threaded graph engines

### DIFF
--- a/docs/source/developer_guide/python_bridge.rst
+++ b/docs/source/developer_guide/python_bridge.rst
@@ -97,7 +97,7 @@ global-state push/pop hooks — address ``hgraph._wiring`` directly):
 Module                        Contents
 ============================ ==================================================
 ``_wiring/_core.py``          The wiring stack (``_wiring_stack`` — THE single
-                              list), ``WiringPort`` + all attached sugar,
+                              list) and top-level wiring lock, ``WiringPort`` + all attached sugar,
                               ``wire()``, ``_OperatorFunction``, the wiring
                               error hierarchy, context publication.
 ``_wiring/_sentinels.py``     ``REMOVED``/``Removed``/``_SetDelta`` and delta
@@ -306,17 +306,23 @@ rule. ``reset_registries`` clears the lookup maps and invalidates Python-side
 generation-keyed caches, but already-published binding objects are never
 destroyed during interpreter teardown.
 
-The single-threaded wiring model
---------------------------------
+Serialized wiring, concurrent execution
+---------------------------------------
 
 Wiring state is a module-level stack (``_wiring/_core.py::_wiring_stack``),
-*not* a thread-local — the runtime is single-threaded by design (ruling
-2026-07-02; the standing "no thread_locals" rule). C++ re-enters Python wiring
-through the *borrowed wiring* pattern: when the C++ side calls back into a
-Python graph function (graph-fn wrapper) or a Python overload (wire
-trampoline), it hands over a borrowed ``PyWiring``; the Python side pushes it
-onto ``_wiring_stack``, wires, and pops. Both re-entry sites follow the same
-push/try/finally/pop shape — if you add a third, copy it exactly.
+*not* a thread-local. Top-level ``run_graph`` / ``evaluate_graph`` authoring is
+serialized by ``_wiring_lock`` because both that stack and native operator
+registration are process-wide. The lock remains held through
+``Wiring::finish()`` and service materialization, where C++ can re-enter Python
+wiring, and is released as soon as the native executor has been constructed.
+The executor run therefore does not hold the wiring lock: distinct native
+executors can progress concurrently on different threads.
+
+C++ re-enters Python wiring through the *borrowed wiring* pattern: when the C++
+side calls back into a Python graph function (graph-fn wrapper) or a Python
+overload (wire trampoline), it hands over a borrowed ``PyWiring``; the Python
+side pushes it onto ``_wiring_stack``, wires, and pops. Both re-entry sites
+follow the same push/try/finally/pop shape — if you add a third, copy it exactly.
 
 ``_wiring_stack`` must remain the **same list object** everywhere it is
 visible (``hgraph._wiring._core``, the ``hgraph._wiring`` aggregation, and

--- a/docs/source/user_guide/authoring_graphs_cpp.rst
+++ b/docs/source/user_guide/authoring_graphs_cpp.rst
@@ -1296,6 +1296,14 @@ wakes and stops a sleeping executor:
    // thread when the controlling thread needs to keep going.
    view.request_stop();   // callable from another thread; wakes the executor
 
+Construct one ``GraphExecutorValue`` per run. Distinct executors may call
+``run()`` concurrently on different threads: each owns its graph, scheduler,
+clock, and ``GlobalState``, so a blocked engine does not hold an execution lock
+needed by another engine. ``run()`` is not re-entrant on the *same* executor,
+and callbacks must synchronise any external state they deliberately share.
+Concurrent engines do not promise aligned wall-clock times or evaluation ticks;
+only the ordering produced inside each graph is defined.
+
 .. code-block:: python
 
    run_graph(price_graph, run_mode=EvaluationMode.REAL_TIME, ...)

--- a/include/hgraph/runtime/executor.h
+++ b/include/hgraph/runtime/executor.h
@@ -242,6 +242,16 @@ namespace hgraph
         /** Whether a failed run stops the graph before propagating its error. */
         [[nodiscard]] bool cleanup_on_error() const noexcept;
 
+        /**
+         * Run this executor on the calling thread.
+         *
+         * Distinct executors may run concurrently on different threads without
+         * coordinating their evaluation. The owning ``GraphExecutorValue`` for
+         * this view must outlive the run. A single executor is mutable run state:
+         * invoking ``run()`` concurrently on two views of the same executor is
+         * not supported. User callbacks remain responsible for synchronising any
+         * external state they deliberately share between graphs.
+         */
         void run() const;
         void request_stop() const noexcept;
 

--- a/python/hgraph/_types.py
+++ b/python/hgraph/_types.py
@@ -2231,6 +2231,9 @@ def _time_series_full_value_type(ts_type):
     if handle.is_ref:
         return _time_series_full_value_type(
             _TsExpr(_hgraph.ref_target(handle), repr(handle)))
+    if handle.kind == _hgraph.TS_KIND_TSW:
+        return _value_type_python_type(
+            _hgraph.vt_element(_hgraph.ts_value_vt(handle)))
     if handle.is_ts:
         python_type = _TS_SCALAR_TYPES.get(handle)
         return python_type if python_type is not None else _value_type_python_type(

--- a/python/hgraph/_types.py
+++ b/python/hgraph/_types.py
@@ -2,6 +2,7 @@
 TSD[str, TS[int]], TSL[TS[int], Size[3]], TSB[Schema]. Each subscription
 resolves to an interned C++ type handle via the _hgraph registry."""
 import datetime
+import functools
 
 import _hgraph
 
@@ -2152,6 +2153,108 @@ class TimeSeriesSchema:
         bundle.__scalar_type__ = schema
         schema.__bundle_type__ = bundle
         return bundle
+
+    @classmethod
+    @functools.lru_cache(maxsize=None)
+    def to_scalar_schema(cls):
+        """Create the full-value ``CompoundScalar`` represented by this TSB.
+
+        This is authoring metadata only: field shapes are derived from the
+        resolved native time-series schemas, while the C++ type registry
+        remains the source of runtime storage and conversion semantics.
+        """
+        import dataclasses
+
+        from ._compat import CompoundScalar
+
+        if cls is TimeSeriesSchema:
+            return CompoundScalar
+        if not issubclass(cls, TimeSeriesSchema):
+            raise TypeError(
+                f"Can only convert bundle schemas to scalar schemas, not {cls!r}")
+
+        scalar_type = cls.__dict__.get("__scalar_type__")
+        if scalar_type is not None:
+            return scalar_type
+
+        bases = tuple(
+            base.to_scalar_schema()
+            if isinstance(base, type) and issubclass(base, TimeSeriesSchema)
+            else base
+            for base in cls.__bases__
+        )
+
+        scalar_schema = type(
+            f"{cls.__name__}Struct",
+            bases,
+            {
+                "__annotations__": {
+                    name: _time_series_full_value_type(field_type)
+                    for name, field_type in _evaluated_annotations(cls).items()
+                },
+                "__module__": cls.__module__,
+            },
+        )
+        if hasattr(scalar_schema, "__dataclass_fields__"):
+            params = scalar_schema.__dataclass_params__
+            scalar_schema = dataclasses.dataclass(
+                scalar_schema,
+                frozen=params.frozen,
+                init=params.init,
+                eq=params.eq,
+                repr=params.repr,
+            )
+        else:
+            scalar_schema = dataclasses.dataclass(frozen=True)(scalar_schema)
+        scalar_schema.__bundle_type__ = cls
+        return scalar_schema
+
+
+def _value_type_python_type(value_type):
+    python_type = _VALUE_SCALAR_TYPES.get(value_type)
+    if python_type is None:
+        python_type = _hgraph.python_type_for_value(value_type)
+    if isinstance(python_type, _hgraph.ValueType):
+        raise TypeError(
+            f"native scalar schema {value_type!r} has no Python type binding")
+    return python_type
+
+
+def _time_series_full_value_type(ts_type):
+    """Python full-value type for one resolved time-series annotation."""
+    if not isinstance(ts_type, _TsExpr):
+        raise TypeError(
+            "to_scalar_schema requires resolved time-series fields, "
+            f"got {ts_type!r}")
+
+    handle = ts_type.handle
+    if handle.is_ref:
+        return _time_series_full_value_type(
+            _TsExpr(_hgraph.ref_target(handle), repr(handle)))
+    if handle.is_ts:
+        python_type = _TS_SCALAR_TYPES.get(handle)
+        return python_type if python_type is not None else _value_type_python_type(
+            _hgraph.ts_value_vt(handle))
+    if handle.is_tss:
+        element = _value_type_python_type(
+            _hgraph.vt_element(_hgraph.ts_value_vt(handle)))
+        return frozenset[element]
+    if handle.is_tsd:
+        key = _value_type_python_type(_hgraph.tsd_key_vt(handle))
+        value = _time_series_full_value_type(
+            _TsExpr(_hgraph.tsd_element_ts(handle), repr(handle)))
+        return dict[key, value]
+    if handle.is_tsl:
+        element = _time_series_full_value_type(
+            _TsExpr(_hgraph.tsl_element_ts(handle), repr(handle)))
+        return tuple[element, ...]
+    if handle.is_tsb:
+        schema = _TSB_SCHEMA_CLASSES.get(handle)
+        if schema is None or not issubclass(schema, TimeSeriesSchema):
+            raise TypeError(f"TSB field {ts_type!r} has no TimeSeriesSchema binding")
+        return schema.to_scalar_schema()
+    raise TypeError(
+        f"to_scalar_schema does not support time-series field {ts_type!r}")
 
 
 class _TSBMeta(type):

--- a/python/hgraph/_wiring/_core.py
+++ b/python/hgraph/_wiring/_core.py
@@ -1,15 +1,19 @@
 """Wiring stack, ports, the erased ``wire`` verb and the wiring errors.
 
-Wiring state is a module-level stack (the runtime is single-threaded by
-design — the standing no-thread-locals ruling). ``_wiring_stack`` is THE
-single list object: tests and C++ re-entry mutate it in place; nothing may
-rebind it."""
+Wiring state is a module-level stack. Top-level ``run_graph`` wiring is
+serialized because the stack and native operator registry are process-wide;
+the serialization ends once the native executor has been built, so distinct
+executors may run concurrently. ``_wiring_stack`` is THE single list object:
+tests and C++ re-entry mutate it in place; nothing may rebind it."""
+import threading
+
 import _hgraph
 
 from .._types import _TsExpr
 from ._sentinels import _REDUCE_ZERO
 
 _wiring_stack = []
+_wiring_lock = threading.RLock()
 
 
 def _current_wiring():

--- a/python/hgraph/_wiring/_runner.py
+++ b/python/hgraph/_wiring/_runner.py
@@ -12,7 +12,7 @@ from .._signature import _is_time_series
 from .._types import (_GenericTsExpr, _TsExpr, _TypeVarSentinel,
                       _type_var_is_scalar)
 from ._core import (WiringError, WiringPort, _OperatorFunction, _unwrap,
-                    _wiring_stack, wire)
+                    _wiring_lock, _wiring_stack, wire)
 from ._graph import _GraphFn
 from ._node import _PyNode
 from ._sentinels import _simplify_delta
@@ -231,7 +231,21 @@ def _evaluate_graph(graph_fn, config, args, kwargs):
     config.graph_logger.setLevel(config.default_log_level)
     w = None
     wiring_pushed = False
+    wiring_lock_held = False
+
+    def wiring_prepared():
+        """End process-wide wiring serialization before native execution."""
+        nonlocal wiring_pushed, wiring_lock_held
+        if wiring_pushed:
+            _wiring_stack.pop()
+            wiring_pushed = False
+        if wiring_lock_held:
+            _wiring_lock.release()
+            wiring_lock_held = False
+
     try:
+        _wiring_lock.acquire()
+        wiring_lock_held = True
         w = _hgraph.Wiring(state._impl)
         w.configure_wiring_observers(
             config.trace_wiring, config.wiring_observers)
@@ -267,7 +281,8 @@ def _evaluate_graph(graph_fn, config, args, kwargs):
                     observers=config.life_cycle_observers,
                     trace_back_depth=config.trace_back_depth,
                     capture_values=config.capture_values,
-                    cleanup_on_error=config.cleanup_on_error)
+                    cleanup_on_error=config.cleanup_on_error,
+                    _on_prepared=wiring_prepared)
     finally:
         if w is not None:
             for line in w.wiring_trace_lines():
@@ -275,6 +290,8 @@ def _evaluate_graph(graph_fn, config, args, kwargs):
             w._release_seed_context()
         if wiring_pushed:
             _wiring_stack.pop()
+        if wiring_lock_held:
+            _wiring_lock.release()
         if previous_logger is missing:
             state.pop(_GRAPH_LOGGER_KEY, None)
         else:

--- a/python/hgraph/adaptors/run_graph_on_thread/run_graph_on_thread.py
+++ b/python/hgraph/adaptors/run_graph_on_thread/run_graph_on_thread.py
@@ -12,6 +12,7 @@ from hgraph import (
     TIME_SERIES_TYPE,
     CompoundScalar,
     EvaluationMode,
+    GraphConfiguration,
     GlobalContext,
     GlobalState,
     TS,
@@ -22,7 +23,7 @@ from hgraph import (
     compute_node,
     const,
     push_queue,
-    run_graph,
+    evaluate_graph,
     service_adaptor,
     service_adaptor_impl,
     sink_node,
@@ -118,6 +119,13 @@ def _as_port(value, output_type):
 
 
 class _RunGraphOnThread:
+    """Run each client graph on its own worker thread.
+
+    Publications retain their order within a client. Relative timing and tick
+    alignment between independently scheduled clients are intentionally not
+    defined.
+    """
+
     __name__ = "run_graph_on_thread"
 
     def __init__(self, output_type=None):
@@ -131,20 +139,32 @@ class _RunGraphOnThread:
         fn,
         global_state=None,
         params=None,
-        *,
+        out_=None,
         path="thread_graph_runner",
     ):
-        if self.output_type is None:
+        output_type = self.output_type
+        if output_type is None:
+            output_type = out_
+        elif out_ is not None and out_ != output_type:
+            raise TypeError(
+                "out_ does not match the bracket-specialized output type")
+        if output_type is None:
             raise TypeError("run_graph_on_thread must be specialized with an output type")
         request = _make_request(
             _as_port(fn, TS[object]),
-            _as_port(global_state or {}, TS[dict[str, object]]),
-            _as_port(params or {}, TS[dict[str, object]]),
+            _as_port(
+                global_state if global_state is not None else {},
+                TS[dict[str, object]],
+            ),
+            _as_port(
+                params if params is not None else {},
+                TS[dict[str, object]],
+            ),
         )
         raw = _run_graph_on_thread(request, path=path)
-        output_schema = RunGraphOutput[self.output_type]
+        output_schema = RunGraphOutput[output_type]
         return TSB[output_schema].from_ts(
-            out=_typed_output[OUT : self.output_type](raw.out),
+            out=_typed_output[OUT : output_type](raw.out),
             started=raw.started,
             finished=raw.finished,
             status=raw.status,
@@ -248,12 +268,25 @@ def _date_at_midnight(value):
 def _run_child(request: _RunGraphRequest, publish):
     params = dict(request.params)
     run_mode = params.pop("run_mode", EvaluationMode.SIMULATION)
-    start_time = params.pop("start_time", None)
-    end_time = params.pop("end_time", None)
+    # Time bounds configure the child engine, but remain available to child
+    # graphs that declare parameters with these names.  This matches the
+    # established Python adaptor contract.
+    start_time = params.get("start_time")
+    end_time = params.get("end_time")
     if start_time is None:
-        start_time = _date_at_midnight(params.pop("start_date", None))
+        start_time = _date_at_midnight(params.get("start_date"))
     if end_time is None:
-        end_time = _date_at_midnight(params.pop("end_date", None))
+        end_time = _date_at_midnight(params.get("end_date"))
+    config_options = {}
+    for name in (
+        "graph_logger",
+        "capture_values",
+        "cleanup_on_error",
+        "trace_back_depth",
+    ):
+        value = params.pop(name, None)
+        if value is not None:
+            config_options[name] = value
 
     state = GlobalState()
     for key, value in request.global_state.items():
@@ -265,11 +298,14 @@ def _run_child(request: _RunGraphRequest, publish):
         def child():
             request.fn(**_wire_graph_parameters(request.fn, params))
 
-        run_graph(
+        evaluate_graph(
             child,
-            start_time=start_time,
-            end_time=end_time,
-            run_mode=run_mode,
+            GraphConfiguration(
+                run_mode=run_mode,
+                start_time=start_time,
+                end_time=end_time,
+                **config_options,
+            ),
         )
     publish({"finished": True, "status": "OK"})
 

--- a/python/py_wiring.cpp
+++ b/python/py_wiring.cpp
@@ -1143,7 +1143,8 @@ namespace hgraph::python_bridge
              nb::arg("trace_back_depth") = 1,
              nb::arg("capture_values") = false,
              nb::arg("cleanup_on_error") = true,
-             nb::arg("snapshot") = false)
+             nb::arg("snapshot") = false,
+             nb::arg("_on_prepared") = nb::none())
         .def("push_source", &PyWiring::push_source, nb::arg("ts_type"), nb::arg("conflate") = false,
              nb::arg("on_start") = nb::none());
 

--- a/python/py_wiring.h
+++ b/python/py_wiring.h
@@ -285,7 +285,8 @@ namespace hgraph::python_bridge
             nb::tuple observers, std::int64_t trace_back_depth,
             bool capture_values,
             bool cleanup_on_error,
-            bool snapshot)
+            bool snapshot,
+            nb::object on_prepared)
         {
             ensure_open();
             if (owned == nullptr) { throw std::logic_error("a borrowed Wiring cannot be run"); }
@@ -333,6 +334,12 @@ namespace hgraph::python_bridge
                 eb.add_lifecycle_observer(run->profiler.get());
             }
             run->executor = eb.make_executor();
+
+            // Python's authoring layer serializes the process-wide wiring
+            // stack through executor construction. Notify it at the exact
+            // phase boundary where all wiring/service materialization is
+            // complete and native execution can proceed independently.
+            if (!on_prepared.is_none()) { on_prepared(); }
 
             nb::object runtime = nb::module_::import_("hgraph._wiring._state");
             runtime.attr("_enter_runtime")();

--- a/python/tests/adaptors/run_graph_on_thread/test_run_graph_on_thread.py
+++ b/python/tests/adaptors/run_graph_on_thread/test_run_graph_on_thread.py
@@ -1,6 +1,7 @@
 from datetime import datetime, timedelta, timezone
 
 import hgraph as hg
+import pytest
 
 from hgraph.adaptors.run_graph_on_thread import (
     RunGraphOutput,
@@ -30,6 +31,20 @@ def test_typed_output_schema_can_be_used_by_eval_node():
     assert hg.eval_node(typed, [3, 4], resolution_dict={"raw": hg.TS[object]}) == [3, 4]
 
 
+def test_typed_output_schema_supports_standard_scalar_schema_operations():
+    schema = RunGraphOutput[hg.TS[int]]
+
+    assert schema.scalar_type() is None
+    scalar_schema = schema.to_scalar_schema()
+    assert scalar_schema.__annotations__ == {
+        "out": int,
+        "started": bool,
+        "finished": bool,
+        "status": str,
+    }
+    assert schema.from_scalar_schema(scalar_schema) is schema
+
+
 def test_publish_output_can_publish_full_values_instead_of_deltas():
     captured = []
 
@@ -45,7 +60,8 @@ def test_publish_output_can_publish_full_values_instead_of_deltas():
     assert captured == [{"a": 1}, {"a": 1, "b": 2}]
 
 
-def test_run_graph_on_thread_simulation_mode():
+@pytest.mark.parametrize("call_style", ["out_keyword", "positional_path"])
+def test_run_graph_on_thread_simulation_mode(call_style):
     captured = []
 
     @hg.sink_node
@@ -57,17 +73,31 @@ def test_run_graph_on_thread_simulation_mode():
     @hg.graph
     def app():
         hg.register_adaptor("thread-test", run_graph_on_thread_impl)
-        result = run_graph_on_thread[hg.TS[int]](
-            _sum_graph,
-            global_state={"seed": 1},
-            params={
-                "a": 1,
-                "b": 2,
-                "start_time": hg.MIN_ST,
-                "end_time": hg.MIN_ST + timedelta(seconds=1),
-            },
-            path="thread-test",
-        )
+        params = {
+            "a": 1,
+            "b": 2,
+            "start_time": hg.MIN_ST,
+            "end_time": hg.MIN_ST + timedelta(seconds=1),
+            "capture_values": True,
+            "cleanup_on_error": True,
+            "trace_back_depth": 2,
+        }
+        if call_style == "out_keyword":
+            result = run_graph_on_thread(
+                _sum_graph,
+                global_state={"seed": 1},
+                params=params,
+                out_=hg.TS[int],
+                path="thread-test",
+            )
+        else:
+            result = run_graph_on_thread(
+                _sum_graph,
+                {"seed": 1},
+                params,
+                hg.TS[int],
+                "thread-test",
+            )
         capture(result)
 
     with hg.GlobalContext(hg.GlobalState()):
@@ -80,3 +110,170 @@ def test_run_graph_on_thread_simulation_mode():
     assert any(value.get("out") == 3 for value in captured)
     assert captured[-1]["finished"] is True
     assert captured[-1]["status"] == "OK"
+
+
+def test_run_graph_on_thread_forwards_time_bounds_to_child_parameters():
+    captured = []
+
+    @hg.graph
+    def child(start_time: datetime, end_time: datetime):
+        publish_output(hg.const(f"{start_time.isoformat()}|{end_time.isoformat()}"))
+
+    @hg.sink_node
+    def capture(
+        result: hg.TSB[RunGraphOutput[hg.TS[str]]],
+        engine: hg.EvaluationEngineApi = None,
+    ):
+        if result.out.modified:
+            captured.append(result.out.value)
+        if result.finished.valid and result.finished.value:
+            engine.request_engine_stop()
+
+    start_time = hg.MIN_ST
+    end_time = hg.MIN_ST + timedelta(seconds=1)
+    expected = f"{start_time.isoformat()}|{end_time.isoformat()}"
+
+    @hg.graph
+    def app():
+        hg.register_adaptor("thread-time-parameters", run_graph_on_thread_impl)
+        result = run_graph_on_thread[hg.TS[str]](
+            child,
+            params={"start_time": start_time, "end_time": end_time},
+            path="thread-time-parameters",
+        )
+        capture(result)
+
+    with hg.GlobalContext(hg.GlobalState()):
+        hg.run_graph(
+            app,
+            run_mode=hg.EvaluationMode.REAL_TIME,
+            end_time=datetime.now(timezone.utc).replace(tzinfo=None)
+            + timedelta(seconds=5),
+        )
+
+    assert captured == [expected]
+
+
+def test_run_graph_on_thread_reports_child_runtime_failure():
+    captured = []
+
+    @hg.compute_node
+    def fail(value: hg.TS[int]) -> hg.TS[int]:
+        raise RuntimeError("expected child failure")
+
+    @hg.graph
+    def child():
+        publish_output(fail(hg.const(1)))
+
+    @hg.sink_node
+    def capture(
+        result: hg.TSB[RunGraphOutput[hg.TS[int]]],
+        engine: hg.EvaluationEngineApi = None,
+    ):
+        captured.append(result.value)
+        if result.finished.valid and result.finished.value:
+            engine.request_engine_stop()
+
+    @hg.graph
+    def app():
+        hg.register_adaptor("thread-failure", run_graph_on_thread_impl)
+        capture(
+            run_graph_on_thread[hg.TS[int]](
+                child,
+                path="thread-failure",
+            )
+        )
+
+    with hg.GlobalContext(hg.GlobalState()):
+        hg.run_graph(
+            app,
+            run_mode=hg.EvaluationMode.REAL_TIME,
+            end_time=datetime.now(timezone.utc).replace(tzinfo=None)
+            + timedelta(seconds=5),
+        )
+
+    assert captured[-1]["finished"] is True
+    assert captured[-1]["status"].startswith("ERROR:")
+    assert "expected child failure" in captured[-1]["status"]
+
+
+def test_run_graph_on_thread_two_clients_preserve_their_output_order():
+    captured = {"left": [], "right": []}
+
+    @hg.generator
+    def values(label: str) -> hg.TS[str]:
+        for index in range(3):
+            yield hg.MIN_ST + index * hg.MIN_TD, f"{label}:{index}"
+
+    @hg.compute_node
+    def with_seed(
+        value: hg.TS[str],
+        global_state: hg.GlobalState = None,
+    ) -> hg.TS[str]:
+        return f"{value.value}:{global_state['seed']}"
+
+    @hg.graph
+    def child(label: str):
+        publish_output(with_seed(values(label)))
+
+    @hg.sink_node(valid=())
+    def capture(
+        left: hg.TSB[RunGraphOutput[hg.TS[str]]],
+        right: hg.TSB[RunGraphOutput[hg.TS[str]]],
+        engine: hg.EvaluationEngineApi = None,
+    ):
+        if left.out.modified:
+            captured["left"].append(left.out.value)
+        if right.out.modified:
+            captured["right"].append(right.out.value)
+        if (
+            left.finished.valid
+            and left.finished.value
+            and right.finished.valid
+            and right.finished.value
+        ):
+            engine.request_engine_stop()
+
+    @hg.graph
+    def app():
+        hg.register_adaptor("thread-order", run_graph_on_thread_impl)
+
+        def params(label):
+            return hg.const(
+                {
+                    "label": label,
+                    "run_mode": hg.EvaluationMode.SIMULATION,
+                    "start_time": hg.MIN_ST,
+                    "end_time": hg.MIN_ST + 4 * hg.MIN_TD,
+                },
+                tp=hg.TS[dict[str, object]],
+            )
+
+        left = run_graph_on_thread[hg.TS[str]](
+            child,
+            global_state=hg.const(
+                {"seed": 11}, tp=hg.TS[dict[str, object]]),
+            params=params("left"),
+            path="thread-order",
+        )
+        right = run_graph_on_thread[hg.TS[str]](
+            child,
+            global_state=hg.const(
+                {"seed": 22}, tp=hg.TS[dict[str, object]]),
+            params=params("right"),
+            path="thread-order",
+        )
+        capture(left, right)
+
+    with hg.GlobalContext(hg.GlobalState()):
+        hg.run_graph(
+            app,
+            run_mode=hg.EvaluationMode.REAL_TIME,
+            end_time=datetime.now(timezone.utc).replace(tzinfo=None)
+            + timedelta(seconds=5),
+        )
+
+    assert captured == {
+        "left": ["left:0:11", "left:1:11", "left:2:11"],
+        "right": ["right:0:22", "right:1:22", "right:2:22"],
+    }

--- a/python/tests/test_compound_scalar_hierarchy.py
+++ b/python/tests/test_compound_scalar_hierarchy.py
@@ -677,8 +677,24 @@ def test_time_series_schema_can_be_lifted_from_compound_scalar():
     schema = TimeSeriesSchema.from_scalar_schema(Value)
 
     assert schema.scalar_type() is Value
+    assert schema.to_scalar_schema() is Value
     assert schema.__annotations__ == {"number": TS[int], "label": TS[str]}
     assert TSB[schema].handle.is_tsb
+
+
+def test_time_series_schema_to_scalar_schema_preserves_inheritance():
+    class BaseBundle(TimeSeriesSchema):
+        number: TS[int]
+
+    class DerivedBundle(BaseBundle):
+        label: TS[str]
+
+    base_scalar = BaseBundle.to_scalar_schema()
+    derived_scalar = DerivedBundle.to_scalar_schema()
+
+    assert issubclass(derived_scalar, base_scalar)
+    assert derived_scalar.__annotations__ == {"label": str}
+    assert derived_scalar(number=7, label="seven").number == 7
 
 
 def test_recursive_base_reference_inside_container_uses_owned_storage():

--- a/python/tests/test_compound_scalar_hierarchy.py
+++ b/python/tests/test_compound_scalar_hierarchy.py
@@ -1,10 +1,11 @@
 from dataclasses import InitVar, dataclass, field
+from datetime import timedelta
 from enum import Enum
 from typing import Callable, Generic, Optional, TypeVar
 
 import _hgraph
 import pytest
-from hgraph import CompoundScalar, TS, TSB, TSD, TimeSeriesSchema, combine, compute_node, const, default, from_json_builder, graph, mesh_, operator, to_json_builder
+from hgraph import CompoundScalar, TS, TSB, TSD, TSW, TimeSeriesSchema, WindowSize, combine, compute_node, const, default, from_json_builder, graph, mesh_, operator, to_json_builder
 # White-box: these tests assert on the interned C++ value-type metadata
 # (qualified names, generic specialisation identity), which has no public
 # introspection surface — the module under test is imported directly.
@@ -695,6 +696,17 @@ def test_time_series_schema_to_scalar_schema_preserves_inheritance():
     assert issubclass(derived_scalar, base_scalar)
     assert derived_scalar.__annotations__ == {"label": str}
     assert derived_scalar(number=7, label="seven").number == 7
+
+
+def test_time_series_schema_to_scalar_schema_supports_windows():
+    class WindowBundle(TimeSeriesSchema):
+        tick: TSW[int, WindowSize[3]]
+        duration: TSW[str, WindowSize[timedelta(seconds=3)]]
+
+    scalar = WindowBundle.to_scalar_schema()
+
+    assert scalar.__annotations__ == {"tick": int, "duration": str}
+    assert scalar(tick=7, duration="seven").duration == "seven"
 
 
 def test_recursive_base_reference_inside_container_uses_owned_storage():

--- a/tests/cpp/CMakeLists.txt
+++ b/tests/cpp/CMakeLists.txt
@@ -139,6 +139,7 @@ endfunction()
 
 hgraph_add_test_objects(hgraph_runtime_test_objects
     test_check_output.cpp
+    test_concurrent_execution.cpp
     test_lifecycle_observers.cpp
     test_context_node.cpp
     test_endpoint_owner.cpp

--- a/tests/cpp/test_concurrent_execution.cpp
+++ b/tests/cpp/test_concurrent_execution.cpp
@@ -1,0 +1,177 @@
+#include <hgraph/lib/testing/runtime_support.h>
+#include <hgraph/lib/testing/record_replay.h>
+#include <hgraph/runtime/runtime.h>
+#include <hgraph/types/graph_wiring.h>
+#include <hgraph/types/metadata/type_registry.h>
+#include <hgraph/types/value/value.h>
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <chrono>
+#include <condition_variable>
+#include <cstddef>
+#include <cstdint>
+#include <mutex>
+#include <optional>
+#include <span>
+#include <stdexcept>
+#include <string_view>
+#include <typeindex>
+#include <utility>
+#include <vector>
+
+namespace
+{
+    using namespace hgraph;
+
+    struct ConcurrentProgress
+    {
+        std::mutex              mutex{};
+        std::condition_variable changed{};
+        bool                    blocked_graph_entered{false};
+        std::size_t             independent_graph_outputs{0};
+    };
+
+    struct BlockedSourceTag
+    {
+    };
+
+    struct IndependentSourceTag
+    {
+    };
+
+    NodeBuilder blocked_source(const TSValueTypeMetaData &ts_int,
+                               ConcurrentProgress &progress)
+    {
+        NodeTypeMetaData schema;
+        schema.display_name      = "blocked_concurrent_source";
+        schema.output_schema     = &ts_int;
+        schema.node_kind         = NodeKind::PullSource;
+        schema.schedule_on_start = true;
+
+        NodeCallbacks callbacks;
+        callbacks.evaluate = [&progress](const NodeView &view,
+                                         DateTime evaluation_time) {
+            {
+                std::unique_lock lock{progress.mutex};
+                progress.blocked_graph_entered = true;
+                progress.changed.notify_all();
+                if (!progress.changed.wait_for(
+                        lock,
+                        std::chrono::seconds{5},
+                        [&] { return progress.independent_graph_outputs == 3; }))
+                {
+                    throw std::runtime_error(
+                        "the independent graph did not progress while its peer was blocked");
+                }
+            }
+            view.graph().global_state().set("progress", Value{Int{1}});
+            testing::set_output_value(view, evaluation_time, Int{101});
+        };
+        return NodeBuilder::native(std::move(schema), std::move(callbacks));
+    }
+
+    NodeBuilder independent_source(const TSValueTypeMetaData &ts_int,
+                                   ConcurrentProgress &progress,
+                                   std::int32_t &emitted)
+    {
+        NodeTypeMetaData schema;
+        schema.display_name      = "independent_concurrent_source";
+        schema.output_schema     = &ts_int;
+        schema.node_kind         = NodeKind::PullSource;
+        schema.schedule_on_start = true;
+
+        NodeCallbacks callbacks;
+        callbacks.evaluate = [&progress, &emitted](const NodeView &view,
+                                                   DateTime evaluation_time) {
+            ++emitted;
+            view.graph().global_state().set("progress", Value{Int{emitted}});
+            testing::set_output_value(view, evaluation_time, Int{200 + emitted});
+            {
+                std::lock_guard lock{progress.mutex};
+                progress.independent_graph_outputs =
+                    static_cast<std::size_t>(emitted);
+            }
+            progress.changed.notify_all();
+            if (emitted < 3)
+            {
+                view.graph_value()->schedule_node(
+                    view.node_index(), evaluation_time + MIN_TD);
+            }
+        };
+        return NodeBuilder::native(std::move(schema), std::move(callbacks));
+    }
+
+    template <typename Tag>
+    void wire_recorded_source(Wiring &wiring, NodeBuilder source,
+                              std::string_view key)
+    {
+        WiringPortRef source_ref = wiring.add_unique_node(
+            std::type_index(typeid(Tag)), std::move(source),
+            std::span<const WiringPortRef>{}, Value{});
+        wire<stdlib::dense_record_impl>(
+            wiring, Port<TS<Int>>{wiring, std::move(source_ref)}, Str{key});
+    }
+
+    GraphExecutorValue make_simulation_executor(Wiring wiring)
+    {
+        GraphExecutorBuilder builder;
+        builder.graph_builder(std::move(wiring).finish())
+            .mode(GraphExecutorMode::Simulation)
+            .start_time(MIN_ST)
+            .end_time(MIN_ST + TimeDelta{10});
+        return builder.make_executor();
+    }
+}  // namespace
+
+TEST_CASE("distinct native graph engines progress independently on different threads",
+          "[runtime][concurrency]")
+{
+    using namespace hgraph;
+
+    auto       &registry     = TypeRegistry::instance();
+    const auto *int_meta     = registry.register_scalar<Int>("int");
+    const auto *ts_int       = registry.ts(int_meta);
+
+    ConcurrentProgress progress;
+    std::int32_t       independent_emitted{0};
+
+    Wiring blocked_graph;
+    wire_recorded_source<BlockedSourceTag>(
+        blocked_graph, blocked_source(*ts_int, progress), "blocked");
+
+    Wiring independent_graph;
+    wire_recorded_source<IndependentSourceTag>(
+        independent_graph,
+        independent_source(*ts_int, progress, independent_emitted),
+        "independent");
+
+    GraphExecutorValue blocked_executor =
+        make_simulation_executor(std::move(blocked_graph));
+    GraphExecutorValue independent_executor =
+        make_simulation_executor(std::move(independent_graph));
+    auto blocked_view     = blocked_executor.view();
+    auto independent_view = independent_executor.view();
+
+    testing::AsyncGraphExecutorRun blocked_run{blocked_view};
+    {
+        std::unique_lock lock{progress.mutex};
+        REQUIRE(progress.changed.wait_for(
+            lock,
+            std::chrono::seconds{5},
+            [&] { return progress.blocked_graph_entered; }));
+    }
+
+    testing::AsyncGraphExecutorRun independent_run{independent_view};
+    independent_run.join();
+    blocked_run.join();
+
+    CHECK(testing::get_recorded_values<Int>(
+              blocked_view.graph().global_state(), "blocked") ==
+          std::vector<std::optional<Int>>{Int{101}});
+    CHECK(testing::get_recorded_values<Int>(
+              independent_view.graph().global_state(), "independent") ==
+          std::vector<std::optional<Int>>{Int{201}, Int{202}, Int{203}});
+    CHECK(blocked_view.graph().global_state().get_as<Int>("progress") == Int{1});
+    CHECK(independent_view.graph().global_state().get_as<Int>("progress") == Int{3});
+}


### PR DESCRIPTION
Closes #218

## Summary

- define and document the public C++ concurrency contract for distinct `GraphExecutorValue` instances
- add a coordinated native test that blocks one engine while another completes three evaluation cycles, including isolated `GlobalState`
- serialize Python graph authoring and service materialization only through executor construction, then release that lock before native execution
- restore the supported `run_graph_on_thread` call forms, configuration forwarding, schema operations, parameter lifting, per-client ordering, copied state, and failure status
- document that independent threaded engines do not guarantee aligned wall-clock time, evaluation ticks, or cross-client arrival order

## Root cause

Python's authoring layer uses a process-global `_wiring_stack`. Two child threads could wire graphs simultaneously, causing one graph to be treated as nested inside the other's `Wiring`; once one thread finished and popped that object, the peer could fail with `WiringError: this Wiring has already been finished/run`.

The authoring/build phase is now protected by a re-entrant wiring lock. A private bridge callback releases it immediately after `make_executor()`, before the runtime marker and GIL-released native `run()`, so distinct C++ engines continue concurrently.

## User impact

Existing Python hgraph code can use bracket specialization, `out_=`, positional `path`, plain or wired `global_state` / `params`, and the established child configuration keys. Start/end time or date values configure the child executor and remain available to child graphs that declare them as scalar parameters. `RunGraphOutput` supports the expected scalar-schema round trips and inheritance behavior. `TSW` fields derive their element scalar type for both tick- and duration-based windows.

Output order is preserved within each client. Cross-engine timing, tick alignment, and client arrival order remain intentionally undefined.

## Validation

- parity recipes: 56/56 valid
- focused schema/adaptor tests: 45 passed
- focused Python concurrency suite: 30 repeated passes
- native concurrency test: 50 repeated passes
- macOS fresh native acceptance: 1,409/1,409 passed
- macOS stable-ABI wheel built with Python 3.12 and tested under fresh Python 3.14: 1,852 passed, 11 skipped
- `hg-linux` fresh native acceptance: 1,409/1,409 passed
- `hg-linux` stable-ABI wheel built with Python 3.12 and tested under fresh Python 3.14 with `polars[rtcompat]`: 1,852 passed, 11 skipped
- `hg-linux` ThreadSanitizer: coordinated concurrency test passed 20/20 runs with no report
