### PR TITLE
RFC 0012: a reply-less request/reply service is a keyed sink

### DIFF
--- a/docs/source/developer_guide/services.rst
+++ b/docs/source/developer_guide/services.rst
@@ -78,12 +78,22 @@ source/capture pair** — applied with different payloads:
     Python's keyed-child lifecycle and preventing cached values from leaking on
     re-add. A client joining a key that another client has kept live samples the
     existing value immediately.
-  - **Request/reply requests** forward **next cycle** by design: the pairing is
-    rank-free (no rank dependency), and the capture schedules the service source
-    for ``evaluation_time + MIN_TD`` (current time during ``start``). The temporal
-    request mutation does not run the implementation in the capture cycle.
-    A request/reply input source retains its earliest outstanding publication
-    time, so a later request cannot postpone work that is already due.
+  - **Request/reply requests** forward **next cycle** *when the service declares
+    a response*: the pairing is rank-free (no rank dependency), and the capture
+    schedules the service source for ``evaluation_time + MIN_TD`` (current time
+    during ``start``). The temporal request mutation does not run the
+    implementation in the capture cycle. A request/reply input source retains
+    its earliest outstanding publication time, so a later request cannot
+    postpone work that is already due.
+  - **A reply-less request/reply service forwards SAME cycle.** With no
+    response there is no response feedback edge, hence no request/reply cycle
+    for the rank-free path to permit, so the capture is declared through
+    ``add_same_cycle_pair`` and built with ``same_cycle`` — the implementation
+    observes a request in the cycle the client sent it. This makes it agree with
+    a sink-only adaptor, which is the same construct at a different keying
+    (:doc:`../rfc/rfc_0012_replyless_request_reply_relay`). The consequence is
+    that a dependency cycle through a reply-less service is reported at wiring
+    time rather than being silently broken by the cycle boundary.
   - **Request/reply responses** cross an explicit feedback source/sink pair in
     the graph that owns the implementation, then publish through the ordinary
     same-cycle shared-output relay. Request/reply clients are omitted from

--- a/docs/source/developer_guide/services.rst
+++ b/docs/source/developer_guide/services.rst
@@ -34,7 +34,7 @@ source/capture pair** — applied with different payloads:
       cons["consumers bind here and are woken by<br/>ordinary output notification"]
 
       client --> cap
-      cap -->|"write state; schedule_node<br/>(ranked adaptors: same cycle / deferred services: +MIN_TD)"| src
+      cap -->|"write state; schedule_node<br/>(ranked boundaries: same cycle / deferred requests: +MIN_TD)"| src
       src -->|"applies state in one mutation<br/>of its own output"| out
       out --> cons
 
@@ -55,19 +55,22 @@ source/capture pair** — applied with different payloads:
 
   - **Ranked boundaries in their owning graph** (reference and subscription
     outputs, adaptor ``from_graph``/``to_graph``, service-adaptor requests,
-    contexts) are **rank-correct and same-cycle**: pairs are declared with
-    ``Wiring::add_same_cycle_pair``
-    (source rank-constrained after every capture); ``Wiring::finish`` re-ranks
-    once all captures are known — which is what keeps chains of multiple
-    adaptors/services correct — and **validates** every pair's final order.
-    The runtime trusts the wiring-time proof: a capture always schedules the
-    source for the **current** evaluation time with no hot-path checks (debug
-    asserts only) — never a silent next-cycle deferral. A dynamically-started
-    child service-adaptor client cannot precede an outer source whose rank has
-    already passed, so its boundary hand-off occurs on the following cycle;
-    the implementation and reply then remain rank-ordered in that owning
-    graph. This is the released Python lifecycle behavior, not the old
-    top-level adaptor delay.
+    reply-less request/reply requests, and contexts) are **rank-correct and
+    same-cycle**. Fixed source/capture pairs use
+    ``Wiring::add_same_cycle_pair``; service clients whose sources can cross a
+    nested boundary use the equivalent sending service-rank relation. In both
+    cases the source is rank-constrained after every capture.
+    ``Wiring::finish`` re-ranks once all captures are known — which is what
+    keeps chains of multiple adaptors/services correct — and validates the
+    final order.
+    For a capture in the graph that owns its source, the runtime trusts the
+    wiring-time proof and schedules the source for the **current** evaluation
+    time with no hot-path checks (debug asserts only). A dynamically-started
+    child service-adaptor client instead hands off to an outer source on the
+    following cycle because that source's rank may already have passed; the
+    implementation and reply then remain rank-ordered in the owning graph.
+    This explicit nested boundary is released Python lifecycle behavior, not a
+    silent fallback to the old top-level adaptor delay.
   - **Subscription keys** in the owning graph are ranked before their source
     and publish in the capture cycle. A dynamically-started nested client hands
     off to the outer source on the following cycle because the outer rank may
@@ -85,20 +88,24 @@ source/capture pair** — applied with different payloads:
     implementation in the capture cycle. A request/reply input source retains
     its earliest outstanding publication time, so a later request cannot
     postpone work that is already due.
-  - **A reply-less request/reply service forwards SAME cycle.** With no
-    response there is no response feedback edge, hence no request/reply cycle
-    for the rank-free path to permit, so the capture is declared through
-    ``add_same_cycle_pair`` and built with ``same_cycle`` — the implementation
-    observes a request in the cycle the client sent it. This makes it agree with
-    a sink-only adaptor, which is the same construct at a different keying
-    (:doc:`../rfc/rfc_0012_replyless_request_reply_relay`). The consequence is
-    that a dependency cycle through a reply-less service is reported at wiring
-    time rather than being silently broken by the cycle boundary.
+  - **A reply-less request/reply service forwards in the owning capture
+    cycle.** With no response there is no response feedback edge, hence no
+    request/reply cycle for the rank-free path to permit. A root client is
+    registered as a sending service-rank dependency and its capture is built
+    with ``same_cycle`` — the implementation observes the request in the cycle
+    the client sent it. This makes it agree with a sink-only adaptor, which is
+    the same construct at a different keying
+    (:doc:`../rfc/rfc_0012_replyless_request_reply_relay`). A dynamically
+    started nested client cannot safely schedule an outer source whose rank
+    may already have passed, so its outer hand-off occurs on the next cycle.
+    Both timings match released hgraph. A root dependency cycle through a
+    reply-less service is reported at wiring time rather than being silently
+    broken by a cycle boundary.
   - **Request/reply responses** cross an explicit feedback source/sink pair in
     the graph that owns the implementation, then publish through the ordinary
-    same-cycle shared-output relay. Request/reply clients are omitted from
-    indirect service ranking, so recursive request/reply calls are legal. No
-    nested client or higher-order operator constructs this feedback path.
+    same-cycle shared-output relay. Reply-full request/reply clients are omitted
+    from indirect service ranking, so recursive request/reply calls are legal.
+    No nested client or higher-order operator constructs this feedback path.
 - **Lifecycle:** the source clears its captured state on ``stop``. A restarted
   graph must republish through capture before the source can produce a live
   shared output.
@@ -169,8 +176,8 @@ A service is declared as a plain struct naming its schemas. The type aliases a
 descriptor declares are its **flavour tag** — exactly one of the three alias
 sets must be present, and the sets are mutually exclusive (checked by concepts
 at compile time: ``output_schema`` = reference, ``key_type`` +
-``value_schema`` = subscription, ``request_schema`` + ``response_schema`` =
-request/reply):
+``value_schema`` = subscription, and ``request_schema`` with an optional
+``response_schema`` = request/reply):
 
 .. code-block:: cpp
 
@@ -192,6 +199,12 @@ request/reply):
        static constexpr std::string_view name{"add_one"};
        using request_schema  = TS<Int>;
        using response_schema = TS<Int>;
+   };
+
+   struct PublishService                  // reply-less request/reply sink
+   {
+       static constexpr std::string_view name{"publish"};
+       using request_schema = TS<Int>;
    };
 
 An implementation is an ordinary node or sub-graph whose signature matches the
@@ -217,11 +230,13 @@ registered:
    register_reference_service<ReferencePricesService, ReferencePricesImpl>(w);
    register_subscription_service<PricesService, PricesImpl>(w);
    register_request_reply_service<AddOneService, AddOneImplNode>(w, path("premium"));
+   register_request_reply_service<PublishService, PublishImpl>(w, path("events"));
 
    // client side — the flavour tag selects the call shape:
    auto prices = wire<ReferencePricesService>(w);                   // reference: no argument
    auto quote  = wire<PricesService>(w, instrument);                // subscription: the key
    auto reply  = wire<AddOneService>(w, path("premium"), request);  // request/reply: the request
+   wire<PublishService>(w, path("events"), event);                  // reply-less: returns void
 
 When a non-default path is used, ``service::path("…")`` is always the **first**
 argument after ``w`` (for registration and consumption alike). Passing an
@@ -258,6 +273,11 @@ output. The per-flavour contract, with the complications each one must handle:
   ``InputValidity::Unchecked`` and gate on ``requests.modified()``; erase
   ``removed_items()``; a request element that ticked **invalid** means the
   client's request went away — erase that reply too.
+- **Reply-less request/reply** (``request_schema`` only): input is the same
+  stable-client-id ``TSD<Int, request_schema>`` and the implementation is a
+  sink (a node/graph with no output). The public call remains
+  ``wire<Service>(w, request)`` but returns ``void``; no reply source, response
+  capture, or response feedback edge is built.
 
 .. code-block:: cpp
 
