### PR TITLE
Cache input builders and reduce target-link churn

### DIFF
--- a/include/hgraph/runtime/node.h
+++ b/include/hgraph/runtime/node.h
@@ -36,6 +36,7 @@ namespace hgraph
 {
     class GraphValue;
     class GraphView;
+    class GraphBuilder;
     class NodeBuilder;
     class NodeValue;
     struct NodeSchedulerState;
@@ -476,6 +477,7 @@ namespace hgraph
         [[nodiscard]] NodeValue make_node(std::size_t node_index = 0) const;
 
       private:
+        friend class GraphBuilder;
         friend class NodeValue;
 
         [[nodiscard]] static NodeBuilder
@@ -483,9 +485,11 @@ namespace hgraph
                              const void *runtime_type_id,
                              TSEndpointSchema input_endpoint);
         NodeBuilder(NodeTypeRef type, TSEndpointSchema input_endpoint);
+        void refresh_input_builder();
 
         NodeTypeRef            type_{};
         TSEndpointSchema       input_endpoint_{};
+        const TSInputBuilder   *input_builder_{nullptr};
         TSEndpointSchema       output_endpoint_{};
         ValueStorageVariant    output_value_storage_{
             ValueStorageVariant::Native};

--- a/include/hgraph/types/time_series/ts_input.h
+++ b/include/hgraph/types/time_series/ts_input.h
@@ -83,6 +83,7 @@ namespace hgraph
         explicit TSInputBuilder(TSInputConstructionPlan plan);
 
         TSInputConstructionPlan plan_;
+        TSInputTypeRef          storage_type_{};
     };
 
     class TSInputBuilderFactory

--- a/include/hgraph/types/time_series/ts_input/detail.h
+++ b/include/hgraph/types/time_series/ts_input/detail.h
@@ -18,6 +18,29 @@ namespace hgraph::detail
     struct TSInputActiveTarget;
     struct TSInputViewOps;
 
+    /**
+     * True when the endpoint's input storage representation is independent of
+     * the graph's TypeRealizationSnapshot.
+     *
+     * Peered leaves own only target-link state, so their storage can be shared
+     * across graph realizations. Non-peered projections are likewise stable
+     * when every descendant is peered. An owned endpoint embeds local payload
+     * storage and must therefore be resolved while the constructing graph's
+     * realization scope is active.
+     */
+    [[nodiscard]] inline bool
+    input_storage_type_is_realization_invariant(const TSEndpointSchema &endpoint) noexcept
+    {
+        if (endpoint.empty()) { return false; }
+        if (endpoint.is_peered()) { return true; }
+        if (endpoint.is_owned()) { return false; }
+        for (const auto &child : endpoint.children())
+        {
+            if (!input_storage_type_is_realization_invariant(child)) { return false; }
+        }
+        return true;
+    }
+
     struct TSInputChildProjection
     {
         TSDataView visible{};

--- a/include/hgraph/types/time_series/ts_input/target_link.h
+++ b/include/hgraph/types/time_series/ts_input/target_link.h
@@ -38,6 +38,10 @@ namespace hgraph::detail
         std::size_t              slot{0};
         bool locally_active{false};
         TSInputObservationKind observation_kind{TSInputObservationKind::Value};
+        /** True only when ``scheduling_notifier`` has its own observer entry.
+            Value observation at the exact target root is coalesced through
+            the target-link state observer instead. */
+        bool scheduling_subscribed{false};
         TSOutputHandle observed{};
         SmallDensePtrMap<std::size_t, TSInputTargetActiveNode> children{};
 

--- a/src/hgraph/runtime/graph.cpp
+++ b/src/hgraph/runtime/graph.cpp
@@ -1841,6 +1841,7 @@ GraphBuilder &GraphBuilder::label(std::string label) {
 }
 
 GraphBuilder &GraphBuilder::add_node(NodeBuilder node) {
+  node.refresh_input_builder();
   nodes_.push_back(std::move(node));
   invalidate_types();
   return *this;

--- a/src/hgraph/runtime/node.cpp
+++ b/src/hgraph/runtime/node.cpp
@@ -274,9 +274,13 @@ namespace hgraph
         }
 
         [[nodiscard]] const TSInputBuilder &input_builder_for(const TSValueTypeMetaData &schema,
-                                                              TSEndpointSchema endpoint)
+                                                              const TSEndpointSchema &endpoint)
         {
-            if (endpoint.empty()) { endpoint = default_input_endpoint(schema); }
+            if (endpoint.empty())
+            {
+                const auto default_endpoint = default_input_endpoint(schema);
+                return TSInputBuilderFactory::checked_builder_for(schema, default_endpoint);
+            }
             return TSInputBuilderFactory::checked_builder_for(schema, endpoint);
         }
 
