### PR TITLE
RFC 0014: Add automatic request/reply transport planning

### DIFF
--- a/docs/source/developer_guide/parity_matrix.rst
+++ b/docs/source/developer_guide/parity_matrix.rst
@@ -568,7 +568,12 @@ Wiring and node-authoring surface
        an empty delta and retains the stale value. Issues
        #105/#117/#119/#133/#145 are pinned by the mapped request/reply Python
        and C++ regressions and the bounded ``switch-flip-map-removal`` parity
-       family.
+       family. RFC 0014 additionally makes a self-coupled response observable
+       one cycle earlier than released hgraph 0.5.34 by removing its redundant
+       response-feedback boundary. Standalone service recipes are bounded by
+       ``request-reply-one-cycle-earlier``; the switch/map family admits the
+       same single-cycle advance only when composed with its exact flip, and
+       the issue-175 outer-input collision remains fingerprint-pinned.
    * - ``dispatch_``
      - Full for Bundle values
      - Native ``dispatch_cases`` / ``dispatch_case`` wiring builds a closed

--- a/docs/source/developer_guide/parity_matrix.rst
+++ b/docs/source/developer_guide/parity_matrix.rst
@@ -310,13 +310,15 @@ model.
        request/reply services, and late subscription to an existing value all
        execute through the erased C++ service runtime. Matching public C++
        tests cover constrained generics, erased specialization identity,
-       reply-less requests, and sampled late subscriptions. Request/reply uses
-       the Python timing model: request capture advances one cycle and reply
-       publication crosses an outer-graph feedback edge before the client sees
-       it. Compiled ``map_`` and ``mesh_`` children import their outer service
-       transport inputs through the nested boundary; request/reply feedback is
-       owned by the outer implementation, not by the child consumer. Private
-       Python service-builder layouts are not compatibility targets.
+       reply-less requests, and sampled late subscriptions. Reply-full
+       request/reply transport is selected by native wiring: decoupled
+       sink/source implementations are direct, self-coupled implementations
+       defer only the request, and service/adaptor-dependent implementations
+       retain full feedback. Compiled ``map_`` and ``mesh_`` children import
+       their outer service transport inputs through the nested boundary; any
+       response feedback is owned by the outer implementation, not by the child
+       consumer. Private Python service-builder layouts are not compatibility
+       targets.
 
 The 215 upstream ``ts_tests`` tests were also copied mechanically to a
 temporary directory and run against the current bridge under Python 3.12.8.

--- a/docs/source/developer_guide/parity_testing.rst
+++ b/docs/source/developer_guide/parity_testing.rst
@@ -228,8 +228,12 @@ way:
   every remaining field to compare within the template's float tolerance;
 * ``switch-flip-map-removal`` requires the candidate to remove exactly every
   currently-live mapped output, opposite the reference's canonical empty-map
-  delta, on the exact ``beta``-to-request/reply-``alpha`` switch flip. Later
-  response payloads and every other tick must still match.
+  delta, on the exact ``beta``-to-request/reply-``alpha`` switch flip. It may
+  additionally remove the one silent response-feedback cycle made obsolete by
+  RFC 0014; the earlier response payload and every other tick must still match;
+* ``request-reply-one-cycle-earlier`` requires a self-coupled request/reply
+  candidate trace to equal the complete released-hgraph trace after removing
+  exactly its leading silent response-feedback cycle.
 
 An unknown relation, payload corruption, unrelated missing field, candidate
 crash, or status difference does not match and therefore continues through

--- a/docs/source/developer_guide/services.rst
+++ b/docs/source/developer_guide/services.rst
@@ -21,8 +21,11 @@ and ``include/hgraph/runtime/context_node.h`` (the shared primitive). Tests:
 The boundary model (design decisions)
 -------------------------------------
 
-Everything on this page is built from one runtime shape — a **feedback-style
-source/capture pair** — applied with different payloads:
+Everything on this page is built from one runtime shape — a boundary
+**source/capture pair** — applied with different payloads. Some pairs are
+ranked for same-cycle delivery, some deliberately defer delivery, and an
+actual feedback pair is retained only where it is needed to break a dependency
+cycle:
 
 .. mermaid::
 
@@ -81,13 +84,42 @@ source/capture pair** — applied with different payloads:
     Python's keyed-child lifecycle and preventing cached values from leaking on
     re-add. A client joining a key that another client has kept live samples the
     existing value immediately.
-  - **Request/reply requests** forward **next cycle** *when the service declares
-    a response*: the pairing is rank-free (no rank dependency), and the capture
-    schedules the service source for ``evaluation_time + MIN_TD`` (current time
-    during ``start``). The temporal request mutation does not run the
-    implementation in the capture cycle. A request/reply input source retains
-    its earliest outstanding publication time, so a later request cannot
-    postpone work that is already due.
+  - **Reply-full request/reply transport is selected automatically after lazy
+    implementation materialization and before ranking.** There is no user flag
+    and no per-tick policy branch:
+
+    .. list-table::
+       :header-rows: 1
+       :widths: 30 24 24 22
+
+       * - Implementation shape
+         - Request relay
+         - Response relay
+         - Engine latency
+       * - Decoupled request sink and response source
+         - ranked, same cycle
+         - ranked, same cycle
+         - none
+       * - Response causally depends on its own request input
+         - next cycle
+         - ranked, same cycle
+         - one cycle
+       * - Calls another service or adaptor
+         - next cycle
+         - feedback, then same cycle
+         - two cycles
+
+    The decoupled form is the external-transport shape: requests may flow to a
+    Kafka or network sink while correlated replies arrive through a push
+    source. The response graph has no causal path from the service request
+    source, so neither side needs an artificial delay. A self-contained graph
+    whose output is driven by its request input defers only that input, which
+    breaks the direct dependency cycle while allowing the resulting response
+    to publish immediately. Calling any service or adaptor from the active
+    implementation conservatively retains the full two-boundary form because
+    the referenced implementation may close a cycle. A deferred request source
+    retains its earliest outstanding publication time, so a later request
+    cannot postpone work that is already due.
   - **A reply-less request/reply service forwards in the owning capture
     cycle.** With no response there is no response feedback edge, hence no
     request/reply cycle for the rank-free path to permit. A root client is
@@ -101,11 +133,12 @@ source/capture pair** — applied with different payloads:
     Both timings match released hgraph. A root dependency cycle through a
     reply-less service is reported at wiring time rather than being silently
     broken by a cycle boundary.
-  - **Request/reply responses** cross an explicit feedback source/sink pair in
-    the graph that owns the implementation, then publish through the ordinary
-    same-cycle shared-output relay. Reply-full request/reply clients are omitted
-    from indirect service ranking, so recursive request/reply calls are legal.
-    No nested client or higher-order operator constructs this feedback path.
+  - **Nested request/reply clients** keep the existing lifecycle hand-off. A
+    dynamically started child cannot safely schedule an outer request source
+    whose rank may already have passed, so its request reaches the owning graph
+    on the following cycle even when the selected root transport is direct.
+    Higher-order operators do not construct response feedback themselves; the
+    owning implementation's one selected plan remains authoritative.
 - **Lifecycle:** the source clears its captured state on ``stop``. A restarted
   graph must republish through capture before the source can produce a live
   shared output.