@@ -299,8 +319,9 @@ interfaces at once. Register it with
   ``Port<TSD<Int, request_schema>>`` for request/reply (a reference service
   has no input);
 - ``service::impl_output<Service>(w[, path], port)`` publishes the
-  implementation's result as that service's shared output (all three
-  flavours).
+  implementation's result as that service's shared output (reference,
+  subscription, and reply-full request/reply; a reply-less service has no
+  output endpoint).
 
 .. code-block:: cpp
 

--- a/docs/source/rfc/index.rst
+++ b/docs/source/rfc/index.rst
@@ -25,4 +25,5 @@ workflow are defined by :doc:`rfc_0000`.
    rfc_0009_time_series_endpoint_visitors
    rfc_0010_value_view_visitors
    rfc_0011_source_only_adaptor_collapse
+   rfc_0012_replyless_request_reply_relay
    rfc_0013_pooled_polymorphic_compound_scalars

--- a/docs/source/rfc/rfc_0011_source_only_adaptor_collapse.rst
+++ b/docs/source/rfc/rfc_0011_source_only_adaptor_collapse.rst
@@ -146,6 +146,13 @@ Explicitly out of scope, because the transports genuinely differ:
   the explicit stub protocol, not the relay. Recorded here as an adjacent
   observation for a possible later RFC; this RFC does not touch it.
 
+  **Superseded in part.** Steps 3 and 4 removed the stub-protocol difference
+  (services gained ``from_graph``/``to_graph`` and a by-stub registration), so
+  this reason no longer holds. The remaining differences are the response
+  feedback edge and the scheduling that follows from it;
+  :doc:`rfc_0012_replyless_request_reply_relay` takes up the reply-less case,
+  where there is no response feedback at all.
+
 Ownership boundary
 ------------------
 

--- a/docs/source/rfc/rfc_0012_replyless_request_reply_relay.rst
+++ b/docs/source/rfc/rfc_0012_replyless_request_reply_relay.rst
@@ -1,7 +1,7 @@
 RFC 0012: A Reply-Less Request/Reply Service Is a Keyed Sink
 ============================================================
 
-:Status: Proposed
+:Status: Accepted
 :Author: Howard Henson
 :Created: 2026-08-02
 :Target: Request/reply service transport and scheduling
@@ -97,11 +97,15 @@ Proposal
 When ``response_schema == nullptr``, wire the request transport the way the
 adaptor input relay is wired:
 
-* the request capture takes the request source as a **ranked** dependency
-  rather than ``rank_dependency = false``; and
 * the pair is declared with ``Wiring::add_same_cycle_pair``, so ``finish``
-  validates the order and the capture schedules the source for the **current**
-  evaluation time.
+  validates the order and the **source** is ranked after the capture; and
+* the capture node is built with ``same_cycle``, so it schedules the paired
+  source for the **current** evaluation time.
+
+The capture's own input on the source stays ``rank_dependency = false``. That is
+not an oversight: a capture must not wait on the source it feeds, and making it
+a ranked dependency produces a wiring cycle. Ordering flows the other way, from
+``add_same_cycle_pair`` — the same shape ``shared_output_relay_capture`` uses.
 
 Nothing else changes: the transport is still keyed by client id, still a
 ``TSD<Int, request_schema>``, still built by ``keyed_request_input_source_node``.
@@ -187,13 +191,28 @@ Acceptance criteria and test plan
 Implementation status
 ---------------------
 
-Not started. This RFC is the first commit on its branch, per
-:doc:`rfc_0000` workflow step 1.
+**Implemented.** The change is three lines of wiring plus the tests.
 
