### PR TITLE
Defer Python owner scheduler construction

### DIFF
--- a/benchmarks/results/python-owner-scheduler-20260803.md
+++ b/benchmarks/results/python-owner-scheduler-20260803.md
@@ -1,0 +1,68 @@
+# Lazy Python owner scheduler — 2026-08-03
+
+The Linux Python-heavy profiles showed that the fast compute path constructed
+and copied a complete `NodeScheduler` for every time-series argument on every
+callback.  The common case only reads the time-series value; it does not ask
+for `owning_node`.
+
+This change keeps scheduler state in the fast node's planned storage, but
+passes an empty scheduler-support marker through each evaluation.  A
+`PyTimeSeries` now constructs the `NodeScheduler` from its live consumer node
+only when Python requests `owning_node`.  The executor's coarse, one-GIL-guard
+per phase design is unchanged.  The implementation uses neither thread-local
+nor process-global state.
+
+## Controlled Linux result
+
+Both revisions were clean Release/LTO builds of `05bcef558d02` on the physical
+`hg-linux` host, pinned to CPU 2, using Python 3.12.13 and 15 fresh processes
+per cell.  Values are median seconds +/- median absolute deviation.
+
+| scenario | main | lazy scheduler | change | legacy C++ | remaining vs legacy |
+|---|---:|---:|---:|---:|---:|
+| `tsd_dense_py` | 0.206531 +/- 0.001112 | 0.192219 +/- 0.000602 | -6.93% | 0.180323 +/- 0.000656 | 6.60% slower |
+| `reduce_tsd_python_combiner` | 0.134381 +/- 0.001082 | 0.120743 +/- 0.000509 | -10.15% | 0.105747 +/- 0.001756 | 14.18% slower |
+| `service_adaptor_py` | 0.065769 +/- 0.000619 | 0.064055 +/- 0.000615 | -2.61% | 0.055808 +/- 0.000270 | 14.78% slower |
+
+Source fingerprints were `718d35d320b65e953c50f2e68f347721282e7476534ffc36c940bd2e6684123c`
+for main and `2440c5700406101837273eafc03119c944f8e345dd3982023616730ef58f934b`
+for the candidate.  `gprofng` no longer reported the eager `NodeView::graph`,
+`graph_value`, and `evaluation_clock` calls in the hot loop.
+
+## macOS parity snapshot
+
+The candidate and released legacy C++ engine were also measured on an Apple
+M4 Max with Python 3.12.10 and 15 fresh processes.  This is a parity snapshot,
+not a controlled candidate-versus-main attribution.
+
+| scenario | candidate | legacy C++ | candidate vs legacy |
+|---|---:|---:|---:|
+| `tsd_dense_py` | 0.105782 +/- 0.001341 | 0.119307 +/- 0.000985 | 11.34% faster |
+| `reduce_tsd_python_combiner` | 0.071853 +/- 0.001204 | 0.068460 +/- 0.000297 | 4.96% slower |
+| `service_adaptor_py` | 0.033676 +/- 0.000602 | 0.034455 +/- 0.000563 | 2.26% faster |
+
+## Validation
+
+- macOS: all 1,431 native tests passed; the stable-ABI wheel built with
+  Python 3.12 and all 1,884 non-WIP compatibility tests passed with Python
+  3.14 (11 skipped).
+- Physical `hg-linux`: all 1,431 native tests passed; the stable-ABI wheel
+  built with Python 3.12 and all 1,884 non-WIP compatibility tests passed with
+  Python 3.14 (11 skipped).
+- Existing ownership coverage verifies that a fast-compute input's
+  `owning_node.notify_next_cycle()` retains the callback scheduler semantics.
+
+## Next profiling targets
+
+The scheduler construction was material for dense-map and reducer workloads,
+but explains little of the remaining service-adaptor gap.  The next campaign
+should separately measure:
+
+1. result publication and Python-to-native value conversion in
+   `apply_py_result`;
+2. keyed notification/scheduling work in the dense map path;
+3. service-adaptor routing independently from the generic Python callback
+   boundary.
+
+An experiment replacing the unwind cleanup guard with a normal scope-exit
+guard was flat to 1.4% slower and was discarded.