@@ -347,7 +351,7 @@ namespace hgraph
 
         void construct_node_storage_impl(const NodeRuntimeContext &context,
                                          const NodeTypeMetaData   &schema,
-                                         TSEndpointSchema          input_endpoint,
+                                         const TSInputBuilder     *input_builder,
                                          TSEndpointSchema          output_endpoint_override,
                                          ValueStorageVariant       output_value_storage,
                                          std::string               runtime_label,
@@ -374,11 +378,15 @@ namespace hgraph
 
             if (context.layout.has_input())
             {
+                if (input_builder == nullptr)
+                {
+                    throw std::logic_error("Node storage input builder is not resolved");
+                }
                 const auto *component = plan.find_component("input");
                 if (component == nullptr) { throw std::logic_error("Node storage plan is missing input"); }
                 std::construct_at(MemoryUtils::cast<TSInput>(
                                       MemoryUtils::advance(memory, component->offset)),
-                                  input_builder_for(*schema.input_schema, std::move(input_endpoint)));
+                                  *input_builder);
                 constructed.push_back(component);
             }
 
@@ -1718,6 +1726,18 @@ namespace hgraph
     {
     }
 
+    void NodeBuilder::refresh_input_builder()
+    {
+        input_builder_ = nullptr;
+        if (!type_) { return; }
+
+        const auto *node_schema = type_.schema();
+        if (node_schema != nullptr && node_schema->input_schema != nullptr)
+        {
+            input_builder_ = &input_builder_for(*node_schema->input_schema, input_endpoint_);
+        }
+    }
+
     NodeBuilder &NodeBuilder::label(std::string label)
     {
         label_ = std::move(label);
@@ -1749,6 +1769,7 @@ namespace hgraph
             }
         }
         input_endpoint_ = std::move(endpoint);
+        input_builder_ = nullptr;
         return *this;
     }
 
@@ -1936,9 +1957,14 @@ namespace hgraph
 
         const auto type = this->type();
         const auto &runtime = runtime_context(type.ops_ref().context);
+        const TSInputBuilder *input_builder = input_builder_;
+        if (runtime.layout.has_input() && input_builder == nullptr)
+        {
+            input_builder = &input_builder_for(*type.schema()->input_schema, input_endpoint());
+        }
         construct_node_storage_impl(runtime,
                                     *type.schema(),
-                                    input_endpoint(),
+                                    input_builder,
                                     output_endpoint(),
                                     output_value_storage(),
                                     std::string{label()},

--- a/src/hgraph/types/time_series/ts_input.cpp
+++ b/src/hgraph/types/time_series/ts_input.cpp
@@ -2636,11 +2636,24 @@ namespace hgraph
         return TSInputConstructionPlan{root_schema, endpoint_schema};
     }
 
-    TSInputBuilder::TSInputBuilder(TSInputConstructionPlan plan)
-        : plan_(std::move(plan)),
-          storage_type_(TSInputTypeRef::checked(input_storage_type_for(plan_.endpoint_schema())))
+    namespace
     {
-        if (!storage_type_) { throw std::logic_error("TSInputBuilder could not resolve input storage type"); }
+        [[nodiscard]] TSInputTypeRef resolved_input_storage_type(const TSInputConstructionPlan &plan,
+                                                                 std::string_view owner)
+        {
+            const auto type = TSInputTypeRef::checked(input_storage_type_for(plan.endpoint_schema()));
+            if (!type) { throw std::logic_error(std::string{owner} + " could not resolve input storage type"); }
+            return type;
+        }
+    }
+
+    TSInputBuilder::TSInputBuilder(TSInputConstructionPlan plan)
+        : plan_(std::move(plan))
+    {
+        if (detail::input_storage_type_is_realization_invariant(plan_.endpoint_schema()))
+        {
+            storage_type_ = resolved_input_storage_type(plan_, "TSInputBuilder");
+        }
     }
 
     const TSValueTypeMetaData &TSInputBuilder::schema() const noexcept
@@ -2719,7 +2732,8 @@ namespace hgraph
     TSInput::TSInput(const TSInputBuilder &builder)
         : builder_(&builder),
           schema_(&builder.plan_.schema()),
-          data_(builder.storage_type_)
+          data_(builder.storage_type_ ? builder.storage_type_
+                                     : resolved_input_storage_type(builder.plan_, "TSInput"))
     {
         attach_root_parent();
     }

--- a/src/hgraph/types/time_series/ts_input.cpp
+++ b/src/hgraph/types/time_series/ts_input.cpp
@@ -469,6 +469,44 @@ namespace hgraph
             return schema != nullptr ? ValuePlanFactory::instance().type_for(schema->value_schema) : nullptr;
         }
 
