### PR TITLE
RFC 0011: unify the service and adaptor surfaces

### DIFF
--- a/docs/source/developer_guide/services.rst
+++ b/docs/source/developer_guide/services.rst
@@ -363,6 +363,45 @@ child is still rejected, because a graph with a push prefix never gets a nested
 graph type interned (``GraphBuilder::nested_type()``). See :doc:`nested_graphs`.
 
 
+The service and adaptor surfaces are one boundary model
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Services and adaptors are not parallel implementations of the same idea; they
+are two spellings over one. Per :doc:`../rfc/rfc_0011_source_only_adaptor_collapse`:
+
+* **One relay.** ``boundary_detail::shared_output_relay_source`` and
+  ``shared_output_relay_capture`` (``types/graph_wiring.h``) are the single
+  implementation of the source/capture pair. ``service::detail::
+  reference_shared_output_source`` and ``adaptor::detail::output_source`` were
+  the same function under two names; both now forward.
+* **One path type.** ``service::ServicePath`` and ``adaptor::AdaptorPath`` are
+  aliases of ``hgraph::BoundaryPath``.
+* **``from_graph`` / ``to_graph`` work for services**, as the adaptor spelling
+  of ``impl_input`` / ``impl_output``. A reference service has no client input
+  and therefore no ``from_graph``.
+* **Clients of either family may pass wiring-time scalar options**, with the
+  same cross-client agreement check, and **either may take time-series inputs
+  supplied at registration**.
+* **``register_services`` is lazy** and, with one interface, is the by-stub
+  single-interface registration. Its interface pack **may mix services and
+  adaptors**, so "a sink-only interface in, a source-only interface out" is one
+  atomic registration.
+* **A catch-all implementation** (``interfaces=()``) is available from
+  ``@service_impl`` as well as ``@adaptor_impl``.
+
+The two concepts are **disjoint**: a source-only adaptor once satisfied both
+``adaptor_interface`` and ``reference_service_interface``, making
+``wire<Interface>`` ambiguous in any translation unit including both headers.
+``reference_service_interface`` now excludes ``adaptor::interface``-derived
+types, detected through a structural tag so ``service_wiring.h`` stays
+independent of ``adaptor_wiring.h``.
+
+Which spelling to choose is a question of intent, not capability: an **adaptor**
+says "this boundary talks to the outside world", a **service** says "this value
+is provided to whoever asks". A source-only adaptor and a reference service
+describe the same wiring; prefer the reference service unless the external-world
+framing is the point.
+
 Adaptors
 --------
 

--- a/docs/source/rfc/rfc_0011_source_only_adaptor_collapse.rst
+++ b/docs/source/rfc/rfc_0011_source_only_adaptor_collapse.rst
@@ -1,7 +1,7 @@
 RFC 0011: Source-Only Adaptors Are Reference Services
 =====================================================
 
-:Status: Proposed
+:Status: Accepted
 :Author: Howard Henson
 :Created: 2026-08-02
 :Target: Public C++ and Python service/adaptor wiring surface
@@ -1129,8 +1129,50 @@ suggested, and most of it is generalising code that already exists.
 Implementation status
 ---------------------
 
-Not started. This RFC is the first commit on its branch, per
-:doc:`rfc_0000` workflow step 1; the plan above is the proposed sequencing.
+**Implemented.** All nine steps landed on
+``agent/rfc-0011-unify-service-adaptor-surface``, one commit per step, each
+green against the full native and Python suites. Final state: 1414 ctest, 1864
+Python tests.
+
+Implementation changed four things in this design, all recorded in the commits:
+
+* **Steps 7 and 8 swapped.** Dedup was planned last as cosmetic cleanup; it is
+  a *prerequisite*. ``service_wiring.h`` and ``adaptor_wiring.h`` do not include
+  each other, so a mixed-flavour group is not expressible until the two path
+  types are one - ``ServicePath`` and ``AdaptorPath`` are now aliases of a
+  shared ``BoundaryPath``.
+* **Mixed groups needed a customization point, not a relaxed assert.** Because
+  neither family header sees the other, ``register_services`` describes each
+  member through ``boundary_detail::group_member``, specialized per family - the
+  same idiom as ``wire_customization``.
+* **The concepts are separated structurally, not by inclusion.**
+  ``reference_service_interface`` excludes adaptor-derived types via a tag
+  member on ``adaptor::interface``, so ``service_wiring.h`` needs no dependency
+  on ``adaptor_wiring.h``.
+* **The source-only spelling was kept, and costs nothing.** With
+  ``boundary_detail::shared_output_relay_source`` / ``_capture`` as the single
+  relay implementation, the spelling is no longer a second implementation, so
+  deleting it buys nothing and would break unknown downstream users. Deletion
+  can follow once exposure is known, with no further RFC.
+
+Two smaller findings worth keeping:
+
+* Client scalar options had **no C++ component at all** and the
+  implementation-consumption half already worked for services; only client
+  recording was missing.
+* Step 5's generic output-schema hole was confirmed by a test that did **not**
+  throw before the fix - after two false starts where the test failed for an
+  unrelated resolution error instead.
+
+One behaviour change beyond the plan: a surplus time-series parameter on a
+service implementation used to be a decoration-time ``TypeError``. It is now
+registration configuration, so the failure moves to registration and names the
+missing parameter.
+
+An accepted-but-unexercised consequence: the pre-existing adaptor semantic
+where a client's *defaulted* scalar option is recorded as though passed, so a
+registration option conflicts with a client that merely defaulted. Left
+unchanged rather than altered as a side effect of lifting it to services.
 
 References
 ----------

--- a/include/hgraph/types/adaptor_wiring.h
+++ b/include/hgraph/types/adaptor_wiring.h
@@ -21,6 +21,10 @@ namespace hgraph::adaptor
 {
     struct interface
     {
+        /** Structural tag letting ``service_wiring.h`` recognise an adaptor
+         *  interface without including this header, so the service and adaptor
+         *  concepts are provably disjoint (RFC 0011 step 9). */
+        using __adaptor_interface_tag__ = void;
     };
 
     /** Alias of the shared ``hgraph::BoundaryPath`` (RFC 0011 step 8): the
@@ -344,24 +348,14 @@ namespace hgraph::adaptor
         [[nodiscard]] Port<REF<output_schema_t<Interface>>> output_source(Wiring &w, const AdaptorPath &user_path)
         {
             using output_schema = output_schema_t<Interface>;
-
-            std::string full_path = adaptor_to_graph_path<Interface>(user_path);
-            const auto *target_meta = resolved_schema_meta<output_schema>(
-                user_path.resolution, "adaptor output");
-            const auto *ref_meta = TypeRegistry::instance().ref(target_meta);
-
-            WiringNodeSchema schema;
-            schema.output = ref_meta;
-            schema.state = ref_meta->value_schema;
-            Value path_key = path_key_value(full_path);
-
-            WiringPortRef port = w.add_node(
-                std::type_index(typeid(output_source_marker)), schema,
-                std::span<const WiringPortRef>{}, std::move(path_key),
-                [path = std::move(full_path), target_meta]() {
-                    return make_shared_output_source_node(path, *target_meta);
-                });
-            return Port<REF<output_schema>>{w, std::move(port)};
+            // Shared with service::detail::reference_shared_output_source
+            // (RFC 0011 step 9) - one relay implementation, two spellings.
+            return Port<REF<output_schema>>{
+                w,
+                boundary_detail::shared_output_relay_source(
+                    w, std::type_index(typeid(output_source_marker)),
+                    resolved_schema_meta<output_schema>(user_path.resolution, "adaptor output"),
+                    adaptor_to_graph_path<Interface>(user_path))};
         }
 
         template <typename Interface, typename OutputSchema>
@@ -371,29 +365,15 @@ namespace hgraph::adaptor
                                              const AdaptorPath &user_path)
         {
             using output_schema = output_schema_t<Interface>;
-
-            std::array<WiringPortRef, 2> sources{output.erased(), shared_output.erased()};
-            std::array<WiringInputRef, 2> inputs{{
-                WiringInputRef{.source = sources[0]},
-                WiringInputRef{.source = sources[1], .rank_dependency = false},
-            }};
             const auto *output_meta = output.erased().schema;
             if (output_meta == nullptr)
             {
                 output_meta = resolved_schema_meta<output_schema>(user_path.resolution, "adaptor output");
             }
-            NodeBuilder builder = make_shared_output_capture_node(
-                adaptor_to_graph_path<Interface>(user_path), *output_meta);
-            builder.input_endpoint(graph_wiring_detail::input_endpoint_for_sources(
-                builder.type().schema()->input_schema,
-                std::span<const WiringPortRef>{sources.data(), sources.size()}));
-
-            WiringPortRef capture = w.add_node(std::type_index(typeid(output_capture_marker)),
-                                               std::move(builder),
-                                               std::span<const WiringInputRef>{inputs.data(), inputs.size()},
-                                               Value{});
-            w.add_same_cycle_pair(capture.peered_node(), shared_output.node());
-            return capture.peered_node();
+            // Shared with service::detail::capture_reference_service_output.
+            return boundary_detail::shared_output_relay_capture(
+                w, std::type_index(typeid(output_capture_marker)), output_meta,
+                adaptor_to_graph_path<Interface>(user_path), output.erased(), shared_output.erased());
         }
 
         template <typename Impl, typename... Args>

--- a/include/hgraph/types/adaptor_wiring.h
+++ b/include/hgraph/types/adaptor_wiring.h
@@ -23,12 +23,10 @@ namespace hgraph::adaptor
     {
     };
 
-    struct AdaptorPath
-    {
-        std::string   value{};
-        ResolutionMap resolution{};
-        bool          has_typed_suffix{false};
-    };
+    /** Alias of the shared ``hgraph::BoundaryPath`` (RFC 0011 step 8): the
+     *  two path types were field-identical, and a single implementation can
+     *  only span services and adaptors if they are one type. */
+    using AdaptorPath = BoundaryPath;
 
     [[nodiscard]] inline AdaptorPath path(std::string_view value)
     {
@@ -264,7 +262,8 @@ namespace hgraph::adaptor
 
         [[nodiscard]] inline Value path_key_value(const std::string &full_path)
         {
-            return Value{Str{full_path}};
+            // Shared implementation (RFC 0011 step 8).
+            return wiring_path_detail::boundary_path_key(full_path);
         }
 
         // Per-ROLE identity markers (the services runtime-identity ruling,

--- a/include/hgraph/types/adaptor_wiring.h
+++ b/include/hgraph/types/adaptor_wiring.h
@@ -688,6 +688,27 @@ namespace hgraph::adaptor
     }
 }  // namespace hgraph::adaptor
 
+namespace hgraph::boundary_detail
+{
+    /** Adaptor interfaces in a multi-interface group (RFC 0011 step 7). */
+    template <typename Interface>
+    struct group_member<Interface, std::enable_if_t<adaptor::detail::adaptor_interface<Interface>>>
+    {
+        [[nodiscard]] static std::string base_path(const BoundaryPath &user_path)
+        {
+            return adaptor::detail::adaptor_base_path<Interface>(user_path);
+        }
+
+        [[nodiscard]] static std::string_view kind() { return "adaptor"; }
+
+        static void append_required_endpoints(
+            std::vector<WiringServiceImplementationEndpoint> &endpoints, const BoundaryPath &user_path)
+        {
+            adaptor::detail::append_required_stub_endpoints<Interface>(endpoints, user_path);
+        }
+    };
+}   // namespace hgraph::boundary_detail
+
 namespace hgraph::graph_wiring_detail
 {
     template <typename Interface, typename OutSchema, typename... Args>

--- a/include/hgraph/types/graph_wiring.h
+++ b/include/hgraph/types/graph_wiring.h
@@ -7,6 +7,7 @@
 #include <hgraph/types/metadata/type_realization.h>     // graph-scoped closed-union value bindings
 #include <hgraph/types/metadata/value_plan_factory.h>   // ValuePlanFactory (scalar bundle binding)
 #include <hgraph/types/static_node.h>                   // StaticNodeSignature, In/Out/State/Scalar markers
+#include <hgraph/runtime/shared_output_node.h>
 #include <hgraph/types/static_schema.h>                 // schema_descriptor
 #include <hgraph/types/time_series/endpoint_schema.h>   // time_series_schema_equivalent
 #include <hgraph/types/type_resolution.h>               // ResolutionMap, ts_resolver, unifiers, ts_type
@@ -504,6 +505,7 @@ namespace hgraph
     {
         template <typename Interface, typename = void>
         struct group_member;   // primary intentionally undefined
+
     }
 
 
@@ -3421,6 +3423,65 @@ namespace hgraph
     {
         return build_graph_with_observers<G>(
             std::span<WiringObserver *const>{}, std::forward<Args>(args)...);
+    }
+
+    namespace boundary_detail
+    {
+        /**
+         * The shared-output relay both boundary families are built from
+         * (RFC 0011 step 9).
+         *
+         * ``service::detail::reference_shared_output_source`` and
+         * ``adaptor::detail::output_source`` were the same function under two
+         * names, as were their capture halves - identical wiring schema,
+         * identical ``rank_dependency = false`` on the capture's second input,
+         * identical ``add_same_cycle_pair`` contract - differing only in a path
+         * string, a marker typeid and an error message. Both now call these,
+         * so there is ONE implementation behind the two spellings.
+         *
+         * The erased runtime already shared its equivalents; this closes the
+         * same gap on the template surface.
+         */
+        [[nodiscard]] inline WiringPortRef shared_output_relay_source(
+            Wiring &w, std::type_index marker, const TSValueTypeMetaData *target_meta,
+            std::string full_path)
+        {
+            const auto *ref_meta = TypeRegistry::instance().ref(target_meta);
+            WiringNodeSchema schema;
+            schema.output = ref_meta;
+            schema.state  = ref_meta->value_schema;
+            Value path_key{Str{full_path}};
+            return w.add_node(
+                marker, schema, std::span<const WiringPortRef>{}, std::move(path_key),
+                [path = std::move(full_path), target_meta]() {
+                    return make_shared_output_source_node(path, *target_meta);
+                });
+        }
+
+        [[nodiscard]] inline const WiringInstance *shared_output_relay_capture(
+            Wiring &w, std::type_index marker, const TSValueTypeMetaData *output_meta,
+            const std::string &full_path, WiringPortRef output, WiringPortRef shared_output)
+        {
+            std::array<WiringPortRef, 2> sources{output, shared_output};
+            std::array<WiringInputRef, 2> inputs{{
+                WiringInputRef{.source = sources[0]},
+                // Sanctioned backward link: the capture reads the source it
+                // feeds, purely to locate it. Not a rank dependency.
+                WiringInputRef{.source = sources[1], .rank_dependency = false},
+            }};
+            NodeBuilder builder = make_shared_output_capture_node(full_path, *output_meta);
+            builder.input_endpoint(graph_wiring_detail::input_endpoint_for_sources(
+                builder.type().schema()->input_schema,
+                std::span<const WiringPortRef>{sources.data(), sources.size()}));
+            WiringPortRef capture = w.add_node(
+                marker, std::move(builder),
+                std::span<const WiringInputRef>{inputs.data(), inputs.size()}, Value{});
+            // Shared-output relays are RANK-CORRECT and same-cycle: the rank
+            // dependency places the paired source after this capture, so the
+            // capture schedules the source for the CURRENT evaluation time.
+            w.add_same_cycle_pair(capture.peered_node(), shared_output.peered_node());
+            return capture.peered_node();
+        }
     }
 
 }  // namespace hgraph