-The branch is stacked on the RFC 0011 implementation
-(``agent/rfc-0011-unify-service-adaptor-surface``, PR #263), which touches the
-same ``register_request_reply_service_impl`` body; the dependency is one of
-merge order, not of design.
+Two findings from implementing it:
+
+* **The rank direction is the opposite of the obvious one.** Making the
+  capture's source input a rank dependency produces a wiring cycle: the capture
+  must NOT wait on the source it feeds. The relay pattern keeps that input
+  rank-free and lets ``add_same_cycle_pair`` order the *source* after the
+  capture — the same shape ``shared_output_relay_capture`` uses. The cycle
+  detector caught this immediately.
+* **The runtime already supported it.** ``make_request_input_capture_node``
+  takes a ``same_cycle`` flag, added for rank-correct service-adaptor captures;
+  the reply-less case just had to pass it. Wiring-level ordering alone changed
+  nothing, because the next-cycle behaviour lives in the capture node's
+  schedule-time computation.
+
+No existing test needed changing, including
+``test_replyless_request_reply_service_captures_requests``, which asserts values
+rather than cycles — which is precisely why the latency went unnoticed, and why
+the new tests assert observed cycle numbers.
+
+Final state: 1414 ctest, 1880 Python tests.
 
 References
 ----------

--- a/docs/source/rfc/rfc_0012_replyless_request_reply_relay.rst
+++ b/docs/source/rfc/rfc_0012_replyless_request_reply_relay.rst
@@ -1,0 +1,206 @@
+RFC 0012: A Reply-Less Request/Reply Service Is a Keyed Sink
+============================================================
+
+:Status: Proposed
+:Author: Howard Henson
+:Created: 2026-08-02
+:Target: Request/reply service transport and scheduling
+
+Summary
+-------
+
+A request/reply service declaring no response (``response_schema == nullptr``)
+is a **sink**: clients send, the implementation consumes, nothing comes back. It
+is nevertheless wired on the request/reply *transport*, whose request half is
+deliberately rank-free and forwards on the **next** cycle. That rank-freedom
+exists to permit request/reply **cycles**, which are resolved by the response
+feedback edge — and a reply-less service has no response, so it has no cycle to
+permit and pays the cost for nothing.
+
+The same shape expressed as a sink-only adaptor uses the rank-correct
+same-cycle relay and delivers immediately. This RFC proposes wiring the
+reply-less case on that relay, making the two constructs agree.
+
+Measured, on the current tree:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 45 25 30
+
+   * - Shape
+     - Client emits at
+     - Implementation sees at
+   * - reply-less request/reply service
+     - cycles 0, 2
+     - cycles **1, 3** (+1 cycle)
+   * - sink-only adaptor
+     - cycles 0, 2
+     - cycles **0, 2** (same cycle)
+
+Motivation
+----------
+
+RFC 0011 established that the service and adaptor surfaces are one boundary
+model and unified the relay both are built from. It scoped the other flavours
+out on the grounds that *"the difference is the explicit stub protocol, not the
+relay"*. Steps 3 and 4 of that RFC removed the stub-protocol difference —
+services gained ``from_graph``/``to_graph`` and a by-stub registration — so the
+stated reason no longer holds and the remaining flavours are worth revisiting.
+
+Taking the flavours as a grid of **direction × keying** makes the gap obvious:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 22 26 26 26
+
+   * - Keying
+     - Output only
+     - Input and output
+     - Input only
+   * - none / merged
+     - reference service **=** source-only adaptor *(unified, RFC 0011)*
+     - duplex adaptor
+     - sink-only adaptor
+   * - by client id
+     - —
+     - request/reply service **=** service adaptor
+     - **reply-less request/reply**
+   * - by user key
+     - —
+     - subscription service
+     - —
+
+The bottom-right and top-right cells are the same construct at different
+keyings: many clients into one implementation, nothing returned. They should
+differ in *how they key*, not in *when the implementation sees the data*.
+
+The cost is not merely cosmetic. ``service_runtime.cpp:566`` records the reason
+the request path is rank-free:
+
+.. code-block:: text
+
+   // Request/reply transport is ordered by its response feedback edge, not
+   // by indirect service dependencies. This permits request/reply cycles.
+
+The request capture takes its source with ``rank_dependency = false``
+(``service_runtime.cpp:551``), so nothing orders the implementation after its
+clients; correctness comes instead from the request stub forwarding on the next
+cycle. For a service with a response that is a sound trade — it is what makes a
+service able to call itself. For a reply-less service there is no response
+feedback edge at all (``register_request_reply_service_impl`` returns before
+building one, ``service_runtime.cpp:611-619``), so the rank-freedom buys
+nothing and the extra cycle is pure latency.
+
+Proposal
+--------
+
+When ``response_schema == nullptr``, wire the request transport the way the
+adaptor input relay is wired:
+
+* the request capture takes the request source as a **ranked** dependency
+  rather than ``rank_dependency = false``; and
+* the pair is declared with ``Wiring::add_same_cycle_pair``, so ``finish``
+  validates the order and the capture schedules the source for the **current**
+  evaluation time.
+
+Nothing else changes: the transport is still keyed by client id, still a
+``TSD<Int, request_schema>``, still built by ``keyed_request_input_source_node``.
+This is a scheduling and rank-ordering change to one flavour of one boundary,
+not a new mechanism — the relay it moves onto is the one RFC 0011 made shared.
+
+Consequences
+------------
+
+**Timing (intended).** A reply-less request/reply implementation observes a
+client's request in the cycle the client sent it, instead of the next one. This
+is the point of the change, and it is directly observable by any graph that
+measures delivery latency.
+
+**Rank ordering (intended).** The implementation is ordered after every client
+that sends to it, in the same way a sink-only adaptor's implementation is. That
+is a stronger guarantee than today's, where ordering is unconstrained and
+correctness rests on the cycle boundary.
+
+**Cycles through a reply-less service become a wiring error.** Today a graph in
+which a reply-less service's implementation ultimately publishes back to that
+same service is tolerated, because the next-cycle boundary breaks the loop
+silently. Ranked ordering will report it as a cycle at wiring time.
+
+This is the one genuinely behaviour-narrowing consequence and the main thing to
+review. The position taken here is that it is a **correction**: such a
+configuration is a real dependency cycle, and reporting it beats silently
+inserting a cycle of latency. Nothing in this tree relies on it. If a concrete
+use emerges, the answer is an explicit opt-in rather than restoring the implicit
+next-cycle behaviour for everyone.
+
+**Reply-full request/reply is untouched.** Its rank-freedom and response
+feedback are exactly what make recursive request/reply legal, and
+``test_service_wiring.cpp`` pins that behaviour.
+
+Alternatives considered
+-----------------------
+
+Leave it; document the latency
+   Rejected. Two spellings of "many clients into one implementation, nothing
+   returned" differing by a cycle is precisely the kind of accidental
+   divergence RFC 0011 exists to remove, and the slower one is the one a user
+   reaches for when they want a *service*.
+
+Make the reply-less case a sink-only adaptor internally
+   Rejected. A sink-only adaptor *merges* clients into one stream, while the
+   request/reply transport keys them by client id. The keying is the useful
+   part and must survive; only the scheduling should change.
+
+Give the whole request/reply flavour the same-cycle relay
+   Rejected. The rank-free request path is load-bearing when a response exists:
+   it is what permits request/reply cycles, which
+   ``test_service_wiring.cpp`` covers for both direct and mapped recursion.
+
+Opt in through a flag on the interface
+   Deferred. It adds surface for a choice that follows from the descriptor —
+   a service either declares a response or it does not. A flag becomes
+   worthwhile only if the cycle-detection consequence above turns out to block
+   a real graph.
+
+Acceptance criteria and test plan
+---------------------------------
+
+* A reply-less request/reply implementation observes a client's request in the
+  **same** cycle the client sent it. A test asserts the observed cycle numbers,
+  not merely the values — the existing coverage
+  (``test_replyless_request_reply_service_captures_requests``) asserts values
+  only and passes either way.
+* The same graph expressed as a sink-only adaptor and as a reply-less
+  request/reply service delivers on the **same** cycle, pinned by one test that
+  evaluates both.
+* Multiple clients at one path are still keyed by client id, and their requests
+  still combine into one cumulative dictionary delta.
+* A reply-*full* request/reply service is unchanged: same timing, and direct and
+  mapped recursion still wire.
+* A dependency cycle through a reply-less service is reported at wiring time
+  with the ordinary cycle diagnostic.
+* ``services.rst`` scheduling matrix records the reply-less case on the
+  same-cycle relay rather than under request stubs.
+* The full native suite and the non-WIP Python suites pass, including
+  ``python/tests/ported``.
+
+Implementation status
+---------------------
+
+Not started. This RFC is the first commit on its branch, per
+:doc:`rfc_0000` workflow step 1.
+
+The branch is stacked on the RFC 0011 implementation
+(``agent/rfc-0011-unify-service-adaptor-surface``, PR #263), which touches the
+same ``register_request_reply_service_impl`` body; the dependency is one of
+merge order, not of design.
+
+References
+----------
+
+* :doc:`rfc_0000` — RFC process.
+* :doc:`rfc_0011_source_only_adaptor_collapse` — the unified boundary model this
+  extends, and whose "explicitly out of scope" note this supersedes for the
+  reply-less case.
+* ``docs/source/developer_guide/services.rst`` — the scheduling matrix
+  distinguishing same-cycle relays from next-cycle request stubs.

--- a/docs/source/rfc/rfc_0012_replyless_request_reply_relay.rst
+++ b/docs/source/rfc/rfc_0012_replyless_request_reply_relay.rst
@@ -9,9 +9,11 @@ RFC 0012: A Reply-Less Request/Reply Service Is a Keyed Sink
 Summary
 -------
 
-A request/reply service declaring no response (``response_schema == nullptr``)
-is a **sink**: clients send, the implementation consumes, nothing comes back. It
-is nevertheless wired on the request/reply *transport*, whose request half is
+A request/reply service declaring no response (an erased
+``response_schema == nullptr`` or a typed C++ descriptor with no
+``response_schema`` alias) is a **sink**: clients send, the implementation
+consumes, nothing comes back. It is nevertheless wired on the request/reply
+*transport*, whose request half is
 deliberately rank-free and forwards on the **next** cycle. That rank-freedom
 exists to permit request/reply **cycles**, which are resolved by the response
 feedback edge — and a reply-less service has no response, so it has no cycle to
@@ -21,7 +23,7 @@ The same shape expressed as a sink-only adaptor uses the rank-correct
 same-cycle relay and delivers immediately. This RFC proposes wiring the
 reply-less case on that relay, making the two constructs agree.
 
-Measured, on the current tree:
+Measured before this RFC:
 
 .. list-table::
    :header-rows: 1
@@ -30,12 +32,17 @@ Measured, on the current tree:
    * - Shape
      - Client emits at
      - Implementation sees at
-   * - reply-less request/reply service
+   * - reply-less request/reply service, root client
      - cycles 0, 2
      - cycles **1, 3** (+1 cycle)
    * - sink-only adaptor
      - cycles 0, 2
      - cycles **0, 2** (same cycle)
+
+Released hgraph additionally establishes the nested lifecycle boundary: a
+reply-less client dynamically started inside ``map_`` at cycles 0 and 2 hands
+its requests to the outer service source at cycles **1 and 3**. The proposal
+changes the root case only; it preserves that nested deferral.
 
 Motivation
 ----------
@@ -74,38 +81,46 @@ The bottom-right and top-right cells are the same construct at different
 keyings: many clients into one implementation, nothing returned. They should
 differ in *how they key*, not in *when the implementation sees the data*.
 
-The cost is not merely cosmetic. ``service_runtime.cpp:566`` records the reason
-the request path is rank-free:
+The cost is not merely cosmetic. The runtime records the reason the reply-full
+request path is rank-free:
 
 .. code-block:: text
 
    // Request/reply transport is ordered by its response feedback edge, not
    // by indirect service dependencies. This permits request/reply cycles.
 
-The request capture takes its source with ``rank_dependency = false``
-(``service_runtime.cpp:551``), so nothing orders the implementation after its
+The request capture takes its source with ``rank_dependency = false``, so
+nothing orders the implementation after its
 clients; correctness comes instead from the request stub forwarding on the next
 cycle. For a service with a response that is a sound trade — it is what makes a
 service able to call itself. For a reply-less service there is no response
-feedback edge at all (``register_request_reply_service_impl`` returns before
-building one, ``service_runtime.cpp:611-619``), so the rank-freedom buys
-nothing and the extra cycle is pure latency.
+feedback edge at all: implementation registration returns before building one.
+The rank-freedom therefore buys nothing for a root client and the extra cycle
+is pure latency there.
 
 Proposal
 --------
 
-When ``response_schema == nullptr``, wire the request transport the way the
-adaptor input relay is wired:
+When the response is omitted (``response_schema == nullptr`` in the erased
+descriptor, or no typed ``response_schema`` alias), wire a root request
+transport the way the adaptor input relay is wired:
 
-* the pair is declared with ``Wiring::add_same_cycle_pair``, so ``finish``
-  validates the order and the **source** is ranked after the capture; and
+* the capture is registered as a sending service client rank, so ``finish``
+  orders the **source** after the capture; and
 * the capture node is built with ``same_cycle``, so it schedules the paired
   source for the **current** evaluation time.
 
 The capture's own input on the source stays ``rank_dependency = false``. That is
 not an oversight: a capture must not wait on the source it feeds, and making it
-a ranked dependency produces a wiring cycle. Ordering flows the other way, from
-``add_same_cycle_pair`` — the same shape ``shared_output_relay_capture`` uses.
+a ranked dependency produces a wiring cycle. Ordering flows the other way,
+through the existing service-rank contract.
+
+A dynamically-started nested capture still schedules the outer source for
+``evaluation_time + MIN_TD``. Its owner can begin after that outer pull source's
+rank has already passed, so current-cycle publication would be unsafe without a
+different nested-boundary construction. This is also released hgraph behavior
+and is part of the compatibility contract, not an implementation gap hidden by
+the root optimization.
 
 Nothing else changes: the transport is still keyed by client id, still a
 ``TSD<Int, request_schema>``, still built by ``keyed_request_input_source_node``.
@@ -116,19 +131,19 @@ Consequences
 ------------
 
 **Timing (intended).** A reply-less request/reply implementation observes a
-client's request in the cycle the client sent it, instead of the next one. This
-is the point of the change, and it is directly observable by any graph that
-measures delivery latency.
+root client's request in the cycle the client sent it, instead of the next one.
+A dynamically-started nested client retains the one-cycle outer hand-off. Both
+cases are directly observable and pinned against released hgraph.
 
 **Rank ordering (intended).** The implementation is ordered after every client
-that sends to it, in the same way a sink-only adaptor's implementation is. That
-is a stronger guarantee than today's, where ordering is unconstrained and
-correctness rests on the cycle boundary.
+that sends to it in the owning graph, in the same way a sink-only adaptor's
+implementation is. A nested hand-off continues to rely on its explicit cycle
+boundary.
 
-**Cycles through a reply-less service become a wiring error.** Today a graph in
-which a reply-less service's implementation ultimately publishes back to that
-same service is tolerated, because the next-cycle boundary breaks the loop
-silently. Ranked ordering will report it as a cycle at wiring time.
+**Root cycles through a reply-less service become a wiring error.** Today a
+graph in which a reply-less service's implementation ultimately publishes back
+to that same root service is tolerated, because the next-cycle boundary breaks
+the loop silently. Ranked ordering reports it as a cycle at wiring time.
 
 This is the one genuinely behaviour-narrowing consequence and the main thing to
 review. The position taken here is that it is a **correction**: such a
@@ -169,20 +184,26 @@ Opt in through a flag on the interface
 Acceptance criteria and test plan
 ---------------------------------
 
-* A reply-less request/reply implementation observes a client's request in the
-  **same** cycle the client sent it. A test asserts the observed cycle numbers,
-  not merely the values — the existing coverage
+* A reply-less request/reply implementation observes a root client's request
+  in the **same** cycle the client sent it. A test asserts the observed cycle
+  numbers, not merely the values — the existing coverage
   (``test_replyless_request_reply_service_captures_requests``) asserts values
   only and passes either way.
-* The same graph expressed as a sink-only adaptor and as a reply-less
+* A dynamically-started ``map_`` client hands its request to the outer source
+  on the **next** cycle, matching released hgraph; both Python and native C++
+  regressions assert the cycle numbers.
+* The same root graph expressed as a sink-only adaptor and as a reply-less
   request/reply service delivers on the **same** cycle, pinned by one test that
   evaluates both.
 * Multiple clients at one path are still keyed by client id, and their requests
   still combine into one cumulative dictionary delta.
 * A reply-*full* request/reply service is unchanged: same timing, and direct and
   mapped recursion still wire.
-* A dependency cycle through a reply-less service is reported at wiring time
-  with the ordinary cycle diagnostic.
+* A root dependency cycle through a reply-less service is reported at wiring
+  time with the ordinary cycle diagnostic.
+* The typed C++ descriptor may omit ``response_schema``. Its implementation
+  consumes ``TSD<Int, request_schema>`` as a sink, ``wire<Service>`` returns
+  ``void``, and no reply endpoint is required or built.
 * ``services.rst`` scheduling matrix records the reply-less case on the
   same-cycle relay rather than under request stubs.
 * The full native suite and the non-WIP Python suites pass, including
@@ -191,28 +212,32 @@ Acceptance criteria and test plan
 Implementation status
 ---------------------
 
-**Implemented.** The change is three lines of wiring plus the tests.
+**Implemented.** The erased and typed C++ surfaces share the existing request
+transport. A reply-less descriptor selects same-cycle capture plus a sending
+service-rank dependency, omits the reply source/feedback path, and returns no
+client port. Root and nested timing are covered in Python and native C++.
 
 Two findings from implementing it:
 
 * **The rank direction is the opposite of the obvious one.** Making the
   capture's source input a rank dependency produces a wiring cycle: the capture
   must NOT wait on the source it feeds. The relay pattern keeps that input
-  rank-free and lets ``add_same_cycle_pair`` order the *source* after the
-  capture — the same shape ``shared_output_relay_capture`` uses. The cycle
-  detector caught this immediately.
+  rank-free and lets the sending service-rank relation order the *source* after
+  the capture. The cycle detector caught this immediately.
 * **The runtime already supported it.** ``make_request_input_capture_node``
   takes a ``same_cycle`` flag, added for rank-correct service-adaptor captures;
   the reply-less case just had to pass it. Wiring-level ordering alone changed
   nothing, because the next-cycle behaviour lives in the capture node's
-  schedule-time computation.
+  schedule-time computation. That computation deliberately retains the nested
+  ``+MIN_TD`` hand-off, matching released hgraph.
 
 No existing test needed changing, including
 ``test_replyless_request_reply_service_captures_requests``, which asserts values
 rather than cycles — which is precisely why the latency went unnoticed, and why
 the new tests assert observed cycle numbers.
 
-Final state: 1414 ctest, 1880 Python tests.
+Final validation counts are recorded on the pull request after the acceptance
+gates complete.
 
 References
 ----------

--- a/include/hgraph/types/graph_wiring.h
+++ b/include/hgraph/types/graph_wiring.h
@@ -840,19 +840,6 @@ namespace hgraph
         Wiring(Wiring &&) noexcept;
         Wiring &operator=(Wiring &&) noexcept;
 
-        /**
-         * True when this wiring is compiling an isolated SUB-GRAPH rather than
-         * the top-level graph.
-         *
-         * A boundary client wired here has its transport source hoisted into
-         * the parent as an external service input, so a same-cycle pair
-         * declared against that source cannot be validated in this wiring -
-         * the node it names is no longer here at ``finish``. Callers use this
-         * to fall back to the next-cycle path, which the runtime already takes
-         * for a nested graph.
-         */
-        [[nodiscard]] bool is_sub_graph() const noexcept;
-
         /** Process-unique identity for associating wiring-lifetime adapter
             state across owned and borrowed language wrappers. */
         [[nodiscard]] std::uint64_t identity() const noexcept;
@@ -930,10 +917,12 @@ namespace hgraph
          * Declare a same-cycle boundary pair (shared-output relays): the
          * ``source`` is rank-constrained after the ``capture``, and ``finish``
          * VALIDATES the final order, so the runtime schedules the source for
-         * the current evaluation time with no hot-path checks. Request stubs
-         * (subscription/request-reply) do not use this helper: their sources
-         * are scheduled for the next cycle. Same-time work is ordered as the
-         * first sending client, then the source, then later sending clients.
+         * the current evaluation time with no hot-path checks. Deferred
+         * request stubs do not use this helper. Ranked reply-less
+         * request/reply clients use the service-rank contract instead because
+         * their source may be external to a nested graph. Same-time work is
+         * ordered as the first sending client, then the source, then later
+         * sending clients.
          */
         void add_same_cycle_pair(const WiringInstance *capture, const WiringInstance *source);
 

--- a/include/hgraph/types/graph_wiring.h
+++ b/include/hgraph/types/graph_wiring.h
@@ -840,6 +840,19 @@ namespace hgraph
         Wiring(Wiring &&) noexcept;
         Wiring &operator=(Wiring &&) noexcept;
 
+        /**
+         * True when this wiring is compiling an isolated SUB-GRAPH rather than
+         * the top-level graph.
+         *
+         * A boundary client wired here has its transport source hoisted into
+         * the parent as an external service input, so a same-cycle pair
+         * declared against that source cannot be validated in this wiring -
+         * the node it names is no longer here at ``finish``. Callers use this
+         * to fall back to the next-cycle path, which the runtime already takes
+         * for a nested graph.
+         */
+        [[nodiscard]] bool is_sub_graph() const noexcept;
+
         /** Process-unique identity for associating wiring-lifetime adapter
             state across owned and borrowed language wrappers. */
         [[nodiscard]] std::uint64_t identity() const noexcept;

--- a/include/hgraph/types/service_wiring.h
+++ b/include/hgraph/types/service_wiring.h
@@ -96,12 +96,25 @@ namespace hgraph::service
      *    register_request_reply_service<AddOne, AddOneImpl>(w);
      *    auto reply = wire<AddOne>(w, request);
      *
+     * Omitting ``response_schema`` declares the keyed request side as a sink:
+     *
+     * .. code-block:: cpp
+     *
+     *    struct Publish {
+     *        static constexpr std::string_view name{"publish"};
+     *        using request_schema = TS<Int>;
+     *    };
+     *
+     *    register_request_reply_service<Publish, PublishImpl>(w);
+     *    wire<Publish>(w, event);  // returns void
+     *
      * The request source owns ``TSD<Int, request_schema>`` plus a mutable
-     * request-delta state. Client capture sinks update that state, and the
-     * source emits the cumulative delta on the next scheduled tick. Responses
-     * pass through one outer-graph feedback edge before publication. This is
-     * the temporal boundary that permits request/reply implementations to call
-     * the same service recursively without introducing a rank cycle.
+     * request-delta state. Reply-full captures forward on the next cycle and
+     * responses pass through one outer-graph feedback edge before publication;
+     * that temporal boundary permits recursive request/reply implementations.
+     * A reply-less root client instead uses the ranked same-cycle sink relay.
+     * A dynamically-started nested client defers its outer hand-off one cycle,
+     * matching released hgraph's lifecycle ordering.
      */
 
     namespace detail
@@ -154,14 +167,23 @@ namespace hgraph::service
         };
 
         template <typename Service, typename = void>
-        struct has_request_reply_schema : std::false_type
+        struct has_request_schema : std::false_type
         {
         };
 
         template <typename Service>
-        struct has_request_reply_schema<
-            Service,
-            std::void_t<typename Service::request_schema, typename Service::response_schema>>
+        struct has_request_schema<Service, std::void_t<typename Service::request_schema>>
+            : std::true_type
+        {
+        };
+
+        template <typename Service, typename = void>
+        struct has_response_schema : std::false_type
+        {
+        };
+
+        template <typename Service>
+        struct has_response_schema<Service, std::void_t<typename Service::response_schema>>
             : std::true_type
         {
         };
@@ -184,19 +206,29 @@ namespace hgraph::service
             !declares_adaptor_interface<Service> &&
             !has_adaptor_input_schema<Service>::value &&
             !has_key_value_schema<Service>::value &&
-            !has_request_reply_schema<Service>::value;
+            !has_request_schema<Service>::value;
 
         template <typename Service>
         concept subscription_service_interface =
             has_key_value_schema<Service>::value &&
             !has_reference_output_schema<Service>::value &&
-            !has_request_reply_schema<Service>::value;
+            !has_request_schema<Service>::value;
 
         template <typename Service>
         concept request_reply_service_interface =
-            has_request_reply_schema<Service>::value &&
+            has_request_schema<Service>::value &&
             !has_reference_output_schema<Service>::value &&
             !has_key_value_schema<Service>::value;
+
+        template <typename Service>
+        concept replying_request_reply_service_interface =
+            request_reply_service_interface<Service> &&
+            has_response_schema<Service>::value;
+
+        template <typename Service>
+        concept replyless_request_reply_service_interface =
+            request_reply_service_interface<Service> &&
+            !has_response_schema<Service>::value;
 
         template <typename Service>
         concept service_interface =
@@ -594,8 +626,11 @@ namespace hgraph::service
             {
                 endpoints.push_back(WiringServiceImplementationEndpoint{
                     request_input_path<Service>(user_path), user_path.resolution});
-                endpoints.push_back(WiringServiceImplementationEndpoint{
-                    request_reply_output_path<Service>(user_path), user_path.resolution});
+                if constexpr (replying_request_reply_service_interface<Service>)
+                {
+                    endpoints.push_back(WiringServiceImplementationEndpoint{
+                        request_reply_output_path<Service>(user_path), user_path.resolution});
+                }
             }
         }
 