+        [[nodiscard]] ValueTypeRef realized_input_value_binding_for(const ValueTypeMetaData *schema)
+        {
+            if (schema == nullptr) { return {}; }
+            if (const auto *snapshot = active_type_realization(); snapshot != nullptr)
+            {
+                if (const auto realized = snapshot->type_for(schema)) { return realized; }
+            }
+            return ValuePlanFactory::instance().type_for(schema);
+        }
+
+        [[nodiscard]] const MemoryUtils::StoragePlan &
+        owned_input_storage_plan(const TSValueTypeMetaData &schema)
+        {
+            const bool scalar = schema.kind == TSTypeKind::TS || schema.kind == TSTypeKind::SIGNAL ||
+                                schema.kind == TSTypeKind::REF;
+            if (scalar)
+            {
+                const auto value = realized_input_value_binding_for(schema.value_schema);
+                if (!value) { throw std::logic_error("TSInput owned scalar value binding is not resolved"); }
+                auto builder = MemoryUtils::named_tuple();
+                builder.reserve(2);
+                builder.add_field("value", value.checked_plan());
+                builder.add_field("tracking", MemoryUtils::plan_for<TSDataTracking>());
+                return builder.build();
+            }
+            if (schema.kind == TSTypeKind::TSB ||
+                (schema.kind == TSTypeKind::TSL && schema.fixed_size() != 0))
+            {
+                const auto *plan = ts_data_plan_factory_detail::synthesise_fixed_plan(schema);
+                if (plan == nullptr) { throw std::logic_error("TSInput owned fixed storage plan is not resolved"); }
+                return *plan;
+            }
+
+            const auto type = regular_ts_data_type_for(&schema);
+            if (!type) { throw std::logic_error("TSInput owned endpoint storage requires a TSData type"); }
+            return type.checked_plan();
+        }
+
         [[nodiscard]] const MemoryUtils::StoragePlan &input_storage_plan(const TSEndpointSchema &endpoint_schema);
         [[nodiscard]] TSRoleTypeRef input_data_type_for(const TSEndpointSchema         &endpoint_schema,
                                                         const MemoryUtils::StoragePlan &root_plan,
@@ -523,9 +561,12 @@ namespace hgraph
             }
             if (endpoint_schema.is_owned())
             {
-                const auto type = regular_ts_data_type_for(endpoint_schema.schema());
-                if (!type) throw std::logic_error("TSInput owned endpoint storage requires a TSData type");
-                return type.checked_plan();
+                const auto *schema = endpoint_schema.schema();
+                if (schema == nullptr)
+                {
+                    throw std::logic_error("TSInput owned endpoint storage requires a TSData schema");
+                }
+                return owned_input_storage_plan(*schema);
             }
 
             const auto *schema = endpoint_schema.schema();
@@ -2151,17 +2192,14 @@ namespace hgraph
                 throw std::invalid_argument("scalar input type requires a peered or owned TS/SIGNAL endpoint");
             }
 
-            const auto data_type = TSDataPlanFactory::instance().data_type_for(schema);
             if (endpoint_schema.is_owned())
             {
-                return checked_ts_role_type(
-                    intern_ts_type(*schema, TypeRole::Input, data_type.checked_plan(), data_type.ops_ref(),
-                                   schema->kind == TSTypeKind::REF
-                                       ? std::string_view{"ts.ref.input.owned"}
-                                       : std::string_view{}),
-                    std::integral_constant<TypeRole, TypeRole::Input>{});
+                const auto &root_plan = input_storage_plan(endpoint_schema);
+                return TSInputTypeRef::checked(input_storage_type_for(
+                    endpoint_schema, root_plan, 0, true, TypeRole::Input));
             }
 
+            const auto data_type = TSDataPlanFactory::instance().data_type_for(schema);
             const auto &root_plan = input_storage_plan(endpoint_schema);
             const auto key = binding_cache_key(endpoint_schema, root_plan, 0);
             std::lock_guard lock{target_link_context_cache_mutex()};
@@ -2257,8 +2295,8 @@ namespace hgraph
 
                 const auto *value = local_plan.find_component("value");
                 const auto *tracking = local_plan.find_component("tracking");
-                const auto value_type = ValuePlanFactory::instance().type_for(schema->value_schema);
-                const auto delta_type = ValuePlanFactory::instance().type_for(schema->delta_value_schema);
+                const auto value_type = realized_input_value_binding_for(schema->value_schema);
+                const auto delta_type = realized_input_value_binding_for(schema->delta_value_schema);
                 if (value == nullptr || tracking == nullptr || !value_type || !delta_type)
                     throw std::logic_error("owned scalar input storage components are not resolved");
                 const auto &ops = ts_data_plan_factory_detail::atomic_ts_data_ops(

--- a/src/hgraph/types/time_series/ts_input.cpp
+++ b/src/hgraph/types/time_series/ts_input.cpp
@@ -2637,8 +2637,10 @@ namespace hgraph
     }
 
     TSInputBuilder::TSInputBuilder(TSInputConstructionPlan plan)