--- a/include/hgraph/types/graph_wiring.h
+++ b/include/hgraph/types/graph_wiring.h
@@ -476,6 +476,23 @@ namespace hgraph
             bool          has_typed_suffix{false};
         };
 
+    }   // reopened below; see BoundaryPath
+
+    /**
+     * The wiring path of a service or adaptor boundary: a path string, the
+     * resolution its scalar qualifiers imply, and whether it carries a typed
+     * suffix.
+     *
+     * ``service::ServicePath`` and ``adaptor::AdaptorPath`` were separate but
+     * field-identical structs; they are now aliases of this one type
+     * (RFC 0011 step 8), which is what lets a single implementation span both
+     * families.
+     */
+    using BoundaryPath = wiring_path_detail::TypedPathValue;
+
+    namespace wiring_path_detail
+    {
+
         inline void append_escaped_path_component(std::string &out, std::string_view value)
         {
             constexpr char hex[] = "0123456789ABCDEF";
@@ -707,6 +724,22 @@ namespace hgraph
             path.resolution = std::move(merged);
             return path;
         }
+
+        /**
+         * Helpers shared by the service and adaptor boundary families
+         * (RFC 0011 step 8). These were byte-for-byte copies in both
+         * ``service_wiring.h`` and ``adaptor_wiring.h``, differing only in an
+         * error string; the family name is now a parameter.
+         */
+
+        /** Wiring intern key for a boundary path. Boundary source nodes do not
+         *  carry a path scalar at runtime - this exists only so two nodes at
+         *  the same path dedup. */
+        [[nodiscard]] inline Value boundary_path_key(const std::string &full_path)
+        {
+            return Value{Str{full_path}};
+        }
+
     }  // namespace wiring_path_detail
 
     /**

--- a/include/hgraph/types/graph_wiring.h
+++ b/include/hgraph/types/graph_wiring.h
@@ -490,6 +490,23 @@ namespace hgraph
      */
     using BoundaryPath = wiring_path_detail::TypedPathValue;
 
+    /**
+     * How one interface participates in a MULTI-interface registration group.
+     *
+     * Specialized for service interfaces in ``service_wiring.h`` and for
+     * adaptor interfaces in ``adaptor_wiring.h``. Those two headers do not
+     * include each other, so the customization point lives here: with both
+     * visible, one implementation may span an adaptor and a service in a
+     * single atomic registration (RFC 0011 step 7). This is the same extension
+     * idiom as ``wire_customization``.
+     */
+    namespace boundary_detail
+    {
+        template <typename Interface, typename = void>
+        struct group_member;   // primary intentionally undefined
+    }
+
+
     namespace wiring_path_detail
     {
 

--- a/include/hgraph/types/service_runtime.h
+++ b/include/hgraph/types/service_runtime.h
@@ -86,18 +86,21 @@ namespace hgraph
                                                                        std::string_view path);
     HGRAPH_EXPORT void register_reference_service_impl(Wiring &w, const RuntimeServiceDescriptor &descriptor,
                                                        std::string_view path, const WiredFn &impl,
+                                                       std::span<const WiringPortRef> implementation_inputs = {},
                                                        bool default_fallback = false);
 
     [[nodiscard]] HGRAPH_EXPORT WiringPortRef subscription_service_subscribe(
         Wiring &w, const RuntimeServiceDescriptor &descriptor, std::string_view path, const WiringPortRef &key);
     HGRAPH_EXPORT void register_subscription_service_impl(Wiring &w, const RuntimeServiceDescriptor &descriptor,
                                                           std::string_view path, const WiredFn &impl,
+                                                          std::span<const WiringPortRef> implementation_inputs = {},
                                                           bool default_fallback = false);
 
     [[nodiscard]] HGRAPH_EXPORT WiringPortRef request_reply_service_call(
         Wiring &w, const RuntimeServiceDescriptor &descriptor, std::string_view path, const WiringPortRef &request);
     HGRAPH_EXPORT void register_request_reply_service_impl(Wiring &w, const RuntimeServiceDescriptor &descriptor,
                                                            std::string_view path, const WiredFn &impl,
+                                                           std::span<const WiringPortRef> implementation_inputs = {},
                                                            bool default_fallback = false);
 
     /**

--- a/include/hgraph/types/service_wiring.h
+++ b/include/hgraph/types/service_wiring.h
@@ -166,9 +166,22 @@ namespace hgraph::service
         {
         };
 
+        /** An interface deriving from ``adaptor::interface``, WITHOUT needing
+         *  ``adaptor_wiring.h`` to be included.
+         *
+         *  A source-only adaptor (output, no input) satisfies every other
+         *  clause of ``reference_service_interface``, so without this the two
+         *  concepts overlap and ``wire<Interface>`` is an ambiguous partial
+         *  specialization in any translation unit including both headers
+         *  (RFC 0011 step 9). Detected structurally via the tag member the
+         *  adaptor base declares, so this header stays independent. */
+        template <typename Interface>
+        concept declares_adaptor_interface = requires { typename Interface::__adaptor_interface_tag__; };
+
         template <typename Service>
         concept reference_service_interface =
             has_reference_output_schema<Service>::value &&
+            !declares_adaptor_interface<Service> &&
             !has_adaptor_input_schema<Service>::value &&
             !has_key_value_schema<Service>::value &&
             !has_request_reply_schema<Service>::value;
@@ -706,24 +719,14 @@ namespace hgraph::service
             const ServicePath &user_path)
         {
             using output_schema = reference_output_schema_t<Service>;
-
-            std::string full_path = reference_output_path<Service>(user_path);
-            const auto *target_meta = resolved_schema_meta<output_schema>(
-                user_path.resolution, "reference service output");
-            const auto *ref_meta = TypeRegistry::instance().ref(target_meta);
-
-            WiringNodeSchema schema;
-            schema.output = ref_meta;
-            schema.state  = ref_meta->value_schema;
-            Value path_key = path_key_value(full_path);
-
-            WiringPortRef port = w.add_node(
-                std::type_index(typeid(reference_output_source_marker)), schema,
-                std::span<const WiringPortRef>{}, std::move(path_key),
-                [path = std::move(full_path), target_meta]() {
-                    return make_shared_output_source_node(path, *target_meta);
-                });
-            return Port<REF<output_schema>>{w, std::move(port)};
+            // Shared with adaptor::detail::output_source (RFC 0011 step 9).
+            return Port<REF<output_schema>>{
+                w,
+                boundary_detail::shared_output_relay_source(
+                    w, std::type_index(typeid(reference_output_source_marker)),
+                    resolved_schema_meta<output_schema>(
+                        user_path.resolution, "reference service output"),
+                    reference_output_path<Service>(user_path))};
         }
 
         template <typename Service>
@@ -907,38 +910,16 @@ namespace hgraph::service
                                                                const ServicePath &user_path)
         {
             using output_schema = reference_output_schema_t<Service>;
-
-            std::array<WiringPortRef, 2> sources{output.erased(), shared_output.erased()};
-            std::array<WiringInputRef, 2> inputs{{
-                WiringInputRef{.source = sources[0]},
-                WiringInputRef{.source = sources[1], .rank_dependency = false},
-            }};
             const auto *output_meta = output.erased().schema;
             if (output_meta == nullptr)
             {
                 output_meta = resolved_schema_meta<output_schema>(
                     user_path.resolution, "reference service output");
             }
-            NodeBuilder builder = make_shared_output_capture_node(
-                reference_output_path<Service>(user_path), *output_meta);
-            builder.input_endpoint(graph_wiring_detail::input_endpoint_for_sources(
-                builder.type().schema()->input_schema,
-                std::span<const WiringPortRef>{sources.data(), sources.size()}));
-
-            WiringPortRef capture = w.add_node(std::type_index(typeid(reference_output_capture_marker)),
-                                               std::move(builder),
-                                               std::span<const WiringInputRef>{inputs.data(), inputs.size()},
-                                               Value{});
-            // Shared-output relays are RANK-CORRECT and same-cycle: the rank
-            // dependency places the paired source after this capture (and
-            // Wiring::finish's topological sort re-ranks once ALL captures are
-            // known), so the capture schedules the source for the CURRENT
-            // evaluation time — no next-cycle workaround. Request/reply stubs
-            // above still schedule their transport sources for the next cycle.
-            // The same rule applies at every add_rank_dependency site below
-            // and in adaptor_wiring.h.
-            w.add_same_cycle_pair(capture.peered_node(), shared_output.node());
-            return capture.peered_node();
+            // Shared with adaptor::detail::capture_output (RFC 0011 step 9).
+            return boundary_detail::shared_output_relay_capture(
+                w, std::type_index(typeid(reference_output_capture_marker)), output_meta,
+                reference_output_path<Service>(user_path), output.erased(), shared_output.erased());
         }
 
         template <typename Service, typename Impl>

--- a/include/hgraph/types/service_wiring.h
+++ b/include/hgraph/types/service_wiring.h
@@ -1178,6 +1178,33 @@ namespace hgraph::service
         impl_output<Service>(w, detail::default_service_path<Service>(), std::move(output));
     }
 
+    /**
+     * ``from_graph`` / ``to_graph`` — the adaptor spelling of ``impl_input`` /
+     * ``impl_output`` (RFC 0011 step 3).
+     *
+     * These are aliases, not a second mechanism: ``impl_output`` and
+     * ``adaptor::to_graph`` already build the same stub registration, shared
+     * output source, capture and rank anchor. The adaptor names are the
+     * discoverable ones for "publish this implementation's output", so a
+     * service implementation may use them too and read the same in either
+     * flavour. ``impl_input`` / ``impl_output`` remain and are unchanged.
+     *
+     * A reference service has no client input, so it has no ``from_graph``.
+     */
+    template <typename Service, typename... Args>
+        requires requires(Wiring &w, Args &&...args) { impl_input<Service>(w, std::forward<Args>(args)...); }
+    [[nodiscard]] decltype(auto) from_graph(Wiring &w, Args &&...args)
+    {
+        return impl_input<Service>(w, std::forward<Args>(args)...);
+    }
+
+    template <typename Service, typename... Args>
+        requires requires(Wiring &w, Args &&...args) { impl_output<Service>(w, std::forward<Args>(args)...); }
+    void to_graph(Wiring &w, Args &&...args)
+    {
+        impl_output<Service>(w, std::forward<Args>(args)...);
+    }
+
     template <typename Impl, typename... Services, typename... Args>
     void register_services(Wiring &w, ServicePath user_path, const Args &...args)
     {

--- a/include/hgraph/types/service_wiring.h
+++ b/include/hgraph/types/service_wiring.h
@@ -1212,29 +1212,69 @@ namespace hgraph::service
                       "register_services requires at least one service interface");
         static_assert((detail::service_interface<Services> && ...),
                       "register_services requires service descriptor types");
+
+        // The base path of each interface this implementation provides. These
+        // are the paths a client request must name for the implementation to
+        // be wanted.
+        std::vector<std::string> base_paths;
+        base_paths.reserve(sizeof...(Services));
         (
             [&] {
                 if constexpr (detail::reference_service_interface<Services>)
                 {
-                    w.register_built_service_path(
-                        detail::reference_base_path<Services>(user_path), "reference service");
+                    base_paths.push_back(detail::reference_base_path<Services>(user_path));
                 }
                 else if constexpr (detail::subscription_service_interface<Services>)
                 {
-                    w.register_built_service_path(
-                        detail::subscription_base_path<Services>(user_path), "subscription service");
+                    base_paths.push_back(detail::subscription_base_path<Services>(user_path));
                 }
                 else if constexpr (detail::request_reply_service_interface<Services>)
                 {
-                    w.register_built_service_path(
-                        detail::request_reply_base_path<Services>(user_path), "request/reply service");
+                    base_paths.push_back(detail::request_reply_base_path<Services>(user_path));
                 }
             }(),
             ...);
-        std::vector<WiringServiceImplementationEndpoint> required_endpoints;
-        (detail::append_required_stub_endpoints<Services>(required_endpoints, user_path), ...);
-        detail::wire_service_graph_with_scope<Impl>(
-            w, user_path, "multi-service implementation", std::move(required_endpoints), args...);
+
+        // LAZY, matching register_adaptors and the erased
+        // register_multi_service_impl (RFC 0011 step 4). This was the only
+        // eager registration on either surface, and it diverged from its own
+        // erased counterpart. Being lazy also makes this the single-interface
+        // BY-STUB registration - the quadrant services previously lacked
+        // against register_adaptor / register_automatic_adaptor.
+        auto stored_args = std::tuple<std::decay_t<Args>...>{args...};
+        w.register_service_implementation_candidate(
+            base_paths, "multi-service implementation",
+            [user_path, stored_args = std::move(stored_args)](Wiring &target) {
+                (
+                    [&] {
+                        if constexpr (detail::reference_service_interface<Services>)
+                        {
+                            target.register_built_service_path(
+                                detail::reference_base_path<Services>(user_path), "reference service");
+                        }
+                        else if constexpr (detail::subscription_service_interface<Services>)
+                        {
+                            target.register_built_service_path(
+                                detail::subscription_base_path<Services>(user_path), "subscription service");
+                        }
+                        else if constexpr (detail::request_reply_service_interface<Services>)
+                        {
+                            target.register_built_service_path(
+                                detail::request_reply_base_path<Services>(user_path),
+                                "request/reply service");
+                        }
+                    }(),
+                    ...);
+                std::vector<WiringServiceImplementationEndpoint> required_endpoints;
+                (detail::append_required_stub_endpoints<Services>(required_endpoints, user_path), ...);
+                std::apply(
+                    [&](const auto &...stored) {
+                        detail::wire_service_graph_with_scope<Impl>(
+                            target, user_path, "multi-service implementation",
+                            std::move(required_endpoints), stored...);
+                    },
+                    stored_args);
+            });
     }
 
     template <typename Service>