@@ -147,10 +180,11 @@ The per-flavour payloads:
   the same source mutation, so the request delta is **cumulative**
   (``make_request_input_source_node`` / ``make_request_input_capture_node``;
   proven by "request/reply source emits cumulative client requests" in
-  ``test_service_wiring.cpp``). The implementation output is captured by an
-  outer-graph feedback sink and replayed on the following cycle before the
-  keyed shared response is published. A direct request therefore has Python's
-  observable sequence ``[None, None, response]``.
+  ``test_service_wiring.cpp``). The implementation output is published using
+  the transport plan above. A self-coupled implementation therefore has the
+  observable sequence ``[None, response]``; a service/adaptor-dependent or
+  recursive implementation retains ``[None, None, response]``; and a truly
+  decoupled external response can arrive without an engine-imposed cycle.
 
 Related decision recorded with this layer: real-time wall-clock scheduler
 alarms use the normal graph schedule queue — ``NodeScheduler(...,
@@ -393,6 +427,14 @@ Genuine nested children are unaffected: a push source inside a
 child is still rejected, because a graph with a push prefix never gets a nested
 graph type interned (``GraphBuilder::nested_type()``). See :doc:`nested_graphs`.
 
+Reply-full request/reply transport planning also relies on this inlining. Once
+all demanded implementations have materialized, wiring can inspect the actual
+native dependency graph rather than infer behavior from a decorator or an API
+signature. ``impl_input``/``from_graph`` records the implementation's request
+source, ``impl_output``/``to_graph`` records its response, and the planner
+selects one immutable transport before ranks are built. The Python decorators
+use this same erased C++ path; Python does not repeat the analysis.
+
 
 The service and adaptor surfaces are one boundary model
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -427,11 +469,13 @@ The two concepts are **disjoint**: a source-only adaptor once satisfied both
 types, detected through a structural tag so ``service_wiring.h`` stays
 independent of ``adaptor_wiring.h``.
 
-Which spelling to choose is a question of intent, not capability: an **adaptor**
-says "this boundary talks to the outside world", a **service** says "this value
-is provided to whoever asks". A source-only adaptor and a reference service
-describe the same wiring; prefer the reference service unless the external-world
-framing is the point.
+For new code, prefer a service whenever its contract fits. A reference service
+covers source-only publication, a reply-less request/reply service covers a
+keyed sink, and a reply-full request/reply service now covers a correlated
+external exchange without imposing feedback on a decoupled implementation.
+The plain adaptor spelling remains useful for an unkeyed merged stream or for
+compatibility with existing adaptor APIs; it is no longer required merely to
+obtain the direct external-transport path.
 
 Adaptors
 --------
@@ -616,9 +660,10 @@ second implementation for the same service kind + path throws
 reads the implementation output by reference (no copy); paths keep shared
 outputs separate; a subscription client's key transitions reach the
 implementation in order and the response flows back keyed with Python timing;
-request/reply replies cross the outer feedback edge and remain keyed by the
-client's request id; two clients' requests reach the implementation as one
-cumulative delta.
+request/reply replies remain keyed by the client's request id; decoupled,
+self-coupled, and service-dependent implementations select direct,
+request-deferred, and full-feedback transport respectively; two clients'
+requests reach the implementation as one cumulative delta.
 
 
 How a client expression lowers

--- a/docs/source/rfc/index.rst
+++ b/docs/source/rfc/index.rst
@@ -27,3 +27,4 @@ workflow are defined by :doc:`rfc_0000`.
    rfc_0011_source_only_adaptor_collapse
    rfc_0012_replyless_request_reply_relay
    rfc_0013_pooled_polymorphic_compound_scalars
+   rfc_0014_request_reply_transport_planning

--- a/docs/source/rfc/rfc_0012_replyless_request_reply_relay.rst
+++ b/docs/source/rfc/rfc_0012_replyless_request_reply_relay.rst
@@ -152,9 +152,10 @@ inserting a cycle of latency. Nothing in this tree relies on it. If a concrete
 use emerges, the answer is an explicit opt-in rather than restoring the implicit
 next-cycle behaviour for everyone.
 
-**Reply-full request/reply is untouched.** Its rank-freedom and response
-feedback are exactly what make recursive request/reply legal, and
-``test_service_wiring.cpp`` pins that behaviour.
+**Reply-full request/reply was outside this RFC.** RFC 0014 subsequently
+replaced its unconditional full-feedback transport with automatic planning,
+while retaining full feedback for service-dependent and recursive
+implementations.
 
 Alternatives considered
 -----------------------
@@ -246,5 +247,7 @@ References
 * :doc:`rfc_0011_source_only_adaptor_collapse` — the unified boundary model this
   extends, and whose "explicitly out of scope" note this supersedes for the
   reply-less case.
+* :doc:`rfc_0014_request_reply_transport_planning` — the later automatic
+  transport selection for reply-full services.
 * ``docs/source/developer_guide/services.rst`` — the scheduling matrix
   distinguishing same-cycle relays from next-cycle request stubs.

--- a/docs/source/rfc/rfc_0014_request_reply_transport_planning.rst
+++ b/docs/source/rfc/rfc_0014_request_reply_transport_planning.rst
@@ -145,7 +145,12 @@ cycle, and an externally supplied response can publish in its arrival cycle.
 **Self-coupled services lose one artificial cycle.** The observable sequence
 for a conventional request-driven implementation changes from
 ``[None, None, response]`` to ``[None, response]``. The request boundary still
-breaks the graph cycle.
+breaks the graph cycle. Differential testing against released hgraph 0.5.34
+tracks this as an exact one-cycle response advance: payloads, ordering, and all
+remaining silent cycles must agree. The same advance may compose with the
+already accepted transient map-removal behavior on a request/reply switch
+flip; the issue-175 response-versus-new-key collision remains an exact pinned
+corpus divergence so a lost or reordered response is never accepted broadly.
 
 **Service-dependent and recursive behavior is retained.** Such an
 implementation continues to observe the full two-boundary sequence. The rule

--- a/docs/source/rfc/rfc_0014_request_reply_transport_planning.rst
+++ b/docs/source/rfc/rfc_0014_request_reply_transport_planning.rst
@@ -1,0 +1,235 @@
+RFC 0014: Automatic Request/Reply Transport Planning
+====================================================
+
+:Status: Accepted
+:Author: Howard Henson
+:Created: 2026-08-04
+:Target: Request/reply service wiring, scheduling, and Python compatibility
+
+Summary
+-------
+
+Reply-full request/reply services no longer unconditionally insert one
+next-cycle request hand-off and one response feedback hand-off. After lazy
+service materialization, native wiring selects the least costly transport that
+preserves the implementation's dependency structure:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 32 23 23 22
+
+   * - Implementation shape
+     - Request
+     - Response
+     - Engine latency
+   * - Decoupled sink/source
+     - direct
+     - direct
+     - none
+   * - Output depends on own request
+     - deferred
+     - direct
+     - one cycle
+   * - Calls a service or adaptor
+     - deferred
+     - feedback
+     - two cycles
+
+The selection is automatic. Existing C++ and Python declarations, calls,
+registration, ``get_service_inputs``/``set_service_output``, and
+``from_graph``/``to_graph`` APIs do not gain a policy argument. The plan is
+fixed before graph ranking and introduces no per-tick policy branch.
+
+Motivation
+----------
+
+The old reply-full transport assumed that the implementation output could feed
+back, directly or through another boundary, to its request input. That was the
+safest universal choice and permits recursion, but it charged two cycles to
+every implementation.
+
+An external request/reply transport has a different shape. A Kafka-backed
+implementation, for example, can sink client requests to an outbound channel
+and publish independently received correlated responses through a push source.
+There is no graph edge from that response source to the request dictionary.
+Neither a request delay nor a response feedback edge breaks a real cycle in
+this shape; both are artificial latency.
+
+RFC 0011 made services and adaptors share one boundary model, and RFC 0012 made
+reply-less request/reply use the direct keyed-sink relay. This RFC completes
+the keyed exchange: a normal request/reply service can now provide the direct
+external-transport behavior that previously encouraged users to choose an
+adaptor solely for scheduling reasons.
+
+User contract
+-------------
+
+No existing user-facing signature changes. Python code continues to declare
+``@request_reply_service`` and ``@service_impl`` and may expose implementation
+boundaries with either:
+
+* a conventional implementation argument and return value;
+* ``get_service_inputs`` and ``set_service_output``; or
+* ``from_graph`` and ``to_graph``.
+
+The native equivalents remain ``register_request_reply_service``,
+``service::impl_input``/``impl_output``, and the service aliases of
+``from_graph``/``to_graph``. All routes lower to the same C++ planner.
+
+A decoupled implementation may send the keyed request dictionary to an
+external sink and provide a keyed response dictionary from a push source. The
+stable client request id remains the correlation key. External concurrency and
+wall-clock timing are not made deterministic by this RFC; the engine preserves
+the ordering presented by the constructed graph and the external transport.
+
+Planning model
+--------------
+
+Planning occurs after ``Wiring::build_services()`` has materialized every
+demanded implementation and before service-rank dependencies are applied. A
+wiring-lifetime planner records:
+
+* each pending reply-full client capture;
+* the implementation-owned request source for each concrete service path;
+* the implementation response port and shared response source; and
+* whether the active implementation wired any service or adaptor client.
+
+The implementation output is tested for backward causal reachability to its
+own request source. Only ordinary data/rank dependencies participate.
+Recovery links, source/capture back-links, and other explicitly rank-free edges
+do not establish causality. Structural ports and resolved delayed bindings are
+followed so bundles and generic wiring do not hide a dependency.
+
+The decision for one concrete service path is:
+
+``FullFeedback``
+   The implementation calls any service or adaptor. The request remains
+   next-cycle and the response crosses a feedback pair before entering the
+   same-cycle shared-output relay. This conservative rule preserves direct and
+   indirect recursion without requiring inter-service whole-graph cycle
+   speculation.
+
+``RequestDeferred``
+   The response causally depends on the implementation's own request source
+   and the implementation has no boundary dependency. Deferring the request
+   breaks that cycle; the computed response then publishes directly in the
+   implementation cycle.
+
+``Direct``
+   The response has no causal path from the request source and the
+   implementation has no service/adaptor dependency. The client capture ranks
+   before the request source, and the response capture ranks before the shared
+   response source, so both relays may publish in their owning cycle.
+
+Key lifetime, request batching, cumulative deltas, response correlation, and
+source ownership do not change. This is selection among existing boundary
+constructions, not a second request/reply runtime.
+
+Nested clients
+--------------
+
+A client dynamically started in a keyed child graph cannot schedule an outer
+request source in the current cycle because the outer source's rank may already
+have passed. It therefore retains the existing next-cycle outer hand-off even
+when the owning implementation selected ``Direct``. The child does not create
+or own a response feedback pair; the root implementation plan remains the
+single owner of response transport.
+
+Consequences
+------------
+
+**Decoupled exchanges gain the direct path immediately.** No opt-in is
+required. A request captured in the owning graph can reach its sink in that
+cycle, and an externally supplied response can publish in its arrival cycle.
+
+**Self-coupled services lose one artificial cycle.** The observable sequence
+for a conventional request-driven implementation changes from
+``[None, None, response]`` to ``[None, response]``. The request boundary still
+breaks the graph cycle.
+
+**Service-dependent and recursive behavior is retained.** Such an
+implementation continues to observe the full two-boundary sequence. The rule
+is deliberately conservative: a service call that does not happen to feed the
+response still selects full feedback because the referenced implementation may
+complete a wider cycle.
+
+**Adaptor scope narrows without a disruptive deprecation.** New keyed,
+correlated external exchanges should use request/reply services. Plain
+adaptors remain supported for existing APIs and unkeyed merged streams. This
+RFC does not emit a deprecation warning; removing or formally deprecating an
+adaptor decorator requires a separate compatibility decision.
+
+C++ ownership
+-------------
+
+The planner, causal analysis, strategy selection, and synthesized boundary
+nodes are C++. The Python bridge supplies erased descriptors and ports to that
+contract. Python does not classify the implementation or build a parallel
+transport, preserving the repository's C++-first ownership rule.
+
+The reusable erased contract lives in
+``include/hgraph/types/request_reply_transport.h``. Its concrete planner and
+feedback representation stay under ``src/hgraph/types/impl``. Semantic service
+owners depend on the contract and do not name the concrete strategy.
+
+Alternatives considered
+-----------------------
+
+Keep full feedback for every reply-full service
+   Rejected. It preserves recursion but imposes two cycles on decoupled
+   external transports and one unnecessary response cycle on self-contained
+   services.
+
+Add a decorator or registration flag
+   Rejected. The correct choice follows from the materialized native graph.
+   Making users predict internal causality duplicates engine knowledge and
+   prevents existing code from receiving the improvement immediately.
+
+Treat every implementation without direct request causality as direct
+   Rejected. Calls through services or adaptors can complete a wider dependency
+   cycle that local reachability does not expose. The active implementation
+   scope therefore records boundary use and selects full feedback.
+
+Always use deferred request and direct response
+   Rejected. It removes one cycle but still delays a truly decoupled transport,
+   and it does not preserve recursive response cycles.
+
+Acceptance criteria
+-------------------
+
+* Public typed C++ wiring proves all three transport selections.
+* Matching Python tests prove self-coupled and service-dependent timing and a
+  real-time Kafka-style sink/push-source exchange through the existing public
+  API.
+* Recursive, mapped, meshed, switch, cumulative-delta, removal, and teardown
+  behavior remains valid.
+* Repeated wiring snapshots do not duplicate synthesized nodes or plans.
+* The public C++ installed-SDK consumer builds against the new erased contract.
+* The complete native and Python 3.14 compatibility suites pass on macOS and
+  GCC 14 Linux; lifetime-sensitive Linux validation includes AddressSanitizer.
+
+Implementation status
+---------------------
+
+The typed C++ and erased Python paths use one automatic native planner. Native
+and Python focused behavior coverage is implemented. The acceptance evidence
+for this implementation is:
+
+* macOS native acceptance: 1,444 tests passed;
+* macOS Python 3.14 compatibility: 1,893 passed, 11 skipped;
+* installed plain-C++ and wheel-extension SDK consumers passed;
+* documentation built with warnings treated as errors;
+* GCC 14.2 Linux native acceptance: 1,444 tests passed;
+* GCC 14.2 Linux stable-ABI wheel on Python 3.14: 1,893 passed, 11
+  skipped; and
+* GCC 14.2 Linux AddressSanitizer compatibility: 1,893 passed, 11 skipped,
+  with no sanitizer findings.
+
+References
+----------
+
+* :doc:`rfc_0011_source_only_adaptor_collapse` — shared service/adaptor
+  boundary substrate.
+* :doc:`rfc_0012_replyless_request_reply_relay` — direct keyed sink behavior.
+* :doc:`../developer_guide/services` — authoritative scheduling matrix and
+  user-facing service/adaptor guide.

--- a/docs/source/user_guide/authoring_graphs_cpp.rst
+++ b/docs/source/user_guide/authoring_graphs_cpp.rst
@@ -1045,10 +1045,12 @@ so its reply is erased:
 
 Two clients of the same service are two independent request-dictionary
 entries; the implementation sees both requests in one cumulative delta and
-each client receives only its own reply. Request capture advances one engine
-cycle and response publication crosses a second, outer-graph feedback edge;
-the observable sequence for one request is therefore
-``[None, None, response]``, matching Python.
+each client receives only its own reply. The runtime selects transport after
+the implementation is wired. This request-driven implementation defers the
+request by one engine cycle and publishes its response directly, so one
+request produces ``[None, response]``. A decoupled external sink/push-source
+implementation needs no engine-imposed delay; an implementation that calls a
+service or adaptor retains the full feedback form required for recursion.
 
 Paths and other service mechanics
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/include/hgraph/runtime/service_node.h
+++ b/include/hgraph/runtime/service_node.h
@@ -78,12 +78,12 @@ namespace hgraph
      * Input field ``request`` is ``request_schema`` and field ``requests`` is
      * the paired source node's ``TSD<int, request_schema>`` output. Only
      * ``request`` is active; ``requests`` is a passive binding used to locate
-     * the source node. Deferred request/reply captures schedule the next engine
-     * tick during normal evaluation. Rank-correct service-adaptor captures set
-     * ``same_cycle`` and schedule the paired source for the current engine time
-     * when both live in the owning graph. Dynamically started child graphs hand
-     * work to the enclosing source on the following engine cycle because its
-     * outer rank may already have passed.
+     * the source node. Captures with ``same_cycle == false`` schedule the next
+     * engine tick during normal evaluation. The request/reply transport planner,
+     * reply-less services, and service adaptors set ``same_cycle`` when they can
+     * prove the paired source ranks later in the owning graph. Dynamically
+     * started child graphs hand work to the enclosing source on the following
+     * engine cycle because its outer rank may already have passed.
      */
     [[nodiscard]] HGRAPH_EXPORT NodeBuilder make_request_input_capture_node(
         std::string path,

--- a/include/hgraph/types/graph_wiring.h
+++ b/include/hgraph/types/graph_wiring.h
@@ -855,6 +855,22 @@ namespace hgraph
         void retain_extension_state(std::shared_ptr<void> state);
 
         /**
+         * Return wiring-lifetime state for ``key``, creating it once on first
+         * use. Native wiring extensions use this to share planning state
+         * without process globals; the state is owned by this Wiring.
+         */
+        [[nodiscard]] std::shared_ptr<void> acquire_extension_state(
+            std::type_index key,
+            std::function<std::shared_ptr<void>()> create);
+
+        /** Register an idempotent extension finalizer run after lazy service
+         *  materialization and before rank dependencies are applied. */
+        void register_pre_rank_finalizer(std::function<void(Wiring &)> finalizer);
+
+        /** Whether this wiring is a root graph or an isolated child graph. */
+        [[nodiscard]] WiringKind kind() const noexcept;
+
+        /**
          * Intern a node with its input edges + scalar configuration and return its
          * output port. ``def`` is the node *definition's* stable identity
          * (``typeid(T)`` for a C++ static node) — two calls with the same ``def``,
@@ -982,6 +998,14 @@ namespace hgraph
         [[nodiscard]] std::vector<std::pair<std::string, std::string>>
         built_service_paths() const;
         [[nodiscard]] std::string_view service_materialization_path() const noexcept;
+
+        /**
+         * Stable state for the active implementation scope. Service/adaptor
+         * client registration flips the value to true. Consumers may retain
+         * the handle until pre-rank finalization, after the scope has closed.
+         */
+        [[nodiscard]] std::shared_ptr<const bool>
+        service_implementation_boundary_dependency() const;
 
         /**
          * RAII wrapper for implementation-owned service/adaptor stub scopes.
@@ -1158,6 +1182,7 @@ namespace hgraph
         [[nodiscard]] WiringScopeEvent begin_observation(WiringScopeEvent event);
         void end_observation(const WiringScopeEvent &event, std::string_view error);
         void apply_service_rank_dependencies();
+        void finalize_extensions();
         /** Shared body of finish()/snapshot(): validate + rank + build; the
             wiring GlobalState is moved when consuming, copied otherwise. */
         [[nodiscard]] GraphBuilder finish_top_level(bool consume_state);

--- a/include/hgraph/types/request_reply_transport.h
+++ b/include/hgraph/types/request_reply_transport.h
@@ -1,0 +1,48 @@
+#ifndef HGRAPH_TYPES_REQUEST_REPLY_TRANSPORT_H
+#define HGRAPH_TYPES_REQUEST_REPLY_TRANSPORT_H
+
+#include <hgraph/hgraph_export.h>
+#include <hgraph/types/graph_wiring.h>
+
+#include <cstdint>
+#include <string>
+#include <typeindex>
+
+namespace hgraph
+{
+    /**
+     * Immutable wiring-time transport selected for one concrete request/reply
+     * implementation (RFC 0014). No policy dispatch occurs at runtime.
+     */
+    enum class RequestReplyTransportPlan : std::uint8_t
+    {
+        Direct,          ///< ranked request relay and direct response relay
+        RequestDeferred, ///< next-cycle request relay and direct response relay
+        FullFeedback,    ///< next-cycle request relay and feedback response relay
+    };
+
+    namespace request_reply_transport
+    {
+        /** Defer a reply-full client capture until its implementation plan is known. */
+        HGRAPH_EXPORT void defer_client(Wiring &w, std::string base_path, std::string request_path,
+                                        std::string response_path, const TSValueTypeMetaData &request_schema,
+                                        WiringPortRef request, WiringPortRef request_source, WiringPortRef request_id,
+                                        WiringPortRef response_source, std::type_index capture_role);
+
+        /** Record the implementation-owned request source used for causality analysis. */
+        HGRAPH_EXPORT void register_implementation_input(Wiring &w, std::string base_path,
+                                                         const WiringInstance *request_source);
+
+        /**
+         * Defer publication of one implementation output. The active
+         * implementation scope is retained so later service/adaptor calls in
+         * the same graph conservatively select full feedback.
+         */
+        HGRAPH_EXPORT void defer_implementation_output(Wiring &w, std::string base_path, std::string response_path,
+                                                       const TSValueTypeMetaData &response_dict_schema,
+                                                       WiringPortRef output, WiringPortRef response_source,
+                                                       std::type_index capture_role);
+    }  // namespace request_reply_transport
+}  // namespace hgraph
+
+#endif

--- a/include/hgraph/types/service_wiring.h
+++ b/include/hgraph/types/service_wiring.h
@@ -3,12 +3,12 @@
 
 #include <hgraph/lib/std/operators/collection.h>
 #include <hgraph/lib/std/operators/container.h>
-#include <hgraph/runtime/feedback_node.h>
 #include <hgraph/runtime/service_node.h>
 #include <hgraph/runtime/shared_output_node.h>
 #include <hgraph/types/metadata/type_registry.h>
 #include <hgraph/types/graph_wiring.h>
 #include <hgraph/types/operator_dispatch.h>
+#include <hgraph/types/request_reply_transport.h>
 #include <hgraph/types/static_schema.h>
 #include <hgraph/types/type_pattern.h>
 
@@ -82,7 +82,7 @@ namespace hgraph::service
      * selected service value by reference; no service value is copied by the
      * wiring layer.
      *
-     * Request/reply services collect client requests through a feedback-style
+     * Request/reply services collect client requests through a keyed
      * source/capture pair:
      *
      * .. code-block:: cpp
@@ -109,11 +109,13 @@ namespace hgraph::service
      *    wire<Publish>(w, event);  // returns void
      *
      * The request source owns ``TSD<Int, request_schema>`` plus a mutable
-     * request-delta state. Reply-full captures forward on the next cycle and
-     * responses pass through one outer-graph feedback edge before publication;
-     * that temporal boundary permits recursive request/reply implementations.
-     * A reply-less root client instead uses the ranked same-cycle sink relay.
-     * A dynamically-started nested client defers its outer hand-off one cycle,
+     * request-delta state. Reply-full transport is selected automatically once
+     * wiring has materialized the implementation: a decoupled implementation
+     * uses direct request and response relays, a response causally driven by
+     * its own request defers only the request, and an implementation that calls
+     * another service/adaptor retains request and response feedback boundaries.
+     * A reply-less root client uses the ranked same-cycle sink relay. A
+     * dynamically-started nested client defers its outer hand-off one cycle,
      * matching released hgraph's lifecycle ordering.
      */
 
@@ -713,41 +715,6 @@ namespace hgraph::service
         {
         };
 
-        struct request_reply_feedback_source_marker
-        {
-        };
-
-        struct request_reply_feedback_sink_marker
-        {
-        };
-
-        [[nodiscard]] inline WiringPortRef request_reply_response_feedback(
-            Wiring &w,
-            WiringPortRef response,
-            const TSValueTypeMetaData &schema)
-        {
-            WiringPortRef feedback = w.add_unique_node(
-                std::type_index(typeid(request_reply_feedback_source_marker)),
-                make_feedback_source_node(schema), std::span<const WiringPortRef>{}, Value{});
-
-            std::array<WiringPortRef, 2> sources{
-                graph_wiring_detail::adapt_source_for_input(w, &schema, std::move(response)),
-                feedback,
-            };
-            std::array<WiringInputRef, 2> inputs{{
-                WiringInputRef{.source = sources[0]},
-                WiringInputRef{.source = sources[1], .rank_dependency = false},
-            }};
-            NodeBuilder sink = make_feedback_sink_node(schema);
-            sink.input_endpoint(graph_wiring_detail::input_endpoint_for_sources(
-                sink.type().schema()->input_schema,
-                std::span<const WiringPortRef>{sources.data(), sources.size()}));
-            static_cast<void>(w.add_unique_node(
-                std::type_index(typeid(request_reply_feedback_sink_marker)), std::move(sink),
-                std::span<const WiringInputRef>{inputs.data(), inputs.size()}, Value{}));
-            return feedback;
-        }
-
         template <typename Service>
         [[nodiscard]] Port<REF<reference_output_schema_t<Service>>> reference_shared_output_source(
             Wiring &w,
@@ -922,7 +889,7 @@ namespace hgraph::service
                 user_path.resolution, "request/reply service request");
             NodeBuilder builder = make_request_input_capture_node(
                 request_input_path<Service>(user_path), *request_meta,
-                replyless_request_reply_service_interface<Service>);
+                true);
             builder.input_endpoint(graph_wiring_detail::input_endpoint_for_sources(
                 builder.type().schema()->input_schema,
                 std::span<const WiringPortRef>{sources.data(), sources.size()}));
@@ -931,9 +898,8 @@ namespace hgraph::service
                                                std::move(builder),
                                                std::span<const WiringInputRef>{inputs.data(), inputs.size()},
                                                Value{});