-        : plan_(std::move(plan))
+        : plan_(std::move(plan)),
+          storage_type_(TSInputTypeRef::checked(input_storage_type_for(plan_.endpoint_schema())))
     {
+        if (!storage_type_) { throw std::logic_error("TSInputBuilder could not resolve input storage type"); }
     }
 
     const TSValueTypeMetaData &TSInputBuilder::schema() const noexcept
@@ -2715,9 +2717,11 @@ namespace hgraph
     TSInput::TSInput() noexcept = default;
 
     TSInput::TSInput(const TSInputBuilder &builder)
-        : builder_(&builder)
+        : builder_(&builder),
+          schema_(&builder.plan_.schema()),
+          data_(builder.storage_type_)
     {
-        rebuild_from_plan(builder.plan_);
+        attach_root_parent();
     }
 
     TSInput::TSInput(const TSInputConstructionPlan &plan)

--- a/src/hgraph/types/time_series/ts_input/target_link.cpp
+++ b/src/hgraph/types/time_series/ts_input/target_link.cpp
@@ -78,8 +78,16 @@ namespace hgraph::detail
         void unsubscribe_node(TSInputTargetActiveNode &node,
                               TSInputTargetLinkState::SchedulingNotifier &notifier) noexcept
         {
-            if (!node.observed.bound()) { return; }
-            [[maybe_unused]] auto reset_observed = make_scope_exit([&]() noexcept { node.observed.reset(); });
+            if (!node.observed.bound())
+            {
+                node.scheduling_subscribed = false;
+                return;
+            }
+            [[maybe_unused]] auto reset_observed = make_scope_exit([&]() noexcept {
+                node.scheduling_subscribed = false;
+                node.observed.reset();
+            });
+            if (!node.scheduling_subscribed) { return; }
             auto view = node.observed.data_view();
             if (view.valid() && view.tracking().observers.contains(&notifier))
             {
@@ -116,7 +124,9 @@ namespace hgraph::detail
         void unsubscribe_tree_noexcept(TSInputTargetActiveNode &node,
                                        TSInputTargetLinkState::SchedulingNotifier &notifier) noexcept
         {
-            unsubscribe_handle_noexcept(node.observed, &notifier);
+            if (node.scheduling_subscribed) { unsubscribe_handle_noexcept(node.observed, &notifier); }
+            else { node.observed.reset(); }
+            node.scheduling_subscribed = false;
             node.children.for_each([&](std::size_t, TSInputTargetActiveNode &child) {
                 unsubscribe_tree_noexcept(child, notifier);
             });
@@ -137,7 +147,10 @@ namespace hgraph::detail
                                     TSInputTargetLinkState::SchedulingNotifier &previous,
                                     TSInputTargetLinkState::SchedulingNotifier &replacement) noexcept
         {
-            replace_observer(node.observed, &previous, &replacement);
+            if (node.scheduling_subscribed)
+            {
+                replace_observer(node.observed, &previous, &replacement);
+            }
             node.children.for_each([&](std::size_t, TSInputTargetActiveNode &child) {
                 replace_tree_observers(child, previous, replacement);
             });
@@ -514,6 +527,29 @@ namespace hgraph::detail
             return TSOutputHandle{link.target_output().output(), std::move(structural)};
         }
 
+        void subscribe_scheduling_notifier(TSInputTargetLinkState &state,
+                                            TSInputTargetActiveNode &node)
+        {
+            node.scheduling_subscribed = false;
+            if (!node.observed.bound() || state.scheduling_notifier.target() == nullptr) { return; }
+
+            // The target-link state already observes the exact root target so
+            // it can maintain input modification state. Reuse that callback
+            // to schedule a root-active consumer instead of registering a
+            // second observer and promoting the source's compact observer set
+            // to heap storage. Descendant and structural observations retain
+            // their dedicated subscription so their filtering is unchanged.
+            if (state.active_root() == &node &&
+                node.observation_kind == TSInputObservationKind::Value &&
+                node.observed.same_as(state.target))
+            {
+                return;
+            }
+
+            node.observed.data_view().subscribe(&state.scheduling_notifier);
+            node.scheduling_subscribed = true;
+        }
+
         void resubscribe_tree(TSInputTargetLinkStorage &link,
                               const TSValueTypeMetaData &schema,
                               TSInputTargetActiveNode &node)
@@ -527,10 +563,7 @@ namespace hgraph::detail
                 {
                     unsubscribe_node(node, state.scheduling_notifier);
                     node.observed = observed;
-                    if (node.observed.bound() && state.scheduling_notifier.target() != nullptr)
-                    {
-                        node.observed.data_view().subscribe(&state.scheduling_notifier);
-                    }
+                    subscribe_scheduling_notifier(state, node);
                 }
             }
 
@@ -641,6 +674,7 @@ namespace hgraph::detail
 
     void TSInputTargetActiveNode::clear_observed() noexcept
     {
+        scheduling_subscribed = false;
         observed.reset();
         children.for_each([](std::size_t, TSInputTargetActiveNode &child) {
             child.clear_observed();
@@ -701,6 +735,14 @@ namespace hgraph::detail
     void TSInputTargetLinkState::notify(DateTime modified_time)
     {
         if (owner != nullptr) { owner->record_target_modified(modified_time); }
+        const auto *root = active_root();
+        if (root != nullptr && root->locally_active &&
+            root->observation_kind == TSInputObservationKind::Value &&
+            !root->scheduling_subscribed &&
+            root->observed.same_as(target))
+        {
+            scheduling_notifier.notify(modified_time);
+        }
     }
 
     void TSInputTargetLinkState::source_invalidated(const TSDataTracking *source) noexcept
@@ -1069,10 +1111,7 @@ namespace hgraph::detail
         active_node.locally_active = true;
         active_node.observation_kind = observation_kind;
         active_node.observed = observed_handle;
-        if (active_node.observed.bound() && target_notifier != nullptr)
-        {
-            active_node.observed.data_view().subscribe(&state.scheduling_notifier);
-        }
+        subscribe_scheduling_notifier(state, active_node);
     }
 
     void TSInputTargetLinkStorage::make_passive(TSInputTargetActiveNode *node)

--- a/tests/cpp/test_map.cpp
+++ b/tests/cpp/test_map.cpp
@@ -529,7 +529,7 @@ TEST_CASE("mapped key source teardown invalidates passive and active direct inpu
 
         REQUIRE(in.bound());
         REQUIRE(in.active() == active);
-        REQUIRE(source->view(time).data_view().observer_count() == (active ? 2 : 1));
+        REQUIRE(source->view(time).data_view().observer_count() == 1);
         scheduling.notifications.clear();
 
         source.reset();
@@ -559,7 +559,7 @@ TEST_CASE("mapped key source has no observers after input-first teardown")
             auto in = input.view(&scheduling, time);
             in.bind_output(source.view(time));
             if (active) { in.make_active(); }
-            REQUIRE(source.view(time).data_view().observer_count() == (active ? 2 : 1));
+            REQUIRE(source.view(time).data_view().observer_count() == 1);
         }
         REQUIRE(source.view(time).data_view().observer_count() == 0);
     }

--- a/tests/cpp/test_ts_input.cpp
+++ b/tests/cpp/test_ts_input.cpp
@@ -141,6 +141,41 @@ TEST_CASE("TSInput target-link plans allocate structural state only for keyed sl
     REQUIRE(static_cast<const void *>(&structural_link->tracking) == structural_storage.data());
 }
 
+TEST_CASE("TSInput storage caching excludes endpoint trees with owned payloads")
+{
+    using namespace hgraph;
+    using detail::input_storage_type_is_realization_invariant;
+
+    auto       &registry = TypeRegistry::instance();
+    const auto *integer = registry.register_scalar<std::int32_t>("int32");
+    const auto *ts = registry.ts(integer);
+    const auto *base = registry.bundle(
+        "tests.ts_input_cache", "Base", {{"id", integer}}, {}, true);
+    registry.bundle(
+        "tests.ts_input_cache", "Leaf", {{"id", integer}, {"value", integer}}, {base});
+    const auto *polymorphic = registry.ts(base);
+    const auto *inner = registry.tsb("TSInputCacheableInner", {{"value", polymorphic}});
+    const auto *root = registry.tsb("TSInputCacheableRoot", {{"scalar", ts}, {"inner", inner}});
+
+    const auto all_peered = TSEndpointSchema::non_peered(
+        root,
+        {TSEndpointSchema::peered(ts),
+         TSEndpointSchema::non_peered(inner, {TSEndpointSchema::peered(polymorphic)})});
+    const auto owned_leaf = TSEndpointSchema::non_peered(
+        root,
+        {TSEndpointSchema::owned(ts),
+         TSEndpointSchema::non_peered(inner, {TSEndpointSchema::peered(polymorphic)})});
+    const auto owned_subtree = TSEndpointSchema::non_peered(
+        root,
+        {TSEndpointSchema::peered(ts), TSEndpointSchema::owned(inner)});
+
+    REQUIRE(input_storage_type_is_realization_invariant(TSEndpointSchema::peered(root)));
+    REQUIRE(input_storage_type_is_realization_invariant(all_peered));
+    REQUIRE_FALSE(input_storage_type_is_realization_invariant(TSEndpointSchema::owned(root)));
+    REQUIRE_FALSE(input_storage_type_is_realization_invariant(owned_leaf));
+    REQUIRE_FALSE(input_storage_type_is_realization_invariant(owned_subtree));
+}
+
 TEST_CASE("TSInput builds a non-peered TSB root with nested peered terminals")
 {
     using namespace hgraph;

--- a/tests/cpp/test_ts_input.cpp
+++ b/tests/cpp/test_ts_input.cpp
@@ -1,5 +1,6 @@
 #include <hgraph/lib/std/value_util.h>
 #include <hgraph/types/metadata/ts_data_plan_factory.h>
+#include <hgraph/types/metadata/type_realization.h>
 #include <hgraph/types/metadata/type_registry.h>
 #include <hgraph/types/time_series/ts_input.h>
 #include <hgraph/types/time_series/ts_input/detail.h>
@@ -174,6 +175,98 @@ TEST_CASE("TSInput storage caching excludes endpoint trees with owned payloads")
     REQUIRE_FALSE(input_storage_type_is_realization_invariant(TSEndpointSchema::owned(root)));
     REQUIRE_FALSE(input_storage_type_is_realization_invariant(owned_leaf));
     REQUIRE_FALSE(input_storage_type_is_realization_invariant(owned_subtree));
+}
+
+TEST_CASE("cached TSInput builders resolve owned polymorphic storage in each graph realization")
+{
+    using namespace hgraph;
+
+    auto       &registry = TypeRegistry::instance();
+    const auto *integer = registry.register_scalar<std::int32_t>("int32");
+    const auto *base = registry.bundle(
+        "tests.ts_input_cache.realization", "Base", {{"id", integer}}, {}, true);
+    registry.bundle(
+        "tests.ts_input_cache.realization", "First", {{"id", integer}, {"value", integer}}, {base});
+    const auto *polymorphic = registry.ts(base);
+    const auto endpoint = TSEndpointSchema::owned(polymorphic);
+
+    const auto first_snapshot = TypeRealizationSnapshot::capture(registry);
+    const TSInputBuilder *builder = nullptr;
+    TSInput first_input;
+    {
+        TypeRealizationScope scope{first_snapshot.get()};
+        builder = &TSInputBuilderFactory::checked_builder_for(*polymorphic, endpoint);
+        first_input = builder->make_input();
+    }
+    const auto first_binding = first_input.view().data_view().layout().value_binding;
+    REQUIRE(first_binding == first_snapshot->type_for(base));
+
+    registry.bundle(
+        "tests.ts_input_cache.realization", "Second",
+        {{"id", integer}, {"value", integer}, {"other", integer}}, {base});
+    const auto second_snapshot = TypeRealizationSnapshot::capture(registry);
+    REQUIRE(second_snapshot != first_snapshot);
+
+    TSInput second_input;
+    {
+        TypeRealizationScope scope{second_snapshot.get()};
+        const auto &reused = TSInputBuilderFactory::checked_builder_for(*polymorphic, endpoint);
+        REQUIRE(&reused == builder);
+        second_input = reused.make_input();
+    }
+    const auto second_binding = second_input.view().data_view().layout().value_binding;
+    REQUIRE(second_binding == second_snapshot->type_for(base));
+    REQUIRE(second_binding != first_binding);
+}
+
+TEST_CASE("cached composite TSInput builders re-realize owned polymorphic leaves")
+{
+    using namespace hgraph;
+
+    auto       &registry = TypeRegistry::instance();
+    const auto *integer = registry.register_scalar<std::int32_t>("int32");
+    const auto *base = registry.bundle(
+        "tests.ts_input_cache.composite", "Base", {{"id", integer}}, {}, true);
+    registry.bundle(
+        "tests.ts_input_cache.composite", "First", {{"id", integer}, {"value", integer}}, {base});
+    const auto *polymorphic = registry.ts(base);
+    const auto *scalar = registry.ts(integer);
+    const auto *root = registry.tsb(
+        "TSInputCacheCompositeRoot", {{"owned", polymorphic}, {"peered", scalar}});
+    const auto endpoint = TSEndpointSchema::non_peered(
+        root, {TSEndpointSchema::owned(polymorphic), TSEndpointSchema::peered(scalar)});
+    const auto owned_binding = [](TSInput &input) {
+        auto root_view = input.view();
+        auto bundle = root_view.as_bundle();
+        return bundle.field("owned").data_view().layout().value_binding;
+    };
+
+    const auto first_snapshot = TypeRealizationSnapshot::capture(registry);
+    const TSInputBuilder *builder = nullptr;
+    TSInput first_input;
+    {
+        TypeRealizationScope scope{first_snapshot.get()};
+        builder = &TSInputBuilderFactory::checked_builder_for(*root, endpoint);
+        first_input = builder->make_input();
+    }
+    const auto first_binding = owned_binding(first_input);
+    REQUIRE(first_binding == first_snapshot->type_for(base));
+
+    registry.bundle(
+        "tests.ts_input_cache.composite", "Second",
+        {{"id", integer}, {"value", integer}, {"other", integer}}, {base});
+    const auto second_snapshot = TypeRealizationSnapshot::capture(registry);
+
+    TSInput second_input;
+    {
+        TypeRealizationScope scope{second_snapshot.get()};
+        const auto &reused = TSInputBuilderFactory::checked_builder_for(*root, endpoint);
+        REQUIRE(&reused == builder);
+        second_input = reused.make_input();
+    }
+    const auto second_binding = owned_binding(second_input);
+    REQUIRE(second_binding == second_snapshot->type_for(base));
+    REQUIRE(second_binding != first_binding);
 }
 
 TEST_CASE("TSInput builds a non-peered TSB root with nested peered terminals")
@@ -1221,6 +1314,9 @@ TEST_CASE("TSInput peered collection descendants can be activated independently"
     REQUIRE_NOTHROW(second.bind_output(output.view()));
     second.make_active();
     REQUIRE(second.active());
+    REQUIRE(output.data_view().observer_count() == 1);
+    REQUIRE(output_list[0].data_view().observer_count() == 0);
+    REQUIRE(output_list[1].data_view().observer_count() == 1);
 
     const auto t1 = MIN_ST + TimeDelta{10};
     const auto t2 = t1 + TimeDelta{1};
@@ -1243,6 +1339,8 @@ TEST_CASE("TSInput peered collection descendants can be activated independently"
     REQUIRE(recorder.notified == std::vector<DateTime>{t2});
 
     second.make_passive();
+    REQUIRE(output.data_view().observer_count() == 1);
+    REQUIRE(output_list[1].data_view().observer_count() == 0);
 }
 
 TEST_CASE("TSInput shape casts return endpoint views for slot collections")
@@ -1413,6 +1511,11 @@ TEST_CASE("TSInput structural activation survives an unbound target link")
     auto dict_binding = dict_input.view(nullptr, t1);
     set_binding.bind_output(set_output.view(t1));
     dict_binding.bind_output(dict_output.view(t1));
+    // TSS structural observation uses the root storage itself. It must retain
+    // a dedicated scheduling subscription rather than taking the value-root
+    // coalescing path.
+    REQUIRE(set_output.data_view().observer_count() == 2);
+    REQUIRE(dict_output.data_view().observer_count() == 1);
 
     Value key{std::int32_t{7}};
     Value value{std::int32_t{42}};

--- a/tests/cpp/test_ts_type_ref.cpp
+++ b/tests/cpp/test_ts_type_ref.cpp
@@ -1046,7 +1046,7 @@ TEST_CASE("scalar output and peered input preserve binding, timing, and subscrip
     in.bind_output(first.view(MIN_ST));
     in.make_active();
     REQUIRE(in.bound());
-    REQUIRE(first.data_view().observer_count() == 2);
+    REQUIRE(first.data_view().observer_count() == 1);
 
     Value one{std::int32_t{1}};
     {
@@ -1060,7 +1060,7 @@ TEST_CASE("scalar output and peered input preserve binding, timing, and subscrip
 
     in.bind_output(second.view(MIN_ST + TimeDelta{1}));
     REQUIRE(first.data_view().observer_count() == 0);
-    REQUIRE(second.data_view().observer_count() == 2);
+    REQUIRE(second.data_view().observer_count() == 1);
     in.unbind_output();
     REQUIRE(second.data_view().observer_count() == 0);
     REQUIRE_FALSE(in.bound());
@@ -1109,7 +1109,7 @@ TEST_CASE("scalar output invalidation preserves active topology without scheduli
     in.bind_output(first->view(MIN_ST));
     in.make_active();
     REQUIRE(in.active());
-    REQUIRE(first->data_view().observer_count() == 2);
+    REQUIRE(first->data_view().observer_count() == 1);
 
     first.reset();
     REQUIRE_FALSE(in.bound());
@@ -1125,7 +1125,7 @@ TEST_CASE("scalar output invalidation preserves active topology without scheduli
     }
     in.bind_output(replacement.view(MIN_ST + TimeDelta{1}));
     REQUIRE(in.active());
-    REQUIRE(replacement.data_view().observer_count() == 2);
+    REQUIRE(replacement.data_view().observer_count() == 1);
 
     scheduling.notifications.clear();
     {
@@ -1173,7 +1173,7 @@ TEST_CASE("root output invalidation detaches direct inputs for migrated and lega
 
             REQUIRE(in.bound());
             REQUIRE(in.active() == active);
-            REQUIRE(output->data_view().observer_count() == (active ? 2 : 1));
+            REQUIRE(output->data_view().observer_count() == 1);
             scheduling.notifications.clear();
 
             output.reset();
@@ -1213,7 +1213,7 @@ TEST_CASE("SIGNAL inputs release legacy root outputs before input teardown")
             REQUIRE(in.bound());
             REQUIRE(in.bound_output().handle().bound());
             REQUIRE(in.active() == active);
-            REQUIRE(output->data_view().observer_count() == (active ? 2 : 1));
+            REQUIRE(output->data_view().observer_count() == 1);
             scheduling.notifications.clear();
 
             output.reset();
@@ -1256,25 +1256,32 @@ TEST_CASE("scalar input teardown and move keep producer subscriptions coherent")
         TypeRegistry::instance().register_scalar<std::int32_t>("int32"));
     TSOutput output{schema};
     RecordingNotifier scheduling;
+    const auto t1 = MIN_ST;
+    const auto t2 = t1 + TimeDelta{1};
 
     {
         TSInput input = scalar_input(schema);
-        auto in = input.view(&scheduling, MIN_ST);
-        in.bind_output(output.view(MIN_ST));
+        auto in = input.view(&scheduling, t1);
+        in.bind_output(output.view(t1));
         in.make_active();
-        REQUIRE(output.data_view().observer_count() == 2);
+        REQUIRE(output.data_view().observer_count() == 1);
 
         TSInput moved{std::move(input)};
-        auto moved_view = moved.view(&scheduling, MIN_ST);
+        auto moved_view = moved.view(&scheduling, t1);
         REQUIRE(moved_view.bound());
         REQUIRE(moved_view.active());
-        REQUIRE(output.data_view().observer_count() == 2);
+        REQUIRE(output.data_view().observer_count() == 1);
+
+        Value value{std::int32_t{7}};
+        auto mutation = output.begin_mutation(t1);
+        REQUIRE(mutation.copy_value_from(value.view()));
+        REQUIRE(scheduling.notifications == std::vector<DateTime>{t1});
     }
 
     REQUIRE(output.data_view().observer_count() == 0);
-    Value value{std::int32_t{7}};
+    Value value{std::int32_t{8}};
     {
-        auto mutation = output.begin_mutation(MIN_ST);
+        auto mutation = output.begin_mutation(t2);
         REQUIRE(mutation.copy_value_from(value.view()));
     }
 }


### PR DESCRIPTION
## Summary

- cache finalized input builders on node builders and cache input storage types only for realization-invariant peered endpoint trees
- resolve owned scalar and fixed input payload storage under each graph's active TypeRealizationSnapshot
- coalesce exact active value-root scheduling with the target-link state observer
- retain dedicated scheduling observers for descendant and structural observations so their filtering semantics remain unchanged
- preserve observer ownership across binding, invalidation, move, passivation, and teardown

## Review follow-up

The first review correction in b51b6a07 correctly stopped storing realization-dependent types in the process-lifetime TSInputBuilder. End-to-end testing then showed that construction still reached the canonical lower TSDataPlanFactory cache, so an owned polymorphic input did not actually receive the graph snapshot's closed-union binding.

bac1865a completes that correction by building owned scalar/fixed input plans and bindings under the active graph realization. The regression reuses the same cached builder across two snapshots, registers a new derived Bundle between them, and verifies both direct owned inputs and owned leaves inside a composite endpoint receive their respective snapshot bindings.

## Why

After #262 removed the first layer of keyed-graph churn, each nested node construction still repeated input endpoint/type resolution and created a second observer for exact active value roots.

The builder cache retains only graph-invariant work. Realization-dependent owned payloads remain graph-scoped. At runtime, the target-link state observer already sees exact root value modifications, so it can schedule the consumer without promoting the source's compact one-observer representation to heap-backed observer storage.

## Performance

native_churn_tsd_map_cycle, compared with the post-#262 baseline:

### macOS

- allocations: 240 -> 70 per cycle (-71%)
- allocated bytes: 20,200 -> 7,400 per cycle (-63%)
- median time: 23.561 us -> 16.894 us per cycle (-28%)

The observer coalescing step alone reduced the preceding PR result from 110 to 70 allocations, 8,520 to 7,400 bytes, and 18.507 us to 16.894 us.

### Physical hg-linux

- allocations: 120 -> 80 per cycle (-33%)
- allocated bytes: 8,795 -> 7,675 per cycle (-13%)
- median time: 28.704 us -> 25.783 us per cycle (-10%)

Advances #213.

## Validation

- macOS fresh native suite: 1,411/1,411 passed
- macOS ASan native suite: 1,411/1,411 passed
- macOS Python 3.12 ABI3 wheel under Python 3.14: 1,845 passed, 11 skipped
- physical hg-linux fresh native suite: 1,411/1,411 passed
- physical hg-linux Python 3.12 ABI3 wheel under Python 3.14: 1,845 passed, 11 skipped

## Scope boundary

The older keyed/dynamic TSData realization caches are unchanged. This PR removes the additional builder-lifetime capture and completes graph-scoped realization for the owned scalar and fixed input paths exercised by the review regression; a broader lower-cache redesign remains separate work.