--- a/include/hgraph/types/service_wiring.h
+++ b/include/hgraph/types/service_wiring.h
@@ -25,12 +25,10 @@
 
 namespace hgraph::service
 {
-    struct ServicePath
-    {
-        std::string   value{};
-        ResolutionMap resolution{};
-        bool          has_typed_suffix{false};
-    };
+    /** Alias of the shared ``hgraph::BoundaryPath`` (RFC 0011 step 8): the
+     *  two path types were field-identical, and a single implementation can
+     *  only span services and adaptors if they are one type. */
+    using ServicePath = BoundaryPath;
 
     [[nodiscard]] inline ServicePath path(std::string_view value)
     {
@@ -899,7 +897,10 @@ namespace hgraph::service
             return capture.peered_node();
         }
 
-        template <typename Service, typename Impl>
+        // ``Impl`` was a template parameter here but never used in the body,
+        // so the two call sites' differing arguments interned to the same node
+        // regardless. Dropped (RFC 0011 step 8).
+        template <typename Service>
         const WiringInstance *capture_reference_service_output(Wiring &w,
                                                                Port<reference_output_schema_t<Service>> output,
                                                                Port<REF<reference_output_schema_t<Service>>> shared_output,
@@ -1076,7 +1077,7 @@ namespace hgraph::service
                         return detail::wire_service_impl<Impl, output_schema>(target, user_path, stored...);
                     }, stored_args);
                 const WiringInstance *capture =
-                    detail::capture_reference_service_output<Service, Impl>(
+                    detail::capture_reference_service_output<Service>(
                         target, output, shared_output, user_path);
                 target.register_service_rank_anchor(base_path, capture);
             });
@@ -1143,7 +1144,7 @@ namespace hgraph::service
             user_path.resolution, w.service_implementation_stub_resolution(endpoint));
         w.register_service_implementation_stub(endpoint, "reference service");
         auto shared_output = detail::reference_shared_output_source<Service>(w, user_path);
-        const WiringInstance *capture = detail::capture_reference_service_output<Service, explicit_impl_output_marker>(
+        const WiringInstance *capture = detail::capture_reference_service_output<Service>(
             w, std::move(output), shared_output, user_path);
         w.register_service_rank_anchor(detail::reference_base_path<Service>(user_path), capture);
     }
@@ -1732,7 +1733,8 @@ namespace hgraph::service_adaptor
 
         [[nodiscard]] inline Value path_key_value(const std::string &full_path)
         {
-            return Value{Str{full_path}};
+            // Shared implementation (RFC 0011 step 8).
+            return wiring_path_detail::boundary_path_key(full_path);
         }
 
         struct request_input_source_marker

--- a/include/hgraph/types/service_wiring.h
+++ b/include/hgraph/types/service_wiring.h
@@ -400,6 +400,30 @@ namespace hgraph::service
             return has_path_scalar<params>(std::make_index_sequence<std::tuple_size_v<params>>{});
         }
 
+        /** Check a GENERIC implementation's output against the resolved
+         *  interface schema.
+         *
+         *  The concrete branch below gets this from ``Port::as<OutputSchema>()``.
+         *  The non-concrete branch previously returned the implementation's
+         *  port unchecked, so a generic service accepted a mismatched output
+         *  and built its capture over the implementation's schema while the
+         *  source used the interface's - exactly the hole this RFC attributes
+         *  to adaptors (RFC 0011 step 5). */
+        template <typename OutputSchema>
+        [[nodiscard]] Port<OutputSchema> checked_generic_output(
+            Wiring &w, const ServicePath &user_path, WiringPortRef output)
+        {
+            const auto *expected = resolved_schema_meta<OutputSchema>(
+                user_path.resolution, "service implementation output");
+            if (output.schema == nullptr ||
+                !graph_wiring_detail::input_accepts_output_schema(expected, output.schema))
+            {
+                throw std::invalid_argument(
+                    "service implementation output does not match the resolved interface schema");
+            }
+            return Port<OutputSchema>{w, std::move(output)};
+        }
+
         template <typename Impl, typename OutputSchema, typename... Args>
         [[nodiscard]] Port<OutputSchema> wire_service_impl(Wiring &w, const ServicePath &user_path, const Args &...args)
         {
@@ -412,7 +436,7 @@ namespace hgraph::service
                 }
                 else
                 {
-                    return Port<OutputSchema>{w, output.erased()};
+                    return checked_generic_output<OutputSchema>(w, user_path, output.erased());
                 }
             }
             else
@@ -424,7 +448,7 @@ namespace hgraph::service
                 }
                 else
                 {
-                    return Port<OutputSchema>{w, output.erased()};
+                    return checked_generic_output<OutputSchema>(w, user_path, output.erased());
                 }
             }
         }

--- a/include/hgraph/types/service_wiring.h
+++ b/include/hgraph/types/service_wiring.h
@@ -1230,68 +1230,88 @@ namespace hgraph::service
         impl_output<Service>(w, std::forward<Args>(args)...);
     }
 