@@ -886,7 +921,8 @@ namespace hgraph::service
             const auto *request_meta = resolved_schema_meta<request_schema>(
                 user_path.resolution, "request/reply service request");
             NodeBuilder builder = make_request_input_capture_node(
-                request_input_path<Service>(user_path), *request_meta);
+                request_input_path<Service>(user_path), *request_meta,
+                replyless_request_reply_service_interface<Service>);
             builder.input_endpoint(graph_wiring_detail::input_endpoint_for_sources(
                 builder.type().schema()->input_schema,
                 std::span<const WiringPortRef>{sources.data(), sources.size()}));
@@ -895,8 +931,9 @@ namespace hgraph::service
                                                std::move(builder),
                                                std::span<const WiringInputRef>{inputs.data(), inputs.size()},
                                                Value{});
-            // Request/reply alone forwards on the next cycle; the temporal
-            // break is what permits recursive request/reply implementations.
+            // Reply-full request/reply forwards on the next cycle; the
+            // temporal break permits recursive implementations. Reply-less
+            // services are sinks and use the ranked same-cycle relay.
             return capture.peered_node();
         }
 
@@ -1161,7 +1198,7 @@ namespace hgraph::service
     }
 
     template <typename Service>
-        requires detail::request_reply_service_interface<Service>
+        requires detail::replying_request_reply_service_interface<Service>
     void impl_output(Wiring &w,
                      ServicePath user_path,
                      Port<detail::request_output_schema_t<Service>> output)