-            // Reply-full request/reply forwards on the next cycle; the
-            // temporal break permits recursive implementations. Reply-less
-            // services are sinks and use the ranked same-cycle relay.
+            // This helper is the reply-less keyed sink path. Reply-full
+            // clients are deferred to the transport planner instead.
             return capture.peered_node();
         }
 
@@ -989,39 +955,6 @@ namespace hgraph::service
                                                std::move(builder),
                                                std::span<const WiringInputRef>{inputs.data(), inputs.size()},
                                                Value{});
-            w.add_same_cycle_pair(capture.peered_node(), shared_output.node());
-            return capture.peered_node();
-        }
-
-        template <typename Service, typename Impl>
-        const WiringInstance *capture_request_reply_service_output(
-            Wiring &w,
-            Port<request_output_schema_t<Service>> output,
-            Port<REF<request_output_schema_t<Service>>> shared_output,
-            const ServicePath &user_path)
-        {
-            const auto *response_meta = resolved_schema_meta<response_schema_t<Service>>(
-                user_path.resolution, "request/reply service response");
-            const auto *output_meta = TypeRegistry::instance().tsd(
-                scalar_descriptor<Int>::value_meta(), response_meta);
-            WiringPortRef feedback = request_reply_response_feedback(
-                w, output.erased(), *output_meta);
-            std::array<WiringPortRef, 2> sources{std::move(feedback), shared_output.erased()};
-            std::array<WiringInputRef, 2> inputs{{
-                WiringInputRef{.source = sources[0]},
-                WiringInputRef{.source = sources[1], .rank_dependency = false},
-            }};
-            NodeBuilder builder = make_shared_output_capture_node(
-                request_reply_output_path<Service>(user_path), *output_meta);
-            builder.input_endpoint(graph_wiring_detail::input_endpoint_for_sources(
-                builder.type().schema()->input_schema,
-                std::span<const WiringPortRef>{sources.data(), sources.size()}));
-
-            WiringPortRef capture = w.add_node(
-                std::type_index(typeid(request_reply_output_capture_marker)),
-                std::move(builder),
-                std::span<const WiringInputRef>{inputs.data(), inputs.size()},
-                Value{});
             w.add_same_cycle_pair(capture.peered_node(), shared_output.node());
             return capture.peered_node();
         }
@@ -1137,6 +1070,11 @@ namespace hgraph::service
         w.register_service_implementation_stub(endpoint, "request/reply service");
         auto source = detail::request_input_source<Service>(w, user_path);
         w.register_service_rank_anchor(detail::request_input_path<Service>(user_path), source.node());
+        if constexpr (detail::replying_request_reply_service_interface<Service>)
+        {
+            request_reply_transport::register_implementation_input(
+                w, detail::request_reply_base_path<Service>(user_path), source.node());
+        }
         return source;
     }
 
@@ -1208,10 +1146,18 @@ namespace hgraph::service
             user_path.resolution, w.service_implementation_stub_resolution(endpoint));
         w.register_service_implementation_stub(endpoint, "request/reply service");
         auto shared_output = detail::request_reply_output_source<Service>(w, user_path);
-        const WiringInstance *capture =
-            detail::capture_request_reply_service_output<Service, explicit_impl_output_marker>(
-            w, std::move(output), shared_output, user_path);
-        w.register_service_rank_anchor(detail::request_reply_output_path<Service>(user_path), capture);
+        const auto *response_meta = detail::resolved_schema_meta<detail::response_schema_t<Service>>(
+            user_path.resolution, "request/reply service response");
+        const auto *output_meta = TypeRegistry::instance().tsd(
+            scalar_descriptor<Int>::value_meta(), response_meta);
+        request_reply_transport::defer_implementation_output(
+            w,
+            detail::request_reply_base_path<Service>(user_path),
+            detail::request_reply_output_path<Service>(user_path),
+            *output_meta,
+            output.erased(),
+            shared_output.erased(),
+            std::type_index(typeid(detail::request_reply_output_capture_marker)));
     }
 
     template <typename Service>
@@ -1486,11 +1432,19 @@ namespace hgraph::service
         auto replies         = detail::request_reply_output_source<Service>(w, user_path);
 
         w.register_service_rank_anchor(detail::request_input_path<Service>(user_path), requests.node());
-        static_cast<void>(
-            detail::capture_request_input<Service>(w, std::move(request), requests, user_path, request_id));
-        // Request/reply responses cross an explicit feedback edge. Unlike the
-        // other service flavours, clients therefore do not participate in
-        // indirect service ranking; this also permits request/reply cycles.
+        const auto *request_meta = detail::resolved_schema_meta<detail::request_schema_t<Service>>(
+            user_path.resolution, "request/reply service request");
+        request_reply_transport::defer_client(
+            w,
+            detail::request_reply_base_path<Service>(user_path),
+            detail::request_input_path<Service>(user_path),
+            detail::request_reply_output_path<Service>(user_path),
+            *request_meta,
+            request.erased(),
+            requests.erased(),
+            request_id.erased(),
+            replies.erased(),
+            std::type_index(typeid(detail::request_input_capture_marker)));
         if constexpr (schema_descriptor<output_schema>::is_concrete())
         {
             auto reply = wire<stdlib::getitem_>(w, replies.template as<output_schema>(), request_id);
@@ -1577,6 +1531,11 @@ namespace hgraph::service
                 }
                 else
                 {
+                    auto scope = target.service_implementation_scope(
+                        "request/reply service " + base_path,
+                        std::vector<WiringServiceImplementationEndpoint>{}, false);
+                    request_reply_transport::register_implementation_input(
+                        target, base_path, requests.node());
                     using output_schema = detail::request_output_schema_t<Service>;
                     auto replies = detail::request_reply_output_source<Service>(target, user_path);
                     auto output = std::apply(
@@ -1585,11 +1544,20 @@ namespace hgraph::service
                                 target, user_path,
                                 detail::service_input_arg<Impl>(requests), stored...);
                         }, stored_args);
-                    const WiringInstance *capture =
-                        detail::capture_request_reply_service_output<Service, Impl>(
-                            target, output, replies, user_path);
-                    target.register_service_rank_anchor(
-                        detail::request_reply_output_path<Service>(user_path), capture);
+                    const auto *response_meta =
+                        detail::resolved_schema_meta<detail::response_schema_t<Service>>(
+                            user_path.resolution, "request/reply service response");
+                    const auto *dict_meta = TypeRegistry::instance().tsd(
+                        scalar_descriptor<Int>::value_meta(), response_meta);
+                    request_reply_transport::defer_implementation_output(
+                        target,
+                        base_path,
+                        detail::request_reply_output_path<Service>(user_path),
+                        *dict_meta,
+                        output.erased(),
+                        replies.erased(),
+                        std::type_index(typeid(detail::request_reply_output_capture_marker)));
+                    scope.complete();
                 }
             });
     }