-    template <typename Impl, typename... Services, typename... Args>
-    void register_services(Wiring &w, ServicePath user_path, const Args &...args)
+}   // namespace hgraph::service
+
+namespace hgraph::boundary_detail
+{
+    /** Service interfaces in a multi-interface group (RFC 0011 step 7). */
+    template <typename Service>
+    struct group_member<Service, std::enable_if_t<service::detail::service_interface<Service>>>
     {
-        static_assert(sizeof...(Services) > 0,
-                      "register_services requires at least one service interface");
-        static_assert((detail::service_interface<Services> && ...),
-                      "register_services requires service descriptor types");
+        [[nodiscard]] static std::string base_path(const BoundaryPath &user_path)
+        {
+            if constexpr (service::detail::reference_service_interface<Service>)
+            {
+                return service::detail::reference_base_path<Service>(user_path);
+            }
+            else if constexpr (service::detail::subscription_service_interface<Service>)
+            {
+                return service::detail::subscription_base_path<Service>(user_path);
+            }
+            else
+            {
+                return service::detail::request_reply_base_path<Service>(user_path);
+            }
+        }
 
-        // The base path of each interface this implementation provides. These
-        // are the paths a client request must name for the implementation to
-        // be wanted.
-        std::vector<std::string> base_paths;
-        base_paths.reserve(sizeof...(Services));
-        (
-            [&] {
-                if constexpr (detail::reference_service_interface<Services>)
-                {
-                    base_paths.push_back(detail::reference_base_path<Services>(user_path));
-                }
-                else if constexpr (detail::subscription_service_interface<Services>)
-                {
-                    base_paths.push_back(detail::subscription_base_path<Services>(user_path));
-                }
-                else if constexpr (detail::request_reply_service_interface<Services>)
-                {
-                    base_paths.push_back(detail::request_reply_base_path<Services>(user_path));
-                }
-            }(),
-            ...);
+        [[nodiscard]] static std::string_view kind()
+        {
+            if constexpr (service::detail::reference_service_interface<Service>)
+            {
+                return "reference service";
+            }
+            else if constexpr (service::detail::subscription_service_interface<Service>)
+            {
+                return "subscription service";
+            }
+            else
+            {
+                return "request/reply service";
+            }
+        }
 
-        // LAZY, matching register_adaptors and the erased
-        // register_multi_service_impl (RFC 0011 step 4). This was the only
-        // eager registration on either surface, and it diverged from its own
-        // erased counterpart. Being lazy also makes this the single-interface
-        // BY-STUB registration - the quadrant services previously lacked
-        // against register_adaptor / register_automatic_adaptor.
+        static void append_required_endpoints(
+            std::vector<WiringServiceImplementationEndpoint> &endpoints, const BoundaryPath &user_path)
+        {
+            service::detail::append_required_stub_endpoints<Service>(endpoints, user_path);
+        }
+    };
+}   // namespace hgraph::boundary_detail
+
+namespace hgraph::service
+{
+    /**
+     * Register ONE implementation providing several interfaces.
+     *
+     * The interface pack may MIX services and adaptors (RFC 0011 step 7):
+     * each member is described through ``boundary_detail::group_member``, which
+     * ``service_wiring.h`` specializes for service interfaces and
+     * ``adaptor_wiring.h`` for adaptor interfaces. This is what keeps the
+     * documented "sink-only interface in, source-only interface out" shape
+     * expressible as a single atomic registration.
+     *
+     * Lazy: the implementation is composed only once a client requests one of
+     * its interfaces.
+     */
+    template <typename Impl, typename... Interfaces, typename... Args>
+    void register_services(Wiring &w, BoundaryPath user_path, const Args &...args)
+    {
+        static_assert(sizeof...(Interfaces) > 0,
+                      "register_services requires at least one interface");
+        std::vector<std::string> base_paths{
+            boundary_detail::group_member<Interfaces>::base_path(user_path)...};
         auto stored_args = std::tuple<std::decay_t<Args>...>{args...};
         w.register_service_implementation_candidate(
             base_paths, "multi-service implementation",
             [user_path, stored_args = std::move(stored_args)](Wiring &target) {
-                (
-                    [&] {
-                        if constexpr (detail::reference_service_interface<Services>)
-                        {
-                            target.register_built_service_path(
-                                detail::reference_base_path<Services>(user_path), "reference service");
-                        }
-                        else if constexpr (detail::subscription_service_interface<Services>)
-                        {
-                            target.register_built_service_path(
-                                detail::subscription_base_path<Services>(user_path), "subscription service");
-                        }
-                        else if constexpr (detail::request_reply_service_interface<Services>)
-                        {
-                            target.register_built_service_path(
-                                detail::request_reply_base_path<Services>(user_path),
-                                "request/reply service");
-                        }
-                    }(),
-                    ...);
+                (target.register_built_service_path(
+                     boundary_detail::group_member<Interfaces>::base_path(user_path),
+                     boundary_detail::group_member<Interfaces>::kind()),
+                 ...);
                 std::vector<WiringServiceImplementationEndpoint> required_endpoints;
-                (detail::append_required_stub_endpoints<Services>(required_endpoints, user_path), ...);
+                (boundary_detail::group_member<Interfaces>::append_required_endpoints(
+                     required_endpoints, user_path),
+                 ...);
                 std::apply(
                     [&](const auto &...stored) {
                         detail::wire_service_graph_with_scope<Impl>(

--- a/python/hgraph/_wiring/_services.py
+++ b/python/hgraph/_wiring/_services.py
@@ -1870,6 +1870,19 @@ def impl_output(stub, out, path=""):
 def _register_resolved_service(path, implementation, kwargs, *, wiring=None):
     wiring = _current_wiring() if wiring is None else wiring
     default_fallback = path is None
+    if not implementation.interfaces:
+        # Catch-all: an implementation declaring NO interface claims every
+        # otherwise-unclaimed endpoint. The underlying candidate mechanism
+        # (register_catch_all_service_implementation_candidate) has no
+        # flavour, so this is the same facility adaptors reach through
+        # @adaptor_impl(interfaces=()) - it is simply no longer
+        # adaptor-exclusive (RFC 0011 step 6).
+        implementation_inputs, scalar_kwargs = _registration_inputs(implementation, kwargs)
+        impl_fn = _bind_registered_impl(implementation, path or "", scalar_kwargs)
+        _hgraph.register_unbound_adaptor_impl(
+            wiring, _wrap_graph_fn(impl_fn),
+            [_unwrap(port) for port in implementation_inputs])
+        return
     if len(implementation.interfaces) > 1:
         resolved_paths = {
             _resolved_service_path(stub, path) for stub in implementation.interfaces

--- a/python/hgraph/_wiring/_services.py
+++ b/python/hgraph/_wiring/_services.py
@@ -1017,24 +1017,43 @@ def service_adaptor(fn=None, resolvers=None):
 
 
 def from_graph(stub, path=""):
-    """Impl-side: the client input of ``stub`` (inside a registered impl)."""
+    """Impl-side: the client input of ``stub`` (inside a registered impl).
+
+    Works for every flavour that has a client input. For services this is the
+    same operation as ``impl_input``/``get_service_inputs`` under the adaptor
+    spelling (RFC 0011 step 3); a reference service has no input and raises.
+    """
     descriptor = stub._require_descriptor() if hasattr(stub, "_require_descriptor") else stub.descriptor
     path = _resolved_service_path(stub, path)
     if stub.flavour == "service_adaptor":
         return WiringPort(_hgraph.service_adaptor_from_graph(
             _current_wiring(), descriptor, path))
-    return WiringPort(_hgraph.adaptor_from_graph(_current_wiring(), descriptor, path))
+    if stub.flavour == "adaptor":
+        return WiringPort(_hgraph.adaptor_from_graph(_current_wiring(), descriptor, path))
+    if stub.flavour == "reference":
+        raise WiringError(
+            f"reference service '{stub.__name__}' has no client input to read")
+    return WiringPort(_hgraph.service_impl_input(_current_wiring(), descriptor, path))
 
 
 def to_graph(stub, out, path=""):
-    """Impl-side: publish the adaptor output of ``stub`` back to clients."""
+    """Impl-side: publish ``stub``'s output back to clients.
+
+    Works for every flavour that has an output. For services this is the same
+    operation as ``impl_output``/``set_service_output`` under the adaptor
+    spelling (RFC 0011 step 3) - the underlying wiring is identical.
+    """
     descriptor = stub._require_descriptor() if hasattr(stub, "_require_descriptor") else stub.descriptor
     path = _resolved_service_path(stub, path)
     if stub.flavour == "service_adaptor":
         _hgraph.service_adaptor_to_graph(
             _current_wiring(), descriptor, path, out=_unwrap(out))
         return
-    _hgraph.adaptor_to_graph(_current_wiring(), descriptor, path, out=_unwrap(out))
+    if stub.flavour == "adaptor":
+        _hgraph.adaptor_to_graph(_current_wiring(), descriptor, path, out=_unwrap(out))
+        return
+    _hgraph.service_impl_output(
+        _current_wiring(), descriptor, path, out=_unwrap(out))
 
 
 def register_adaptor(path, implementation, resolution_dict=None, **kwargs):

--- a/python/hgraph/_wiring/_services.py
+++ b/python/hgraph/_wiring/_services.py
@@ -1066,7 +1066,7 @@ def register_adaptor(path, implementation, resolution_dict=None, **kwargs):
 def _register_resolved_adaptor(path, implementation, kwargs, wiring=None):
     wiring = wiring or _current_wiring()
     default_fallback = path is None
-    implementation_inputs, scalar_kwargs = _adaptor_registration_inputs(
+    implementation_inputs, scalar_kwargs = _registration_inputs(
         implementation, kwargs)
     if not implementation.interfaces:
         impl_fn = _bind_registered_impl(implementation, path, scalar_kwargs)
@@ -1106,17 +1106,34 @@ def _register_resolved_adaptor(path, implementation, kwargs, wiring=None):
             default_fallback=default_fallback)
 
 
-def _adaptor_registration_inputs(implementation, config):
+def _registration_inputs(implementation, config):
+    """Split time-series values out of a registration's keyword configuration.
+
+    Two shapes supply implementation inputs at registration time:
+
+    * a MANUAL adaptor, whose every time-series parameter is supplied by the
+      registration rather than by the interface; and
+    * a service (or automatic adaptor) declaring time-series parameters BEYOND
+      the ones its interface supplies - the surplus is registration
+      configuration (RFC 0011 step 2).
+
+    Returns ``(ports, remaining_scalar_config)``.
+    """
     config = dict(config)
-    if not implementation.manual_adaptor:
+    if implementation.manual_adaptor:
+        wanted = implementation.ts_parameters
+        described = f"manual adaptor implementation '{implementation.__name__}'"
+    else:
+        wanted = implementation.registration_ts_parameters
+        described = f"implementation '{implementation.__name__}'"
+    if not wanted:
         return (), config
     inputs = []
     from ._node import _lift_time_series_argument
-    for parameter in implementation.ts_parameters:
+    for parameter in wanted:
         if parameter.name not in config:
             raise WiringError(
-                f"manual adaptor implementation '{implementation.__name__}' requires "
-                f"time-series configuration '{parameter.name}'")
+                f"{described} requires time-series configuration '{parameter.name}'")
         value = config.pop(parameter.name)
         if not isinstance(value, WiringPort):
             value = _lift_time_series_argument(value, parameter.annotation)
@@ -1226,6 +1243,7 @@ class _ServiceImpl:
             and parameter.name not in ts_names
             and parameter.annotation not in _INJECTABLE_MARKERS)
         ts_params = self.ts_parameters
+        self.registration_ts_parameters = ()
         if len(self.interfaces) > 1:
             # Multi-interface implementations take NO wired inputs: they
             # fetch each interface's input via impl_input and publish via
@@ -1243,11 +1261,16 @@ class _ServiceImpl:
                     continue
                 if stub.flavour == "adaptor":
                     _validate_interface_implementation_signature(self, stub)
-                if len(ts_params) != expected:
+                if len(ts_params) < expected:
                     raise TypeError(
                         f"@service_impl '{self.__name__}': a {stub.flavour} implementation takes "
                         f"{expected} time-series parameter(s), found {len(ts_params)}"
                     )
+                # Time-series parameters beyond the interface's own are
+                # supplied at registration (RFC 0011 step 2). Adaptors express
+                # the same thing through manual_adaptor.
+                if not self.manual_adaptor:
+                    self.registration_ts_parameters = ts_params[expected:]
 
     @staticmethod
     def _resolve(stub):
@@ -1317,18 +1340,24 @@ def _bind_registered_impl(implementation, path, config):
         stub, "implementation_arity", _FLAVOUR_TS_ARITY[stub.flavour]
     )
     port_parameters = list(implementation.ts_parameters)
+    # Registration-supplied inputs are still ports the bound function
+    # receives - they arrive appended to the flavour's transport input rather
+    # than from the transport itself (RFC 0011 step 2).
+    registration_count = len(implementation.registration_ts_parameters)
     manual_adaptor = bool(
         implementation.manual_adaptor
         and (stub is None or stub.flavour == "adaptor"))
     if manual_adaptor:
         expected_ports = len(port_parameters)
         native_ports = len(port_parameters)
+        transport_ports = native_ports
     else:
-        native_ports = (
+        transport_ports = (
             0 if stub is None or stub.flavour == "reference"
             or (stub.flavour == "adaptor" and expected_ports == 0) else 1
         )
-    if len(port_parameters) != expected_ports:
+        native_ports = transport_ports + registration_count
+    if len(port_parameters) != expected_ports + registration_count:
         raise WiringError(
             f"implementation '{implementation.__name__}' requires {expected_ports} native service input(s)"
         )
@@ -1386,11 +1415,14 @@ def _bind_registered_impl(implementation, path, config):
             raise WiringError(
                 f"implementation '{implementation.__name__}' received {len(ports)} native service inputs"
             )
+        # The transport port(s) come first, then the registration inputs.
+        transport = list(ports[:len(ports) - registration_count]) if registration_count else list(ports)
+        extras = list(ports[len(ports) - registration_count:]) if registration_count else []
         user_ports = (
-            _split_service_requests(stub, ports[0])
-            if not manual_adaptor and native_ports and expected_ports > 1
-            else list(ports)
-        )
+            _split_service_requests(stub, transport[0])
+            if not manual_adaptor and transport_ports and expected_ports > 1
+            else transport
+        ) + extras
         arguments = dict(zip((param.name for param in port_parameters), user_ports))
         effective_path = path
         matched_stub = stub
@@ -1834,9 +1866,13 @@ def _register_resolved_service(path, implementation, kwargs, *, wiring=None):
     stub = implementation.interfaces[0]
     resolved_path = _resolved_service_path(stub, path)
     user_path = getattr(stub, "_default_path", "") if path is None else path
-    impl_fn = _bind_registered_impl(implementation, user_path, kwargs)
+    # Time-series values in the registration kwargs become implementation
+    # inputs; the rest stays scalar configuration (RFC 0011 step 2).
+    implementation_inputs, scalar_kwargs = _registration_inputs(implementation, kwargs)
+    impl_fn = _bind_registered_impl(implementation, user_path, scalar_kwargs)
     _hgraph.register_service_impl(
         wiring, stub.descriptor, resolved_path, _wrap_graph_fn(impl_fn),
+        inputs=[_unwrap(port) for port in implementation_inputs],
         default_fallback=default_fallback)
 
 

--- a/python/hgraph/_wiring/_services.py
+++ b/python/hgraph/_wiring/_services.py
@@ -24,8 +24,8 @@ from ._node import _PyNode, _warn_deprecated
 
 _TS_ANNOTATIONS = (_TsExpr, _GenericTsExpr)
 _SERVICE_ADAPTOR_CLIENT_TOKENS = itertools.count()
-_ADAPTOR_CLIENT_CONFIGS = {}
-_ADAPTOR_CLIENT_CONFIG_CLEANUPS = set()
+_CLIENT_CONFIGS = {}
+_CLIENT_CONFIG_CLEANUPS = set()
 
 
 def _is_ts_annotation(annotation):
@@ -49,8 +49,28 @@ def _is_resolution_annotation(annotation):
     )
 
 
-def _record_adaptor_client_config(stub, path, bound):
-    """Record the wiring-time scalar options shared by one adaptor path."""
+_FLAVOUR_LABELS = {
+    "reference": "reference service",
+    "subscription": "subscription service",
+    "request_reply": "request/reply service",
+    "adaptor": "adaptor",
+    "service_adaptor": "service adaptor",
+}
+
+
+def _flavour_label(flavour):
+    """Human-readable name for a flavour, for diagnostics.
+
+    ``flavour`` alone reads oddly for services ("reference 'x' clients"), and
+    these messages became service-visible when client scalar options were
+    lifted onto the service surface (RFC 0011 step 1).
+    """
+    return _FLAVOUR_LABELS.get(flavour, flavour.replace("_", " "))
+
+
+def _record_client_config(stub, path, bound):
+    """Record the wiring-time scalar options shared by one service or
+    adaptor path. Flavour-neutral: the key carries ``stub.flavour``."""
     config = {
         parameter.name: bound.arguments[parameter.name]
         for parameter in stub._signature.parameters.values()
@@ -61,43 +81,49 @@ def _record_adaptor_client_config(stub, path, bound):
     }
     wiring = _wiring_stack[0] if _wiring_stack else _current_wiring()
     identity = wiring.identity()
-    if identity not in _ADAPTOR_CLIENT_CONFIG_CLEANUPS:
+    if identity not in _CLIENT_CONFIG_CLEANUPS:
         def clear_configs():
-            for existing in tuple(_ADAPTOR_CLIENT_CONFIGS):
+            # The C++ Wiring may outlive this module: at interpreter shutdown
+            # module globals are cleared to None, and the cleanup still fires.
+            # Nothing is left to release at that point, so bail out quietly
+            # rather than raising out of a destructor.
+            if _CLIENT_CONFIGS is None or _CLIENT_CONFIG_CLEANUPS is None:
+                return
+            for existing in tuple(_CLIENT_CONFIGS):
                 if existing[0] == identity:
-                    del _ADAPTOR_CLIENT_CONFIGS[existing]
-            _ADAPTOR_CLIENT_CONFIG_CLEANUPS.discard(identity)
+                    del _CLIENT_CONFIGS[existing]
+            _CLIENT_CONFIG_CLEANUPS.discard(identity)
 
         # The C++ Wiring owns this callback. A temporary borrowed PyWiring can
         # disappear before build_services(), but its underlying Wiring retains
         # both the config and cleanup for its actual lifetime.
         wiring._retain_cleanup(clear_configs)
-        _ADAPTOR_CLIENT_CONFIG_CLEANUPS.add(identity)
+        _CLIENT_CONFIG_CLEANUPS.add(identity)
     key = (
         identity, stub.flavour, stub.__name__,
         stub._specialization, path,
     )
-    previous = _ADAPTOR_CLIENT_CONFIGS.setdefault(key, config)
+    previous = _CLIENT_CONFIGS.setdefault(key, config)
     if previous != config:
         differences = sorted(
             name for name in previous.keys() | config.keys()
             if previous.get(name) != config.get(name)
         )
         raise WiringError(
-            f"{stub.flavour.replace('_', ' ')} '{stub.__name__}' clients at "
+            f"{_flavour_label(stub.flavour)} '{stub.__name__}' clients at "
             f"path {path!r} disagree on wiring-time option(s) {differences!r}")
 
 
-def _adaptor_client_config(stub, path):
+def _client_config(stub, path):
     wiring = _wiring_stack[0] if _wiring_stack else _current_wiring()
     key = (
         wiring.identity(), stub.flavour, stub.__name__,
         stub._specialization, path,
     )
-    return _ADAPTOR_CLIENT_CONFIGS.get(key, {})
+    return _CLIENT_CONFIGS.get(key, {})
 
 
-def _resolved_adaptor_client_path(stub, path):
+def _resolved_client_path(stub, path):
     """Return the config key and concrete native client path."""
     resolved = stub._resolved_path(path) if path else stub._default_path
     resolved = resolved or f"{stub.__name__}_default"
@@ -488,11 +514,14 @@ class _ServiceStub:
             path = ""
         if not isinstance(path, str):
             raise TypeError(f"service '{self.__name__}' path must be a string")
-        return path, [bound.arguments[p.name] for p in self._request_params]
+        # ``bound`` carries the client's wiring-time scalar options; the caller
+        # records them so the registered implementation can read them back
+        # (RFC 0011 step 1 - the same channel adaptor clients have always had).
+        return path, [bound.arguments[p.name] for p in self._request_params], bound
 
     def __call__(self, *args, **kwargs):
         _warn_deprecated(self.__name__, self._deprecated)
-        path, requests = self._bind_call(args, kwargs)
+        path, requests, bound = self._bind_call(args, kwargs)
         if requests:
             from ._node import _lift_time_series_argument
 
@@ -537,6 +566,11 @@ class _ServiceStub:
                 pending_registrations=self._pending_registrations,
                 registered_resolutions=self._registered_resolutions)
         _materialize_pending_registrations(self, stub._resolution, w)
+        # Record the client's wiring-time scalar options against the resolved
+        # path, exactly as adaptor clients do. The key carries the flavour, and
+        # ``_bind_registered_impl`` reads it back through ``_client_config``.
+        config_path, _ = _resolved_client_path(stub, path)
+        _record_client_config(stub, config_path, bound)
         request = None
         if len(requests) == 1:
             request = _unwrap(requests[0])
@@ -620,7 +654,7 @@ class _AdaptorClientStub:
         if path is None:
             path = ""
         if not isinstance(path, str):
-            raise TypeError(f"{self.flavour.replace('_', ' ')} '{self.__name__}' path must be a string")
+            raise TypeError(f"{_flavour_label(self.flavour)} '{self.__name__}' path must be a string")
 
         from ._node import _lift_time_series_argument
         requests = [
@@ -638,15 +672,15 @@ class _AdaptorClientStub:
                 if not resolution.match(
                         _pattern_of(parameter.annotation), _unwrap(request).ts_type):
                     raise TypeError(
-                        f"generic {self.flavour.replace('_', ' ')} '{self.__name__}' "
+                        f"generic {_flavour_label(self.flavour)} '{self.__name__}' "
                         "request does not match its type pattern")
             _apply_service_defaults(self._signature, resolution)
             _apply_service_resolvers(resolution, self._resolvers)
             specialization = _specialization_label(resolution)
             stub = self._specialized_stub(resolution, specialization)
         self._materialize_client_registration(stub)
-        config_path, path = _resolved_adaptor_client_path(stub, path)
-        _record_adaptor_client_config(stub, config_path, bound)
+        config_path, path = _resolved_client_path(stub, path)
+        _record_client_config(stub, config_path, bound)
         request = (
             None if not requests else requests[0]
             if len(requests) == 1 else WiringPort(_hgraph.tsb_port(
@@ -1378,7 +1412,7 @@ def _bind_registered_impl(implementation, path, config):
         if any(param.name == "path" for param in parameters):
             arguments["path"] = effective_path
         client_config = (
-            _adaptor_client_config(matched_stub, effective_path)
+            _client_config(matched_stub, effective_path)
             if matched_stub is not None else {})
         for param in scalar_parameters:
             configured = resolved_config.get(param.name, inspect.Parameter.empty)
@@ -1388,7 +1422,7 @@ def _bind_registered_impl(implementation, path, config):
                         and client_value != configured):
                     raise WiringError(
                         f"implementation '{implementation.__name__}' option "
-                        f"'{param.name}' conflicts with adaptor clients at path "
+                        f"'{param.name}' conflicts with clients at path "
                         f"{effective_path!r}")
                 arguments[param.name] = configured
             elif client_value is not inspect.Parameter.empty:

--- a/python/hgraph/_wiring/_services.py
+++ b/python/hgraph/_wiring/_services.py
@@ -1462,9 +1462,30 @@ def _bind_registered_impl(implementation, path, config):
                     effective_path = effective_path[:-len(typed_suffix)]
         if any(param.name == "path" for param in parameters):
             arguments["path"] = effective_path
-        client_config = (
-            _client_config(matched_stub, effective_path)
-            if matched_stub is not None else {})
+        if matched_stub is not None:
+            client_config = _client_config(matched_stub, effective_path)
+        else:
+            # A MULTI-interface implementation has no single stub, and
+            # service_materialization_path() is only exposed while
+            # materializing default-fallback candidates - so an exact
+            # multi-interface registration would otherwise see no client
+            # configuration at all and silently substitute its own defaults.
+            # Merge across every interface the implementation provides,
+            # rejecting interfaces that disagree at the same path.
+            client_config = {}
+            sources = {}
+            for candidate in implementation.interfaces:
+                for name, value in _client_config(candidate, effective_path).items():
+                    if name in client_config and client_config[name] != value:
+                        raise WiringError(
+                            f"implementation '{implementation.__name__}' clients at path "
+                            f"{effective_path!r} disagree on wiring-time option {name!r}: "
+                            f"{_flavour_label(sources[name].flavour)} "
+                            f"'{sources[name].__name__}' says {client_config[name]!r}, "
+                            f"{_flavour_label(candidate.flavour)} "
+                            f"'{candidate.__name__}' says {value!r}")
+                    client_config[name] = value
+                    sources[name] = candidate
         for param in scalar_parameters:
             configured = resolved_config.get(param.name, inspect.Parameter.empty)
             client_value = client_config.get(param.name, inspect.Parameter.empty)

--- a/python/py_state_services.cpp
+++ b/python/py_state_services.cpp
@@ -348,27 +348,30 @@ namespace hgraph::python_bridge
         throw std::logic_error("unreachable");
     }, nb::arg("w"), nb::arg("desc"), nb::arg("path") = std::string{}, nb::arg("ts") = nb::none());
     m.def("register_service_impl", [](PyWiring &w, const PyServiceDesc &desc, const std::string &path,
-                                      const PyWiredFn &impl, bool default_fallback) {
+                                      const PyWiredFn &impl, nb::list inputs, bool default_fallback) {
+        // Extra time-series inputs supplied at registration, mirroring
+        // register_adaptor_impl. They follow the flavour's transport input.
+        auto implementation_inputs = wiring_ports(inputs);
         switch (desc.descriptor->flavour)
         {
             case ServiceFlavour::Reference:
                 register_reference_service_impl(w.wiring_ref(), *desc.descriptor, path, impl.fn,
-                                                default_fallback);
+                                                implementation_inputs, default_fallback);
                 return;
             case ServiceFlavour::Subscription:
                 register_subscription_service_impl(w.wiring_ref(), *desc.descriptor, path, impl.fn,
-                                                   default_fallback);
+                                                   implementation_inputs, default_fallback);
                 return;
             case ServiceFlavour::RequestReply:
                 register_request_reply_service_impl(w.wiring_ref(), *desc.descriptor, path, impl.fn,
-                                                    default_fallback);
+                                                    implementation_inputs, default_fallback);
                 return;
             case ServiceFlavour::Adaptor:
             case ServiceFlavour::ServiceAdaptor:
                 throw std::logic_error("register_service_impl does not accept adaptor descriptors");
         }
     }, nb::arg("w"), nb::arg("desc"), nb::arg("path") = std::string{}, nb::arg("impl"),
-       nb::arg("default_fallback") = false);
+       nb::arg("inputs") = nb::list(), nb::arg("default_fallback") = false);
 
     m.def("mesh_scope_exists", [](const std::string &name) {
         return OperatorRegistry::instance().resolve_mesh_scope(name) != nullptr;

--- a/python/tests/test_hgraph_api.py
+++ b/python/tests/test_hgraph_api.py
@@ -1569,7 +1569,7 @@ def test_adaptor_client_config_follows_cxx_first_wiring_lifetime():
     import _hgraph
     import gc
     from hgraph._wiring import _wiring_stack
-    from hgraph._wiring._services import _ADAPTOR_CLIENT_CONFIGS
+    from hgraph._wiring._services import _CLIENT_CONFIGS
 
     built_config = []
 
@@ -1606,7 +1606,7 @@ def test_adaptor_client_config_follows_cxx_first_wiring_lifetime():
           f"invalid public Wiring identity: {wiring_identity!r}")
     check(wiring.identity() == wiring_identity,
           "public Wiring identity changed during its lifetime")
-    check(any(key[0] == wiring_identity for key in _ADAPTOR_CLIENT_CONFIGS),
+    check(any(key[0] == wiring_identity for key in _CLIENT_CONFIGS),
           "C++-first adaptor config was not retained")
     wiring.build_services()
     check(built_config == [(6, "cxx")],
@@ -1614,7 +1614,7 @@ def test_adaptor_client_config_follows_cxx_first_wiring_lifetime():
 
     del client, source, wiring
     gc.collect()
-    check(not any(key[0] == wiring_identity for key in _ADAPTOR_CLIENT_CONFIGS),
+    check(not any(key[0] == wiring_identity for key in _CLIENT_CONFIGS),
           "C++-first adaptor config outlived its Wiring")
 
 

--- a/python/tests/test_hgraph_api.py
+++ b/python/tests/test_hgraph_api.py
@@ -959,11 +959,30 @@ def test_services_from_python():
     out = eval_node(rr_graph, [5, 7], __end_time__=hg.MIN_ST + 4 * hg.MIN_TD)
     check(out == [None, None, 10, 14], f"request/reply service: {out}")
 
-    # @service_impl validates: wrong signature shape for the flavour...
+    # @service_impl validates the shape for the flavour. A reference impl
+    # takes no interface input, so a surplus time-series parameter is now
+    # REGISTRATION configuration (RFC 0011 step 2) rather than a decoration
+    # error - the failure moves to registration when it is not supplied.
+    @hg.service_impl(interfaces=base_rate)
+    def surplus_impl(extra) -> TS[int]:
+        return hg.const(1, tp=TS[int])
+
+    @graph
+    def unsupplied(x: TS[int]) -> TS[int]:
+        hg.register_service("surplus", surplus_impl)
+        return x
+
     try:
-        @hg.service_impl(interfaces=base_rate)
-        def bad_impl(extra) -> TS[int]:
-            return hg.const(1, tp=TS[int])
+        eval_node(unsupplied, [1])
+        check(False, "expected a missing time-series configuration error")
+    except hg.WiringError as error:
+        check("extra" in str(error), f"missing ts config names the parameter: {error}")
+
+    # Too FEW time-series parameters is still a decoration-time shape error.
+    try:
+        @hg.service_impl(interfaces=doubler)
+        def too_few_impl() -> TSD[int, TS[int]]:
+            return hg.nothing(TSD[int, TS[int]])
         check(False, "expected a shape validation error")
     except TypeError:
         pass

--- a/python/tests/test_service_catch_all.py
+++ b/python/tests/test_service_catch_all.py
@@ -1,0 +1,55 @@
+"""``@service_impl(interfaces=())`` may serve as a catch-all.
+
+RFC 0011 step 6. ``register_catch_all_service_implementation_candidate`` has
+no flavour at all - it sweeps the recorded client endpoints and claims every
+one no exact candidate claimed. It was reachable only through
+``@adaptor_impl(interfaces=())``; it is no longer adaptor-exclusive.
+"""
+
+import pytest
+
+import hgraph as hg
+from hgraph import TS, graph
+from hgraph.test import eval_node
+
+
+def test_service_catch_all_serves_an_unclaimed_path():
+    @hg.adaptor
+    def echo(value: TS[int], path: str = "e") -> TS[int]: ...
+
+    @hg.service_impl(interfaces=())
+    def catch_all():
+        # Claims whatever endpoint asked and was not otherwise implemented.
+        request = hg.from_graph(echo, "unclaimed")
+        hg.to_graph(echo, request + 1, "unclaimed")
+
+    @graph
+    def app(value: TS[int]) -> TS[int]:
+        hg.register_service(None, catch_all)
+        return echo(value, path="unclaimed")
+
+    assert eval_node(app, [4]) == [5]
+
+
+def test_exact_service_registration_takes_precedence_over_the_catch_all():
+    @hg.adaptor
+    def echo(value: TS[int], path: str = "e") -> TS[int]: ...
+
+    @hg.adaptor_impl(interfaces=echo)
+    def exact_impl(value: TS[int], path: str = "e") -> TS[int]:
+        return value + 100
+
+    @hg.service_impl(interfaces=())
+    def catch_all():
+        # Only "other" is left unclaimed; "exact" belongs to exact_impl.
+        request = hg.from_graph(echo, "other")
+        hg.to_graph(echo, request + 1, "other")
+
+    @graph
+    def app(value: TS[int]) -> TS[int]:
+        hg.register_adaptor("exact", exact_impl)
+        hg.register_service(None, catch_all)
+        return echo(value, path="exact") + echo(value, path="other")
+
+    # 104 from the exact implementation, 5 from the catch-all.
+    assert eval_node(app, [4]) == [109]

--- a/python/tests/test_service_client_options.py
+++ b/python/tests/test_service_client_options.py
@@ -167,3 +167,86 @@ def test_distinct_paths_keep_separate_options():
 
     assert eval_node(app) == [7]
     assert sorted(observed) == [("a", 2), ("b", 5)], observed
+
+
+def test_multi_interface_implementation_receives_client_options():
+    """An exact multi-interface registration must still see client options.
+
+    ``_bind_registered_impl`` has no single stub for a multi-interface
+    implementation, and ``service_materialization_path()`` is exposed only
+    while materializing DEFAULT-fallback candidates - so an exact registration
+    saw no client configuration at all and silently substituted its own
+    defaults. Regression for that gap.
+    """
+    observed = []
+
+    @hg.reference_service
+    def rate(path: str = "m", multiplier: int = 1) -> TS[int]: ...
+
+    @hg.request_reply_service
+    def double(value: TS[int], path: str = "m") -> TS[int]: ...
+
+    @hg.service_impl(interfaces=(rate, double))
+    def impl(path: str, multiplier: int = 1):
+        observed.append(multiplier)
+        hg.to_graph(rate, hg.const(multiplier), path)
+        requests = hg.from_graph(double, path)
+        hg.to_graph(double, hg.map_(lambda v: v * 2, requests), path)
+
+    @graph
+    def app(value: TS[int]) -> TS[int]:
+        hg.register_service("m", impl)
+        return rate(path="m", multiplier=7) + double(value, path="m")
+
+    out = eval_node(app, [1], __end_time__=hg.MIN_ST + 6 * hg.MIN_TD)
+    assert observed == [7], observed
+    assert out[-1] == 9, out
+
+
+def test_multi_interface_options_may_come_from_either_interface():
+    observed = []
+
+    @hg.reference_service
+    def rate(path: str = "m") -> TS[int]: ...
+
+    @hg.request_reply_service
+    def double(value: TS[int], path: str = "m", multiplier: int = 1) -> TS[int]: ...
+
+    @hg.service_impl(interfaces=(rate, double))
+    def impl(path: str, multiplier: int = 1):
+        observed.append(multiplier)
+        hg.to_graph(rate, hg.const(0), path)
+        requests = hg.from_graph(double, path)
+        hg.to_graph(double, hg.map_(lambda v: v * multiplier, requests), path)
+
+    @graph
+    def app(value: TS[int]) -> TS[int]:
+        hg.register_service("m", impl)
+        # Only the request/reply interface declares the option.
+        return rate(path="m") + double(value, path="m", multiplier=5)
+
+    out = eval_node(app, [3], __end_time__=hg.MIN_ST + 6 * hg.MIN_TD)
+    assert observed == [5], observed
+    assert out[-1] == 15, out
+
+
+def test_multi_interface_options_must_agree_across_interfaces():
+    @hg.reference_service
+    def rate(path: str = "m", multiplier: int = 1) -> TS[int]: ...
+
+    @hg.request_reply_service
+    def double(value: TS[int], path: str = "m", multiplier: int = 1) -> TS[int]: ...
+
+    @hg.service_impl(interfaces=(rate, double))
+    def impl(path: str, multiplier: int = 1):
+        hg.to_graph(rate, hg.const(multiplier), path)
+        requests = hg.from_graph(double, path)
+        hg.to_graph(double, hg.map_(lambda v: v * multiplier, requests), path)
+
+    @graph
+    def app(value: TS[int]) -> TS[int]:
+        hg.register_service("m", impl)
+        return rate(path="m", multiplier=2) + double(value, path="m", multiplier=3)
+
+    with pytest.raises(hg.WiringError, match="disagree on wiring-time option"):
+        eval_node(app, [1], __end_time__=hg.MIN_ST + 6 * hg.MIN_TD)

--- a/python/tests/test_service_client_options.py
+++ b/python/tests/test_service_client_options.py
@@ -1,0 +1,169 @@
+"""Service clients may pass wiring-time scalar options to the implementation.
+
+RFC 0011 step 1. Adaptor clients have always had this channel
+(``_record_client_config``); it was reached only from the adaptor client stub.
+The store was already keyed by ``stub.flavour`` and ``_bind_registered_impl``
+already merged it generically, so lifting it onto services is a matter of
+recording from ``_ServiceStub.__call__``.
+
+For a source-only interface this is the *only* client parameterisation channel,
+which is why it has to exist on the service surface before source-only adaptors
+can collapse onto reference services.
+"""
+
+import pytest
+
+import hgraph as hg
+from hgraph import TS, TSD, TSS, graph
+from hgraph.test import eval_node
+
+
+def test_reference_service_client_supplies_scalar_options():
+    observed = []
+
+    @hg.reference_service
+    def scaled(path: str = "scaled", multiplier: int = 1) -> TS[int]: ...
+
+    @hg.service_impl(interfaces=scaled)
+    def scaled_impl(path: str = "scaled", multiplier: int = 1) -> TS[int]:
+        observed.append(multiplier)
+        return hg.const(multiplier)
+
+    @graph
+    def app() -> TS[int]:
+        hg.register_service("scaled", scaled_impl)
+        return scaled(path="scaled", multiplier=7)
+
+    assert eval_node(app) == [7]
+    assert observed == [7], observed
+
+
+def test_subscription_service_client_supplies_scalar_options():
+    observed = []
+
+    @hg.subscription_service
+    def quotes(key: TS[str], path: str = "quotes", multiplier: int = 1) -> TS[int]: ...
+
+    @hg.service_impl(interfaces=quotes)
+    def quotes_impl(
+        keys: TSS[str], path: str = "quotes", multiplier: int = 1,
+    ) -> TSD[str, TS[int]]:
+        observed.append(multiplier)
+        return hg.map_(lambda key: hg.const(multiplier), __keys__=keys)
+
+    @graph
+    def app() -> TS[int]:
+        hg.register_service("quotes", quotes_impl)
+        return quotes(hg.const("k"), path="quotes", multiplier=4)
+
+    assert eval_node(app, __end_time__=hg.MIN_ST + 5 * hg.MIN_TD)[-1] == 4
+    assert observed == [4], observed
+
+
+def test_request_reply_service_client_supplies_scalar_options():
+    observed = []
+
+    @hg.request_reply_service
+    def scale(value: TS[int], path: str = "scale", multiplier: int = 1) -> TS[int]: ...
+
+    @hg.service_impl(interfaces=scale)
+    def scale_impl(
+        value: TSD[int, TS[int]], path: str = "scale", multiplier: int = 1,
+    ) -> TSD[int, TS[int]]:
+        observed.append(multiplier)
+        return hg.map_(lambda v: v * multiplier, value)
+
+    @graph
+    def app(value: TS[int]) -> TS[int]:
+        hg.register_service("scale", scale_impl)
+        return scale(value, path="scale", multiplier=3)
+
+    assert eval_node(
+        app, [5], __end_time__=hg.MIN_ST + 5 * hg.MIN_TD)[-1] == 15
+    assert observed == [3], observed
+
+
+def test_service_clients_must_agree_on_options():
+    @hg.reference_service
+    def scaled(path: str = "scaled", multiplier: int = 1) -> TS[int]: ...
+
+    @hg.service_impl(interfaces=scaled)
+    def scaled_impl(path: str = "scaled", multiplier: int = 1) -> TS[int]:
+        return hg.const(multiplier)
+
+    @graph
+    def app() -> TS[int]:
+        hg.register_service("scaled", scaled_impl)
+        first = scaled(path="scaled", multiplier=2)
+        second = scaled(path="scaled", multiplier=3)
+        return first + second
+
+    # The flavour is named in the diagnostic - the store is shared with
+    # adaptors, so the message must read correctly for a service too.
+    with pytest.raises(
+            hg.WiringError,
+            match=r"reference service 'scaled' clients .*disagree.*multiplier"):
+        eval_node(app)
+
+
+def test_service_registration_option_supplies_a_value_clients_do_not_declare():
+    observed = []
+
+    # The stub declares no default for ``multiplier``, so a client that does
+    # not pass one records nothing for it and the registration value is used.
+    # (A stub-level default is recorded as if the client had passed it -
+    # ``bind`` applies defaults - which is the pre-existing adaptor semantic
+    # this shares. See the RFC note on defaulted client options.)
+    @hg.reference_service
+    def scaled(path: str = "scaled") -> TS[int]: ...
+
+    @hg.service_impl(interfaces=scaled)
+    def scaled_impl(path: str = "scaled", multiplier: int = 1) -> TS[int]:
+        observed.append(multiplier)
+        return hg.const(multiplier)
+
+    @graph
+    def app() -> TS[int]:
+        hg.register_service("scaled", scaled_impl, multiplier=9)
+        return scaled(path="scaled")
+
+    assert eval_node(app) == [9]
+    assert observed == [9], observed
+
+
+def test_service_registration_option_conflicting_with_client_is_rejected():
+    @hg.reference_service
+    def scaled(path: str = "scaled", multiplier: int = 1) -> TS[int]: ...
+
+    @hg.service_impl(interfaces=scaled)
+    def scaled_impl(path: str = "scaled", multiplier: int = 1) -> TS[int]:
+        return hg.const(multiplier)
+
+    @graph
+    def app() -> TS[int]:
+        hg.register_service("scaled", scaled_impl, multiplier=9)
+        return scaled(path="scaled", multiplier=2)
+
+    with pytest.raises(hg.WiringError, match="conflicts with"):
+        eval_node(app)
+
+
+def test_distinct_paths_keep_separate_options():
+    observed = []
+
+    @hg.reference_service
+    def scaled(path: str = "scaled", multiplier: int = 1) -> TS[int]: ...
+
+    @hg.service_impl(interfaces=scaled)
+    def scaled_impl(path: str = "scaled", multiplier: int = 1) -> TS[int]:
+        observed.append((path, multiplier))
+        return hg.const(multiplier)
+
+    @graph
+    def app() -> TS[int]:
+        hg.register_service("a", scaled_impl)
+        hg.register_service("b", scaled_impl)
+        return scaled(path="a", multiplier=2) + scaled(path="b", multiplier=5)
+
+    assert eval_node(app) == [7]
+    assert sorted(observed) == [("a", 2), ("b", 5)], observed

--- a/python/tests/test_service_from_to_graph.py
+++ b/python/tests/test_service_from_to_graph.py
@@ -1,0 +1,100 @@
+"""``from_graph`` / ``to_graph`` work for services, not just adaptors.
+
+RFC 0011 step 3. These are the adaptor spelling of ``impl_input`` /
+``impl_output``. They are aliases onto the same wiring - ``service::impl_output``
+and ``adaptor::to_graph`` already build the same stub registration, shared
+output source, capture and rank anchor - so the observable behaviour must be
+identical either way.
+
+By-stub publishing currently requires an implementation scope, which only a
+multi-interface registration opens; these tests therefore use multi-interface
+implementations. Step 4 adds the lazy single-interface by-stub registration,
+at which point the same verbs work there too.
+"""
+
+import pytest
+
+import hgraph as hg
+from hgraph import TS, TSD, TSS, graph
+from hgraph.test import eval_node
+
+
+def test_service_from_to_graph_match_impl_input_output_exactly():
+    @hg.subscription_service
+    def price(key: TS[str], path: str = "p") -> TS[int]: ...
+
+    @hg.request_reply_service
+    def double(value: TS[int], path: str = "p") -> TS[int]: ...
+
+    @hg.service_impl(interfaces=(price, double))
+    def impl_verbs(path: str):
+        keys = hg.impl_input(price, path)
+        hg.impl_output(price, hg.map_(lambda key: hg.const(3), __keys__=keys), path)
+        requests = hg.impl_input(double, path)
+        hg.impl_output(double, hg.map_(lambda v: v * 2, requests), path)
+
+    @hg.service_impl(interfaces=(price, double))
+    def graph_verbs(path: str):
+        keys = hg.from_graph(price, path)
+        hg.to_graph(price, hg.map_(lambda key: hg.const(3), __keys__=keys), path)
+        requests = hg.from_graph(double, path)
+        hg.to_graph(double, hg.map_(lambda v: v * 2, requests), path)
+
+    @graph
+    def with_impl_verbs(value: TS[int]) -> TS[int]:
+        hg.register_service("a", impl_verbs)
+        return price(hg.const("k"), path="a") + double(value, path="a")
+
+    @graph
+    def with_graph_verbs(value: TS[int]) -> TS[int]:
+        hg.register_service("b", graph_verbs)
+        return price(hg.const("k"), path="b") + double(value, path="b")
+
+    end = hg.MIN_ST + 6 * hg.MIN_TD
+    via_impl = eval_node(with_impl_verbs, [6], __end_time__=end)
+    via_graph = eval_node(with_graph_verbs, [6], __end_time__=end)
+    assert via_impl == via_graph, (via_impl, via_graph)
+    # 3 (subscription) + 12 (request/reply doubling 6)
+    assert via_impl[-1] == 15, via_impl
+
+
+def test_to_graph_publishes_a_reference_service_output():
+    @hg.reference_service
+    def rate(path: str = "r") -> TS[int]: ...
+
+    @hg.request_reply_service
+    def double(value: TS[int], path: str = "r") -> TS[int]: ...
+
+    @hg.service_impl(interfaces=(rate, double))
+    def impl(path: str):
+        hg.to_graph(rate, hg.const(21), path)
+        requests = hg.from_graph(double, path)
+        hg.to_graph(double, hg.map_(lambda v: v * 2, requests), path)
+
+    @graph
+    def app(value: TS[int]) -> TS[int]:
+        hg.register_service("r", impl)
+        return rate(path="r") + double(value, path="r")
+
+    out = eval_node(app, [2], __end_time__=hg.MIN_ST + 6 * hg.MIN_TD)
+    assert out[-1] == 25, out
+
+
+def test_reference_service_has_no_from_graph():
+    @hg.reference_service
+    def rate(path: str = "r") -> TS[int]: ...
+
+    @hg.request_reply_service
+    def double(value: TS[int], path: str = "r") -> TS[int]: ...
+
+    @hg.service_impl(interfaces=(rate, double))
+    def impl(path: str):
+        hg.from_graph(rate, path)
+
+    @graph
+    def app(value: TS[int]) -> TS[int]:
+        hg.register_service("r", impl)
+        return rate(path="r") + double(value, path="r")
+
+    with pytest.raises(hg.WiringError, match="no client input"):
+        eval_node(app, [1])

--- a/python/tests/test_service_registration_inputs.py
+++ b/python/tests/test_service_registration_inputs.py
@@ -1,0 +1,125 @@
+"""Service implementations may take time-series inputs supplied at registration.
+
+RFC 0011 step 2. Adaptors have always had this through ``manual_adaptor``;
+``register_service_impl`` had no ``inputs`` parameter at all. A service
+implementation may now declare time-series parameters BEYOND the ones its
+interface supplies, and ``register_service`` binds them.
+
+Registration inputs follow the flavour's own transport input, matching the
+adaptor contract.
+"""
+
+import pytest
+
+import hgraph as hg
+from hgraph import TS, TSD, TSS, graph
+from hgraph.test import eval_node
+
+
+def test_reference_service_impl_takes_a_registration_input():
+    @hg.reference_service
+    def offset_rate(path: str = "rate") -> TS[int]: ...
+
+    @hg.service_impl(interfaces=offset_rate)
+    def offset_rate_impl(offset: TS[int], path: str = "rate") -> TS[int]:
+        return offset + 100
+
+    @graph
+    def app() -> TS[int]:
+        hg.register_service("rate", offset_rate_impl, offset=hg.const(5))
+        return offset_rate(path="rate")
+
+    assert eval_node(app) == [105]
+
+
+def test_subscription_service_impl_takes_a_registration_input():
+    @hg.subscription_service
+    def quotes(key: TS[str], path: str = "quotes") -> TS[int]: ...
+
+    @hg.service_impl(interfaces=quotes)
+    def quotes_impl(
+        keys: TSS[str], base: TS[int], path: str = "quotes",
+    ) -> TSD[str, TS[int]]:
+        # ``keys`` is the interface input; ``base`` comes from registration.
+        return hg.map_(lambda key, b: b, __keys__=keys, b=base)
+
+    @graph
+    def app() -> TS[int]:
+        hg.register_service("quotes", quotes_impl, base=hg.const(11))
+        return quotes(hg.const("k"), path="quotes")
+
+    assert eval_node(app, __end_time__=hg.MIN_ST + 5 * hg.MIN_TD)[-1] == 11
+
+
+def test_request_reply_service_impl_takes_a_registration_input():
+    @hg.request_reply_service
+    def scale(value: TS[int], path: str = "scale") -> TS[int]: ...
+
+    @hg.service_impl(interfaces=scale)
+    def scale_impl(
+        value: TSD[int, TS[int]], factor: TS[int], path: str = "scale",
+    ) -> TSD[int, TS[int]]:
+        return hg.map_(lambda v, f: v * f, value, f=factor)
+
+    @graph
+    def app(value: TS[int]) -> TS[int]:
+        hg.register_service("scale", scale_impl, factor=hg.const(3))
+        return scale(value, path="scale")
+
+    assert eval_node(app, [5], __end_time__=hg.MIN_ST + 5 * hg.MIN_TD)[-1] == 15
+
+
+def test_registration_input_may_be_a_plain_value():
+    # Non-port values are lifted, as they are for manual adaptors.
+    @hg.reference_service
+    def offset_rate(path: str = "rate") -> TS[int]: ...
+
+    @hg.service_impl(interfaces=offset_rate)
+    def offset_rate_impl(offset: TS[int], path: str = "rate") -> TS[int]:
+        return offset + 1
+
+    @graph
+    def app() -> TS[int]:
+        hg.register_service("rate", offset_rate_impl, offset=41)
+        return offset_rate(path="rate")
+
+    assert eval_node(app) == [42]
+
+
+def test_missing_registration_input_is_reported():
+    @hg.reference_service
+    def offset_rate(path: str = "rate") -> TS[int]: ...
+
+    @hg.service_impl(interfaces=offset_rate)
+    def offset_rate_impl(offset: TS[int], path: str = "rate") -> TS[int]:
+        return offset + 1
+
+    @graph
+    def app() -> TS[int]:
+        hg.register_service("rate", offset_rate_impl)
+        return offset_rate(path="rate")
+
+    with pytest.raises(hg.WiringError, match="time-series configuration 'offset'"):
+        eval_node(app)
+
+
+def test_registration_inputs_combine_with_scalar_options():
+    observed = []
+
+    @hg.reference_service
+    def offset_rate(path: str = "rate") -> TS[int]: ...
+
+    @hg.service_impl(interfaces=offset_rate)
+    def offset_rate_impl(
+        offset: TS[int], path: str = "rate", label: str = "none",
+    ) -> TS[int]:
+        observed.append(label)
+        return offset + 1
+
+    @graph
+    def app() -> TS[int]:
+        hg.register_service("rate", offset_rate_impl, offset=1, label="tagged")
+        return offset_rate(path="rate")
+
+    assert eval_node(app) == [2]
+    assert observed == ["tagged"], observed

--- a/src/hgraph/types/service_runtime.cpp
+++ b/src/hgraph/types/service_runtime.cpp
@@ -177,6 +177,29 @@ namespace hgraph
             return capture.peered_node();
         }
 
+        /** Combine the flavour's own transport input (if any) with the extra
+         *  time-series inputs supplied at registration, and check the total
+         *  against the implementation's arity. Registration inputs follow the
+         *  flavour input, matching the adaptor contract. */
+        [[nodiscard]] std::vector<WiringPortRef> combine_impl_inputs(
+            const RuntimeServiceDescriptor &descriptor,
+            const WiredFn &impl,
+            std::span<const WiringPortRef> flavour_inputs,
+            std::span<const WiringPortRef> registration_inputs)
+        {
+            std::vector<WiringPortRef> inputs;
+            inputs.reserve(flavour_inputs.size() + registration_inputs.size());
+            inputs.insert(inputs.end(), flavour_inputs.begin(), flavour_inputs.end());
+            inputs.insert(inputs.end(), registration_inputs.begin(), registration_inputs.end());
+            if (impl.arity != inputs.size())
+            {
+                throw std::invalid_argument(
+                    "service '" + descriptor.name +
+                    "' implementation input count does not match supplied inputs");
+            }
+            return inputs;
+        }
+
         [[nodiscard]] WiringPortRef wire_impl(Wiring &w, const RuntimeServiceDescriptor &descriptor,
                                               const WiredFn &impl, std::span<const WiringPortRef> inputs)
         {
@@ -271,20 +294,28 @@ namespace hgraph
 
     void register_reference_service_impl(Wiring &w, const RuntimeServiceDescriptor &descriptor,
                                          std::string_view path, const WiredFn &impl,
+                                         std::span<const WiringPortRef> implementation_inputs,
                                          bool default_fallback)
     {
         require_flavour(descriptor, ServiceFlavour::Reference, "reference");
         const std::string base = reference_base(descriptor, path);
         const auto *descriptor_ptr = &descriptor;
-        auto materialize = [descriptor_ptr, impl](Wiring &target, std::string_view requested_path) {
+        std::vector<WiringPortRef> stored_inputs{
+            implementation_inputs.begin(), implementation_inputs.end()};
+        auto materialize = [descriptor_ptr, impl, stored_inputs](Wiring &target,
+                                                                 std::string_view requested_path) {
                 const std::string requested_base = reference_base(*descriptor_ptr, requested_path);
                 target.register_built_service_path(requested_base, "reference service");
                 WiringPortRef shared = shared_output_source_node(
                     target, std::type_index(typeid(service::detail::reference_output_source_marker)),
                     descriptor_ptr->output_schema, requested_base);
+                // A reference service has no transport input, so the whole
+                // input list is the registration configuration.
+                const auto impl_inputs = combine_impl_inputs(
+                    *descriptor_ptr, impl, {}, stored_inputs);
                 WiringPortRef output = describe_service_output(
                     *descriptor_ptr, descriptor_ptr->output_schema,
-                    wire_impl(target, *descriptor_ptr, impl, {}));
+                    wire_impl(target, *descriptor_ptr, impl, impl_inputs));
                 const WiringInstance *capture = shared_output_capture_node(
                     target, std::type_index(typeid(service::detail::reference_output_capture_marker)),
                     descriptor_ptr->output_schema, requested_base, output, shared);
@@ -396,12 +427,16 @@ namespace hgraph
 
     void register_subscription_service_impl(Wiring &w, const RuntimeServiceDescriptor &descriptor,
                                             std::string_view path, const WiredFn &impl,
+                                            std::span<const WiringPortRef> implementation_inputs,
                                             bool default_fallback)
     {
         require_flavour(descriptor, ServiceFlavour::Subscription, "subscription");
         const std::string base      = subscription_base(descriptor, path);
         const auto *descriptor_ptr = &descriptor;
-        auto materialize = [descriptor_ptr, impl](Wiring &target, std::string_view requested_path) {
+        std::vector<WiringPortRef> stored_inputs{
+            implementation_inputs.begin(), implementation_inputs.end()};
+        auto materialize = [descriptor_ptr, impl, stored_inputs](Wiring &target,
+                                                                 std::string_view requested_path) {
                 const std::string requested_base = subscription_base(*descriptor_ptr, requested_path);
                 const std::string subs_path = requested_base + "/subs";
                 const std::string out_path  = requested_base + "/out";
@@ -421,7 +456,9 @@ namespace hgraph
                     target, std::type_index(typeid(service::detail::shared_output_source_marker)),
                     dict_meta, out_path);
                 target.register_service_rank_anchor(subs_path, subscriptions.peered_node());
-                std::array<WiringPortRef, 1> impl_inputs{subscriptions};
+                std::array<WiringPortRef, 1> transport{subscriptions};
+                const auto impl_inputs = combine_impl_inputs(
+                    *descriptor_ptr, impl, transport, stored_inputs);
                 WiringPortRef output = describe_service_output(
                     *descriptor_ptr, dict_meta,
                     wire_impl(target, *descriptor_ptr, impl, impl_inputs));
@@ -551,19 +588,25 @@ namespace hgraph
 
     void register_request_reply_service_impl(Wiring &w, const RuntimeServiceDescriptor &descriptor,
                                              std::string_view path, const WiredFn &impl,
+                                             std::span<const WiringPortRef> implementation_inputs,
                                              bool default_fallback)
     {
         require_flavour(descriptor, ServiceFlavour::RequestReply, "request/reply");
         const std::string base         = request_reply_base(descriptor, path);
         const auto *descriptor_ptr = &descriptor;
-        auto materialize = [descriptor_ptr, impl](Wiring &target, std::string_view requested_path) {
+        std::vector<WiringPortRef> stored_inputs{
+            implementation_inputs.begin(), implementation_inputs.end()};
+        auto materialize = [descriptor_ptr, impl, stored_inputs](Wiring &target,
+                                                                 std::string_view requested_path) {
                 const std::string requested_base = request_reply_base(*descriptor_ptr, requested_path);
                 const std::string request_path = requested_base + "/request";
                 const std::string replies_path = requested_base + "/replies";
                 target.register_built_service_path(requested_base, "request/reply service");
                 WiringPortRef requests = request_input_source_node(target, *descriptor_ptr, request_path);
                 target.register_service_rank_anchor(request_path, requests.peered_node());
-                std::array<WiringPortRef, 1> impl_inputs{requests};
+                std::array<WiringPortRef, 1> transport{requests};
+                const auto impl_inputs = combine_impl_inputs(
+                    *descriptor_ptr, impl, transport, stored_inputs);
                 WiringPortRef output = wire_impl(target, *descriptor_ptr, impl, impl_inputs);
                 if (descriptor_ptr->response_schema == nullptr)
                 {

--- a/tests/cpp/test_service_push_sources.cpp
+++ b/tests/cpp/test_service_push_sources.cpp
@@ -315,16 +315,14 @@ namespace
     // Adaptor (confirmatory — adaptors were designed for exactly this)
     // ---------------------------------------------------------------------
 
-    // Deliberately DUPLEX. A source-only adaptor (``adaptor::interface`` with only
-    // ``output_schema``) also satisfies ``service::detail::reference_service_interface``,
-    // so ``wire<Interface>`` is an ambiguous partial specialization in any
-    // translation unit that includes both service_wiring.h and adaptor_wiring.h.
-    // Declaring ``input_schema`` excludes the service concept and keeps this test
-    // about push sources rather than about that overlap.
+    // SOURCE-ONLY. This was duplex when the test was written, because a
+    // source-only adaptor also satisfied reference_service_interface and
+    // wire<Interface> was ambiguous in any translation unit including both
+    // boundary headers. RFC 0011 step 9 made the concepts disjoint, so the
+    // workaround is gone and this is the shape the test always wanted.
     struct TickAdaptor : adaptor::interface
     {
         static constexpr std::string_view name{"tick_adaptor"};
-        using input_schema  = TS<Int>;
         using output_schema = TS<Int>;
     };
 
@@ -334,9 +332,6 @@ namespace
 
         static void compose(Wiring &w)
         {
-            // The client input exists only to keep the adaptor duplex; the output
-            // is driven entirely by the implementation-owned push source.
-            static_cast<void>(wire<stdlib::null_sink>(w, adaptor::from_graph<TickAdaptor>(w)));
             adaptor::to_graph<TickAdaptor>(
                 w, push_source_port<TS<Int>>(w, std::type_index(typeid(AdaptorTicksTag)), adaptor_sender));
         }
@@ -349,7 +344,7 @@ namespace
         static void compose(Wiring &w)
         {
             adaptor::register_adaptor<TickAdaptor, TickAdaptorImpl>(w);
-            collect(w, wire<TickAdaptor>(w, wire<stdlib::const_>(w, Int{0}).as<TS<Int>>()), 1);
+            collect(w, wire<TickAdaptor>(w), 1);
         }
     };
 

--- a/tests/cpp/test_service_wiring.cpp
+++ b/tests/cpp/test_service_wiring.cpp
@@ -4,6 +4,7 @@
 #include <hgraph/lib/std/std_nodes.h>
 #include <hgraph/lib/testing/check_output.h>
 #include <hgraph/lib/testing/eval_node.h>
+#include <hgraph/types/adaptor_wiring.h>
 #include <hgraph/types/service_wiring.h>
 #include <hgraph/types/static_node.h>
 #include <hgraph/types/value/value_builder.h>
@@ -1624,6 +1625,48 @@ namespace
         }
     };
 
+    // RFC 0011 step 7: ONE implementation spanning an adaptor and a service.
+    // This is the shape services.rst documents as "a sink-only interface in, a
+    // source-only interface out" - now expressible as a single atomic
+    // registration rather than two.
+    struct CollectAdaptor : adaptor::interface
+    {
+        static constexpr std::string_view name{"collect_in"};
+        using input_schema = TS<Int>;
+    };
+
+    struct PublishService
+    {
+        static constexpr std::string_view name{"publish_out"};
+        using output_schema = TS<Int>;
+    };
+
+    struct MixedFlavourImpl
+    {
+        [[maybe_unused]] static constexpr auto name = "mixed_flavour_impl";
+
+        static void compose(Wiring &w, Scalar<"path", Str> path)
+        {
+            const auto custom = service::path(path.value());
+            auto collected = adaptor::from_graph<CollectAdaptor>(w, custom);
+            service::to_graph<PublishService>(
+                w, custom, wire<AddOneValueNode>(w, collected).as<TS<Int>>());
+        }
+    };
+
+    struct MixedFlavourGraph
+    {
+        [[maybe_unused]] static constexpr auto name = "mixed_flavour_graph";
+
+        static Port<TS<Int>> compose(Wiring &w, Port<TS<Int>> value)
+        {
+            const auto custom = service::path("mixed");
+            service::register_services<MixedFlavourImpl, CollectAdaptor, PublishService>(w, custom);
+            adaptor::adaptor<CollectAdaptor>(w, custom, value);
+            return wire<PublishService>(w, custom);
+        }
+    };
+
     inline int single_interface_stub_compositions = 0;
 
     // RFC 0011 step 4: register_services with ONE interface is the
@@ -2331,6 +2374,17 @@ TEST_CASE("service wiring: multi-interface implementation graph wires explicit s
     hgraph::stdlib::register_standard_operators();
 
     CHECK_OUTPUT(eval_node<MultiServiceClientGraph>(values<Int>(1)), values<Int>(none, none, 13));
+}
+
+TEST_CASE("service wiring: one implementation may span an adaptor and a service")
+{
+    hgraph::stdlib::register_standard_operators();
+
+    // RFC 0011 step 7. register_services describes each member through
+    // boundary_detail::group_member, so the pack may mix families when both
+    // headers are visible. Value in through the sink-only adaptor, out through
+    // the reference service, +1 in between.
+    CHECK_OUTPUT(eval_node<MixedFlavourGraph>(values<Int>(1, 2)), values<Int>(2, 3));
 }
 
 TEST_CASE("service wiring: a generic implementation output must match the resolved interface schema")

--- a/tests/cpp/test_service_wiring.cpp
+++ b/tests/cpp/test_service_wiring.cpp
@@ -1625,6 +1625,40 @@ namespace
         }
     };
 
+    // RFC 0011 step 9: a SOURCE-ONLY adaptor (output, no input) in a
+    // translation unit that includes BOTH service_wiring.h and
+    // adaptor_wiring.h. Before the concepts were made disjoint this did not
+    // compile - wire<Interface> matched both wire_customization
+    // specializations. It now lowers onto the reference-service machinery.
+    struct SourceOnlyFeedAdaptor : adaptor::interface
+    {
+        static constexpr std::string_view name{"source_only_feed"};
+        using output_schema = TS<Int>;
+    };
+
+    struct SourceOnlyFeedImpl
+    {
+        [[maybe_unused]] static constexpr auto name = "source_only_feed_impl";
+
+        static void compose(Wiring &w, Scalar<"path", Str> path)
+        {
+            adaptor::to_graph<SourceOnlyFeedAdaptor>(
+                w, service::path(path.value()), wire<stdlib::const_>(w, Int{9}).as<TS<Int>>());
+        }
+    };
+
+    struct SourceOnlyFeedGraph
+    {
+        [[maybe_unused]] static constexpr auto name = "source_only_feed_graph";
+
+        static Port<TS<Int>> compose(Wiring &w)
+        {
+            const auto custom = service::path("feed");
+            adaptor::register_adaptor<SourceOnlyFeedAdaptor, SourceOnlyFeedImpl>(w, custom);
+            return wire<SourceOnlyFeedAdaptor>(w, custom);
+        }
+    };
+
     // RFC 0011 step 7: ONE implementation spanning an adaptor and a service.
     // This is the shape services.rst documents as "a sink-only interface in, a
     // source-only interface out" - now expressible as a single atomic
@@ -2374,6 +2408,16 @@ TEST_CASE("service wiring: multi-interface implementation graph wires explicit s
     hgraph::stdlib::register_standard_operators();
 
     CHECK_OUTPUT(eval_node<MultiServiceClientGraph>(values<Int>(1)), values<Int>(none, none, 13));
+}
+
+TEST_CASE("service wiring: a source-only adaptor is unambiguous alongside services")
+{
+    hgraph::stdlib::register_standard_operators();
+
+    // RFC 0011 step 9. The value of this case is largely that it COMPILES:
+    // this file includes both boundary headers, which previously made
+    // wire<SourceOnlyFeedAdaptor> an ambiguous partial specialization.
+    CHECK_OUTPUT(eval_node<SourceOnlyFeedGraph>(), values<Int>(9));
 }
 
 TEST_CASE("service wiring: one implementation may span an adaptor and a service")

--- a/tests/cpp/test_service_wiring.cpp
+++ b/tests/cpp/test_service_wiring.cpp
@@ -1599,6 +1599,39 @@ namespace
         }
     };
 
+    // RFC 0011 step 3: the adaptor spelling of impl_input/impl_output. Same
+    // wiring, so the same graph must produce the same result.
+    struct MultiRequestReplyFromToGraphImpl
+    {
+        [[maybe_unused]] static constexpr auto name = "multi_request_reply_from_to_graph_impl";
+
+        static void compose(Wiring &w, Scalar<"path", Str> path)
+        {
+            const auto custom = service::path(path.value());
+            auto add_one_requests = service::from_graph<AddOneService>(w, custom);
+            auto add_ten_requests = service::from_graph<AddTenService>(w, custom);
+            auto add_one_replies = wire<AddOneImplNode>(w, add_one_requests).as<TSD<Int, TS<Int>>>();
+            auto add_ten_replies = wire<AddTenImplNode>(w, add_ten_requests).as<TSD<Int, TS<Int>>>();
+            service::to_graph<AddOneService>(w, custom, add_one_replies);
+            service::to_graph<AddTenService>(w, custom, add_ten_replies);
+        }
+    };
+
+    struct MultiServiceFromToGraphClientGraph
+    {
+        [[maybe_unused]] static constexpr auto name = "multi_service_from_to_graph_client_graph";
+
+        static Port<TS<Int>> compose(Wiring &w, Port<TS<Int>> request)
+        {
+            const auto custom = service::path("multi_from_to");
+            service::register_services<
+                MultiRequestReplyFromToGraphImpl, AddOneService, AddTenService>(w, custom);
+            auto add_one = wire<AddOneService>(w, custom, request);
+            auto add_ten = wire<AddTenService>(w, custom, request);
+            return wire<stdlib::add_>(w, add_one, add_ten).as<TS<Int>>();
+        }
+    };
+
     struct MultiServiceClientGraph
     {
         [[maybe_unused]] static constexpr auto name = "multi_service_client_graph";
@@ -2215,6 +2248,17 @@ TEST_CASE("service wiring: multi-interface implementation graph wires explicit s
     hgraph::stdlib::register_standard_operators();
 
     CHECK_OUTPUT(eval_node<MultiServiceClientGraph>(values<Int>(1)), values<Int>(none, none, 13));
+}
+
+TEST_CASE("service wiring: service from_graph/to_graph spell the same wiring as impl_input/impl_output")
+{
+    hgraph::stdlib::register_standard_operators();
+
+    // RFC 0011 step 3. Identical to the case above, written with the adaptor
+    // verbs - they are aliases onto impl_input/impl_output, not a second
+    // mechanism, so the observable result must match exactly.
+    CHECK_OUTPUT(eval_node<MultiServiceFromToGraphClientGraph>(values<Int>(1)),
+                 values<Int>(none, none, 13));
 }
 
 TEST_CASE("service wiring: shared replay service hands clients to the live reference")

--- a/tests/cpp/test_service_wiring.cpp
+++ b/tests/cpp/test_service_wiring.cpp
@@ -1590,6 +1590,40 @@ namespace
         }
     };
 
+    // RFC 0011 step 5: a GENERIC reference service whose implementation
+    // returns the wrong resolved type. The concrete path has always rejected
+    // this via Port::as<>; the non-concrete branch of wire_service_impl did
+    // not compare against the resolved meta at all.
+    struct GenericRateService
+    {
+        static constexpr std::string_view name{"generic_rate"};
+        using output_schema = TS<ScalarVar<"NUMBER", Int, Float>>;
+    };
+
+    struct MismatchedGenericRateImpl
+    {
+        [[maybe_unused]] static constexpr auto name = "mismatched_generic_rate_impl";
+
+        // Declared NUMBER=Int by the registration path, but produces a Float.
+        static Port<TS<Float>> compose(Wiring &w)
+        {
+            return wire<stdlib::const_>(w, Float{1.5}).as<TS<Float>>();
+        }
+    };
+
+    struct MismatchedGenericRateGraph
+    {
+        [[maybe_unused]] static constexpr auto name = "mismatched_generic_rate_graph";
+
+        static Port<TS<Int>> compose(Wiring &w)
+        {
+            service::register_reference_service<GenericRateService, MismatchedGenericRateImpl>(
+                w, service::path("generic_rate", arg<"NUMBER">(scalar_type<Int>())));
+            return wire<GenericRateService>(
+                w, service::path("generic_rate", arg<"NUMBER">(scalar_type<Int>()))).as<TS<Int>>();
+        }
+    };
+
     inline int single_interface_stub_compositions = 0;
 
     // RFC 0011 step 4: register_services with ONE interface is the
@@ -2297,6 +2331,17 @@ TEST_CASE("service wiring: multi-interface implementation graph wires explicit s
     hgraph::stdlib::register_standard_operators();
 
     CHECK_OUTPUT(eval_node<MultiServiceClientGraph>(values<Int>(1)), values<Int>(none, none, 13));
+}
+
+TEST_CASE("service wiring: a generic implementation output must match the resolved interface schema")
+{
+    hgraph::stdlib::register_standard_operators();
+
+    // RFC 0011 step 5. Without the resolved-meta comparison in the
+    // non-concrete branch of wire_service_impl this builds happily and the
+    // capture is created over the IMPLEMENTATION's schema while the source
+    // uses the interface's - the same unchecked mismatch adaptors had.
+    CHECK_THROWS_AS(build_graph<MismatchedGenericRateGraph>(), std::invalid_argument);
 }
 
 TEST_CASE("service wiring: a single-interface implementation may publish by stub")

--- a/tests/cpp/test_service_wiring.cpp
+++ b/tests/cpp/test_service_wiring.cpp
@@ -1579,7 +1579,56 @@ namespace
 
         static void compose(Wiring &w)
         {
-            service::register_services<MissingMultiServiceOutputImpl, AddOneService>(w, service::path("missing"));
+            const auto custom = service::path("missing");
+            service::register_services<MissingMultiServiceOutputImpl, AddOneService>(w, custom);
+            // register_services is LAZY (RFC 0011 step 4), so an implementation
+            // nothing asks for is never materialized and never validated. A
+            // client makes the candidate wanted, at which point the
+            // required-endpoint scope fires as before.
+            static_cast<void>(wire<AddOneService>(
+                w, custom, wire<stdlib::const_>(w, Int{1}).as<TS<Int>>()));
+        }
+    };
+
+    inline int single_interface_stub_compositions = 0;
+
+    // RFC 0011 step 4: register_services with ONE interface is the
+    // single-interface BY-STUB registration - the quadrant services lacked
+    // against register_adaptor / register_automatic_adaptor.
+    struct SingleInterfaceStubImpl
+    {
+        [[maybe_unused]] static constexpr auto name = "single_interface_stub_impl";
+
+        static void compose(Wiring &w, Scalar<"path", Str> path)
+        {
+            ++single_interface_stub_compositions;
+            const auto custom = service::path(path.value());
+            auto requests = service::from_graph<AddOneService>(w, custom);
+            service::to_graph<AddOneService>(
+                w, custom, wire<AddOneImplNode>(w, requests).as<TSD<Int, TS<Int>>>());
+        }
+    };
+
+    struct SingleInterfaceStubClientGraph
+    {
+        [[maybe_unused]] static constexpr auto name = "single_interface_stub_client_graph";
+
+        static Port<TS<Int>> compose(Wiring &w, Port<TS<Int>> request)
+        {
+            const auto custom = service::path("single_stub");
+            service::register_services<SingleInterfaceStubImpl, AddOneService>(w, custom);
+            return wire<AddOneService>(w, custom, request);
+        }
+    };
+
+    struct UnrequestedMultiServiceGraph
+    {
+        [[maybe_unused]] static constexpr auto name = "unrequested_multi_service_graph";
+
+        static void compose(Wiring &w)
+        {
+            service::register_services<SingleInterfaceStubImpl, AddOneService>(
+                w, service::path("unrequested"));
         }
     };
 
@@ -2248,6 +2297,30 @@ TEST_CASE("service wiring: multi-interface implementation graph wires explicit s
     hgraph::stdlib::register_standard_operators();
 
     CHECK_OUTPUT(eval_node<MultiServiceClientGraph>(values<Int>(1)), values<Int>(none, none, 13));
+}
+
+TEST_CASE("service wiring: a single-interface implementation may publish by stub")
+{
+    hgraph::stdlib::register_standard_operators();
+
+    // RFC 0011 step 4. register_services with one interface publishes through
+    // from_graph/to_graph rather than by returning a port.
+    single_interface_stub_compositions = 0;
+    CHECK_OUTPUT(eval_node<SingleInterfaceStubClientGraph>(values<Int>(1)),
+                 values<Int>(none, none, 2));
+    CHECK(single_interface_stub_compositions == 1);
+}
+
+TEST_CASE("service wiring: register_services materializes only on demand")
+{
+    hgraph::stdlib::register_standard_operators();
+
+    // RFC 0011 step 4: register_services is now LAZY, matching
+    // register_adaptors and the erased register_multi_service_impl. An
+    // implementation nothing requests is never composed.
+    single_interface_stub_compositions = 0;
+    CHECK_NOTHROW(build_graph<UnrequestedMultiServiceGraph>());
+    CHECK(single_interface_stub_compositions == 0);
 }
 
 TEST_CASE("service wiring: service from_graph/to_graph spell the same wiring as impl_input/impl_output")


### PR DESCRIPTION
Implements [RFC 0011](../blob/main/docs/source/rfc/rfc_0011_source_only_adaptor_collapse.rst) end to end — nine commits, one per step, each green against the full suites. The RFC is marked **Accepted** in the final commit.

**Result: 1414 ctest, 1864 Python tests, 0 failures.** No behaviour regressions; two intended behaviour changes noted below.

## What this does

The RFC's finding was that a source-only adaptor and a reference service are the same construct — the relay construction was *identical*, and the erased runtime already shared its implementation. Per your ruling the fix is **union, not intersection**: lift the adaptor's usage model onto services first, then collapse.

**Stage 1 — lift (steps 1-8), all additive:**

| Step | What |
|---|---|
| 1 | Service clients pass wiring-time scalar options, all three flavours, with the cross-client agreement check |
| 2 | Service implementations take time-series inputs supplied at registration |
| 3 | `from_graph`/`to_graph` spell the service verbs too |
| 4 | `register_services` is lazy — which *is* the single-interface by-stub registration |
| 5 | Generic implementation output schemas are checked |
| 6 | `@service_impl(interfaces=())` may serve as a catch-all |
| 7 | One implementation may span an adaptor and a service |
| 8 | Shared boundary helpers deduplicated |

**Stage 2 — collapse (step 9):** the concepts are made disjoint (fixing the `wire<>` ambiguity), and `boundary_detail::shared_output_relay_source`/`_capture` become the **single relay implementation** both families forward to.

## Four things implementation changed

- **Steps 7 and 8 swapped.** Dedup was planned as cleanup-last; it is a *prerequisite*. The family headers don't include each other, so a mixed group isn't expressible until `ServicePath`/`AdaptorPath` are one type.
- **Mixed groups needed a customization point**, not a relaxed `static_assert` — `boundary_detail::group_member`, specialized per family, same idiom as `wire_customization`.
- **The concepts are separated structurally** via a tag member on `adaptor::interface`, so `service_wiring.h` needs no dependency on `adaptor_wiring.h`.
- **The source-only spelling was kept.** With one shared relay it is no longer a second implementation, so deleting it buys nothing and would break unknown downstream users. Deletion can follow once exposure is known, no further RFC needed.

## Two intended behaviour changes

1. A surplus time-series parameter on a service implementation used to be a decoration-time `TypeError`; it is now registration configuration, so the failure moves to registration and names the missing parameter. `test_services_from_python` updated, keeping a decoration-time case for *too few* parameters.
2. `register_services` being lazy means a never-published **unused** registration is no longer caught at build time — the accepted consequence. `MissingMultiServiceStubGraph` gains a client, after which the same throw fires as before.

## Notes

- Step 5's hole was confirmed by a test that did **not** throw before the fix, after two false starts where it failed for an unrelated resolution error.
- `test_service_push_sources.cpp` drops the duplex workaround it carried from #257 and declares the source-only adaptor it always wanted.
- Client scalar options turned out to have **no C++ component at all**, and the implementation-consumption half already worked — only client recording was missing.
- `services.rst` gains "The service and adaptor surfaces are one boundary model", including when to reach for each spelling: intent, not capability.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