@@ -1178,7 +1215,7 @@ namespace hgraph::service
     }
 
     template <typename Service>
-        requires detail::request_reply_service_interface<Service>
+        requires detail::replying_request_reply_service_interface<Service>
     void impl_output(Wiring &w, Port<detail::request_output_schema_t<Service>> output)
     {
         impl_output<Service>(w, detail::default_service_path<Service>(), std::move(output));
@@ -1433,6 +1470,7 @@ namespace hgraph::service
     }
 
     template <typename Service, typename RequestSchema>
+        requires detail::replying_request_reply_service_interface<Service>
     [[nodiscard]] Port<typename Service::response_schema> request_reply_service(
         Wiring &w,
         Port<RequestSchema> request,
@@ -1474,6 +1512,7 @@ namespace hgraph::service
     }
 
     template <typename Service, typename RequestSchema>
+        requires detail::replying_request_reply_service_interface<Service>
     [[nodiscard]] Port<typename Service::response_schema> request_reply_service(
         Wiring &w,
         Port<RequestSchema> request)
@@ -1482,11 +1521,42 @@ namespace hgraph::service
             w, std::move(request), detail::default_service_path<Service>());
     }
 
+    template <typename Service, typename RequestSchema>
+        requires detail::replyless_request_reply_service_interface<Service>
+    void request_reply_service(
+        Wiring &w,
+        Port<RequestSchema> request,
+        ServicePath user_path)
+    {
+        user_path = detail::resolve_request_reply_client_path<Service>(
+            std::move(user_path), request);
+        const std::string base_path =
+            detail::request_reply_base_path<Service>(user_path);
+        const std::string request_path =
+            detail::request_input_path<Service>(user_path);
+        w.register_service_client_path(base_path, "request/reply service");
+
+        auto request_id = detail::request_id_source(w);
+        auto requests = detail::request_input_source<Service>(w, user_path);
+        w.register_service_rank_anchor(request_path, requests.node());
+        const WiringInstance *capture = detail::capture_request_input<Service>(
+            w, std::move(request), requests, user_path, request_id);
+        w.register_service_client_rank(
+            request_path, "request/reply service", capture, false);
+    }
+
+    template <typename Service, typename RequestSchema>
+        requires detail::replyless_request_reply_service_interface<Service>
+    void request_reply_service(Wiring &w, Port<RequestSchema> request)
+    {
+        request_reply_service<Service>(
+            w, std::move(request), detail::default_service_path<Service>());
+    }
+
     template <typename Service, typename Impl, typename... Args>
+        requires detail::request_reply_service_interface<Service>
     void register_request_reply_service(Wiring &w, ServicePath user_path, const Args &...args)
     {
-        using output_schema = detail::request_output_schema_t<Service>;
-
         const std::string base_path = detail::request_reply_base_path<Service>(user_path);
         auto stored_args = std::tuple<std::decay_t<Args>...>{args...};
         w.register_service_implementation_candidate(
@@ -1494,29 +1564,45 @@ namespace hgraph::service
             [user_path = std::move(user_path), stored_args = std::move(stored_args), base_path](Wiring &target) {
                 target.register_built_service_path(base_path, "request/reply service");
                 auto requests = detail::request_input_source<Service>(target, user_path);
-                auto replies  = detail::request_reply_output_source<Service>(target, user_path);
                 target.register_service_rank_anchor(
                     detail::request_input_path<Service>(user_path), requests.node());
-                auto output = std::apply(
-                    [&](const auto &...stored) {
-                        return detail::wire_service_impl<Impl, output_schema>(
-                            target, user_path, detail::service_input_arg<Impl>(requests), stored...);
-                    }, stored_args);
-                const WiringInstance *capture =
-                    detail::capture_request_reply_service_output<Service, Impl>(
-                        target, output, replies, user_path);
-                target.register_service_rank_anchor(
-                    detail::request_reply_output_path<Service>(user_path), capture);
+                if constexpr (detail::replyless_request_reply_service_interface<Service>)
+                {
+                    std::apply(
+                        [&](const auto &...stored) {
+                            detail::wire_service_graph<Impl>(
+                                target, user_path,
+                                detail::service_input_arg<Impl>(requests), stored...);
+                        }, stored_args);
+                }
+                else
+                {
+                    using output_schema = detail::request_output_schema_t<Service>;
+                    auto replies = detail::request_reply_output_source<Service>(target, user_path);
+                    auto output = std::apply(
+                        [&](const auto &...stored) {
+                            return detail::wire_service_impl<Impl, output_schema>(
+                                target, user_path,
+                                detail::service_input_arg<Impl>(requests), stored...);
+                        }, stored_args);
+                    const WiringInstance *capture =
+                        detail::capture_request_reply_service_output<Service, Impl>(
+                            target, output, replies, user_path);
+                    target.register_service_rank_anchor(
+                        detail::request_reply_output_path<Service>(user_path), capture);
+                }
             });
     }
 
     template <typename Service, typename Impl, typename... Args>
+        requires detail::request_reply_service_interface<Service>
     void register_request_reply_service(Wiring &w, const Args &...args)
     {
         register_request_reply_service<Service, Impl>(w, detail::default_service_path<Service>(), args...);
     }
 
     template <typename Service, typename Impl, typename... Args>
+        requires detail::replying_request_reply_service_interface<Service>
     [[nodiscard]] Port<typename Service::response_schema> request_reply_service_impl(
         Wiring &w,
         Port<typename Service::request_schema> request,
@@ -1528,12 +1614,36 @@ namespace hgraph::service
     }
 
     template <typename Service, typename Impl, typename... Args>
+        requires detail::replying_request_reply_service_interface<Service>
     [[nodiscard]] Port<typename Service::response_schema> request_reply_service_impl(
         Wiring &w,
         Port<typename Service::request_schema> request,
         const Args &...args)
     {
         return request_reply_service_impl<Service, Impl>(
+            w, std::move(request), detail::default_service_path<Service>(), args...);
+    }
+
+    template <typename Service, typename Impl, typename... Args>
+        requires detail::replyless_request_reply_service_interface<Service>
+    void request_reply_service_impl(
+        Wiring &w,
+        Port<typename Service::request_schema> request,
+        ServicePath user_path,
+        const Args &...args)
+    {
+        register_request_reply_service<Service, Impl>(w, user_path, args...);
+        request_reply_service<Service>(w, std::move(request), std::move(user_path));
+    }
+
+    template <typename Service, typename Impl, typename... Args>
+        requires detail::replyless_request_reply_service_interface<Service>
+    void request_reply_service_impl(
+        Wiring &w,
+        Port<typename Service::request_schema> request,
+        const Args &...args)
+    {
+        request_reply_service_impl<Service, Impl>(
             w, std::move(request), detail::default_service_path<Service>(), args...);
     }
 }  // namespace hgraph::service
@@ -1846,8 +1956,8 @@ namespace hgraph::service_adaptor
             // Service-adaptor sends are rank-correct and same-cycle in their
             // owning graph. A dynamically-started child hands off to its outer
             // source on the following cycle because that outer rank may already