@@ -1956,8 +1924,8 @@ namespace hgraph::service_adaptor
             // Service-adaptor sends are rank-correct and same-cycle in their
             // owning graph. A dynamically-started child hands off to its outer
             // source on the following cycle because that outer rank may already
-            // have passed. Only reply-full request/reply is unconditionally
-            // deferred to permit recursion.
+            // have passed. Reply-full service transport is planned separately
+            // after its implementation materializes.
             return capture.peered_node();
         }
 

--- a/python/tests/ported/_wiring/test_service.py
+++ b/python/tests/ported/_wiring/test_service.py
@@ -277,8 +277,8 @@ def test_specialized_numeric_request_reply_services_use_native_exchange():
         hg.register_service("adjust", float_adjust_impl)
         return float_adjust(value, path="adjust")
 
-    assert eval_node(integer_client, [1], __end_time__=hg.MIN_ST + 3 * hg.MIN_TD) == [None, None, 2]
-    assert eval_node(float_client, [1.5], __end_time__=hg.MIN_ST + 3 * hg.MIN_TD) == [None, None, 2.0]
+    assert eval_node(integer_client, [1], __end_time__=hg.MIN_ST + 3 * hg.MIN_TD) == [None, 2]
+    assert eval_node(float_client, [1.5], __end_time__=hg.MIN_ST + 3 * hg.MIN_TD) == [None, 2.0]
 
 
 def test_request_reply_accepts_positional_path_and_multiple_requests():
@@ -298,7 +298,7 @@ def test_request_reply_accepts_positional_path_and_multiple_requests():
 
     assert eval_node(
         client, [1], [2], __end_time__=hg.MIN_ST + 3 * hg.MIN_TD,
-    ) == [None, None, 3]
+    ) == [None, 3]
 
 
 def test_replyless_request_reply_service_captures_requests():
@@ -349,7 +349,7 @@ def test_higher_order_child_calls_outer_request_reply_service(higher_order):
         client,
         [{1: 10, 2: 20}],
         __end_time__=hg.MIN_ST + 6 * hg.MIN_TD,
-    ) == [{}, None, {1: 12, 2: 22}]
+    ) == [{}, {1: 12, 2: 22}]
 
 
 def test_mapped_subscription_result_uses_the_declared_value_schema():

--- a/python/tests/test_hgraph_api.py
+++ b/python/tests/test_hgraph_api.py
@@ -955,9 +955,10 @@ def test_services_from_python():
         hg.register_service("dbl", doubler_impl)
         return doubler(x, path="dbl")
 
-    # Requests and responses each cross their next-cycle transport boundary.
+    # This self-coupled implementation defers the request and publishes the
+    # response directly.
     out = eval_node(rr_graph, [5, 7], __end_time__=hg.MIN_ST + 4 * hg.MIN_TD)
-    check(out == [None, None, 10, 14], f"request/reply service: {out}")
+    check(out == [None, 10, 14], f"request/reply service: {out}")
 
     # @service_impl validates the shape for the flavour. A reference impl
     # takes no interface input, so a surplus time-series parameter is now
@@ -1724,7 +1725,7 @@ def test_multi_interface_service_impl():
         return boost(x, path="svc") + hg.passive(rate(path="svc"))
 
     out = eval_node(g, [5, 7], __end_time__=hg.MIN_ST + 4 * hg.MIN_TD)
-    check(out == [None, None, 205, 207], f"multi-interface: {out}")
+    check(out == [None, 205, 207], f"multi-interface: {out}")
 
     # The stub-method spellings work too (hgraph parity).
     check(hasattr(boost, "wire_impl_inputs_stub") and hasattr(rate, "wire_impl_out_stub"),

--- a/python/tests/test_parity_fixes.py
+++ b/python/tests/test_parity_fixes.py
@@ -236,6 +236,7 @@ def test_keyed_child_response_survives_new_key_in_delivery_cycle(use_mesh):
         keyed_operator = hg.mesh_ if use_mesh else hg.map_
         return keyed_operator(per_key, values, selector)
 
-    # k2 arrives EXACTLY in k1's response-delivery cycle (t2).
+    # The direct response leg advances both deliveries by one cycle; the
+    # higher-order worklist must still keep each due child.
     assert eval_node(g, [{"k1": 8}, None, {"k2": -2}], ["alpha", None, None]) == [
-        {}, None, {"k1": 8}, None, {"k2": -2}]
+        {}, {"k1": 8}, {}, {"k2": -2}]

--- a/python/tests/test_parity_harness.py
+++ b/python/tests/test_parity_harness.py
@@ -942,6 +942,47 @@ def test_mesh_empty_initial_fingerprint_is_pinned_and_suppressed(monkeypatch):
     assert not any(arguments[:2] == ["issue", "create"] for arguments in calls)
 
 
+def test_issue_175_rfc_14_timing_fingerprint_is_pinned():
+    from tools.parity.known import load_known_divergences
+
+    fingerprints, _families = load_known_divergences()
+    recipe = Recipe.load(
+        CORPUS / "issue-175-map-response-delivery-vs-new-key.json"
+    )
+    mapped = lambda entries: {"$map": entries}
+    reference = {
+        "status": "ok",
+        "trace": [
+            mapped([]),
+            None,
+            mapped([["k1", 8]]),
+            None,
+            mapped([["k2", -2]]),
+        ],
+    }
+    candidate = {
+        "status": "ok",
+        "trace": [
+            mapped([]),
+            mapped([["k1", 8]]),
+            mapped([]),
+            mapped([["k2", -2]]),
+        ],
+    }
+    difference = compare_outcomes(reference, candidate)
+    failure = {
+        "minimized_recipe": recipe.to_dict(),
+        "difference": difference.to_dict(),
+        "reference": reference,
+        "candidate": candidate,
+    }
+    fingerprint = failure_fingerprint(failure)
+    assert fingerprint == (
+        "70b8f025dfa3f8d634861689a9bdf0ca1ec3c46b0dccb6d8153d340f57e66fa1"
+    )
+    assert fingerprint in fingerprints
+
+
 def test_generated_key_set_recipes_avoid_ruled_no_tick_space():
     # The generator stays out of the ruled no-change space: dedup_size is
     # always true, the initial map is never empty, and no delta nets to no
@@ -1203,6 +1244,22 @@ def test_switch_flip_map_removal_relation_is_narrowly_bounded():
         )
 
     assert classify(reference, candidate)
+    earlier_candidate = [initial, candidate[1], response]
+    assert classify(reference, earlier_candidate)
+    # Only the single silent feedback cycle immediately after the flip may be
+    # removed; multiple-cycle shifts and altered earlier responses are defects.
+    assert not classify(
+        [initial, mapped([]), None, None, response],
+        earlier_candidate,
+    )
+    assert not classify(
+        reference,
+        [initial, candidate[1], mapped([["k1", 4], ["k2", 6]])],
+    )
+    assert not classify(
+        [initial, mapped([]), mapped([]), response],
+        earlier_candidate,
+    )
     # The removal must cover exactly every output live before the flip.
     assert not classify(
         reference,
@@ -1240,6 +1297,51 @@ def test_switch_flip_map_removal_relation_is_narrowly_bounded():
         },
     }
     assert not classify(reference, candidate, with_recipe=initial_alpha)
+
+
+def test_request_reply_one_cycle_earlier_relation_is_exact():
+    from tools.parity.known import (
+        is_known_family_failure,
+        load_known_divergences,
+        matches_known_family,
+    )
+
+    _fingerprints, families = load_known_divergences()
+    timing_families = [
+        family
+        for family in families
+        if family["family"] == "self-coupled-request-reply-one-cycle-earlier"
+    ]
+    assert len(timing_families) == 1
+    recipe = {
+        "template": "service_request_reply",
+        "inputs": {"value": [5, 7, None, 2]},
+        "parameters": {"increment": 3, "path": "requests"},
+    }
+    assert matches_known_family(recipe, timing_families)
+    ok = lambda trace: {"status": "ok", "trace": trace}
+
+    def classify(reference, candidate):
+        difference = compare_outcomes(ok(reference), ok(candidate))
+        assert difference is not None
+        return is_known_family_failure(
+            recipe,
+            difference.to_dict(),
+            ok(reference),
+            ok(candidate),
+            timing_families,
+        )
+
+    reference = [None, None, 8, 10, None, 5]
+    candidate = [None, 8, 10, None, 5]
+    assert classify(reference, candidate)
+    # Payload changes, interior-cycle removal, and multiple-cycle advances are
+    # not the RFC 0014 timing difference.
+    assert not classify(reference, [None, 8, 11, None, 5])
+    assert not classify(reference, [None, 8, 10, 5, None])
+    assert not classify(reference, [8, 10, None, 5])
+    # A trace without a response is not accepted merely because it is shorter.
+    assert not classify([None, None], [None])
 
 
 def test_nested_no_change_retick_family_is_elision_only():

--- a/python/tests/test_python_authoring.py
+++ b/python/tests/test_python_authoring.py
@@ -771,7 +771,7 @@ def test_request_reply_service_path_and_scalar_configuration():
         return adjust(value, path="rr")
 
     out = eval_node(app, [5], __end_time__=hg.MIN_ST + 4 * hg.MIN_TD)
-    check(out == [None, None, 10], f"configured request/reply: {out}")
+    check(out == [None, 10], f"configured request/reply: {out}")
 
 
 def test_subscription_service_can_use_a_python_compute_node():

--- a/python/tests/test_replyless_request_reply_timing.py
+++ b/python/tests/test_replyless_request_reply_timing.py
@@ -3,8 +3,8 @@
 RFC 0012. A request/reply service declaring no response is a sink: clients
 send, the implementation consumes, nothing comes back. It used to be wired on
 the rank-free request transport, which forwards on the NEXT cycle - rank-freedom
-that exists to permit request/reply *cycles* via the response feedback edge. A
-reply-less service builds no feedback, so it paid the latency for nothing.
+that exists to permit request/reply *cycles*. A reply-less service has no
+response path, so it paid the latency for nothing.
 
 The same root shape as a sink-only adaptor always delivered in the same cycle;
 these tests pin that the two now agree while dynamically-started nested clients
@@ -155,8 +155,8 @@ def test_replyless_service_in_dynamic_map_defers_the_outer_handoff():
     assert seen == [(1, 1), (3, 2)], seen
 
 
-def test_reply_full_request_reply_timing_is_unchanged():
-    """The rank-free path is load-bearing when a response exists."""
+def test_self_coupled_reply_full_request_reply_keeps_one_boundary():
+    """A direct input-to-output implementation defers its request once."""
     @hg.request_reply_service
     def double(value: TS[int], path: str = "d") -> TS[int]: ...
 
@@ -169,6 +169,6 @@ def test_reply_full_request_reply_timing_is_unchanged():
         hg.register_service("d", double_impl)
         return double(value, path="d")
 
-    # Request and response each cross their own transport boundary.
+    # The request breaks the cycle; the response publishes directly.
     out = eval_node(app, [5], __end_time__=hg.MIN_ST + 6 * hg.MIN_TD)
-    assert out == [None, None, 10], out
+    assert out == [None, 10], out

