### PR TITLE
Reduce keyed graph churn allocations

### DIFF
--- a/src/hgraph/runtime/graph.cpp
+++ b/src/hgraph/runtime/graph.cpp
@@ -18,6 +18,7 @@
 #include <deque>
 #include <limits>
 #include <memory>
+#include <optional>
 #include <stdexcept>
 #include <type_traits>
 #include <unordered_map>
@@ -169,7 +170,11 @@ struct GraphRuntimeBaseStorage {
   bool evaluation_failed{false};
   /** Graph traits (parent-chained key-value metadata; GraphView::trait_or).
       The same value-layer ``Map<string, Any>`` store as GlobalState. */
-  GlobalState traits{};
+  // Most graphs have no local traits. Keep that case allocation-free: a
+  // GlobalState owns a mutable map, so default-constructing one for every
+  // short-lived nested graph would allocate even though trait lookup simply
+  // bubbles to the parent.
+  std::optional<GlobalState> traits{};
   /** The executor-owned lifecycle observer list, cached once at construction
       (root: from the root executor; nested: one hop to the parent graph's own
       cached pointer) so the hot path never walks the nested-parent chain. */
@@ -602,7 +607,7 @@ template <typename Storage>
 ValueView graph_trait_impl(const void *context, void *memory,
                            std::string_view name) noexcept {
   auto &traits = graph_header<Storage>(graph_context(context), memory).traits;
-  return traits.view().get(name);
+  return traits.has_value() ? traits->view().get(name) : ValueView{};
 }
 
 GlobalStateView root_global_state_impl(const void *context, void *memory) {
@@ -1658,7 +1663,9 @@ GraphValue::GraphValue(const GraphBuilder &builder, ExecutorPtr root_executor) {
                 "Root graph construction requires a live executor parent");
           }
           state.global_state = builder.global_state_;
-          state.traits = builder.traits_;
+          if (builder.traits_.as_value().view().as_map().size() != 0) {
+            state.traits.emplace(builder.traits_);
+          }
           state.root_executor_ptr = root_executor;
           state.lifecycle_observers =
               &GraphExecutorView{root_executor}.lifecycle_observers();
@@ -1681,7 +1688,9 @@ GraphValue::GraphValue(const GraphBuilder &builder, NodePtr parent_node) {
   storage_ = storage_type::owning_constructed(*type.record(), [&](void *dst) {
     construct_graph_storage<NestedGraphRuntimeStorage>(
         type, builder, dst, [&](NestedGraphRuntimeStorage &state) {
-          state.traits = builder.traits_;
+          if (builder.traits_.as_value().view().as_map().size() != 0) {
+            state.traits.emplace(builder.traits_);
+          }
           if (!parent_node.has_value()) {
             throw std::invalid_argument(
                 "Nested graph construction requires a live node parent");
@@ -1724,7 +1733,9 @@ GraphValue::GraphValue(const GraphBuilder &builder, NodePtr parent_node,
 
   construct_graph_storage<NestedGraphRuntimeStorage>(
       type, builder, external_memory, [&](NestedGraphRuntimeStorage &state) {
-        state.traits = builder.traits_;
+        if (builder.traits_.as_value().view().as_map().size() != 0) {
+          state.traits.emplace(builder.traits_);
+        }
         if (!parent_node.has_value()) {
           throw std::invalid_argument(
               "Nested graph construction requires a live node parent");

--- a/src/hgraph/runtime/node.cpp
+++ b/src/hgraph/runtime/node.cpp
@@ -291,13 +291,56 @@ namespace hgraph
             return binding;
         }
 
-        void destroy_constructed_components(
-            const std::vector<const MemoryUtils::CompositeComponent *> &constructed,
-            void *memory) noexcept
+        constexpr std::size_t inline_constructed_component_capacity = 16;
+
+        struct ConstructedComponents
         {
-            for (std::size_t index = constructed.size(); index > 0; --index)
+            explicit ConstructedComponents(std::size_t component_count)
             {
-                const auto &component = *constructed[index - 1];
+                if (component_count > inline_constructed_component_capacity)
+                {
+                    overflow.reserve(component_count - inline_constructed_component_capacity);
+                }
+            }
+
+            void push_back(const MemoryUtils::CompositeComponent *component)
+            {
+                if (inline_count < inline_components.size())
+                {
+                    inline_components[inline_count++] = component;
+                }
+                else
+                {
+                    overflow.push_back(component);
+                }
+            }
+
+            [[nodiscard]] bool contains(const MemoryUtils::CompositeComponent *component) const noexcept
+            {
+                if (std::find(inline_components.begin(), inline_components.begin() + inline_count, component) !=
+                    inline_components.begin() + inline_count)
+                {
+                    return true;
+                }
+                return std::find(overflow.begin(), overflow.end(), component) != overflow.end();
+            }
+
+            std::array<const MemoryUtils::CompositeComponent *, inline_constructed_component_capacity>
+                inline_components{};
+            std::size_t inline_count{0};
+            std::vector<const MemoryUtils::CompositeComponent *> overflow{};
+        };
+
+        void destroy_constructed_components(const ConstructedComponents &constructed, void *memory) noexcept
+        {
+            for (std::size_t index = constructed.overflow.size(); index > 0; --index)
+            {
+                const auto &component = *constructed.overflow[index - 1];
+                component.plan->destroy(MemoryUtils::advance(memory, component.offset));
+            }
+            for (std::size_t index = constructed.inline_count; index > 0; --index)
+            {
+                const auto &component = *constructed.inline_components[index - 1];
                 component.plan->destroy(MemoryUtils::advance(memory, component.offset));
             }
         }
@@ -314,8 +357,7 @@ namespace hgraph
             if (context.plan == nullptr) { throw std::logic_error("Node runtime context has no storage plan"); }
             const MemoryUtils::StoragePlan &plan = *context.plan;
 
-            std::vector<const MemoryUtils::CompositeComponent *> constructed;
-            constructed.reserve(9);
+            ConstructedComponents constructed{plan.components().size()};
             auto rollback = make_scope_exit([&]() noexcept {
                 destroy_constructed_components(constructed, memory);
             });
@@ -435,8 +477,7 @@ namespace hgraph
 
             for (const MemoryUtils::CompositeComponent &component : plan.components())
             {
-                const auto constructed_it = std::find(constructed.begin(), constructed.end(), &component);
-                if (constructed_it != constructed.end()) { continue; }
+                if (constructed.contains(&component)) { continue; }
                 if (component.plan == nullptr)
                 {
                     throw std::logic_error("Node storage plan component is missing a child plan");


### PR DESCRIPTION
## Summary

- avoid allocating an empty graph-traits `GlobalState` for each short-lived nested graph
- keep normal node-construction rollback tracking in inline storage, with a heap fallback for unusually large custom layouts
- preserve construction order, reverse rollback destruction, and the existing slot-store lifecycle protocol

## Why

Keyed map churn reconstructs nested graph and node state in retained slot storage. Two construction-only containers still allocated for every child: an empty graph trait map and the node component rollback vector. Neither allocation carried state across child lifetimes.

This change removes those common-path allocations without caching stopped graphs or introducing retired-object side storage.

## Performance

macOS arm64 `native_churn_tsd` benchmark, five child replacements per cycle:

| Metric | Before | After | Change |
| --- | ---: | ---: | ---: |
| Map allocations/cycle | 330 | 240 | -27.3% |
| Map allocated bytes/cycle | 28,120 | 20,200 | -28.2% |
| Map time | 26,964 ns | 23,561 ns | -12.6% |
| Map + reduce time | 29,798 ns | 26,865 ns | -9.8% |

Independent source and reduce controls remain allocation-free.

Physical `hg-linux` measured 260 allocations and 21,425 bytes per map cycle; source and reduce controls remained allocation-free.

## Validation

- macOS Release C++: 1,408/1,408 passed
- macOS ASan C++: 1,408/1,408 passed
- macOS stable-ABI wheel under Python 3.14: 1,845 passed, 11 skipped
- physical `hg-linux` Release C++: 1,408/1,408 passed
- physical `hg-linux` stable-ABI wheel under Python 3.14: 1,845 passed, 11 skipped
- post-rebase focused map tests: 50 cases / 64 assertions passed
- post-rebase graph-trait tests: 3 cases / 12 assertions passed

Relates to #213.