-            // have passed. Only request/reply is unconditionally deferred to
-            // permit recursion.
+            // have passed. Only reply-full request/reply is unconditionally
+            // deferred to permit recursion.
             return capture.peered_node();
         }
 

--- a/python/tests/test_replyless_request_reply_timing.py
+++ b/python/tests/test_replyless_request_reply_timing.py
@@ -1,0 +1,139 @@
+"""A reply-less request/reply service delivers in the client's own cycle.
+
+RFC 0012. A request/reply service declaring no response is a sink: clients
+send, the implementation consumes, nothing comes back. It used to be wired on
+the rank-free request transport, which forwards on the NEXT cycle - rank-freedom
+that exists to permit request/reply *cycles* via the response feedback edge. A
+reply-less service builds no feedback, so it paid the latency for nothing.
+
+The same shape as a sink-only adaptor always delivered in the same cycle; these
+tests pin that the two now agree.
+"""
+
+import hgraph as hg
+from hgraph import TS, TSD, graph
+from hgraph.test import eval_node
+
+
+def _cycle(clock):
+    return int((clock.evaluation_time - hg.MIN_ST) / hg.MIN_TD)
+
+
+def test_replyless_service_delivers_in_the_senders_cycle():
+    seen = []
+
+    @hg.request_reply_service
+    def publish(path: str, value: TS[int]): ...
+
+    @hg.service_impl(interfaces=publish)
+    def publish_impl(values: TSD[int, TS[int]]):
+        @hg.sink_node
+        def observe(ts: TSD[int, TS[int]], _clock: hg.CLOCK = None):
+            for _, v in ts.modified_items():
+                seen.append((_cycle(_clock), v.value))
+
+        observe(values)
+
+    @graph
+    def client(value: TS[int]) -> TS[int]:
+        hg.register_service("events", publish_impl)
+        publish("events", value)
+        return value
+
+    assert eval_node(
+        client, [1, None, 2], __end_time__=hg.MIN_ST + 6 * hg.MIN_TD) == [1, None, 2]
+    # Sent at cycles 0 and 2; seen at 0 and 2, not 1 and 3.
+    assert seen == [(0, 1), (2, 2)], seen
+
+
+def test_replyless_service_and_sink_only_adaptor_agree_on_timing():
+    """The point of the change: two spellings of the same shape, same cycle."""
+    service_seen = []
+    adaptor_seen = []
+
+    @hg.request_reply_service
+    def svc_publish(path: str, value: TS[int]): ...
+
+    @hg.service_impl(interfaces=svc_publish)
+    def svc_impl(values: TSD[int, TS[int]]):
+        @hg.sink_node
+        def observe(ts: TSD[int, TS[int]], _clock: hg.CLOCK = None):
+            for _, v in ts.modified_items():
+                service_seen.append((_cycle(_clock), v.value))
+
+        observe(values)
+
+    @hg.adaptor
+    def adp_publish(value: TS[int], path: str = "a"): ...
+
+    @hg.adaptor_impl(interfaces=adp_publish)
+    def adp_impl(value: TS[int], path: str = "a"):
+        @hg.sink_node
+        def observe(ts: TS[int], _clock: hg.CLOCK = None):
+            adaptor_seen.append((_cycle(_clock), ts.value))
+
+        observe(value)
+
+    @graph
+    def via_service(value: TS[int]) -> TS[int]:
+        hg.register_service("s", svc_impl)
+        svc_publish("s", value)
+        return value
+
+    @graph
+    def via_adaptor(value: TS[int]) -> TS[int]:
+        hg.register_adaptor("a", adp_impl)
+        adp_publish(value, path="a")
+        return value
+
+    end = hg.MIN_ST + 6 * hg.MIN_TD
+    eval_node(via_service, [1, None, 2], __end_time__=end)
+    eval_node(via_adaptor, [1, None, 2], __end_time__=end)
+    assert service_seen == adaptor_seen, (service_seen, adaptor_seen)
+
+
+def test_replyless_service_keys_multiple_clients_by_request_id():
+    """Keying survives the scheduling change - only the timing moved."""
+    seen = []
+
+    @hg.request_reply_service
+    def publish(path: str, value: TS[int]): ...
+
+    @hg.service_impl(interfaces=publish)
+    def publish_impl(values: TSD[int, TS[int]]):
+        @hg.sink_node
+        def observe(ts: TSD[int, TS[int]]):
+            seen.append({k: v.value for k, v in ts.modified_items()})
+
+        observe(values)
+
+    @graph
+    def client(value: TS[int]) -> TS[int]:
+        hg.register_service("events", publish_impl)
+        publish("events", value)
+        publish("events", value + 100)
+        return value
+
+    eval_node(client, [1], __end_time__=hg.MIN_ST + 6 * hg.MIN_TD)
+    # Two clients, two distinct request ids, one cumulative delta.
+    assert seen and len(seen[0]) == 2, seen
+    assert sorted(seen[0].values()) == [1, 101], seen
+
+
+def test_reply_full_request_reply_timing_is_unchanged():
+    """The rank-free path is load-bearing when a response exists."""
+    @hg.request_reply_service
+    def double(value: TS[int], path: str = "d") -> TS[int]: ...
+
+    @hg.service_impl(interfaces=double)
+    def double_impl(value: TSD[int, TS[int]], path: str = "d") -> TSD[int, TS[int]]:
+        return hg.map_(lambda v: v * 2, value)
+
+    @graph
+    def app(value: TS[int]) -> TS[int]:
+        hg.register_service("d", double_impl)
+        return double(value, path="d")
+
+    # Request and response each cross their own transport boundary.
+    out = eval_node(app, [5], __end_time__=hg.MIN_ST + 6 * hg.MIN_TD)
+    assert out == [None, None, 10], out

--- a/python/tests/test_replyless_request_reply_timing.py
+++ b/python/tests/test_replyless_request_reply_timing.py
@@ -1,4 +1,4 @@
-"""A reply-less request/reply service delivers in the client's own cycle.
+"""A root reply-less request/reply service delivers in the client's own cycle.
 
 RFC 0012. A request/reply service declaring no response is a sink: clients
 send, the implementation consumes, nothing comes back. It used to be wired on
@@ -6,8 +6,9 @@ the rank-free request transport, which forwards on the NEXT cycle - rank-freedom
 that exists to permit request/reply *cycles* via the response feedback edge. A
 reply-less service builds no feedback, so it paid the latency for nothing.
 