--- a/python/tests/test_service_push_sources.py
+++ b/python/tests/test_service_push_sources.py
@@ -19,6 +19,7 @@ and the one ``@service_impl`` case (kafka) needs a broker.
 """
 
 import datetime
+import queue
 import threading
 import time
 
@@ -148,6 +149,57 @@ def test_request_reply_service_impl_may_own_a_push_queue():
     for thread in threads:
         thread.join()
     assert collected == [55]
+
+
+def test_request_reply_from_to_graph_decouples_request_sink_and_response_source():
+    """The Kafka-style shape needs no artificial request/response feedback."""
+    collected = []
+    outbound = queue.Queue()
+    workers = []
+
+    @hg.request_reply_service
+    def exchange(value: TS[int], path: str = "exchange") -> TS[int]: ...
+
+    @hg.reference_service
+    def transport_ready(path: str = "exchange") -> TS[bool]: ...
+
+    @hg.push_queue(TSD[int, TS[int]])
+    def response_source(sender):
+        def respond():
+            # The graph runs for two seconds; leave additional headroom for a
+            # loaded CI worker without allowing a missing request to hang.
+            request_id, value = outbound.get(timeout=5.0)
+            sender({request_id: value + 100})
+
+        worker = threading.Thread(target=respond)
+        workers.append(worker)
+        worker.start()
+
+    @hg.sink_node
+    def request_sink(requests: TSD[int, TS[int]]) -> None:
+        for request_id, value in requests.modified_items():
+            if value.valid:
+                outbound.put((request_id, value.value))
+
+    @hg.service_impl(interfaces=(exchange, transport_ready))
+    def exchange_impl(path: str):
+        request_sink(hg.from_graph(exchange, path))
+        hg.to_graph(exchange, response_source(), path)
+        hg.to_graph(transport_ready, hg.const(True), path)
+
+    @hg.sink_node
+    def collect(value: TS[int]) -> None:
+        collected.append(value.value)
+
+    @graph
+    def live() -> None:
+        hg.register_service("exchange", exchange_impl)
+        collect(exchange(hg.const(7), path="exchange"))
+
+    _run(live)
+    for worker in workers:
+        worker.join()
+    assert collected == [107]
 
 
 def test_push_queue_inside_a_nested_graph_is_still_rejected():

--- a/python/tests/test_service_timing_semantics.py
+++ b/python/tests/test_service_timing_semantics.py
@@ -2,7 +2,8 @@
 
 The scheduling matrix in ``docs/source/developer_guide/services.rst`` is the
 design record: adaptors are rank-correct and same-cycle, subscription changes
-are delivered in order, and request/reply alone retains its temporal break.
+are delivered in order, and self-coupled request/reply retains one temporal
+break while publishing its response directly.
 
 Issue #95 is a separate reduce boundary: released hgraph waits when a keyed
 mapped slot is live but not yet valid, whereas hg_cpp reduces the currently
@@ -113,7 +114,7 @@ def test_request_reply_inside_a_mapped_switch_keeps_late_keys():
         [{"k1": 3}, {"k2": 4}, None, {"k1": hg.REMOVE}],
         ["alpha", None, "beta", None],
         __end_time__=hg.MIN_ST + 10 * hg.MIN_TD,
-    ) == [0, None, 10, 6]
+    ) == [0, 5, 10, 6]
 
 
 def test_request_reply_switch_flip_removes_transiently_invalid_map_output():
@@ -147,13 +148,41 @@ def test_request_reply_switch_flip_removes_transiently_invalid_map_output():
     # Issues #105/#117/#119/#133/#145: changing branches invalidates the
     # switch output while the request/reply response is in flight. A TSD
     # contains only valid child outputs, so the old beta value is explicitly
-    # removed and the alpha response later adds the key again.
+    # removed and the alpha response adds the key on the following tick.
     assert eval_node(
         app,
         [{"k1": 3}, None],
         ["beta", "alpha"],
         __end_time__=hg.MIN_ST + 6 * hg.MIN_TD,
-    ) == [{"k1": 4}, {"k1": hg.REMOVE}, None, {"k1": 5}]
+    ) == [{"k1": 4}, {"k1": hg.REMOVE}, {"k1": 5}]
+
+
+def test_service_dependent_request_reply_retains_full_feedback():
+    @hg.reference_service
+    def offset(path: str = "dependency") -> TS[int]: ...
+
+    @hg.service_impl(interfaces=offset)
+    def offset_impl(path: str = "dependency") -> TS[int]:
+        return hg.const(1)
+
+    @hg.request_reply_service
+    def adjust(value: TS[int], path: str = "dependent") -> TS[int]: ...
+
+    @hg.service_impl(interfaces=adjust)
+    def adjust_impl(values: TSD[int, TS[int]]) -> TSD[int, TS[int]]:
+        increment = offset(path="dependency")
+        return hg.map_(lambda value, amount: value + amount,
+                       values, amount=increment)
+
+    @graph
+    def app(value: TS[int]) -> TS[int]:
+        hg.register_service("dependency", offset_impl)
+        hg.register_service("dependent", adjust_impl)
+        return adjust(value, path="dependent")
+
+    assert eval_node(
+        app, [5], __end_time__=hg.MIN_ST + 5 * hg.MIN_TD,
+    ) == [None, None, 6]
 
 
 def test_subscription_inside_a_mapped_switch_keeps_late_keys():

--- a/python/tests/test_signature_compatibility.py
+++ b/python/tests/test_signature_compatibility.py
@@ -307,8 +307,8 @@ def test_service_resolvers_and_registration_resolution_dict():
             value, path="registered-adaptor")
 
     end_time = hg.MIN_ST + 4 * hg.MIN_TD
-    assert hg.eval_node(resolved_app, [1], __end_time__=end_time) == [None, None, 1]
-    assert hg.eval_node(registered_app, [2], __end_time__=end_time) == [None, None, 2]
+    assert hg.eval_node(resolved_app, [1], __end_time__=end_time) == [None, 1]
+    assert hg.eval_node(registered_app, [2], __end_time__=end_time) == [None, 2]
     assert hg.eval_node(
         registered_adaptor_app, [3], __end_time__=end_time) == [3]
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -99,6 +99,7 @@ set(HGRAPH_WIRING_SOURCES
     hgraph/types/operator_dispatch.cpp
     hgraph/types/record_replay.cpp
     hgraph/types/registry_reset.cpp
+    hgraph/types/impl/request_reply_transport.cpp
     hgraph/types/service_runtime.cpp
     hgraph/types/type_pattern.cpp
     hgraph/types/wiring_observer.cpp

--- a/src/hgraph/types/graph_wiring.cpp
+++ b/src/hgraph/types/graph_wiring.cpp
@@ -1114,6 +1114,7 @@ struct Wiring::Impl {
     std::unordered_set<std::string> required_endpoints{};
     std::unordered_map<std::string, ResolutionMap> endpoint_resolutions{};
     std::unordered_set<std::string> used_endpoints{};
+    std::shared_ptr<bool> boundary_dependency{std::make_shared<bool>(false)};
     bool require_all{true};
   };
 
@@ -1173,6 +1174,8 @@ struct Wiring::Impl {
   GlobalState global_state{};  // stateless-wiring fallback (no live context)
   bool live_seeded{false};
   std::vector<std::shared_ptr<void>> extension_state{};
+  std::unordered_map<std::type_index, std::shared_ptr<void>> keyed_extension_state{};
+  std::vector<std::function<void(Wiring &)>> pre_rank_finalizers{};
   std::shared_ptr<WiringObserverRegistry> observers{};
   std::vector<std::string> wiring_path{};
   WiringKind kind{WiringKind::TopLevel};
@@ -1348,6 +1351,33 @@ void Wiring::retain_extension_state(std::shared_ptr<void> state) {
   }
   impl_->extension_state.push_back(std::move(state));
 }
+
+std::shared_ptr<void> Wiring::acquire_extension_state(
+    std::type_index key, std::function<std::shared_ptr<void>()> create) {
+  if (const auto found = impl_->keyed_extension_state.find(key);
+      found != impl_->keyed_extension_state.end()) {
+    return found->second;
+  }
+  if (!create) {
+    throw std::invalid_argument("Wiring extension state requires a factory");
+  }
+  std::shared_ptr<void> state = create();
+  if (state == nullptr) {
+    throw std::invalid_argument("Wiring extension state factory returned null");
+  }
+  impl_->keyed_extension_state.emplace(key, state);
+  return state;
+}
+
+void Wiring::register_pre_rank_finalizer(
+    std::function<void(Wiring &)> finalizer) {
+  if (!finalizer) {
+    throw std::invalid_argument("Wiring pre-rank finalizer must be callable");
+  }
+  impl_->pre_rank_finalizers.push_back(std::move(finalizer));
+}
+
+WiringKind Wiring::kind() const noexcept { return impl_->kind; }
 
 ErasedDelayedBindingWiringPort::ErasedDelayedBindingWiringPort(
     Wiring &wiring, const TSValueTypeMetaData *schema) {
@@ -1730,6 +1760,9 @@ void Wiring::register_service_client_path(std::string path,
     throw std::invalid_argument(
         "service/adaptor client path must not be empty");
   }
+  for (auto &scope : impl_->implementation_scopes) {
+    *scope.boundary_dependency = true;
+  }
   auto [it, inserted] = impl_->client_service_paths.try_emplace(
       std::move(path), Impl::ServiceClientIdentity{
           .kind = std::string{kind},
@@ -2073,6 +2106,14 @@ std::string_view Wiring::service_materialization_path() const noexcept {
   return impl_->service_materialization_path;
 }
 
+std::shared_ptr<const bool>
+Wiring::service_implementation_boundary_dependency() const {
+  if (impl_->implementation_scopes.empty()) {
+    return {};
+  }
+  return impl_->implementation_scopes.back().boundary_dependency;
+}
+
 Wiring::ServiceImplementationScope::ServiceImplementationScope(
     Wiring &wiring, std::string description,
     std::vector<WiringServiceImplementationEndpoint> required_endpoints,
@@ -2402,6 +2443,15 @@ void Wiring::apply_service_rank_dependencies() {
   }
 }
 
+void Wiring::finalize_extensions() {
+  // Finalizers are required to be idempotent because snapshot() may be called
+  // repeatedly. Use an index so an extension registered by another finalizer
+  // in this pass is also given a chance to complete before ranking.
+  for (std::size_t index = 0; index < impl_->pre_rank_finalizers.size(); ++index) {
+    impl_->pre_rank_finalizers[index](*this);
+  }
+}
+
 GraphBuilder Wiring::finish_top_level(bool consume_state) {
   if (!impl_->implementation_scopes.empty()) {
     throw std::logic_error("Wiring::finish encountered an unterminated "
@@ -2415,6 +2465,7 @@ GraphBuilder Wiring::finish_top_level(bool consume_state) {
     }
   }
 
+  finalize_extensions();
   apply_service_rank_dependencies(); // add_rank_dependency de-dupes: idempotent
   GlobalState *live = impl_->kind == WiringKind::TopLevel && impl_->live_seeded
                           ? GlobalContext::active_state()
@@ -2462,6 +2513,7 @@ CompiledSubGraph Wiring::finish_subgraph(
     throw std::logic_error("Wiring::finish_subgraph encountered an "
                            "unterminated service/adaptor implementation scope");
   }
+  finalize_extensions();
   apply_service_rank_dependencies();
   const TypeRealizationSnapshot *active_realization =
       active_type_realization();

--- a/src/hgraph/types/impl/request_reply_transport.cpp
+++ b/src/hgraph/types/impl/request_reply_transport.cpp
@@ -1,0 +1,322 @@
+#include <hgraph/types/request_reply_transport.h>
+
+#include <hgraph/runtime/feedback_node.h>
+#include <hgraph/runtime/service_node.h>
+#include <hgraph/runtime/shared_output_node.h>
+
+#include <array>
+#include <memory>
+#include <optional>
+#include <stdexcept>
+#include <unordered_map>
+#include <unordered_set>
+#include <utility>
+#include <vector>
+
+namespace hgraph::request_reply_transport
+{
+    namespace
+    {
+        struct request_reply_feedback_source_marker
+        {
+        };
+
+        struct request_reply_feedback_sink_marker
+        {
+        };
+
+        struct PendingClient
+        {
+            std::string                base_path{};
+            std::string                request_path{};
+            std::string                response_path{};
+            const TSValueTypeMetaData *request_schema{nullptr};
+            WiringPortRef              request{};
+            WiringPortRef              request_source{};
+            WiringPortRef              request_id{};
+            WiringPortRef              response_source{};
+            std::type_index            capture_role{typeid(void)};
+        };
+
+        struct PendingOutput
+        {
+            std::string                 base_path{};
+            std::string                 response_path{};
+            const TSValueTypeMetaData  *response_dict_schema{nullptr};
+            WiringPortRef               output{};
+            WiringPortRef               response_source{};
+            std::type_index             capture_role{typeid(void)};
+            std::shared_ptr<const bool> boundary_dependency{};
+        };
+
+        struct Planner
+        {
+            std::unordered_map<std::string, const WiringInstance *>    implementation_inputs{};
+            std::unordered_map<std::string, RequestReplyTransportPlan> plans{};
+            std::vector<PendingClient>                                 clients{};
+            std::vector<PendingOutput>                                 outputs{};
+            std::size_t                                                finalized_clients{0};
+            std::size_t                                                finalized_outputs{0};
+
+            void finalize(Wiring &w);
+        };
+
+        [[nodiscard]] bool port_depends_on(const WiringPortRef &port, const WiringInstance *target,
+                                           std::unordered_set<const WiringInstance *> &visited);
+
+        [[nodiscard]] bool node_depends_on(const WiringInstance *node, const WiringInstance *target,
+                                           std::unordered_set<const WiringInstance *> &visited)
+        {
+            if (node == target)
+            {
+                return true;
+            }
+            if (node == nullptr || !visited.insert(node).second)
+            {
+                return false;
+            }
+            for (const WiringInputRef &input : node->inputs)
+            {
+                // Passive/recovery links do not establish data causality and
+                // are deliberately excluded from the transport decision.
+                if (input.rank_dependency && port_depends_on(input.source, target, visited))
+                {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        [[nodiscard]] bool port_depends_on(const WiringPortRef &port, const WiringInstance *target,
+                                           std::unordered_set<const WiringInstance *> &visited)
+        {
+            if (port.is_delayed_source())
+            {
+                const auto &state = port.delayed_state();
+                return state != nullptr && state->source.has_value() &&
+                       port_depends_on(*state->source, target, visited);
+            }
+            if (port.is_peered_source())
+            {
+                return node_depends_on(port.peered_node(), target, visited);
+            }
+            if (port.is_structural_source())
+            {
+                for (const WiringPortRef &child : port.structural_children())
+                {
+                    if (port_depends_on(child, target, visited))
+                    {
+                        return true;
+                    }
+                }
+            }
+            return false;
+        }
+
+        [[nodiscard]] bool output_depends_on(const WiringPortRef &output, const WiringInstance *request_source)
+        {
+            std::unordered_set<const WiringInstance *> visited;
+            return port_depends_on(output, request_source, visited);
+        }
+
+        [[nodiscard]] WiringPortRef response_feedback(Wiring &w, WiringPortRef response,
+                                                      const TSValueTypeMetaData &schema)
+        {
+            WiringPortRef feedback =
+                w.add_unique_node(std::type_index(typeid(request_reply_feedback_source_marker)),
+                                  make_feedback_source_node(schema), std::span<const WiringPortRef>{}, Value{});
+            std::array<WiringPortRef, 2> sources{
+                graph_wiring_detail::adapt_source_for_input(w, &schema, std::move(response)),
+                feedback,
+            };
+            std::array<WiringInputRef, 2> inputs{{
+                WiringInputRef{.source = sources[0]},
+                WiringInputRef{.source = sources[1], .rank_dependency = false},
+            }};
+            NodeBuilder                   sink = make_feedback_sink_node(schema);
+            sink.input_endpoint(graph_wiring_detail::input_endpoint_for_sources(
+                sink.type().schema()->input_schema, std::span<const WiringPortRef>{sources.data(), sources.size()}));
+            static_cast<void>(
+                w.add_unique_node(std::type_index(typeid(request_reply_feedback_sink_marker)), std::move(sink),
+                                  std::span<const WiringInputRef>{inputs.data(), inputs.size()}, Value{}));
+            return feedback;
+        }
+
+        [[nodiscard]] const WiringInstance *publish_response(Wiring &w, const PendingOutput &pending,
+                                                             RequestReplyTransportPlan plan)
+        {
+            WiringPortRef output = pending.output;
+            if (plan == RequestReplyTransportPlan::FullFeedback)
+            {
+                output = response_feedback(w, std::move(output), *pending.response_dict_schema);
+            }
+            else
+            {
+                output =
+                    graph_wiring_detail::adapt_source_for_input(w, pending.response_dict_schema, std::move(output));
+            }
+
+            std::array<WiringPortRef, 2>  sources{std::move(output), pending.response_source};
+            std::array<WiringInputRef, 2> inputs{{
+                WiringInputRef{.source = sources[0]},
+                WiringInputRef{.source = sources[1], .rank_dependency = false},
+            }};
+            NodeBuilder builder = make_shared_output_capture_node(pending.response_path, *pending.response_dict_schema);
+            builder.input_endpoint(graph_wiring_detail::input_endpoint_for_sources(
+                builder.type().schema()->input_schema, std::span<const WiringPortRef>{sources.data(), sources.size()}));
+            WiringPortRef capture = w.add_node(pending.capture_role, std::move(builder),
+                                               std::span<const WiringInputRef>{inputs.data(), inputs.size()}, Value{});
+            w.add_same_cycle_pair(capture.peered_node(), pending.response_source.peered_node());
+            w.register_service_rank_anchor(pending.response_path, capture.peered_node());
+            return capture.peered_node();
+        }
+
+        void publish_request(Wiring &w, const PendingClient &pending, RequestReplyTransportPlan plan)
+        {
+            const bool                    direct = plan == RequestReplyTransportPlan::Direct;
+            std::array<WiringPortRef, 3>  sources{pending.request, pending.request_source, pending.request_id};
+            std::array<WiringInputRef, 3> inputs{{
+                WiringInputRef{.source = sources[0]},
+                WiringInputRef{.source = sources[1], .rank_dependency = false},
+                WiringInputRef{.source = sources[2]},
+            }};
+            NodeBuilder                   builder =
+                make_request_input_capture_node(pending.request_path, *pending.request_schema, direct);
+            builder.input_endpoint(graph_wiring_detail::input_endpoint_for_sources(
+                builder.type().schema()->input_schema, std::span<const WiringPortRef>{sources.data(), sources.size()}));
+            WiringPortRef capture = w.add_node(pending.capture_role, std::move(builder),
+                                               std::span<const WiringInputRef>{inputs.data(), inputs.size()}, Value{});
+            if (direct)
+            {
+                w.register_service_client_rank(pending.request_path, "request/reply service", capture.peered_node(),
+                                               false);
+            }
+            if (plan != RequestReplyTransportPlan::FullFeedback)
+            {
+                w.register_service_client_rank(pending.response_path, "request/reply service",
+                                               pending.response_source.peered_node(), true);
+            }
+        }
+
+        void Planner::finalize(Wiring &w)
+        {
+            while (finalized_outputs < outputs.size())
+            {
+                const PendingOutput &pending = outputs[finalized_outputs++];
+                const auto           input = implementation_inputs.find(pending.base_path);
+                if (input == implementation_inputs.end() || input->second == nullptr)
+                {
+                    throw std::logic_error("request/reply implementation '" + pending.base_path +
+                                           "' published an output without its request input");
+                }
+
+                RequestReplyTransportPlan plan = RequestReplyTransportPlan::Direct;
+                if (pending.boundary_dependency != nullptr && *pending.boundary_dependency)
+                {
+                    plan = RequestReplyTransportPlan::FullFeedback;
+                }
+                else if (output_depends_on(pending.output, input->second))
+                {
+                    plan = RequestReplyTransportPlan::RequestDeferred;
+                }
+                auto [it, inserted] = plans.try_emplace(pending.base_path, plan);
+                if (!inserted && it->second != plan)
+                {
+                    throw std::logic_error("request/reply implementation '" + pending.base_path +
+                                           "' produced conflicting transport plans");
+                }
+                static_cast<void>(publish_response(w, pending, plan));
+            }
+
+            while (finalized_clients < clients.size())
+            {
+                const PendingClient &pending = clients[finalized_clients++];
+                const auto           selected = plans.find(pending.base_path);
+                if (selected == plans.end())
+                {
+                    if (w.kind() == WiringKind::TopLevel)
+                    {
+                        throw std::logic_error("request/reply implementation '" + pending.base_path +
+                                               "' did not publish a response transport");
+                    }
+                    // A child externalizes the service. Both request modes hand
+                    // off to the owner on the next tick, so retain the
+                    // conservative unranked capture in the compiled child.
+                    publish_request(w, pending, RequestReplyTransportPlan::RequestDeferred);
+                    continue;
+                }
+                publish_request(w, pending, selected->second);
+            }
+        }
+
+        [[nodiscard]] std::shared_ptr<Planner> planner_for(Wiring &w)
+        {
+            auto state = std::static_pointer_cast<Planner>(w.acquire_extension_state(
+                std::type_index(typeid(Planner)), [] { return std::make_shared<Planner>(); }));
+            if (state->clients.empty() && state->outputs.empty() && state->implementation_inputs.empty())
+            {
+                std::weak_ptr<Planner> weak = state;
+                w.register_pre_rank_finalizer(
+                    [weak](Wiring &target)
+                    {
+                        if (const auto planner = weak.lock())
+                        {
+                            planner->finalize(target);
+                        }
+                    });
+            }
+            return state;
+        }
+    }  // namespace
+
+    void defer_client(Wiring &w, std::string base_path, std::string request_path, std::string response_path,
+                      const TSValueTypeMetaData &request_schema, WiringPortRef request, WiringPortRef request_source,
+                      WiringPortRef request_id, WiringPortRef response_source, std::type_index capture_role)
+    {
+        planner_for(w)->clients.push_back(PendingClient{
+            .base_path = std::move(base_path),
+            .request_path = std::move(request_path),
+            .response_path = std::move(response_path),
+            .request_schema = &request_schema,
+            .request = std::move(request),
+            .request_source = std::move(request_source),
+            .request_id = std::move(request_id),
+            .response_source = std::move(response_source),
+            .capture_role = capture_role,
+        });
+    }
+
+    void register_implementation_input(Wiring &w, std::string base_path, const WiringInstance *request_source)
+    {
+        if (request_source == nullptr)
+        {
+            throw std::invalid_argument("request/reply implementation input must name a source");
+        }
+        auto planner = planner_for(w);
+        auto [it, inserted] = planner->implementation_inputs.try_emplace(std::move(base_path), request_source);
+        if (!inserted && it->second != request_source)
+        {
+            throw std::invalid_argument("duplicate request/reply implementation input for '" + it->first + "'");
+        }
+    }
+
+    void defer_implementation_output(Wiring &w, std::string base_path, std::string response_path,
+                                     const TSValueTypeMetaData &response_dict_schema, WiringPortRef output,
+                                     WiringPortRef response_source, std::type_index capture_role)
+    {
+        auto dependency = w.service_implementation_boundary_dependency();
+        if (dependency == nullptr)
+        {
+            throw std::logic_error("request/reply output must be wired inside its implementation scope");
+        }
+        planner_for(w)->outputs.push_back(PendingOutput{
+            .base_path = std::move(base_path),
+            .response_path = std::move(response_path),
+            .response_dict_schema = &response_dict_schema,
+            .output = std::move(output),
+            .response_source = std::move(response_source),
+            .capture_role = capture_role,
+            .boundary_dependency = std::move(dependency),
+        });
+    }
+}  // namespace hgraph::request_reply_transport

--- a/src/hgraph/types/service_runtime.cpp
+++ b/src/hgraph/types/service_runtime.cpp
@@ -3,6 +3,7 @@
 #include <hgraph/types/graph_wiring.h>
 #include <hgraph/types/operator_dispatch.h>
 #include <hgraph/types/adaptor_wiring.h>
+#include <hgraph/types/request_reply_transport.h>
 #include <hgraph/types/service_wiring.h>
 
 #include <unordered_set>
@@ -545,38 +546,32 @@ namespace hgraph
         WiringPortRef requests = request_input_source_node(w, descriptor, request_path);
         w.register_service_rank_anchor(request_path, requests.peered_node());
 
-        // A REPLY-LESS service is a keyed sink: there is no response, hence no
-        // response feedback edge, hence no request/reply cycle to permit. It
-        // therefore takes the ranked same-cycle relay, like a sink-only
-        // adaptor, and the implementation observes a request in the cycle the
-        // client sent it rather than the next one (RFC 0012). A service WITH a
-        // response keeps the rank-free path below: that is what makes
-        // recursive request/reply legal, and its ordering comes from the
-        // feedback edge instead.
+        // A REPLY-LESS service is a keyed sink and takes the ranked same-cycle
+        // relay (RFC 0012). Reply-full clients are deferred until their
+        // implementation has materialized so RFC 0014 can choose the least
+        // costly transport that preserves its dependency cycles.
         const bool reply_less = descriptor.response_schema == nullptr;
-
-        WiringPortRef adapted_request = graph_wiring_detail::adapt_source_for_input(
-            w, descriptor.request_schema, request);
-        std::array<WiringPortRef, 3>  sources{std::move(adapted_request), requests, request_id};
-        std::array<WiringInputRef, 3> inputs{{
-            WiringInputRef{.source = sources[0]},
-            // Never a rank dependency: the capture must not wait on the source
-            // it feeds. Ordering comes from the reply-less service-client rank
-            // below or from the response feedback edge (reply-full).
-            WiringInputRef{.source = sources[1], .rank_dependency = false},
-            WiringInputRef{.source = sources[2]},
-        }};
-        NodeBuilder builder = make_request_input_capture_node(
-            request_path, *descriptor.request_schema, /*same_cycle=*/reply_less);
-        builder.input_endpoint(graph_wiring_detail::input_endpoint_for_sources(
-            builder.type().schema()->input_schema,
-            std::span<const WiringPortRef>{sources.data(), sources.size()}));
-        WiringPortRef capture = w.add_node(
-            std::type_index(typeid(service::detail::request_input_capture_marker)), std::move(builder),
-            std::span<const WiringInputRef>{inputs.data(), inputs.size()}, Value{});
 
         if (reply_less)
         {
+            WiringPortRef adapted_request = graph_wiring_detail::adapt_source_for_input(
+                w, descriptor.request_schema, request);
+            std::array<WiringPortRef, 3> sources{
+                std::move(adapted_request), requests, request_id};
+            std::array<WiringInputRef, 3> inputs{{
+                WiringInputRef{.source = sources[0]},
+                WiringInputRef{.source = sources[1], .rank_dependency = false},
+                WiringInputRef{.source = sources[2]},
+            }};
+            NodeBuilder builder = make_request_input_capture_node(
+                request_path, *descriptor.request_schema, true);
+            builder.input_endpoint(graph_wiring_detail::input_endpoint_for_sources(
+                builder.type().schema()->input_schema,
+                std::span<const WiringPortRef>{sources.data(), sources.size()}));
+            WiringPortRef capture = w.add_node(
+                std::type_index(typeid(service::detail::request_input_capture_marker)),
+                std::move(builder),
+                std::span<const WiringInputRef>{inputs.data(), inputs.size()}, Value{});
             // A reply-less client is a sending boundary, like a sink-only
             // adaptor. At the root the capture ranks before the request source.
             // A dynamically-started nested capture retains the runtime's
@@ -587,6 +582,19 @@ namespace hgraph
         }
 
         WiringPortRef replies = reply_output_source_node(w, descriptor, replies_path);
+        WiringPortRef adapted_request = graph_wiring_detail::adapt_source_for_input(
+            w, descriptor.request_schema, request);
+        request_reply_transport::defer_client(
+            w,
+            base,
+            request_path,
+            replies_path,
+            *descriptor.request_schema,
+            std::move(adapted_request),
+            requests,
+            request_id,
+            replies,
+            std::type_index(typeid(service::detail::request_input_capture_marker)));
 
         WiringPortRef dict = replies;
         dict.schema        = TypeRegistry::instance().tsd(scalar_descriptor<Int>::value_meta(),
@@ -627,9 +635,10 @@ namespace hgraph
                 std::array<WiringPortRef, 1> transport{requests};
                 const auto impl_inputs = combine_impl_inputs(
                     *descriptor_ptr, impl, transport, stored_inputs);
-                WiringPortRef output = wire_impl(target, *descriptor_ptr, impl, impl_inputs);
                 if (descriptor_ptr->response_schema == nullptr)
                 {
+                    WiringPortRef output = wire_impl(
+                        target, *descriptor_ptr, impl, impl_inputs);
                     if (output.schema != nullptr)
                     {
                         throw std::invalid_argument("reply-less service '" + descriptor_ptr->name +
@@ -637,16 +646,26 @@ namespace hgraph
                     }
                     return;
                 }
+                auto scope = target.service_implementation_scope(
+                    "request/reply service " + requested_base,
+                    std::vector<WiringServiceImplementationEndpoint>{}, false);
+                request_reply_transport::register_implementation_input(
+                    target, requested_base, requests.peered_node());
+                WiringPortRef output = wire_impl(
+                    target, *descriptor_ptr, impl, impl_inputs);
                 WiringPortRef replies = reply_output_source_node(target, *descriptor_ptr, replies_path);
                 const auto *dict_meta = TypeRegistry::instance().tsd(
                     scalar_descriptor<Int>::value_meta(), descriptor_ptr->response_schema);
                 output = describe_service_output(*descriptor_ptr, dict_meta, std::move(output));
-                output = service::detail::request_reply_response_feedback(
-                    target, std::move(output), *dict_meta);
-                const WiringInstance *capture = shared_output_capture_node(
-                    target, std::type_index(typeid(service::detail::request_reply_output_capture_marker)),
-                    dict_meta, replies_path, output, replies);
-                target.register_service_rank_anchor(replies_path, capture);
+                request_reply_transport::defer_implementation_output(
+                    target,
+                    requested_base,
+                    replies_path,
+                    *dict_meta,
+                    std::move(output),
+                    std::move(replies),
+                    std::type_index(typeid(service::detail::request_reply_output_capture_marker)));
+                scope.complete();
             };
         if (default_fallback)
         {
@@ -741,10 +760,16 @@ namespace hgraph
                 return source;
             }
             case ServiceFlavour::RequestReply: {
-                const std::string endpoint = request_reply_base(descriptor, path) + "/request";
+                const std::string base = request_reply_base(descriptor, path);
+                const std::string endpoint = base + "/request";
                 w.register_service_implementation_stub(endpoint, "request/reply service");
                 WiringPortRef source = request_input_source_node(w, descriptor, endpoint);
                 w.register_service_rank_anchor(endpoint, source.peered_node());
+                if (descriptor.response_schema != nullptr)
+                {
+                    request_reply_transport::register_implementation_input(
+                        w, base, source.peered_node());
+                }
                 return source;
             }
             case ServiceFlavour::ServiceAdaptor:
@@ -792,17 +817,20 @@ namespace hgraph
                     throw std::invalid_argument("reply-less service '" + descriptor.name +
                                                 "' has no implementation output");
                 }
-                const std::string endpoint = request_reply_base(descriptor, path) + "/replies";
+                const std::string base = request_reply_base(descriptor, path);
+                const std::string endpoint = base + "/replies";
                 w.register_service_implementation_stub(endpoint, "request/reply service");
                 WiringPortRef shared = reply_output_source_node(w, descriptor, endpoint);
                 const auto *dict_meta = TypeRegistry::instance().tsd(scalar_descriptor<Int>::value_meta(),
                                                                      descriptor.response_schema);
-                WiringPortRef feedback = service::detail::request_reply_response_feedback(
-                    w, out, *dict_meta);
-                const WiringInstance *capture = shared_output_capture_node(
-                    w, std::type_index(typeid(service::detail::request_reply_output_capture_marker)),
-                    dict_meta, endpoint, feedback, shared);
-                w.register_service_rank_anchor(endpoint, capture);
+                request_reply_transport::defer_implementation_output(
+                    w,
+                    base,
+                    endpoint,
+                    *dict_meta,
+                    out,
+                    std::move(shared),
+                    std::type_index(typeid(service::detail::request_reply_output_capture_marker)));
                 return;
             }
             case ServiceFlavour::ServiceAdaptor:

--- a/tests/cpp/test_service_wiring.cpp
+++ b/tests/cpp/test_service_wiring.cpp
@@ -1272,6 +1272,41 @@ namespace
         }
     };
 
+    struct DecoupledRequestReplyImplGraph
+    {
+        [[maybe_unused]] static constexpr auto name =
+            "decoupled_request_reply_impl_graph";
+
+        static void compose(
+            Wiring &w,
+            Port<TSD<Int, TS<Int>>> responses,
+            Scalar<"path", Str> path)
+        {
+            const auto custom = service::path(path.value());
+            auto requests = service::from_graph<AddOneService>(w, custom);
+            static_cast<void>(wire<ObserveReplylessRequestsNode>(w, requests));
+            service::to_graph<AddOneService>(w, custom, responses);
+        }
+    };
+
+    struct DecoupledRequestReplyClientGraph
+    {
+        [[maybe_unused]] static constexpr auto name =
+            "decoupled_request_reply_client_graph";
+
+        static Port<TS<Int>> compose(
+            Wiring &w,
+            Port<TS<Int>> request,
+            Port<TSD<Int, TS<Int>>> responses)
+        {
+            const auto custom = service::path("decoupled");
+            service::register_services<
+                DecoupledRequestReplyImplGraph, AddOneService>(
+                    w, custom, responses);
+            return wire<AddOneService>(w, custom, request);
+        }
+    };
+
     struct ReplylessPublishTwoClientGraph
     {
         [[maybe_unused]] static constexpr auto name =
@@ -2344,7 +2379,22 @@ TEST_CASE("service wiring: request/reply client receives keyed implementation re
 {
     hgraph::stdlib::register_standard_operators();
 
-    CHECK_OUTPUT(eval_node<AddOneClientGraph>(values<Int>(1)), values<Int>(none, none, 2));
+    CHECK_OUTPUT(eval_node<AddOneClientGraph>(values<Int>(1)), values<Int>(none, 2));
+}
+
+TEST_CASE("service wiring: decoupled request/reply transport is direct")
+{
+    hgraph::stdlib::register_standard_operators();
+    observed_replyless_requests.clear();
+    const Int response_key = next_request_id() + Int{1};
+
+    CHECK_OUTPUT(
+        eval_node<DecoupledRequestReplyClientGraph>(
+            values<Int>(7),
+            values<Value>(dict_delta<Int, TS<Int>>({{response_key, 107}}))),
+        values<Int>(107));
+    CHECK(observed_replyless_requests ==
+          std::vector<std::pair<std::size_t, Int>>{{0, 7}});
 }
 
 TEST_CASE("service wiring: reply-less clients use the typed same-cycle sink path")
@@ -2401,7 +2451,7 @@ TEST_CASE("service wiring: request/reply service supports explicit paths")
 {
     hgraph::stdlib::register_standard_operators();
 
-    CHECK_OUTPUT(eval_node<AddOnePathClientGraph>(values<Int>(7)), values<Int>(none, none, 107));
+    CHECK_OUTPUT(eval_node<AddOnePathClientGraph>(values<Int>(7)), values<Int>(none, 107));
 }
 
 TEST_CASE("service wiring: request/reply source emits cumulative client requests")
@@ -2409,22 +2459,21 @@ TEST_CASE("service wiring: request/reply source emits cumulative client requests
     hgraph::stdlib::register_standard_operators();
 
     CHECK_OUTPUT(eval_node<AddOneTwoClientGraph>(values<Int>(1), values<Int>(10)),
-                 values<Int>(none, none, 13));
+                 values<Int>(none, 13));
 }
 
-TEST_CASE("service wiring: response feedback preserves requests from successive cycles")
+TEST_CASE("service wiring: request relay preserves requests from successive cycles")
 {
     hgraph::stdlib::register_standard_operators();
 
     CHECK_OUTPUT(
         eval_node<AddOneClientGraph>(values<Int>(1, 2)),
-        values<Int>(none, none, 2, 3));
+        values<Int>(none, 2, 3));
 
     CHECK_OUTPUT(
         eval_node<AddOneStagedClientGraph>(
             values<Int>(1, none), values<Int>(none, 10)),
         values<Value>(
-            none,
             none,
             list_delta<TS<Int>>({2, none}),
             list_delta<TS<Int>>({none, 11})));
@@ -2436,10 +2485,10 @@ TEST_CASE("service wiring: request/reply transports recursive bundle deltas")
 
     CHECK_OUTPUT(eval_node<SumPairClientGraph>(values<Int>(1, none, 2),
                                                values<Int>(10, none, none)),
-                 values<Int>(none, none, 11, none, 12));
+                 values<Int>(none, 11, none, 12));
 }
 
-TEST_CASE("service wiring: request/reply feedback belongs to the owning graph")
+TEST_CASE("service wiring: self-contained request/reply omits response feedback")
 {
     hgraph::stdlib::register_standard_operators();
 
@@ -2447,6 +2496,31 @@ TEST_CASE("service wiring: request/reply feedback belongs to the owning graph")
     auto requests = ts_harness<TSD<Int, TS<Int>>>::wire_replay(
         wiring, "request_reply_feedback_owner");
     static_cast<void>(MappedServiceClientGraph::compose(wiring, requests));
+    const GraphBuilder first_snapshot = wiring.snapshot();
+    const GraphBuilder graph = wiring.snapshot();
+    CHECK(graph.nodes().size() == first_snapshot.nodes().size());
+    std::size_t feedback_sources = 0;
+    std::size_t feedback_sinks = 0;
+    for (const NodeBuilder &node : graph.nodes())
+    {
+        const NodeTypeMetaData *meta = node.type().schema();
+        if (meta == nullptr || meta->display_name == nullptr) { continue; }
+        const std::string_view name{meta->display_name};
+        feedback_sources += name == "feedback_source" ? 1 : 0;
+        feedback_sinks += name == "feedback_sink" ? 1 : 0;
+    }
+    CHECK(feedback_sources == 0);
+    CHECK(feedback_sinks == 0);
+}
+
+TEST_CASE("service wiring: a service-dependent request/reply retains full feedback")
+{
+    hgraph::stdlib::register_standard_operators();
+
+    Wiring wiring;
+    auto request = ts_harness<TS<Int>>::wire_replay(
+        wiring, "request_reply_recursive_feedback_owner");
+    static_cast<void>(RecursiveAddOneClientGraph::compose(wiring, request));
     const GraphBuilder graph = std::move(wiring).finish();
     std::size_t feedback_sources = 0;
     std::size_t feedback_sinks = 0;
@@ -2469,7 +2543,6 @@ TEST_CASE("service wiring: map and mesh children call an outer request/reply ser
     const auto requests = values<Value>(dict_delta<Int, TS<Int>>({{1, 10}, {2, 20}}));
     const auto expected = values<Value>(
         dict_delta<Int, TS<Int>>({}),
-        none,
         dict_delta<Int, TS<Int>>({{1, 12}, {2, 22}}));
     CHECK_OUTPUT(eval_node<MappedServiceClientGraph>(requests), expected);
     CHECK_OUTPUT(eval_node<MeshedServiceClientGraph>(requests), expected);
@@ -2489,7 +2562,7 @@ TEST_CASE("service wiring: request/reply under map switch retains late keys")
                 none,
                 dict_delta<Int, TS<Int>>({}, {1})),
             values<Str>(Str{"alpha"}, none, Str{"beta"}, none)),
-        values<Int>(0, none, 10, 6));
+        values<Int>(0, 4, 10, 6));
 }
 
 TEST_CASE("service wiring: request/reply switch flip removes an invalid map output")
@@ -2506,7 +2579,6 @@ TEST_CASE("service wiring: request/reply switch flip removes an invalid map outp
         values<Value>(
             dict_delta<Int, TS<Int>>({{1, 6}}),
             dict_delta<Int, TS<Int>>({}, {1}),
-            none,
             dict_delta<Int, TS<Int>>({{1, 5}})));
 }
 
@@ -2528,10 +2600,10 @@ TEST_CASE("service wiring: a mapped response survives a new key in its delivery 
                           none),
             values<Str>(Str{"alpha"}, none, none, none, none)),
         values<Value>(dict_delta<Int, TS<Int>>({}),
-                      none,
                       dict_delta<Int, TS<Int>>({{1, 5}}),
-                      none,
-                      dict_delta<Int, TS<Int>>({{2, 11}})));
+                      dict_delta<Int, TS<Int>>({}),
+                      dict_delta<Int, TS<Int>>({{2, 11}}),
+                      none));
 }
 
 TEST_CASE("service wiring: a meshed response survives a new key in its delivery cycle")
@@ -2549,10 +2621,10 @@ TEST_CASE("service wiring: a meshed response survives a new key in its delivery 
                           none),
             values<Str>(Str{"alpha"}, none, none, none, none)),
         values<Value>(dict_delta<Int, TS<Int>>({}),
-                      none,
                       dict_delta<Int, TS<Int>>({{1, 5}}),
-                      none,
-                      dict_delta<Int, TS<Int>>({{2, 11}})));
+                      dict_delta<Int, TS<Int>>({}),
+                      dict_delta<Int, TS<Int>>({{2, 11}}),
+                      none));
 }
 
 TEST_CASE("service wiring: subscription under map switch retains late keys")
@@ -2612,7 +2684,7 @@ TEST_CASE("service wiring: multi-interface implementation graph wires explicit s
 {
     hgraph::stdlib::register_standard_operators();
 
-    CHECK_OUTPUT(eval_node<MultiServiceClientGraph>(values<Int>(1)), values<Int>(none, none, 13));
+    CHECK_OUTPUT(eval_node<MultiServiceClientGraph>(values<Int>(1)), values<Int>(none, 13));
 }
 
 TEST_CASE("service wiring: a source-only adaptor is unambiguous alongside services")
@@ -2655,7 +2727,7 @@ TEST_CASE("service wiring: a single-interface implementation may publish by stub
     // from_graph/to_graph rather than by returning a port.
     single_interface_stub_compositions = 0;
     CHECK_OUTPUT(eval_node<SingleInterfaceStubClientGraph>(values<Int>(1)),
-                 values<Int>(none, none, 2));
+                 values<Int>(none, 2));
     CHECK(single_interface_stub_compositions == 1);
 }
 
@@ -2679,7 +2751,7 @@ TEST_CASE("service wiring: service from_graph/to_graph spell the same wiring as 
     // verbs - they are aliases onto impl_input/impl_output, not a second
     // mechanism, so the observable result must match exactly.
     CHECK_OUTPUT(eval_node<MultiServiceFromToGraphClientGraph>(values<Int>(1)),
-                 values<Int>(none, none, 13));
+                 values<Int>(none, 13));
 }
 
 TEST_CASE("service wiring: shared replay service hands clients to the live reference")
@@ -2786,16 +2858,16 @@ TEST_CASE("service wiring: templated service descriptors bind as concrete interf
 {
     hgraph::stdlib::register_standard_operators();
 
-    CHECK_OUTPUT(eval_node<TemplateServiceClientGraph>(values<Int>(3)), values<Int>(none, none, 4));
+    CHECK_OUTPUT(eval_node<TemplateServiceClientGraph>(values<Int>(3)), values<Int>(none, 4));
 }
 
 TEST_CASE("service wiring: generic service descriptors resolve from client inputs")
 {
     hgraph::stdlib::register_standard_operators();
 
-    CHECK_OUTPUT(eval_node<GenericServiceClientGraph>(values<Int>(3)), values<Int>(none, none, 4));
+    CHECK_OUTPUT(eval_node<GenericServiceClientGraph>(values<Int>(3)), values<Int>(none, 4));
     CHECK_OUTPUT(eval_node<GenericFloatServiceClientGraph>(values<Float>(1.5)),
-                 values<Float>(none, none, 2.0));
+                 values<Float>(none, 2.0));
     CHECK_OUTPUT(eval_node<GenericServiceAdaptorClientGraph>(values<Int>(3)), values<Int>(23));
     CHECK_THROWS_AS((void)eval_node<GenericStringServiceClientGraph>(values<Str>("not numeric")),
                     std::invalid_argument);

--- a/tools/parity/corpus/service-request-reply-multi-tick.json
+++ b/tools/parity/corpus/service-request-reply-multi-tick.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
   "id": "service-request-reply-multi-tick",
-  "description": "Request/reply service transport across delayed request and response boundaries.",
+  "description": "Self-coupled request/reply transport with a deferred request and direct response.",
   "template": "service_request_reply",
   "inputs": {
     "value": [5, 7, null, -2, 0, null, 11, 3, null, 4]

--- a/tools/parity/known.py
+++ b/tools/parity/known.py
@@ -30,6 +30,7 @@ KEY_SET_SIZE_NO_RETICK = "key-set-size-no-retick"
 NO_CHANGE_ELISION = "no-change-elision"
 VALID_SUBSET_REDUCE = "valid-subset-reduce"
 SWITCH_FLIP_MAP_REMOVAL = "switch-flip-map-removal"
+REQUEST_REPLY_ONE_CYCLE_EARLIER = "request-reply-one-cycle-earlier"
 
 
 def load_known_divergences(
@@ -318,6 +319,33 @@ def _canonical_map_entries(tick: Any) -> list[Any] | None:
     return None
 
 
+def _request_reply_one_cycle_earlier_relation(
+    _recipe: dict[str, Any],
+    difference: dict[str, Any],
+    reference: dict[str, Any],
+    candidate: dict[str, Any],
+    _family: dict[str, Any],
+) -> bool:
+    """RFC 0014 self-coupled request/reply transport removes exactly the
+    released implementation's leading response-feedback cycle.
+
+    Preserve every payload and silent cycle after that boundary.  This is a
+    sequence relation, not a general tolerance for shifted or missing ticks.
+    """
+    if difference.get("classification") != "length":
+        return False
+    reference_trace = reference.get("trace")
+    candidate_trace = candidate.get("trace")
+    return (
+        isinstance(reference_trace, list)
+        and isinstance(candidate_trace, list)
+        and len(reference_trace) == len(candidate_trace) + 1
+        and reference_trace[0] is None
+        and any(tick is not None for tick in candidate_trace)
+        and reference_trace[1:] == candidate_trace
+    )
+
+
 def _switch_flip_map_removal_relation(
     recipe: dict[str, Any],
     difference: dict[str, Any],
@@ -333,16 +361,16 @@ def _switch_flip_map_removal_relation(
 
     Admit only removal-only candidate deltas for every currently-live output,
     exactly on those flips, opposite a canonical empty reference delta.
-    Everything else must match, including later response payloads.
+    RFC 0014 may additionally remove the single silent response-feedback tick
+    immediately after one such flip. Everything else must match, including
+    the response payload now delivered one cycle earlier.
     """
     if difference.get("classification") not in ("value", "length"):
         return False
     reference_trace = reference.get("trace")
     candidate_trace = candidate.get("trace")