--- a/python/py_nodes.cpp
+++ b/python/py_nodes.cpp
@@ -20,6 +20,25 @@ using namespace hgraph;
 using namespace hgraph::python_bridge;
 
 namespace hgraph::python_bridge {
+/** Reserves scheduler state for fast Python nodes without eagerly building a
+ *  full NodeScheduler on every callback.  Time-series ownership metadata
+ *  materializes that view only when Python requests ``owning_node``. */
+struct PyOwnerSchedulerSupport {};
+} // namespace hgraph::python_bridge
+
+namespace hgraph::static_node_detail {
+template <>
+struct is_scheduler_selector<python_bridge::PyOwnerSchedulerSupport>
+    : std::true_type {};
+
+template <> struct arg_provider<python_bridge::PyOwnerSchedulerSupport> {
+  static python_bridge::PyOwnerSchedulerSupport get(const NodeView &, DateTime) {
+    return {};
+  }
+};
+} // namespace hgraph::static_node_detail
+
+namespace hgraph::python_bridge {
 void apply_py_result(nb::handle result, Out<TsVar<"O">> &out) {
   if (result.is_none()) {
     return;
@@ -407,7 +426,6 @@ struct PyFastComputeStateRef {
 };
 
 [[nodiscard]] bool py_make_ts_arg(char kind, TSInputView child,
-                                  NodeScheduler scheduler,
                                   const PyTsLease &lease, nb::object &result) {
   const auto &evaluation_data = child.data_view();
   const bool has_current_value =
@@ -426,15 +444,14 @@ struct PyFastComputeStateRef {
   const auto evaluation_storage = evaluation_data.valid()
                                       ? evaluation_data.storage_ref()
                                       : TSDataStorageRef<>{};
-  PyTimeSeries wrapped{std::move(child), scheduler, lease, evaluation_storage};
+  PyTimeSeries wrapped{std::move(child), lease, evaluation_storage};
   wrapped.refresh_evaluation_data(evaluation_storage, has_current_value);
   result = nb::cast(std::move(wrapped));
   return true;
 }
 
 [[nodiscard]] bool py_make_direct_ts_arg(PyFastComputeCache &cache,
-                                         DateTime now, NodeScheduler scheduler,
-                                         const PyTsLease &lease,
+                                         DateTime now, const PyTsLease &lease,
                                          nb::object &result) {
   TSInputView child = cache.input.borrowed_ref(now);
   const auto &evaluation_data = child.data_view();
@@ -457,7 +474,6 @@ struct PyFastComputeStateRef {
   // the cache entry with a fresh wrapper.
   if (cache.input_object != nullptr && Py_REFCNT(cache.input_object) == 1) {
     cache.input_wrapper->view = std::move(child);
-    cache.input_wrapper->scheduler = scheduler;
     cache.input_wrapper->lease.generation = lease.generation;
     cache.input_wrapper->refresh_evaluation_data(evaluation_storage,
                                                  has_current_value);
@@ -470,7 +486,7 @@ struct PyFastComputeStateRef {
     cache.input_object = nullptr;
     cache.input_wrapper = nullptr;
   }
-  PyTimeSeries wrapped{std::move(child), scheduler, lease, evaluation_storage};
+  PyTimeSeries wrapped{std::move(child), lease, evaluation_storage};
   wrapped.refresh_evaluation_data(evaluation_storage, has_current_value);
   result = nb::cast(std::move(wrapped));
   cache.input_object = result.ptr();
@@ -482,7 +498,6 @@ struct PyFastComputeStateRef {
 [[nodiscard]] bool py_make_cached_pair_ts_arg(PyFastComputeCache &cache,
                                               std::size_t slot, char kind,
                                               TSInputView child,
-                                              NodeScheduler scheduler,
                                               const PyTsLease &lease,
                                               nb::object &result) {
   const auto &evaluation_data = child.data_view();
@@ -503,7 +518,6 @@ struct PyFastComputeStateRef {
   PyTimeSeries *&cached_wrapper = cache.pair_wrappers.at(slot);
   if (cached_object != nullptr && Py_REFCNT(cached_object) == 1) {
     cached_wrapper->view = std::move(child);
-    cached_wrapper->scheduler = scheduler;
     cached_wrapper->lease.generation = lease.generation;
     cached_wrapper->refresh_evaluation_data(evaluation_storage,
                                             has_current_value);
@@ -516,7 +530,7 @@ struct PyFastComputeStateRef {
     cached_object = nullptr;
     cached_wrapper = nullptr;
   }
-  PyTimeSeries wrapped{std::move(child), scheduler, lease, evaluation_storage};
+  PyTimeSeries wrapped{std::move(child), lease, evaluation_storage};
   wrapped.refresh_evaluation_data(evaluation_storage, has_current_value);
   result = nb::cast(std::move(wrapped));
   cached_object = result.ptr();
@@ -552,7 +566,7 @@ struct PyFastComputeStateRef {
     case 'P': {
       auto child = bundle[ts_index++];
       nb::object ts_obj;
-      if (!py_make_ts_arg(kind, std::move(child), scheduler, lease, ts_obj)) {
+      if (!py_make_ts_arg(kind, std::move(child), lease, ts_obj)) {
         return false;
       }
       call_args.append(ts_obj);
@@ -658,7 +672,6 @@ struct PyFastComputeStateRef {
                                          std::string_view layout,
                                          const TSInputView &args,
                                          const ValueView &scalars,
-                                         NodeScheduler scheduler,
                                          const PyTsLease &lease,
                                          nb::list &call_args) {
   auto bundle = args.as_bundle();
@@ -675,8 +688,8 @@ struct PyFastComputeStateRef {
     case 'a':
     case 'A': {
       nb::object ts_obj;
-      if (!py_make_ts_arg(kind, cache.arg_at(args, bundle, ts_index++),
-                          scheduler, lease, ts_obj)) {
+      if (!py_make_ts_arg(kind, cache.arg_at(args, bundle, ts_index++), lease,
+                          ts_obj)) {
         return false;
       }
       call_args.append(ts_obj);
@@ -726,8 +739,8 @@ void py_assemble_lifecycle_args(std::string_view layout,
             "python lifecycle callback: stop input index is out of range");
       }
       nb::object ts_object;
-      static_cast<void>(py_make_ts_arg(
-          'U', bundle[index], scheduler, lease, ts_object));
+      static_cast<void>(
+          py_make_ts_arg('U', bundle[index], lease, ts_object));
       call_args.append(ts_object);
       break;
     }
@@ -1000,7 +1013,7 @@ struct py_fast_compute_node {
       Scalar<"start_scalars", ScalarVar<"SSV">>, Scalar<"stop_fn", PyNodeRef>,
       Scalar<"stop_enabled", Bool>, Scalar<"stop_config", Str>,
       Scalar<"stop_scalars", ScalarVar<"XSV">>, State<PyFastComputeStateRef>,
-      NodeScheduler, Out<TsVar<"O">>>;
+      PyOwnerSchedulerSupport, Out<TsVar<"O">>>;
 
   static bool requires_(const ResolutionMap &, OperatorCallContext context) {
     return py_fast_compute_eligible(context);
@@ -1053,8 +1066,8 @@ struct py_fast_compute_node {
     static_cast<void>(cache.release());
   }
 
-  static void eval(State<PyFastComputeStateRef> state, NodeScheduler scheduler,
-                   DateTime now) {
+  static void eval(State<PyFastComputeStateRef> state,
+                   PyOwnerSchedulerSupport, DateTime now) {
     PyFastComputeCache *cache = state.get().cache;
     if (cache == nullptr) {
       throw std::logic_error("fast python node has no runtime cache");
@@ -1067,7 +1080,7 @@ struct py_fast_compute_node {
       nb::object result;
       if (cache->direct()) {
         nb::object ts_obj;
-        if (!py_make_direct_ts_arg(*cache, now, scheduler, lease, ts_obj)) {
+        if (!py_make_direct_ts_arg(*cache, now, lease, ts_obj)) {
           return;
         }
         result = cache->record->fn(ts_obj);
@@ -1078,10 +1091,10 @@ struct py_fast_compute_node {
         nb::object rhs;
         if (!py_make_cached_pair_ts_arg(*cache, 0, cache->shape.layout[0],
                                         cache->arg_at(input, bundle, 0),
-                                        scheduler, lease, lhs) ||
+                                        lease, lhs) ||
             !py_make_cached_pair_ts_arg(*cache, 1, cache->shape.layout[1],
                                         cache->arg_at(input, bundle, 1),
-                                        scheduler, lease, rhs)) {
+                                        lease, rhs)) {
           return;
         }
         result = cache->record->fn(lhs, rhs);
@@ -1089,8 +1102,7 @@ struct py_fast_compute_node {
         TSInputView input = cache->input.borrowed_ref(now);
         nb::list call_args;
         if (!py_assemble_fast_args(*cache, cache->shape.layout, input,
-                                   cache->scalars, scheduler, lease,
-                                   call_args)) {
+                                   cache->scalars, lease, call_args)) {
           return;
         }
         auto call_kwargs = py_peel_kwargs(call_args, cache->shape.kw_names);

--- a/python/py_runtime.h
+++ b/python/py_runtime.h
@@ -715,7 +715,6 @@ namespace hgraph::python_bridge
     struct PyTimeSeries
     {
         TSInputView       view;
-        NodeScheduler     scheduler;
         PyTsLease         lease;
         TSDataStorageRef<> evaluation_data{};
         const TSDataOps   *python_value_ops{nullptr};
@@ -751,10 +750,17 @@ namespace hgraph::python_bridge
 
         [[nodiscard]] nb::object owning_node() const
         {
-            const NodeView owner = checked().consumer_node();
-            return owner.valid()
-                       ? nb::cast(PyNode{owner.pointer(), scheduler, lease})
-                       : nb::none();
+            const auto    &current = checked();
+            const NodeView owner   = current.consumer_node();
+            if (!owner.valid()) { return nb::none(); }
+            auto       executor            = owner.graph().executor();
+            const bool supports_wall_clock = executor.valid() &&
+                                             executor.schema()->mode == GraphExecutorMode::RealTime;
+            NodeScheduler scheduler{
+                owner.scheduler_state(), owner.graph_value(), owner.node_index(),
+                current.evaluation_time(), owner.started(), owner.evaluation_clock(),
+                supports_wall_clock};
+            return nb::cast(PyNode{owner.pointer(), scheduler, lease});
         }
 
         [[nodiscard]] nb::object owning_graph() const
@@ -837,7 +843,7 @@ namespace hgraph::python_bridge
                     const auto &field = schema->fields()[index];
                     auto child = bundle.at(index);
                     result[nb::str{field.name}] =
-                        PyTimeSeries{std::move(child), scheduler, lease}.value();
+                        PyTimeSeries{std::move(child), lease}.value();
                 }
                 return materialize_tsb_value(schema, std::move(result));
             }
@@ -896,23 +902,20 @@ namespace hgraph::python_bridge
             {
                 case TSTypeKind::TSD: {
                     Value key_value = py_to_value_as(key, ts.schema()->key_type());
-                    return PyTimeSeries{
-                        ts.as_dict().at(key_value.view()), scheduler, lease};
+                    return PyTimeSeries{ts.as_dict().at(key_value.view()), lease};
                 }
                 case TSTypeKind::TSL: {
                     auto list = ts.as_list();
-                    return PyTimeSeries{
-                        list[nb::cast<std::size_t>(key)], scheduler, lease};
+                    return PyTimeSeries{list[nb::cast<std::size_t>(key)], lease};
                 }
                 case TSTypeKind::TSB: {
                     auto bundle = ts.as_bundle();
                     if (nb::isinstance<nb::str>(key))
                     {
                         return PyTimeSeries{
-                            bundle.field(nb::cast<std::string>(key)), scheduler, lease};
+                            bundle.field(nb::cast<std::string>(key)), lease};
                     }
-                    return PyTimeSeries{
-                        bundle[nb::cast<std::size_t>(key)], scheduler, lease};
+                    return PyTimeSeries{bundle[nb::cast<std::size_t>(key)], lease};
                 }
                 default: throw nb::type_error("this time-series kind has no children");
             }
@@ -954,7 +957,7 @@ namespace hgraph::python_bridge
             for (auto &&[key, child] : dict.modified_items())
             {
                 result.append(nb::make_tuple(
-                    value_to_py(key), PyTimeSeries{std::move(child), scheduler, lease}));
+                    value_to_py(key), PyTimeSeries{std::move(child), lease}));
             }
             return result;
         }
@@ -966,7 +969,7 @@ namespace hgraph::python_bridge
             for (auto &&[key, child] : dict.modified_items())
             {
                 static_cast<void>(key);
-                result.append(PyTimeSeries{std::move(child), scheduler, lease});
+                result.append(PyTimeSeries{std::move(child), lease});
             }
             return result;
         }
@@ -982,8 +985,7 @@ namespace hgraph::python_bridge
                     auto dict = ts.as_dict();
                     for (const ValueView &key : dict.keys())
                     {
-                        result.append(
-                            nb::cast(PyTimeSeries{dict.at(key), scheduler, lease}));
+                        result.append(nb::cast(PyTimeSeries{dict.at(key), lease}));
                     }
                     return result;
                 }
@@ -991,8 +993,7 @@ namespace hgraph::python_bridge
                     auto bundle = ts.as_bundle();
                     for (std::size_t index = 0; index < bundle.size(); ++index)
                     {
-                        result.append(
-                            nb::cast(PyTimeSeries{bundle[index], scheduler, lease}));
+                        result.append(nb::cast(PyTimeSeries{bundle[index], lease}));
                     }
                     return result;
                 }
@@ -1000,8 +1001,7 @@ namespace hgraph::python_bridge
                     auto list = ts.as_list();
                     for (std::size_t index = 0; index < list.size(); ++index)
                     {
-                        result.append(
-                            nb::cast(PyTimeSeries{list[index], scheduler, lease}));
+                        result.append(nb::cast(PyTimeSeries{list[index], lease}));
                     }
                     return result;
                 }


### PR DESCRIPTION
## Summary

- keep planned scheduler storage for fast Python compute nodes without constructing a full `NodeScheduler` on every callback
- materialize the scheduler lazily when Python requests `TimeSeries.owning_node`
- preserve callback ownership/notification semantics, the coarse per-executor-phase GIL design, and avoid thread-local or process-global state
- record controlled Linux and macOS performance evidence

## Why

Linux profiles showed eager `NodeScheduler` construction and copying in Python-heavy hot paths even though normal callbacks only read time-series values. Constructing it only for the uncommon `owning_node` access removes that work from every callback.

Controlled physical `hg-linux` results versus current main:

- `tsd_dense_py`: 6.93% faster
- `reduce_tsd_python_combiner`: 10.15% faster
- `service_adaptor_py`: 2.61% faster

## Validation

- macOS: 1,431 native tests passed
- macOS stable-ABI wheel: built with Python 3.12; 1,884 non-WIP tests passed with Python 3.14, 11 skipped
- physical `hg-linux`: 1,431 native tests passed
- Linux stable-ABI wheel: built with Python 3.12; 1,884 non-WIP tests passed with Python 3.14, 11 skipped
- focused ownership test confirms `owning_node.notify_next_cycle()` retains callback scheduler behavior
