### PR TITLE
Fix graph-scoped realization for owned keyed inputs

### DIFF
--- a/include/hgraph/types/metadata/ts_data_plan_factory_detail.h
+++ b/include/hgraph/types/metadata/ts_data_plan_factory_detail.h
@@ -36,8 +36,14 @@ namespace hgraph::ts_data_plan_factory_detail
         const TSValueTypeMetaData &schema,
         ValueTypeRef value_binding);
     [[nodiscard]] const MemoryUtils::StoragePlan *synthesise_fixed_plan(const TSValueTypeMetaData &schema);
+    [[nodiscard]] const MemoryUtils::StoragePlan *synthesise_fixed_plan(
+        const TSValueTypeMetaData &schema,
+        TypeRole role);
     [[nodiscard]] const MemoryUtils::StoragePlan *synthesise_dynamic_list_plan(const TSValueTypeMetaData &schema);
     [[nodiscard]] const MemoryUtils::StoragePlan *synthesise_window_plan(const TSValueTypeMetaData &schema);
+    [[nodiscard]] const MemoryUtils::StoragePlan *synthesise_window_plan(
+        const TSValueTypeMetaData &schema,
+        ValueTypeRef element_binding);
     [[nodiscard]] const MemoryUtils::StoragePlan *synthesise_slot_plan(const TSValueTypeMetaData &schema);
     [[nodiscard]] const MemoryUtils::StoragePlan *synthesise_slot_plan(
         const TSValueTypeMetaData &schema,
@@ -83,6 +89,13 @@ namespace hgraph::ts_data_plan_factory_detail
                                                       std::size_t value_offset,
                                                       std::size_t tracking_offset,
                                                       TypeRole role = TypeRole::Data,
+                                                      bool embedded = false);
+    [[nodiscard]] const TSDataOps &window_ts_data_ops(const TSValueTypeMetaData      &schema,
+                                                      const MemoryUtils::StoragePlan &plan,
+                                                      std::size_t value_offset,
+                                                      std::size_t tracking_offset,
+                                                      ValueTypeRef element_binding,
+                                                      TypeRole role,
                                                       bool embedded = false);
 
     [[nodiscard]] const TSDataOps &slot_ts_data_ops(const TSValueTypeMetaData      &schema,

--- a/src/hgraph/types/metadata/ts_data_fixed_structured_plan.cpp
+++ b/src/hgraph/types/metadata/ts_data_fixed_structured_plan.cpp
@@ -77,6 +77,11 @@ namespace hgraph::ts_data_plan_factory_detail
             return factory.output_type_for(&schema).as_role();
         }
 