-    if (
-        not isinstance(reference_trace, list)
-        or not isinstance(candidate_trace, list)
-        or len(reference_trace) != len(candidate_trace)
+    if not isinstance(reference_trace, list) or not isinstance(
+        candidate_trace, list
     ):
         return False
 
@@ -356,6 +384,26 @@ def _switch_flip_map_removal_relation(
         if selector == "alpha" and active_selector == "beta":
             flip_to_alpha.add(index)
         active_selector = selector
+
+    if len(reference_trace) != len(candidate_trace):
+        if (
+            len(reference_trace) != len(candidate_trace) + 1
+            or len(flip_to_alpha) != 1
+        ):
+            return False
+        flip = next(iter(flip_to_alpha))
+        if (
+            flip + 2 >= len(reference_trace)
+            or reference_trace[flip + 1] is not None
+            or reference_trace[flip + 2] is None
+        ):
+            return False
+        # Align the traces only by removing the old response-feedback cycle.
+        # The loop below still proves the flip removal and every payload.
+        reference_trace = [
+            *reference_trace[: flip + 1],
+            *reference_trace[flip + 2 :],
+        ]
 
     live_keys: set[str] = set()
     admitted = 0
@@ -410,6 +458,9 @@ RELATIONS = {
     VALID_SUBSET_REDUCE: _valid_subset_reduce_relation,
     SWITCH_FLIP_VALID_SUBSET: _switch_flip_valid_subset_relation,
     SWITCH_FLIP_MAP_REMOVAL: _switch_flip_map_removal_relation,
+    REQUEST_REPLY_ONE_CYCLE_EARLIER: (
+        _request_reply_one_cycle_earlier_relation
+    ),
     KEY_SET_SIZE_NO_RETICK: _key_set_size_no_retick_relation,
 }
 

--- a/tools/parity/known_divergences.json
+++ b/tools/parity/known_divergences.json
@@ -18,9 +18,24 @@
       "issue": "https://github.com/hhenson/hg_cpp/pull/67",
       "reason": "No-change-means-no-tick ruling (2026-07-17, roadmap.rst): a mesh over an initially empty key set emits no tick in hg_cpp where released hgraph ticks an empty map. Fingerprint pinned by test_parity_harness.py against the corpus recipe mesh-empty-initial-no-tick.",
       "review_after": "2027-07-26"
+    },
+    {
+      "fingerprint": "70b8f025dfa3f8d634861689a9bdf0ca1ec3c46b0dccb6d8153d340f57e66fa1",
+      "issue": "https://github.com/hhenson/hg_cpp/pull/270",
+      "reason": "RFC 0014 intentional timing difference composed with issue #175: the mapped request/reply response and the next outer-key event preserve their order and payloads but each occupies the preceding candidate output cycle after removal of the response-feedback boundary. The fixed corpus recipe and public map scheduling regressions continue to detect response loss or starvation.",
+      "review_after": "2027-08-04"
     }
   ],
   "families": [
+    {
+      "family": "self-coupled-request-reply-one-cycle-earlier",
+      "template": "service_request_reply",
+      "parameters_not_equal": {},
+      "relation": "request-reply-one-cycle-earlier",
+      "issue": "https://github.com/hhenson/hg_cpp/pull/270",
+      "reason": "RFC 0014 selects deferred-request/direct-response transport for the self-coupled request/reply template. Relative to released hgraph 0.5.34, hg_cpp removes exactly the leading silent response-feedback cycle while preserving every subsequent payload and silent cycle.",
+      "review_after": "2027-08-04"
+    },
     {
       "family": "key-set-size-no-retick",
       "template": "tsd_key_set_pipeline",
@@ -100,8 +115,8 @@
       "parameters_not_equal": {},
       "relation": "switch-flip-map-removal",
       "issue": "https://github.com/hhenson/hg_cpp/issues/105",
-      "reason": "Accepted map-validity deviation (issues #105/#117/#119/#133/#145, nested_graphs.rst): a beta-to-request-reply-alpha switch flip transiently invalidates the mapped child while the response is in flight. Released hgraph publishes an empty TSD delta and retains the stale element; hg_cpp removes every currently-live invalid child output so the map contains exactly its valid outputs, then republishes the response normally. Suppress only an all-live-key, removal-only candidate delta opposite the reference's canonical empty-map delta on the exact beta-to-alpha flip; all other ticks and payloads must match.",
-      "review_after": "2027-07-28"
+      "reason": "Accepted map-validity deviation (issues #105/#117/#119/#133/#145, nested_graphs.rst) composed with RFC 0014 timing: a beta-to-request-reply-alpha switch flip transiently invalidates the mapped child while the response is in flight. Released hgraph publishes an empty TSD delta and retains the stale element; hg_cpp removes every currently-live invalid child output so the map contains exactly its valid outputs. Suppress only an all-live-key, removal-only candidate delta opposite the reference's canonical empty-map delta on the exact beta-to-alpha flip, plus at most the single silent response-feedback cycle removed immediately afterward by RFC 0014; the earlier response and every other payload must match.",
+      "review_after": "2027-08-04"
     }
   ]
 }