-The same shape as a sink-only adaptor always delivered in the same cycle; these
-tests pin that the two now agree.
+The same root shape as a sink-only adaptor always delivered in the same cycle;
+these tests pin that the two now agree while dynamically-started nested clients
+retain released hgraph's one-cycle outer hand-off.
 """
 
 import hgraph as hg
@@ -118,6 +119,40 @@ def test_replyless_service_keys_multiple_clients_by_request_id():
     # Two clients, two distinct request ids, one cumulative delta.
     assert seen and len(seen[0]) == 2, seen
     assert sorted(seen[0].values()) == [1, 101], seen
+
+
+def test_replyless_service_in_dynamic_map_defers_the_outer_handoff():
+    """A late-starting child cannot publish after the outer source has run."""
+    seen = []
+
+    @hg.request_reply_service
+    def publish(path: str, value: TS[int]): ...
+
+    @hg.service_impl(interfaces=publish)
+    def publish_impl(values: TSD[int, TS[int]]):
+        @hg.sink_node
+        def observe(ts: TSD[int, TS[int]], _clock: hg.CLOCK = None):
+            for _, value in ts.modified_items():
+                seen.append((_cycle(_clock), value.value))
+
+        observe(values)
+
+    @graph
+    def per_key(value: TS[int]) -> None:
+        publish("events", value)
+
+    @graph
+    def client(values: TSD[str, TS[int]]) -> TSD[str, TS[int]]:
+        hg.register_service("events", publish_impl)
+        assert hg.map_(per_key, values) is None
+        return values
+
+    inputs = [{"a": 1}, {"a": hg.REMOVE}, {"b": 2}]
+    assert eval_node(
+        client, inputs, __end_time__=hg.MIN_ST + 6 * hg.MIN_TD) == inputs
+    # Released hgraph also hands a dynamically-started child's request to the
+    # outer graph on the next cycle. Root clients remain same-cycle.
+    assert seen == [(1, 1), (3, 2)], seen
 
 
 def test_reply_full_request_reply_timing_is_unchanged():

--- a/src/hgraph/types/graph_wiring.cpp
+++ b/src/hgraph/types/graph_wiring.cpp
@@ -1263,10 +1263,6 @@ Wiring Wiring::child_wiring() const {
   return Wiring{WiringKind::SubGraph, impl_->observers, impl_->wiring_path};
 }
 
-bool Wiring::is_sub_graph() const noexcept {
-  return impl_->kind == WiringKind::SubGraph;
-}
-
 std::vector<std::string> Wiring::current_wiring_path() const {
   return impl_->wiring_path;
 }

--- a/src/hgraph/types/graph_wiring.cpp
+++ b/src/hgraph/types/graph_wiring.cpp
@@ -1263,6 +1263,10 @@ Wiring Wiring::child_wiring() const {
   return Wiring{WiringKind::SubGraph, impl_->observers, impl_->wiring_path};
 }
 
+bool Wiring::is_sub_graph() const noexcept {
+  return impl_->kind == WiringKind::SubGraph;
+}
+
 std::vector<std::string> Wiring::current_wiring_path() const {
   return impl_->wiring_path;
 }

--- a/src/hgraph/types/service_runtime.cpp
+++ b/src/hgraph/types/service_runtime.cpp
@@ -561,8 +561,8 @@ namespace hgraph
         std::array<WiringInputRef, 3> inputs{{
             WiringInputRef{.source = sources[0]},
             // Never a rank dependency: the capture must not wait on the source
-            // it feeds. Ordering comes from add_same_cycle_pair below (reply-less)
-            // or from the response feedback edge (reply-full).
+            // it feeds. Ordering comes from the reply-less service-client rank
+            // below or from the response feedback edge (reply-full).
             WiringInputRef{.source = sources[1], .rank_dependency = false},
             WiringInputRef{.source = sources[2]},
         }};
@@ -577,21 +577,12 @@ namespace hgraph
 
         if (reply_less)
         {
-            // Rank-correct and same-cycle: Wiring::finish validates the order,
-            // so the capture schedules the source for the CURRENT evaluation
-            // time with no hot-path check.
-            //
-            // NOT inside a sub-graph: there the transport source is hoisted
-            // into the parent as an external service input, so a pair declared
-            // against it names a node this wiring no longer owns at finish.
-            // The runtime already forwards on the next cycle for a nested
-            // graph (the outer rank may have passed), which is what the client
-            // gets - so a reply-less service wires anywhere, and only its
-            // timing follows its location.
-            if (!w.is_sub_graph())
-            {
-                w.add_same_cycle_pair(capture.peered_node(), requests.peered_node());
-            }
+            // A reply-less client is a sending boundary, like a sink-only
+            // adaptor. At the root the capture ranks before the request source.
+            // A dynamically-started nested capture retains the runtime's
+            // next-cycle outer hand-off, matching released hgraph.
+            w.register_service_client_rank(
+                request_path, "request/reply service", capture.peered_node(), false);
             return {};
         }
 

--- a/src/hgraph/types/service_runtime.cpp
+++ b/src/hgraph/types/service_runtime.cpp
@@ -545,26 +545,44 @@ namespace hgraph
         WiringPortRef requests = request_input_source_node(w, descriptor, request_path);
         w.register_service_rank_anchor(request_path, requests.peered_node());
 
+        // A REPLY-LESS service is a keyed sink: there is no response, hence no
+        // response feedback edge, hence no request/reply cycle to permit. It
+        // therefore takes the ranked same-cycle relay, like a sink-only
+        // adaptor, and the implementation observes a request in the cycle the
+        // client sent it rather than the next one (RFC 0012). A service WITH a
+        // response keeps the rank-free path below: that is what makes
+        // recursive request/reply legal, and its ordering comes from the
+        // feedback edge instead.
+        const bool reply_less = descriptor.response_schema == nullptr;
+
         WiringPortRef adapted_request = graph_wiring_detail::adapt_source_for_input(
             w, descriptor.request_schema, request);
         std::array<WiringPortRef, 3>  sources{std::move(adapted_request), requests, request_id};
         std::array<WiringInputRef, 3> inputs{{
             WiringInputRef{.source = sources[0]},
+            // Never a rank dependency: the capture must not wait on the source
+            // it feeds. Ordering comes from add_same_cycle_pair below (reply-less)
+            // or from the response feedback edge (reply-full).
             WiringInputRef{.source = sources[1], .rank_dependency = false},
             WiringInputRef{.source = sources[2]},
         }};
-        NodeBuilder builder =
-            make_request_input_capture_node(request_path, *descriptor.request_schema);
+        NodeBuilder builder = make_request_input_capture_node(
+            request_path, *descriptor.request_schema, /*same_cycle=*/reply_less);
         builder.input_endpoint(graph_wiring_detail::input_endpoint_for_sources(
             builder.type().schema()->input_schema,
             std::span<const WiringPortRef>{sources.data(), sources.size()}));
-        static_cast<void>(w.add_node(
+        WiringPortRef capture = w.add_node(
             std::type_index(typeid(service::detail::request_input_capture_marker)), std::move(builder),
-            std::span<const WiringInputRef>{inputs.data(), inputs.size()}, Value{}));
-        // Request/reply transport is ordered by its response feedback edge, not
-        // by indirect service dependencies. This permits request/reply cycles.
+            std::span<const WiringInputRef>{inputs.data(), inputs.size()}, Value{});
 
-        if (descriptor.response_schema == nullptr) { return {}; }
+        if (reply_less)
+        {
+            // Rank-correct and same-cycle: Wiring::finish validates the order,
+            // so the capture schedules the source for the CURRENT evaluation
+            // time with no hot-path check.
+            w.add_same_cycle_pair(capture.peered_node(), requests.peered_node());
+            return {};
+        }
 
         WiringPortRef replies = reply_output_source_node(w, descriptor, replies_path);
 

--- a/src/hgraph/types/service_runtime.cpp
+++ b/src/hgraph/types/service_runtime.cpp
@@ -580,7 +580,18 @@ namespace hgraph
             // Rank-correct and same-cycle: Wiring::finish validates the order,
             // so the capture schedules the source for the CURRENT evaluation
             // time with no hot-path check.
-            w.add_same_cycle_pair(capture.peered_node(), requests.peered_node());
+            //
+            // NOT inside a sub-graph: there the transport source is hoisted
+            // into the parent as an external service input, so a pair declared
+            // against it names a node this wiring no longer owns at finish.
+            // The runtime already forwards on the next cycle for a nested
+            // graph (the outer rank may have passed), which is what the client
+            // gets - so a reply-less service wires anywhere, and only its
+            // timing follows its location.
+            if (!w.is_sub_graph())
+            {
+                w.add_same_cycle_pair(capture.peered_node(), requests.peered_node());
+            }
             return {};
         }
 

--- a/tests/cpp/test_service_wiring.cpp
+++ b/tests/cpp/test_service_wiring.cpp
@@ -1,3 +1,4 @@
+#include <catch2/matchers/catch_matchers_string.hpp>
 #include <catch2/catch_test_macros.hpp>
 
 #include <hgraph/lib/std/std_operators.h>
@@ -9,6 +10,9 @@
 #include <hgraph/types/static_node.h>
 #include <hgraph/types/value/value_builder.h>
 
+#include <algorithm>
+#include <cstddef>
+#include <concepts>
 #include <stdexcept>
 #include <string>
 #include <tuple>
@@ -90,6 +94,12 @@ namespace
         static constexpr std::string_view name{"add_ten"};
         using request_schema  = TS<Int>;
         using response_schema = TS<Int>;
+    };
+
+    struct ReplylessPublishService
+    {
+        static constexpr std::string_view name{"replyless_publish"};
+        using request_schema = TS<Int>;
     };
 
     using PairRequest = TSB<"PairRequest",
@@ -453,6 +463,42 @@ namespace
                 Value response{request.value() + Int{1}};
                 mutation.set(request_id, response.view());
             }
+        }
+    };
+
+    inline std::vector<std::pair<std::size_t, Int>> observed_replyless_requests;
+
+    struct ObserveReplylessRequestsNode
+    {
+        static constexpr auto name = "observe_replyless_requests_node";
+
+        static void eval(
+            DateTime evaluation_time,
+            In<"requests", TSD<Int, TS<Int>>, InputValidity::Unchecked> requests)
+        {
+            if (!requests.modified()) { return; }
+            const auto cycle = static_cast<std::size_t>(
+                (evaluation_time - MIN_ST) / MIN_TD);
+            for (const auto &[request_id, request] : requests.modified_items())
+            {
+                (void)request_id;
+                if (request.valid())
+                {
+                    observed_replyless_requests.emplace_back(cycle, request.value());
+                }
+            }
+        }
+    };
+
+    struct ReplylessPublishImplGraph
+    {
+        [[maybe_unused]] static constexpr auto name =
+            "replyless_publish_impl_graph";
+
+        static void compose(
+            Wiring &w, Port<TSD<Int, TS<Int>>> requests)
+        {
+            static_cast<void>(wire<ObserveReplylessRequestsNode>(w, requests));
         }
     };
 
@@ -1223,6 +1269,115 @@ namespace
         {
             service::register_request_reply_service<AddOneService, AddOneImplNode>(w);
             return wire<AddOneService>(w, request);
+        }
+    };
+
+    struct ReplylessPublishTwoClientGraph
+    {
+        [[maybe_unused]] static constexpr auto name =
+            "replyless_publish_two_client_graph";
+
+        static Port<TS<Int>> compose(
+            Wiring &w, Port<TS<Int>> lhs, Port<TS<Int>> rhs)
+        {
+            const auto custom = service::path("events");
+            service::register_request_reply_service<
+                ReplylessPublishService, ReplylessPublishImplGraph>(w, custom);
+            static_assert(std::same_as<
+                          decltype(wire<ReplylessPublishService>(w, custom, lhs)),
+                          void>);
+            wire<ReplylessPublishService>(w, custom, lhs);
+            wire<ReplylessPublishService>(w, custom, rhs);
+            return lhs;
+        }
+    };
+
+    struct ReplylessPublishMappedFunction
+    {
+        [[maybe_unused]] static constexpr auto name =
+            "replyless_publish_mapped_function";
+
+        static void compose(Wiring &w, Port<TS<Int>> request)
+        {
+            wire<ReplylessPublishService>(
+                w, service::path("mapped_events"), request);
+        }
+    };
+
+    struct ReplylessPublishMappedClientGraph
+    {
+        [[maybe_unused]] static constexpr auto name =
+            "replyless_publish_mapped_client_graph";
+
+        static Port<TSD<Int, TS<Int>>> compose(
+            Wiring &w, Port<TSD<Int, TS<Int>>> requests)
+        {
+            service::register_request_reply_service<
+                ReplylessPublishService, ReplylessPublishImplGraph>(
+                    w, service::path("mapped_events"));
+            wire<stdlib::map_sink_>(
+                w, fn<ReplylessPublishMappedFunction>(), requests);
+            return requests;
+        }
+    };
+
+    struct ReplylessPublishStubImplGraph
+    {
+        [[maybe_unused]] static constexpr auto name =
+            "replyless_publish_stub_impl_graph";
+
+        static void compose(Wiring &w, Scalar<"path", Str> path)
+        {
+            auto requests = service::impl_input<ReplylessPublishService>(
+                w, service::path(path.value()));
+            static_cast<void>(wire<ObserveReplylessRequestsNode>(w, requests));
+        }
+    };
+
+    struct ReplylessPublishStubClientGraph
+    {
+        [[maybe_unused]] static constexpr auto name =
+            "replyless_publish_stub_client_graph";
+
+        static Port<TS<Int>> compose(Wiring &w, Port<TS<Int>> request)
+        {
+            const auto custom = service::path("replyless_stub");
+            service::register_services<
+                ReplylessPublishStubImplGraph, ReplylessPublishService>(w, custom);
+            wire<ReplylessPublishService>(w, custom, request);
+            return request;
+        }
+    };
+
+    struct RecursiveReplylessPublishImplGraph
+    {
+        [[maybe_unused]] static constexpr auto name =
+            "recursive_replyless_publish_impl_graph";
+
+        static void compose(
+            Wiring &w, Port<TSD<Int, TS<Int>>> requests)
+        {
+            auto total = wire<stdlib::reduce_>(
+                             w, fn<stdlib::add_>(), requests, Int{0})
+                             .as<TS<Int>>();
+            wire<ReplylessPublishService>(
+                w, service::path("replyless_cycle"), total);
+        }
+    };
+
+    struct RecursiveReplylessPublishClientGraph
+    {
+        [[maybe_unused]] static constexpr auto name =
+            "recursive_replyless_publish_client_graph";
+
+        static Port<TS<Int>> compose(Wiring &w, Port<TS<Int>> request)
+        {
+            const auto custom = service::path("replyless_cycle");
+            service::register_request_reply_service<
+                ReplylessPublishService, RecursiveReplylessPublishImplGraph>(
+                    w, custom);
+            wire<ReplylessPublishService>(w, custom, request);
+            return request;
         }
     };
 
@@ -2190,6 +2345,56 @@ TEST_CASE("service wiring: request/reply client receives keyed implementation re
     hgraph::stdlib::register_standard_operators();
 
     CHECK_OUTPUT(eval_node<AddOneClientGraph>(values<Int>(1)), values<Int>(none, none, 2));
+}
+
+TEST_CASE("service wiring: reply-less clients use the typed same-cycle sink path")
+{
+    hgraph::stdlib::register_standard_operators();
+    observed_replyless_requests.clear();
+
+    CHECK_OUTPUT(
+        eval_node<ReplylessPublishTwoClientGraph>(
+            values<Int>(1, none, 2), values<Int>(101, none, 102)),
+        values<Int>(1, none, 2));
+
+    std::ranges::sort(observed_replyless_requests);
+    CHECK(observed_replyless_requests ==
+          std::vector<std::pair<std::size_t, Int>>{
+              {0, 1}, {0, 101}, {2, 2}, {2, 102}});
+}
+
+TEST_CASE("service wiring: a mapped reply-less client defers its outer hand-off")
+{
+    hgraph::stdlib::register_standard_operators();
+    observed_replyless_requests.clear();
+
+    const auto requests = values<Value>(
+        dict_delta<Int, TS<Int>>({{1, 10}}),
+        dict_delta<Int, TS<Int>>({}, {1}),
+        dict_delta<Int, TS<Int>>({{2, 20}}));
+    CHECK_OUTPUT(eval_node<ReplylessPublishMappedClientGraph>(requests), requests);
+    CHECK(observed_replyless_requests ==
+          std::vector<std::pair<std::size_t, Int>>{{1, 10}, {3, 20}});
+}
+
+TEST_CASE("service wiring: reply-less supports the typed implementation-stub API")
+{
+    hgraph::stdlib::register_standard_operators();
+    observed_replyless_requests.clear();
+
+    CHECK_OUTPUT(
+        eval_node<ReplylessPublishStubClientGraph>(values<Int>(7)),
+        values<Int>(7));
+    CHECK(observed_replyless_requests ==
+          std::vector<std::pair<std::size_t, Int>>{{0, 7}});
+}
+
+TEST_CASE("service wiring: a root reply-less dependency cycle is rejected")
+{
+    hgraph::stdlib::register_standard_operators();
+    CHECK_THROWS_WITH(
+        (void)eval_node<RecursiveReplylessPublishClientGraph>(values<Int>(1)),
+        Catch::Matchers::ContainsSubstring("cycle"));
 }
 
 TEST_CASE("service wiring: request/reply service supports explicit paths")

--- a/tests/install_consumer/main.cpp
+++ b/tests/install_consumer/main.cpp
@@ -3,6 +3,8 @@
 #include <hgraph/runtime/node.h>
 #include <hgraph/runtime/registry_snapshot.h>
 #include <hgraph/types/frame.h>
+#include <hgraph/types/service_wiring.h>
+#include <hgraph/types/static_node.h>
 #include <hgraph/types/metadata/type_realization.h>
 #include <hgraph/types/metadata/type_record.h>
 #include <hgraph/types/metadata/type_registry.h>
@@ -23,6 +25,7 @@
 #include <arrow/api.h>
 
 #include <cstddef>
+#include <concepts>
 #include <cstdint>
 #include <memory>
 #include <stdexcept>
@@ -33,6 +36,38 @@ namespace
     struct ConsumerExtensionScalar
     {
         std::int32_t value{0};
+    };
+
+    struct ConsumerReplylessService
+    {
+        static constexpr std::string_view name{"consumer_replyless"};
+        using request_schema = hgraph::TS<hgraph::Int>;
+    };
+
+    struct ConsumerReplylessSink
+    {
+        static constexpr auto name = "consumer_replyless_sink";
+
+        static void eval(
+            hgraph::In<"requests", hgraph::TSD<hgraph::Int, hgraph::TS<hgraph::Int>>,
+                       hgraph::InputValidity::Unchecked>)
+        {
+        }
+    };
+
+    struct ConsumerReplylessGraph
+    {
+        static hgraph::Port<hgraph::TS<hgraph::Int>> compose(
+            hgraph::Wiring &w, hgraph::Port<hgraph::TS<hgraph::Int>> request)
+        {
+            hgraph::service::register_request_reply_service<
+                ConsumerReplylessService, ConsumerReplylessSink>(w);
+            static_assert(std::same_as<
+                          decltype(hgraph::wire<ConsumerReplylessService>(w, request)),
+                          void>);
+            hgraph::wire<ConsumerReplylessService>(w, request);
+            return request;
+        }
     };
 }
 


### PR DESCRIPTION
## Summary

RFC 0012 defines a request/reply service with no response as a keyed sink and implements that contract on both public authoring surfaces.

- A root reply-less client delivers to the implementation in the sender's cycle.
- A dynamically started nested client retains the one-cycle outer-graph hand-off used by released Python hgraph.
- A typed C++ descriptor may omit `response_schema`; `wire<Service>` then returns `void`, the implementation consumes `TSD<int, request_schema>`, and no reply endpoint or feedback path is built.
- Reply-producing request/reply services retain their existing rank-free request transport and response feedback semantics.

The branch is rebased directly onto `main`; it no longer depends on or contains RFC 0011's branch history.

## Why

The reply-full request transport deliberately defers requests because its response feedback edge permits recursive request/reply graphs. A reply-less service has no response feedback edge, so applying that transport unchanged introduced avoidable latency for root clients.

Reply-less clients now register the capture through the existing sending-service rank contract and use same-cycle scheduling at the root. Nested captures continue to schedule the outer source for `evaluation_time + MIN_TD`, because their dynamically started owner may run after the outer pull source's rank has passed. That distinction matches released hgraph rather than changing nested graph scheduling semantics.

## Observable contract

| Shape | Client emits | Implementation observes |
|---|---:|---:|
| Reply-less, root client | cycles 0, 2 | cycles 0, 2 |
| Reply-less, dynamically started `map_` client | cycles 0, 2 | cycles 1, 3 |
| Reply-full request/reply | unchanged | unchanged |

A root dependency cycle through a reply-less service is now reported as a wiring cycle instead of being hidden by an implicit next-cycle delay. Reply-full recursion remains supported and covered.

## Coverage

- Native C++ tests exercise the typed descriptor, `void` return contract, keyed sink implementation, multiple root clients, dynamic nested clients, and root cycle detection.
- Python tests pin root and nested cycle numbers.
- The installed-SDK consumer compiles the public typed C++ API.
- RFC and service documentation describe the same contract.
- Differential recipes and focused tests against released Python hgraph validate the compatibility boundary.

## Validation

- macOS native: 1,441/1,441 passed
- macOS stable-ABI wheel on Python 3.14: 1,891 passed, 11 skipped
- Ubuntu x86_64 with GCC/G++ 14.2.0: 1,442/1,442 native tests passed
- GCC 14.2.0 stable-ABI wheel on Python 3.14: 1,891 passed, 11 skipped
- Installed-SDK consumer: passed
- Sphinx warnings-as-errors: passed
- Differential parity corpus: 56/56 recipes passed
- Focused released-hgraph timing reference: 5/5 passed