+        [[nodiscard]] TSRoleTypeRef realized_input_type(const TSValueTypeMetaData &schema)
+        {
+            return standalone_ts_storage_type(schema, TypeRole::Input);
+        }
+
         [[nodiscard]] const MemoryUtils::StoragePlan &ts_data_aux_plan_for_role(
             const TSValueTypeMetaData &schema, TypeRole role)
         {
@@ -89,7 +94,7 @@ namespace hgraph::ts_data_plan_factory_detail
             }
             if (is_slot_ts_data(schema))
             {
-                if (role == TypeRole::Output)
+                if (role == TypeRole::Input || role == TypeRole::Output)
                 {
                     const auto *key_schema = schema.kind == TSTypeKind::TSS
                                                  ? schema.value_schema->element_type
@@ -102,8 +107,10 @@ namespace hgraph::ts_data_plan_factory_detail
                         {
                             throw std::logic_error("TSDataPlanFactory: TSD element schema is not resolved");
                         }
-                        const auto *plan = synthesise_slot_tsd_plan(
-                            schema, key_binding, realized_output_type(*element_schema));
+                        const auto element_type = role == TypeRole::Input
+                                                      ? realized_input_type(*element_schema)
+                                                      : realized_output_type(*element_schema);
+                        const auto *plan = synthesise_slot_tsd_plan(schema, key_binding, element_type);
                         if (plan == nullptr)
                         {
                             throw std::logic_error("TSDataPlanFactory: realized TSD auxiliary plan is not resolved");
@@ -135,7 +142,10 @@ namespace hgraph::ts_data_plan_factory_detail
             }
             if (is_window_ts_data(schema))
             {
-                const auto *plan = synthesise_window_plan(schema);
+                const auto *plan = role == TypeRole::Input
+                                       ? synthesise_window_plan(
+                                             schema, realized_value_binding(schema.value_type))
+                                       : synthesise_window_plan(schema);
                 if (plan == nullptr)
                 {
                     throw std::logic_error("TSDataPlanFactory: window auxiliary plan is not resolved");
@@ -460,19 +470,21 @@ namespace hgraph::ts_data_plan_factory_detail
             const auto *key_schema = schema.kind == TSTypeKind::TSS
                                          ? schema.value_schema->element_type
                                          : schema.key_type();
-            const auto key_binding = role == TypeRole::Output
+            const auto key_binding = role == TypeRole::Input || role == TypeRole::Output
                                          ? realized_value_binding(key_schema)
                                          : ValuePlanFactory::instance().type_for(key_schema);
             const auto *plan = synthesise_slot_plan(schema, key_binding);
             if (plan == nullptr) throw std::logic_error("embedded keyed TSData plan is not resolved");
-            if (role == TypeRole::Output && schema.kind == TSTypeKind::TSD)
+            if ((role == TypeRole::Input || role == TypeRole::Output) && schema.kind == TSTypeKind::TSD)
             {
                 const auto *element_schema = schema.element_ts();
                 if (element_schema == nullptr)
                 {
                     throw std::logic_error("embedded TSD element schema is not resolved");
                 }
-                const auto element_type = realized_output_type(*element_schema);
+                const auto element_type = role == TypeRole::Input
+                                              ? realized_input_type(*element_schema)
+                                              : realized_output_type(*element_schema);
                 plan = synthesise_slot_tsd_plan(schema, key_binding, element_type);
                 if (plan == nullptr)
                 {
@@ -544,6 +556,13 @@ namespace hgraph::ts_data_plan_factory_detail
 
     [[nodiscard]] const MemoryUtils::StoragePlan *synthesise_fixed_plan(const TSValueTypeMetaData &schema)
     {
+        return synthesise_fixed_plan(schema, TypeRole::Data);
+    }
+
+    [[nodiscard]] const MemoryUtils::StoragePlan *synthesise_fixed_plan(
+        const TSValueTypeMetaData &schema,
+        TypeRole role)
+    {
         const auto value_binding = fixed_value_storage_binding(schema);
         if (!value_binding)
         {
@@ -552,7 +571,7 @@ namespace hgraph::ts_data_plan_factory_detail
         auto builder = MemoryUtils::named_tuple();
         builder.reserve(2);
         builder.add_field("value", value_binding.checked_plan());
-        builder.add_field("aux", ts_data_aux_plan(schema));
+        builder.add_field("aux", ts_data_aux_plan(schema, role));
         return &builder.build();
     }
 

--- a/src/hgraph/types/metadata/ts_data_plan_factory.cpp
+++ b/src/hgraph/types/metadata/ts_data_plan_factory.cpp
@@ -2,6 +2,7 @@
 
 #include <hgraph/types/metadata/debug_descriptor.h>
 #include <hgraph/types/metadata/ts_data_plan_factory_detail.h>
+#include <hgraph/types/metadata/type_realization.h>
 
 #include <hgraph/types/metadata/value_plan_factory.h>
 #include <hgraph/types/time_series/endpoint_schema.h>
@@ -22,6 +23,15 @@ namespace hgraph
             return schema != nullptr &&
                    (schema->kind == TSTypeKind::TSB ||
                     (schema->kind == TSTypeKind::TSL && schema->fixed_size() != 0));
+        }
+
+        [[nodiscard]] ValueTypeRef realized_value_binding(const ValueTypeMetaData *schema)
+        {
+            if (const auto *snapshot = active_type_realization(); snapshot != nullptr)
+            {
+                if (const auto realized = snapshot->type_for(schema)) { return realized; }
+            }
+            return ValuePlanFactory::instance().type_for(schema);
         }
 
         [[nodiscard]] bool slot_root(const TSValueTypeMetaData *schema) noexcept
@@ -100,6 +110,115 @@ namespace hgraph
                 throw std::invalid_argument("standalone TSData storage requires a time-series role");
             if (!is_migrated_ts_root_schema(&schema))
                 throw std::invalid_argument("standalone TSData storage requires a migrated schema");
+
+            if (role == TypeRole::Input)
+            {
+                if (is_dynamic_list_ts_data(schema))
+                {
+                    const auto *element_schema = schema.element_ts();
+                    if (element_schema == nullptr)
+                        throw std::logic_error("dynamic TSL element schema is not resolved");
+                    const auto *plan = synthesise_dynamic_list_plan(schema);
+                    if (plan == nullptr)
+                        throw std::logic_error("standalone dynamic TSL storage plan is not resolved");
+                    const bool element_embedded = is_dynamic_list_ts_data(*element_schema) ||
+                                                  is_window_ts_data(*element_schema);
+                    const auto element_type = standalone_ts_storage_type(
+                        *element_schema, role, element_embedded);
+                    const auto &ops = dynamic_list_ts_data_ops(
+                        schema, *plan, 0, element_type, role, embedded);
+                    return TSRoleTypeRef{
+                        intern_ts_type(schema, role, *plan, ops, standalone_label(schema, role, embedded))};
+                }
+
+                if (is_window_ts_data(schema))
+                {
+                    const auto element_binding = realized_value_binding(schema.value_type);
+                    const auto *plan = synthesise_window_plan(schema, element_binding);
+                    const auto *window = plan != nullptr ? plan->find_component("window") : nullptr;
+                    const auto *tracking = plan != nullptr ? plan->find_component("tracking") : nullptr;
+                    if (plan == nullptr || window == nullptr || tracking == nullptr)
+                        throw std::logic_error("standalone TSW storage components are not resolved");
+                    const auto &ops = window_ts_data_ops(
+                        schema, *plan, window->offset, tracking->offset,
+                        element_binding, role, embedded);
+                    return TSRoleTypeRef{
+                        intern_ts_type(schema, role, *plan, ops, standalone_label(schema, role, embedded))};
+                }
+
+                if (is_fixed_structured_ts_data(schema))
+                {
+                    const auto *plan = synthesise_fixed_plan(schema, role);
+                    const auto *value = plan != nullptr ? plan->find_component("value") : nullptr;
+                    const auto *aux = plan != nullptr ? plan->find_component("aux") : nullptr;
+                    if (plan == nullptr || value == nullptr || aux == nullptr)
+                        throw std::logic_error("standalone fixed TSData components are not resolved");
+                    return embedded_ts_storage_type(
+                        schema, role, *plan, value->offset, aux->offset, !embedded);
+                }
+
+                if (is_slot_ts_data(schema))
+                {
+                    const auto *key_schema = schema.kind == TSTypeKind::TSS
+                                                 ? schema.value_schema->element_type
+                                                 : schema.key_type();
+                    const auto key_binding = realized_value_binding(key_schema);
+                    if (!key_binding)
+                        throw std::logic_error("standalone keyed TSData key binding is not resolved");
+
+                    const MemoryUtils::StoragePlan *plan = nullptr;
+                    const TSDataOps *ops = nullptr;
+                    if (schema.kind == TSTypeKind::TSD)
+                    {
+                        const auto *element_schema = schema.element_ts();
+                        if (element_schema == nullptr)
+                            throw std::logic_error("standalone TSD element schema is not resolved");
+                        const auto element_type = standalone_ts_storage_type(*element_schema, role);
+                        plan = synthesise_slot_tsd_plan(schema, key_binding, element_type);
+                        if (plan != nullptr)
+                            ops = &slot_tsd_ts_data_ops(
+                                schema, *plan, 0, key_binding, element_type, role, embedded);
+                    }
+                    else
+                    {
+                        plan = synthesise_slot_plan(schema, key_binding);
+                        if (plan != nullptr)
+                            ops = &slot_ts_data_ops(
+                                schema, *plan, 0, key_binding, role, embedded);
+                    }
+                    if (plan == nullptr || ops == nullptr)
+                        throw std::logic_error("standalone keyed TSData storage is not resolved");
+                    const auto label = schema.kind == TSTypeKind::TSS
+                                           ? embedded ? std::string_view{"ts.tss.input.embedded"}
+                                                      : std::string_view{"ts.tss.input.owned"}
+                                           : embedded ? std::string_view{"ts.tsd.input.embedded"}
+                                                      : std::string_view{"ts.tsd.input.owned"};
+                    return TSRoleTypeRef{intern_ts_type(schema, role, *plan, *ops, label)};
+                }
+
+                const auto value_type = realized_value_binding(schema.value_schema);
+                const auto delta_type = realized_value_binding(schema.delta_value_schema);
+                if (!value_type || !delta_type)
+                    throw std::logic_error("standalone scalar TSData value types are not resolved");
+                auto builder = MemoryUtils::named_tuple();
+                builder.reserve(2);
+                builder.add_field("value", value_type.checked_plan());
+                builder.add_field("tracking", MemoryUtils::plan_for<TSDataTracking>());
+                const auto &plan = builder.build();
+                const auto *value = plan.find_component("value");
+                const auto *tracking = plan.find_component("tracking");
+                if (value == nullptr || tracking == nullptr)
+                    throw std::logic_error("standalone scalar TSData components are not resolved");
+                if (embedded)
+                    return embedded_ts_storage_type(
+                        schema, role, plan, value->offset, tracking->offset, false);
+                const auto &ops = atomic_ts_data_ops(
+                    schema.kind, value_type, delta_type, plan, value->offset, tracking->offset);
+                const auto label = schema.kind == TSTypeKind::REF
+                                       ? std::string_view{"ts.ref.input.owned"}
+                                       : std::string_view{};
+                return TSRoleTypeRef{intern_ts_type(schema, role, plan, ops, label)};
+            }
 
             auto &factory = TSDataPlanFactory::instance();
             const auto *plan = factory.plan_for(&schema);

--- a/src/hgraph/types/metadata/ts_data_window_ops.cpp
+++ b/src/hgraph/types/metadata/ts_data_window_ops.cpp
@@ -730,10 +730,29 @@ namespace hgraph::ts_data_plan_factory_detail
             const MemoryUtils::StoragePlan      *root_plan{nullptr};
         };
 
-        [[nodiscard]] std::unordered_map<const TSValueTypeMetaData *, std::unique_ptr<WindowPlanEntry>> &
+        struct WindowPlanKey
+        {
+            const TSValueTypeMetaData *schema{nullptr};
+            const TypeRecord          *element_binding{nullptr};
+
+            [[nodiscard]] bool operator==(const WindowPlanKey &) const noexcept = default;
+        };
+
+        struct WindowPlanKeyHash
+        {
+            [[nodiscard]] std::size_t operator()(const WindowPlanKey &key) const noexcept
+            {
+                return combine_hash(std::hash<const TSValueTypeMetaData *>{}(key.schema),
+                                    std::hash<const TypeRecord *>{}(key.element_binding));
+            }
+        };
+
+        [[nodiscard]] std::unordered_map<WindowPlanKey, std::unique_ptr<WindowPlanEntry>,
+                                         WindowPlanKeyHash> &
         window_plan_entries() noexcept
         {
-            static std::unordered_map<const TSValueTypeMetaData *, std::unique_ptr<WindowPlanEntry>> entries;
+            static std::unordered_map<WindowPlanKey, std::unique_ptr<WindowPlanEntry>,
+                                      WindowPlanKeyHash> entries;
             return entries;
         }
 
@@ -1458,6 +1477,7 @@ namespace hgraph::ts_data_plan_factory_detail
             const MemoryUtils::StoragePlan *plan{nullptr};
             std::size_t                     value_offset{0};
             std::size_t                     tracking_offset{0};
+            const TypeRecord *element_binding{nullptr};
             TypeRole                        role{TypeRole::Invalid};
             bool                            embedded{false};
 
@@ -1472,6 +1492,7 @@ namespace hgraph::ts_data_plan_factory_detail
                                          std::hash<const MemoryUtils::StoragePlan *>{}(key.plan));
                 seed = combine_hash(seed, key.value_offset);
                 seed = combine_hash(seed, key.tracking_offset);
+                seed = combine_hash(seed, std::hash<const TypeRecord *>{}(key.element_binding));
                 seed = combine_hash(seed, static_cast<std::size_t>(key.role));
                 seed = combine_hash(seed, key.embedded);
                 return seed;
@@ -1500,20 +1521,28 @@ namespace hgraph::ts_data_plan_factory_detail
 
     [[nodiscard]] const MemoryUtils::StoragePlan *synthesise_window_plan(const TSValueTypeMetaData &schema)
     {
+        return synthesise_window_plan(
+            schema, ValuePlanFactory::instance().type_for(schema.value_type));
+    }
+
+    [[nodiscard]] const MemoryUtils::StoragePlan *synthesise_window_plan(
+        const TSValueTypeMetaData &schema,
+        ValueTypeRef element_binding)
+    {
         if (!is_window_ts_data(schema))
         {
             throw std::logic_error("TSDataPlanFactory: TSW storage requires a TSW schema");
         }
-        const auto element_binding = ValuePlanFactory::instance().type_for(schema.value_type);
-        if (!element_binding)
+        if (!element_binding || element_binding.schema() != schema.value_type)
         {
             throw std::logic_error("TSDataPlanFactory: TSW element binding is not resolved");
         }
         const auto time_binding = window_time_binding();
+        const WindowPlanKey key{&schema, element_binding.record()};
 
         std::lock_guard<std::mutex> lock(window_plan_mutex());
         auto                       &entries = window_plan_entries();
-        if (const auto it = entries.find(&schema); it != entries.end()) { return it->second->root_plan; }
+        if (const auto it = entries.find(key); it != entries.end()) { return it->second->root_plan; }
 
         auto entry = std::make_unique<WindowPlanEntry>();
         if (schema.is_duration_based())
@@ -1568,7 +1597,7 @@ namespace hgraph::ts_data_plan_factory_detail
         entry->root_plan = &builder.build();
 
         const auto *result = entry->root_plan;
-        entries.emplace(&schema, std::move(entry));
+        entries.emplace(key, std::move(entry));
         return result;
     }
 
@@ -1579,8 +1608,20 @@ namespace hgraph::ts_data_plan_factory_detail
                                                       TypeRole role,
                                                       bool embedded)
     {
-        const auto element_binding = ValuePlanFactory::instance().type_for(schema.value_type);
-        if (!element_binding)
+        return window_ts_data_ops(
+            schema, plan, value_offset, tracking_offset,
+            ValuePlanFactory::instance().type_for(schema.value_type), role, embedded);
+    }
+
+    [[nodiscard]] const TSDataOps &window_ts_data_ops(const TSValueTypeMetaData      &schema,
+                                                      const MemoryUtils::StoragePlan &plan,
+                                                      std::size_t value_offset,
+                                                      std::size_t tracking_offset,
+                                                      ValueTypeRef element_binding,
+                                                      TypeRole role,
+                                                      bool embedded)
+    {
+        if (!element_binding || element_binding.schema() != schema.value_type)
         {
             throw std::logic_error("TSDataPlanFactory: TSW element binding is not resolved");
         }
@@ -1588,7 +1629,8 @@ namespace hgraph::ts_data_plan_factory_detail
 
         std::lock_guard<std::mutex> lock(window_context_mutex());
         auto                       &contexts = window_contexts();
-        const TSWContextKey         key{&schema, &plan, value_offset, tracking_offset, role, embedded};
+        const TSWContextKey key{
+            &schema, &plan, value_offset, tracking_offset, element_binding.record(), role, embedded};
         if (const auto it = contexts.find(key); it != contexts.end()) { return it->second->ops; }
 
         const auto *window_component = plan.find_component("window");
@@ -1600,13 +1642,13 @@ namespace hgraph::ts_data_plan_factory_detail
         std::unique_ptr<TSWContextCommon> context;
         if (schema.is_duration_based())
         {
-            context = std::make_unique<TimeTSWContext>(schema, *window_component->plan, time_binding, element_binding,
-                                                       value_offset, tracking_offset);
+            context = std::make_unique<TimeTSWContext>(schema, *window_component->plan, time_binding,
+                                                       element_binding, value_offset, tracking_offset);
         }
         else
         {
-            context = std::make_unique<SizeTSWContext>(schema, *window_component->plan, time_binding, element_binding,
-                                                       value_offset, tracking_offset);
+            context = std::make_unique<SizeTSWContext>(schema, *window_component->plan, time_binding,
+                                                       element_binding, value_offset, tracking_offset);
         }
         auto *result = context.get();
         contexts.emplace(key, std::move(context));

--- a/src/hgraph/types/time_series/ts_input.cpp
+++ b/src/hgraph/types/time_series/ts_input.cpp
@@ -479,6 +479,38 @@ namespace hgraph
             return ValuePlanFactory::instance().type_for(schema);
         }
 
+        [[nodiscard]] ValueTypeRef realized_input_key_binding_for(const TSValueTypeMetaData &schema)
+        {
+            const auto *key_schema = schema.kind == TSTypeKind::TSS
+                                         ? schema.value_schema != nullptr
+                                               ? schema.value_schema->element_type
+                                               : nullptr
+                                         : schema.kind == TSTypeKind::TSD ? schema.key_type() : nullptr;
+            const auto binding = realized_input_value_binding_for(key_schema);
+            if (!binding) { throw std::logic_error("TSInput owned keyed binding is not resolved"); }
+            return binding;
+        }
+
+        [[nodiscard]] const MemoryUtils::StoragePlan &input_storage_plan(const TSEndpointSchema &endpoint_schema);
+        [[nodiscard]] TSRoleTypeRef input_storage_type_for(const TSEndpointSchema         &endpoint_schema,
+                                                           const MemoryUtils::StoragePlan &root_plan,
+                                                           std::size_t storage_offset,
+                                                           bool root_record,
+                                                           TypeRole storage_role);
+
+        [[nodiscard]] TSRoleTypeRef owned_element_type_for(const TSValueTypeMetaData &schema,
+                                                           TypeRole storage_role)
+        {
+            const auto *element_schema = schema.element_ts();
+            if (element_schema == nullptr)
+            {
+                throw std::logic_error("TSInput owned dynamic element schema is not resolved");
+            }
+            const auto endpoint = TSEndpointSchema::owned(element_schema);
+            const auto &plan = input_storage_plan(endpoint);
+            return input_storage_type_for(endpoint, plan, 0, true, storage_role);
+        }
+
         [[nodiscard]] const MemoryUtils::StoragePlan &
         owned_input_storage_plan(const TSValueTypeMetaData &schema)
         {
@@ -497,8 +529,41 @@ namespace hgraph
             if (schema.kind == TSTypeKind::TSB ||
                 (schema.kind == TSTypeKind::TSL && schema.fixed_size() != 0))
             {
-                const auto *plan = ts_data_plan_factory_detail::synthesise_fixed_plan(schema);
+                const auto *plan = ts_data_plan_factory_detail::synthesise_fixed_plan(
+                    schema, TypeRole::Input);
                 if (plan == nullptr) { throw std::logic_error("TSInput owned fixed storage plan is not resolved"); }
+                return *plan;
+            }
+
+            if (schema.kind == TSTypeKind::TSS)
+            {
+                const auto *plan = ts_data_plan_factory_detail::synthesise_slot_plan(
+                    schema, realized_input_key_binding_for(schema));
+                if (plan == nullptr) { throw std::logic_error("TSInput owned TSS plan is not resolved"); }
+                return *plan;
+            }
+            if (schema.kind == TSTypeKind::TSD)
+            {
+                const auto *plan = ts_data_plan_factory_detail::synthesise_slot_tsd_plan(
+                    schema, realized_input_key_binding_for(schema),
+                    owned_element_type_for(schema, TypeRole::Input));
+                if (plan == nullptr) { throw std::logic_error("TSInput owned TSD plan is not resolved"); }
+                return *plan;
+            }
+            if (schema.kind == TSTypeKind::TSL && schema.fixed_size() == 0)
+            {
+                const auto *plan = ts_data_plan_factory_detail::synthesise_dynamic_list_plan(schema);
+                if (plan == nullptr)
+                {
+                    throw std::logic_error("TSInput owned dynamic TSL plan is not resolved");
+                }
+                return *plan;
+            }
+            if (schema.kind == TSTypeKind::TSW)
+            {
+                const auto *plan = ts_data_plan_factory_detail::synthesise_window_plan(
+                    schema, realized_input_value_binding_for(schema.value_type));
+                if (plan == nullptr) { throw std::logic_error("TSInput owned TSW plan is not resolved"); }
                 return *plan;
             }
 
@@ -507,18 +572,11 @@ namespace hgraph
             return type.checked_plan();
         }
 
-        [[nodiscard]] const MemoryUtils::StoragePlan &input_storage_plan(const TSEndpointSchema &endpoint_schema);
         [[nodiscard]] TSRoleTypeRef input_data_type_for(const TSEndpointSchema         &endpoint_schema,
                                                         const MemoryUtils::StoragePlan &root_plan,
                                                         std::size_t storage_offset,
                                                         TypeRole storage_role,
                                                         std::string_view implementation_label);
-        [[nodiscard]] TSRoleTypeRef input_storage_type_for(const TSEndpointSchema         &endpoint_schema,
-                                                              const MemoryUtils::StoragePlan &root_plan,
-                                                              std::size_t storage_offset,
-                                                              bool root_record,
-                                                              TypeRole storage_role);
-
         [[nodiscard]] std::string child_component_name(const TSValueTypeMetaData *schema, std::size_t index)
         {
             if (schema != nullptr && schema->kind == TSTypeKind::TSB)
@@ -583,8 +641,8 @@ namespace hgraph
                 {
                     throw std::logic_error("TSInput non-peered TSD element type is not resolved");
                 }
-                const auto *plan =
-                    ts_data_plan_factory_detail::synthesise_slot_tsd_plan(*schema, element_type);
+                const auto *plan = ts_data_plan_factory_detail::synthesise_slot_tsd_plan(
+                    *schema, realized_input_key_binding_for(*schema), element_type);
                 if (plan == nullptr)
                 {
                     throw std::logic_error("TSInput non-peered TSD storage plan is not resolved");
@@ -1942,15 +2000,15 @@ namespace hgraph
                 {
                     throw std::logic_error("TSInput non-peered TSD element type is not resolved");
                 }
-                const auto *expected_plan =
-                    ts_data_plan_factory_detail::synthesise_slot_tsd_plan(
-                        *schema, element_type);
+                const auto key_binding = realized_input_key_binding_for(*schema);
+                const auto *expected_plan = ts_data_plan_factory_detail::synthesise_slot_tsd_plan(
+                    *schema, key_binding, element_type);
                 if (expected_plan == nullptr || expected_plan != &root_plan)
                 {
                     throw std::logic_error("TSInput non-peered TSD binding received the wrong storage plan");
                 }
                 const auto &ops = ts_data_plan_factory_detail::slot_tsd_ts_data_ops(
-                    *schema, root_plan, storage_offset, element_type, storage_role);
+                    *schema, root_plan, storage_offset, key_binding, element_type, storage_role);
                 return intern_ts_type(*schema, storage_role, root_plan, ops,
                                       implementation_label);
             }
@@ -2230,6 +2288,48 @@ namespace hgraph
                     (schema->kind == TSTypeKind::TSL && schema->fixed_size() != 0));
         }
 
+        [[nodiscard]] std::string_view dynamic_owned_label(const TSValueTypeMetaData &schema,
+                                                           TypeRole role,
+                                                           bool root_record)
+        {
+            const auto by_role = [role](std::string_view data,
+                                        std::string_view input,
+                                        std::string_view output) {
+                switch (role)
+                {
+                case TypeRole::Data: return data;
+                case TypeRole::Input: return input;
+                case TypeRole::Output: return output;
+                default: throw std::invalid_argument("owned dynamic TSData role is not supported");
+                }
+            };
+            if (schema.kind == TSTypeKind::TSL && schema.fixed_size() == 0)
+            {
+                return root_record
+                           ? by_role("ts.tsl.dynamic.data.root", "ts.tsl.dynamic.input.owned",
+                                     "ts.tsl.dynamic.output.root")
+                           : by_role("ts.tsl.dynamic.data.embedded", "ts.tsl.dynamic.input.embedded",
+                                     "ts.tsl.dynamic.output.embedded");
+            }
+            if (schema.kind == TSTypeKind::TSW)
+            {
+                if (schema.is_duration_based())
+                {
+                    return root_record
+                               ? by_role("ts.tsw.duration.data.root", "ts.tsw.duration.input.owned",
+                                         "ts.tsw.duration.output.root")
+                               : by_role("ts.tsw.duration.data.embedded", "ts.tsw.duration.input.embedded",
+                                         "ts.tsw.duration.output.embedded");
+                }
+                return root_record
+                           ? by_role("ts.tsw.tick.data.root", "ts.tsw.tick.input.owned",
+                                     "ts.tsw.tick.output.root")
+                           : by_role("ts.tsw.tick.data.embedded", "ts.tsw.tick.input.embedded",
+                                     "ts.tsw.tick.output.embedded");
+            }
+            throw std::invalid_argument("owned dynamic TSData label requires dynamic TSL or TSW");
+        }
+
         [[nodiscard]] TSRoleTypeRef input_storage_type_for(const TSEndpointSchema         &endpoint_schema,
                                                               const MemoryUtils::StoragePlan &root_plan,
                                                               std::size_t storage_offset,
@@ -2267,20 +2367,49 @@ namespace hgraph
             if (endpoint_schema.is_owned())
             {
                 const auto &local_plan = input_storage_plan(endpoint_schema);
-                if (dynamic_list || window)
-                    return ts_data_plan_factory_detail::standalone_ts_storage_type(
-                        *schema, storage_role, !root_record);
+                if (dynamic_list)
+                {
+                    const auto element_type = owned_element_type_for(*schema, storage_role);
+                    const auto &ops = ts_data_plan_factory_detail::dynamic_list_ts_data_ops(
+                        *schema, local_plan, 0, element_type, storage_role, !root_record);
+                    return intern_ts_type(
+                        *schema, storage_role, local_plan, ops,
+                        dynamic_owned_label(*schema, storage_role, root_record));
+                }
+                if (window)
+                {
+                    const auto *value = local_plan.find_component("window");
+                    const auto *tracking = local_plan.find_component("tracking");
+                    const auto element_binding = realized_input_value_binding_for(schema->value_type);
+                    if (value == nullptr || tracking == nullptr || !element_binding)
+                    {
+                        throw std::logic_error("owned TSW input storage components are not resolved");
+                    }
+                    const auto &ops = ts_data_plan_factory_detail::window_ts_data_ops(
+                        *schema, local_plan, value->offset, tracking->offset,
+                        element_binding, storage_role, !root_record);
+                    return intern_ts_type(
+                        *schema, storage_role, local_plan, ops,
+                        dynamic_owned_label(*schema, storage_role, root_record));
+                }
                 if (keyed)
                 {
                     const auto &keyed_plan = root_record ? root_plan : local_plan;
-                    const auto &ops = ts_data_plan_factory_detail::slot_ts_data_ops(
-                        *schema, keyed_plan, 0, storage_role, !root_record);
+                    const auto key_binding = realized_input_key_binding_for(*schema);
+                    const auto *ops = schema->kind == TSTypeKind::TSD
+                                          ? &ts_data_plan_factory_detail::slot_tsd_ts_data_ops(
+                                                *schema, keyed_plan, 0, key_binding,
+                                                owned_element_type_for(*schema, storage_role),
+                                                storage_role, !root_record)
+                                          : &ts_data_plan_factory_detail::slot_ts_data_ops(
+                                                *schema, keyed_plan, 0, key_binding,
+                                                storage_role, !root_record);
                     const auto label = schema->kind == TSTypeKind::TSS
                                            ? root_record ? std::string_view{"ts.tss.input.owned"}
                                                          : std::string_view{"ts.tss.input.embedded"}
                                            : root_record ? std::string_view{"ts.tsd.input.owned"}
                                                          : std::string_view{"ts.tsd.input.embedded"};
-                    return intern_ts_type(*schema, storage_role, keyed_plan, ops, label);
+                    return intern_ts_type(*schema, storage_role, keyed_plan, *ops, label);
                 }
                 if (fixed)
                 {
@@ -2319,8 +2448,10 @@ namespace hgraph
                 const auto &child_plan = input_storage_plan(child_schema);
                 const auto element_type = input_storage_type_for(
                     child_schema, child_plan, 0, true, storage_role);
+                const auto key_binding = realized_input_key_binding_for(*schema);
                 const auto &ops = ts_data_plan_factory_detail::slot_tsd_ts_data_ops(
-                    *schema, root_plan, storage_offset, element_type, storage_role, false, true);
+                    *schema, root_plan, storage_offset, key_binding, element_type,
+                    storage_role, false, true);
                 const auto label = storage_role == TypeRole::Output
                                        ? std::string_view{"ts.tsd.output.root"}
                                        : std::string_view{"ts.tsd.input.composite"};

--- a/tests/cpp/test_ts_input.cpp
+++ b/tests/cpp/test_ts_input.cpp
@@ -16,6 +16,7 @@
 #include <stdexcept>
 #include <string>
 #include <string_view>
+#include <tuple>
 #include <type_traits>
 #include <utility>
 #include <vector>
@@ -267,6 +268,351 @@ TEST_CASE("cached composite TSInput builders re-realize owned polymorphic leaves
     const auto second_binding = owned_binding(second_input);
     REQUIRE(second_binding == second_snapshot->type_for(base));
     REQUIRE(second_binding != first_binding);
+}
+
+TEST_CASE("cached owned TSS inputs re-realize polymorphic keys")
+{
+    using namespace hgraph;
+
+    auto &registry = TypeRegistry::instance();
+    const auto *integer = registry.register_scalar<std::int32_t>("int32");
+    const auto *base = registry.bundle("tests.ts_input_cache.tss", "Base", {{"id", integer}}, {}, true);
+    registry.bundle("tests.ts_input_cache.tss", "First", {{"id", integer}, {"value", integer}}, {base});
+    const auto *schema = registry.tss(base);
+    const auto endpoint = TSEndpointSchema::owned(schema);
+    const auto key_binding = [](TSInput &input)
+    {
+        auto root = input.view();
+        return root.as_set().data_view().layout().key_binding;
+    };
+
+    const auto first_snapshot = TypeRealizationSnapshot::capture(registry);
+    const TSInputBuilder *builder = nullptr;
+    TSInput first_input;
+    {
+        TypeRealizationScope scope{first_snapshot.get()};
+        builder = &TSInputBuilderFactory::checked_builder_for(*schema, endpoint);
+        first_input = builder->make_input();
+    }
+    const auto first_binding = key_binding(first_input);
+    auto first_root = first_input.view();
+    const auto *first_plan = first_root.data_view().storage_type().plan();
+    REQUIRE(first_binding == first_snapshot->type_for(base));
+
+    registry.bundle("tests.ts_input_cache.tss", "Second", {{"id", integer}, {"value", integer}, {"other", integer}},
+                    {base});
+    const auto second_snapshot = TypeRealizationSnapshot::capture(registry);
+
+    TSInput second_input;
+    {
+        TypeRealizationScope scope{second_snapshot.get()};
+        const auto &reused = TSInputBuilderFactory::checked_builder_for(*schema, endpoint);
+        REQUIRE(&reused == builder);
+        second_input = reused.make_input();
+    }
+    const auto second_binding = key_binding(second_input);
+    auto second_root = second_input.view();
+    const auto *second_plan = second_root.data_view().storage_type().plan();
+    REQUIRE(second_binding == second_snapshot->type_for(base));
+    REQUIRE(second_binding != first_binding);
+    REQUIRE(second_plan != first_plan);
+}
+
+TEST_CASE("cached owned TSD inputs re-realize polymorphic keys and values")
+{
+    using namespace hgraph;
+
+    auto &registry = TypeRegistry::instance();
+    const auto *integer = registry.register_scalar<std::int32_t>("int32");
+    const auto *key_base = registry.bundle("tests.ts_input_cache.tsd_key", "Base", {{"id", integer}}, {}, true);
+    const auto *value_base = registry.bundle("tests.ts_input_cache.tsd_value", "Base", {{"id", integer}}, {}, true);
+    registry.bundle("tests.ts_input_cache.tsd_key", "First", {{"id", integer}, {"value", integer}}, {key_base});
+    registry.bundle("tests.ts_input_cache.tsd_value", "First", {{"id", integer}, {"value", integer}}, {value_base});
+    const auto *schema = registry.tsd(key_base, registry.ts(value_base));
+    const auto endpoint = TSEndpointSchema::owned(schema);
+    const auto bindings = [](TSInput &input)
+    {
+        auto root = input.view();
+        auto dict = root.as_dict();
+        auto data = dict.data_view();
+        const auto &layout = data.layout();
+        return std::pair{layout.key_binding, layout.element_layout->value_binding};
+    };
+
+    const auto first_snapshot = TypeRealizationSnapshot::capture(registry);
+    const TSInputBuilder *builder = nullptr;
+    TSInput first_input;
+    {
+        TypeRealizationScope scope{first_snapshot.get()};
+        builder = &TSInputBuilderFactory::checked_builder_for(*schema, endpoint);
+        first_input = builder->make_input();
+    }
+    const auto first = bindings(first_input);
+    auto first_root = first_input.view();
+    const auto *first_plan = first_root.data_view().storage_type().plan();
+    REQUIRE(first.first == first_snapshot->type_for(key_base));
+    REQUIRE(first.second == first_snapshot->type_for(value_base));
+
+    registry.bundle("tests.ts_input_cache.tsd_key", "Second", {{"id", integer}, {"value", integer}, {"other", integer}},
+                    {key_base});
+    registry.bundle("tests.ts_input_cache.tsd_value", "Second",
+                    {{"id", integer}, {"value", integer}, {"other", integer}}, {value_base});
+    const auto second_snapshot = TypeRealizationSnapshot::capture(registry);
+
+    TSInput second_input;
+    {
+        TypeRealizationScope scope{second_snapshot.get()};
+        const auto &reused = TSInputBuilderFactory::checked_builder_for(*schema, endpoint);
+        REQUIRE(&reused == builder);
+        second_input = reused.make_input();
+    }
+    const auto second = bindings(second_input);
+    auto second_root = second_input.view();
+    const auto *second_plan = second_root.data_view().storage_type().plan();
+    REQUIRE(second.first == second_snapshot->type_for(key_base));
+    REQUIRE(second.second == second_snapshot->type_for(value_base));
+    REQUIRE(second.first != first.first);
+    REQUIRE(second.second != first.second);
+    REQUIRE(second_plan != first_plan);
+}
+
+TEST_CASE("cached composite TSD inputs re-realize polymorphic keys and owned "
+          "values")
+{
+    using namespace hgraph;
+
+    auto &registry = TypeRegistry::instance();
+    const auto *integer = registry.register_scalar<std::int32_t>("int32");
+    const auto *key_base =
+        registry.bundle("tests.ts_input_cache.composite_tsd_key", "Base", {{"id", integer}}, {}, true);
+    const auto *value_base =
+        registry.bundle("tests.ts_input_cache.composite_tsd_value", "Base", {{"id", integer}}, {}, true);
+    registry.bundle("tests.ts_input_cache.composite_tsd_key", "First", {{"id", integer}, {"value", integer}},
+                    {key_base});
+    registry.bundle("tests.ts_input_cache.composite_tsd_value", "First", {{"id", integer}, {"value", integer}},
+                    {value_base});
+    const auto *element = registry.ts(value_base);
+    const auto *schema = registry.tsd(key_base, element);
+    const auto endpoint = TSEndpointSchema::non_peered_dict(schema, TSEndpointSchema::owned(element));
+    const auto bindings = [](TSInput &input)
+    {
+        auto root = input.view();
+        auto dict = root.as_dict();
+        auto data = dict.data_view();
+        const auto &layout = data.layout();
+        return std::pair{layout.key_binding, layout.element_layout->value_binding};
+    };
+
+    const auto first_snapshot = TypeRealizationSnapshot::capture(registry);
+    const TSInputBuilder *builder = nullptr;
+    TSInput first_input;
+    {
+        TypeRealizationScope scope{first_snapshot.get()};
+        builder = &TSInputBuilderFactory::checked_builder_for(*schema, endpoint);
+        first_input = builder->make_input();
+    }
+    const auto first = bindings(first_input);
+    auto first_root = first_input.view();
+    const auto *first_plan = first_root.data_view().storage_type().plan();
+    REQUIRE(first.first == first_snapshot->type_for(key_base));
+    REQUIRE(first.second == first_snapshot->type_for(value_base));
+
+    registry.bundle("tests.ts_input_cache.composite_tsd_key", "Second",
+                    {{"id", integer}, {"value", integer}, {"other", integer}}, {key_base});
+    registry.bundle("tests.ts_input_cache.composite_tsd_value", "Second",
+                    {{"id", integer}, {"value", integer}, {"other", integer}}, {value_base});
+    const auto second_snapshot = TypeRealizationSnapshot::capture(registry);
+
+    TSInput second_input;
+    {
+        TypeRealizationScope scope{second_snapshot.get()};
+        const auto &reused = TSInputBuilderFactory::checked_builder_for(*schema, endpoint);
+        REQUIRE(&reused == builder);
+        second_input = reused.make_input();
+    }
+    const auto second = bindings(second_input);
+    auto second_root = second_input.view();
+    const auto *second_plan = second_root.data_view().storage_type().plan();
+    REQUIRE(second.first == second_snapshot->type_for(key_base));
+    REQUIRE(second.second == second_snapshot->type_for(value_base));
+    REQUIRE(second.first != first.first);
+    REQUIRE(second.second != first.second);
+    REQUIRE(second_plan != first_plan);
+}
+
+TEST_CASE("cached owned dynamic TSL inputs re-realize polymorphic elements")
+{
+    using namespace hgraph;
+
+    auto &registry = TypeRegistry::instance();
+    const auto *integer = registry.register_scalar<std::int32_t>("int32");
+    const auto *base = registry.bundle("tests.ts_input_cache.dynamic_tsl", "Base", {{"id", integer}}, {}, true);
+    registry.bundle("tests.ts_input_cache.dynamic_tsl", "First", {{"id", integer}, {"value", integer}}, {base});
+    const auto *schema = registry.tsl(registry.ts(base));
+    const auto endpoint = TSEndpointSchema::owned(schema);
+    const auto element_binding = [](TSInput &input)
+    {
+        auto root = input.view();
+        auto list = root.as_list();
+        auto data = list.data_view();
+        const auto &layout = static_cast<const FixedTSLDataLayout &>(data.layout());
+        return layout.element_layout->value_binding;
+    };
+
+    const auto first_snapshot = TypeRealizationSnapshot::capture(registry);
+    const TSInputBuilder *builder = nullptr;
+    TSInput first_input;
+    {
+        TypeRealizationScope scope{first_snapshot.get()};
+        builder = &TSInputBuilderFactory::checked_builder_for(*schema, endpoint);
+        first_input = builder->make_input();
+    }
+    const auto first_binding = element_binding(first_input);
+    auto first_root = first_input.view();
+    const auto *first_plan = first_root.data_view().storage_type().plan();
+    REQUIRE(first_binding == first_snapshot->type_for(base));
+
+    registry.bundle("tests.ts_input_cache.dynamic_tsl", "Second",
+                    {{"id", integer}, {"value", integer}, {"other", integer}}, {base});
+    const auto second_snapshot = TypeRealizationSnapshot::capture(registry);
+
+    TSInput second_input;
+    {
+        TypeRealizationScope scope{second_snapshot.get()};
+        const auto &reused = TSInputBuilderFactory::checked_builder_for(*schema, endpoint);
+        REQUIRE(&reused == builder);
+        second_input = reused.make_input();
+    }
+    const auto second_binding = element_binding(second_input);
+    auto second_root = second_input.view();
+    const auto *second_plan = second_root.data_view().storage_type().plan();
+    REQUIRE(second_binding == second_snapshot->type_for(base));
+    REQUIRE(second_binding != first_binding);
+    REQUIRE(second_plan == first_plan);
+}
+
+TEST_CASE("cached owned TSW inputs re-realize polymorphic elements")
+{
+    using namespace hgraph;
+
+    auto &registry = TypeRegistry::instance();
+    const auto *integer = registry.register_scalar<std::int32_t>("int32");
+    const auto *base = registry.bundle("tests.ts_input_cache.tsw", "Base", {{"id", integer}}, {}, true);
+    registry.bundle("tests.ts_input_cache.tsw", "First", {{"id", integer}, {"value", integer}}, {base});
+    const auto *schema = registry.tsw(base, 3, 1);
+    const auto endpoint = TSEndpointSchema::owned(schema);
+    const auto element_binding = [](TSInput &input)
+    {
+        auto root = input.view();
+        return root.as_window().data_view().layout().element_binding;
+    };
+
+    const auto first_snapshot = TypeRealizationSnapshot::capture(registry);
+    const TSInputBuilder *builder = nullptr;
+    TSInput first_input;
+    {
+        TypeRealizationScope scope{first_snapshot.get()};
+        builder = &TSInputBuilderFactory::checked_builder_for(*schema, endpoint);
+        first_input = builder->make_input();
+    }
+    const auto first_binding = element_binding(first_input);
+    auto first_root = first_input.view();
+    const auto *first_plan = first_root.data_view().storage_type().plan();
+    REQUIRE(first_binding == first_snapshot->type_for(base));
+
+    registry.bundle("tests.ts_input_cache.tsw", "Second", {{"id", integer}, {"value", integer}, {"other", integer}},
+                    {base});
+    const auto second_snapshot = TypeRealizationSnapshot::capture(registry);
+
+    TSInput second_input;
+    {
+        TypeRealizationScope scope{second_snapshot.get()};
+        const auto &reused = TSInputBuilderFactory::checked_builder_for(*schema, endpoint);
+        REQUIRE(&reused == builder);
+        second_input = reused.make_input();
+    }
+    const auto second_binding = element_binding(second_input);
+    auto second_root = second_input.view();
+    const auto *second_plan = second_root.data_view().storage_type().plan();
+    REQUIRE(second_binding == second_snapshot->type_for(base));
+    REQUIRE(second_binding != first_binding);
+    REQUIRE(second_plan != first_plan);
+}
+
+TEST_CASE("cached wholly owned fixed inputs re-realize nested keyed and dynamic storage")
+{
+    using namespace hgraph;
+
+    auto &registry = TypeRegistry::instance();
+    const auto *integer = registry.register_scalar<std::int32_t>("int32");
+    const auto *key_base =
+        registry.bundle("tests.ts_input_cache.nested_key", "Base", {{"id", integer}}, {}, true);
+    const auto *dict_base =
+        registry.bundle("tests.ts_input_cache.nested_dict", "Base", {{"id", integer}}, {}, true);
+    const auto *list_base =
+        registry.bundle("tests.ts_input_cache.nested_list", "Base", {{"id", integer}}, {}, true);
+    registry.bundle("tests.ts_input_cache.nested_key", "First", {{"id", integer}, {"value", integer}}, {key_base});
+    registry.bundle("tests.ts_input_cache.nested_dict", "First", {{"id", integer}, {"value", integer}},
+                    {dict_base});
+    registry.bundle("tests.ts_input_cache.nested_list", "First", {{"id", integer}, {"value", integer}},
+                    {list_base});
+
+    const auto *dict = registry.tsd(key_base, registry.ts(dict_base));
+    const auto *list = registry.tsl(registry.ts(list_base));
+    const auto *root = registry.tsb("TSInputCacheNestedOwnedRoot", {{"dict", dict}, {"list", list}});
+    const auto endpoint = TSEndpointSchema::owned(root);
+    const auto bindings = [](TSInput &input)
+    {
+        auto root_view = input.view();
+        auto bundle = root_view.data_view().as_bundle();
+        auto dict_data = bundle.field("dict");
+        auto list_data = bundle.field("list");
+        const auto &dict_layout =
+            static_cast<const TSDDataLayout &>(dict_data.layout());
+        const auto &list_layout =
+            static_cast<const FixedTSLDataLayout &>(list_data.layout());
+        return std::tuple{
+            dict_layout.key_binding,
+            dict_layout.element_layout->value_binding,
+            list_layout.element_layout->value_binding,
+        };
+    };
+
+    const auto first_snapshot = TypeRealizationSnapshot::capture(registry);
+    const TSInputBuilder *builder = nullptr;
+    TSInput first_input;
+    {
+        TypeRealizationScope scope{first_snapshot.get()};
+        builder = &TSInputBuilderFactory::checked_builder_for(*root, endpoint);
+        first_input = builder->make_input();
+    }
+    const auto first = bindings(first_input);
+    REQUIRE(std::get<0>(first) == first_snapshot->type_for(key_base));
+    REQUIRE(std::get<1>(first) == first_snapshot->type_for(dict_base));
+    REQUIRE(std::get<2>(first) == first_snapshot->type_for(list_base));
+
+    registry.bundle("tests.ts_input_cache.nested_key", "Second",
+                    {{"id", integer}, {"value", integer}, {"other", integer}}, {key_base});
+    registry.bundle("tests.ts_input_cache.nested_dict", "Second",
+                    {{"id", integer}, {"value", integer}, {"other", integer}}, {dict_base});
+    registry.bundle("tests.ts_input_cache.nested_list", "Second",
+                    {{"id", integer}, {"value", integer}, {"other", integer}}, {list_base});
+    const auto second_snapshot = TypeRealizationSnapshot::capture(registry);
+
+    TSInput second_input;
+    {
+        TypeRealizationScope scope{second_snapshot.get()};
+        const auto &reused = TSInputBuilderFactory::checked_builder_for(*root, endpoint);
+        REQUIRE(&reused == builder);
+        second_input = reused.make_input();
+    }
+    const auto second = bindings(second_input);
+    REQUIRE(std::get<0>(second) == second_snapshot->type_for(key_base));
+    REQUIRE(std::get<1>(second) == second_snapshot->type_for(dict_base));
+    REQUIRE(std::get<2>(second) == second_snapshot->type_for(list_base));
+    REQUIRE(std::get<0>(second) != std::get<0>(first));
+    REQUIRE(std::get<1>(second) != std::get<1>(first));
+    REQUIRE(std::get<2>(second) != std::get<2>(first));
 }
 
 TEST_CASE("TSInput builds a non-peered TSB root with nested peered terminals")


### PR DESCRIPTION
## Summary

- realize owned TSS/TSD keys and TSD/dynamic-TSL/TSW elements from the active graph's `TypeRealizationSnapshot`
- make window lifecycle-plan and operation caches element-binding aware
- recursively realize keyed and dynamic storage nested inside wholly owned fixed structures
- add regressions that reuse one cached `TSInputBuilder` across distinct graph realization snapshots

## Root cause

Owned input storage plans were synthesized and cached from unresolved metadata without consistently carrying the active graph's concrete key or element binding. Reusing a cached builder across graphs could therefore retain the first realization or construct nested storage from the unresolved schema.

This change keeps plan reuse while including the graph-scoped realization in plan selection and storage construction. Peered target-link storage remains canonical and realization-independent.

## Impact

Polymorphic owned keyed and dynamic inputs now construct the correct concrete storage for each graph realization, including when nested within fixed structures. This preserves builder caching without leaking type realization between graph instances.

Follow-up to #264.

## Validation

- macOS fresh native acceptance: 1431/1431 passed
- macOS stable-ABI wheel built with Python 3.12 and full non-WIP suite run under Python 3.14: 1884 passed, 11 skipped
- installed C++ SDK consumer test: passed
- physical `hg-linux` (x86_64, GCC 14.3) fresh native acceptance: 1431/1431 passed
- physical `hg-linux` Python 3.14 compatibility suite: 1884 passed, 11 skipped
- ASan: six focused realization regressions passed with leak detection enabled; complete native suite passed 1431/1431 with leak detection disabled
- the full leak-enabled ASan run reached an unrelated, documented intentional 24-byte process-lifetime allocation in `tests/cpp/test_bundle_builder.cpp:305`; all test assertions passed