### PR DESCRIPTION
## Summary

- select reply-full request/reply transport automatically after lazy service materialization
- use direct request/direct response relays for decoupled sink/push-source implementations
- defer only the request for implementations whose output depends on their own request input
- retain request and response feedback for service/adaptor-dependent and recursive implementations
- route both typed C++ and erased Python-compatible wiring through one C++ planner
- track the intentional one-cycle differential timing with bounded relations that still reject payload, ordering, and lifecycle regressions
- document RFC 0014 and update the service scheduling and parity matrices

## Why

A normal request/reply service may wrap a fully decoupled external transport: client requests leave through a sink while correlated responses arrive through a push source. The previous unconditional request delay and response feedback added two artificial engine cycles and encouraged users to model keyed exchanges as adaptors.

The materialized native graph already contains enough information to choose the least costly safe transport. This change makes that choice once at wiring time, so existing request/reply code receives the improvement immediately without a decorator flag or per-tick policy branch.

| Implementation shape | Request | Response | Engine latency |
| --- | --- | --- | --- |
| Decoupled sink/source | direct | direct | none |
| Output depends on own request | deferred | direct | one cycle |
| Calls a service or adaptor | deferred | feedback | two cycles |

## Compatibility

- Existing Python and C++ request/reply signatures are unchanged.
- `@request_reply_service`, `from_graph`/`to_graph`, and explicit implementation stubs use the same planner.
- Self-coupled services intentionally move from `[None, None, response]` to `[None, response]`.
- Differential parity accepts only that exact one-cycle advance; map/switch composition remains bounded to the existing all-live-key removal relation, and the issue-175 collision is fingerprint-pinned.
- Service/adaptor-dependent and recursive behavior retains the existing full-feedback timing.
- Reply-less request/reply behavior from RFC 0012 is unchanged.
- Plain adaptors remain supported for compatibility and unkeyed merged streams, but are no longer needed solely to obtain direct external-transport scheduling.

Follow-up to #266.

## Validation

- macOS native acceptance: 1,444 tests passed
- macOS Python 3.14 compatibility: 1,895 passed, 11 skipped
- parity controller: 37 tests passed; 56 committed recipes validated
- Ubuntu Python 3.14 differential PR campaign against hgraph 0.5.34: 104/104 attempted, 89 matched, 15 documented mismatches, 0 verified mismatches, 0 quarantined
- installed plain-C++ SDK consumer passed
- installed-wheel extension consumer passed
- documentation warning-as-error build passed
- GCC 14.2 Linux native acceptance: 1,444 tests passed
- GCC 14.2 Linux stable-ABI wheel on Python 3.14: 1,893 passed, 11 skipped
- GCC 14.2 Linux ASan compatibility: 1,893 passed, 11 skipped, with no sanitizer findings
