### PR TITLE
RFC 0014: Extend transport planning to subscription services

### DIFF
--- a/docs/source/developer_guide/parity_matrix.rst
+++ b/docs/source/developer_guide/parity_matrix.rst
@@ -310,11 +310,15 @@ model.
        request/reply services, and late subscription to an existing value all
        execute through the erased C++ service runtime. Matching public C++
        tests cover constrained generics, erased specialization identity,
-       reply-less requests, and sampled late subscriptions. Reply-full
-       request/reply transport is selected by native wiring: decoupled
-       sink/source implementations are direct, self-coupled implementations
-       defer only the request, and service/adaptor-dependent implementations
-       retain full feedback. Compiled ``map_`` and ``mesh_`` children import
+       reply-less requests, and sampled late subscriptions. Keyed-service
+       transport for both subscription and reply-full request/reply is selected
+       by native wiring: decoupled sink/source implementations are direct,
+       self-coupled implementations defer only the request, and service/adaptor-
+       dependent request/reply implementations retain full feedback.
+       Service-dependent subscription defers its key but keeps its response
+       direct, preserving released rapid-transition behavior and shared
+       mapped/reference value identity. Compiled ``map_``
+       and ``mesh_`` children import
        their outer service transport inputs through the nested boundary; any
        response feedback is owned by the outer implementation, not by the child
        consumer. Private Python service-builder layouts are not compatibility

--- a/docs/source/developer_guide/services.rst
+++ b/docs/source/developer_guide/services.rst
@@ -74,27 +74,17 @@ cycle:
     implementation and reply then remain rank-ordered in the owning graph.
     This explicit nested boundary is released Python lifecycle behavior, not a
     silent fallback to the old top-level adaptor delay.
-  - **Subscription keys** in the owning graph are ranked before their source
-    and publish in the capture cycle. A dynamically-started nested client hands
-    off to the outer source on the following cycle because the outer rank may
-    already have passed. Changes are queued by observed engine time so rapid
-    replacements cannot coalesce. When a key becomes globally live, the
-    response boundary invalidates an old keyed value immediately and publishes
-    the first fresh implementation value one cycle after it arrives, matching
-    Python's keyed-child lifecycle and preventing cached values from leaking on
-    re-add. A client joining a key that another client has kept live samples the
-    existing value immediately.
-  - **Reply-full request/reply transport is selected automatically after lazy
-    implementation materialization and before ranking.** There is no user flag
-    and no per-tick policy branch:
+  - **Subscription keys and reply-full request/reply use one automatic keyed-
+    service transport planner after lazy implementation materialization and
+    before ranking.** There is no user flag and no per-tick policy branch:
 
     .. list-table::
        :header-rows: 1
        :widths: 30 24 24 22
 
        * - Implementation shape
-         - Request relay
-         - Response relay
+         - Key/request relay
+         - Selected response relay
          - Engine latency
        * - Decoupled request sink and response source
          - ranked, same cycle
@@ -106,20 +96,34 @@ cycle:
          - one cycle
        * - Calls another service or adaptor
          - next cycle
-         - feedback, then same cycle
-         - two cycles
+         - request/reply: feedback; subscription: ranked, same cycle
+         - request/reply: two cycles; subscription: one cycle
 
     The decoupled form is the external-transport shape: requests may flow to a
     Kafka or network sink while correlated replies arrive through a push
-    source. The response graph has no causal path from the service request
-    source, so neither side needs an artificial delay. A self-contained graph
-    whose output is driven by its request input defers only that input, which
-    breaks the direct dependency cycle while allowing the resulting response
-    to publish immediately. Calling any service or adaptor from the active
-    implementation conservatively retains the full two-boundary form because
-    the referenced implementation may close a cycle. A deferred request source
-    retains its earliest outstanding publication time, so a later request
-    cannot postpone work that is already due.
+    source. Request/reply correlates with a stable integer request id;
+    subscription uses the subscription key itself and has only a ``TSS<key>``
+    input. When the response graph has no causal path from that input, neither
+    side needs an artificial delay. A self-contained graph whose output is
+    driven by its request input defers only that input, which breaks the direct
+    dependency cycle while allowing the resulting response to publish
+    immediately. Calling any service or adaptor from the active implementation
+    conservatively retains the full two-boundary form for request/reply because
+    the referenced implementation may close a cycle. Subscription defers its
+    key relay but keeps the shared dictionary and per-client response direct.
+    Its key is both the request and the response identity, so a second response
+    boundary can hide a short-lived value after the subscription has already
+    changed. The single deferred key boundary preserves released subscription
+    timing and ordering while still breaking the input dependency.
+    Subscription freshness remains strict in every plan: a re-added key cannot
+    expose a cached value, while a client joining a key another client already
+    keeps live still samples immediately. The response gate is a concrete port
+    as soon as the client is wired; only the key capture waits for planning, so
+    subscription values remain usable as context across nested graph boundaries.
+    Changes are queued by observed engine time so rapid replacements cannot
+    coalesce. A deferred request source
+    retains its earliest outstanding publication time, so later work cannot
+    postpone a publication already due.
   - **A reply-less request/reply service forwards in the owning capture
     cycle.** With no response there is no response feedback edge, hence no
     request/reply cycle for the rank-free path to permit. A root client is
@@ -427,13 +431,14 @@ Genuine nested children are unaffected: a push source inside a
 child is still rejected, because a graph with a push prefix never gets a nested
 graph type interned (``GraphBuilder::nested_type()``). See :doc:`nested_graphs`.
 
-Reply-full request/reply transport planning also relies on this inlining. Once
-all demanded implementations have materialized, wiring can inspect the actual
-native dependency graph rather than infer behavior from a decorator or an API
-signature. ``impl_input``/``from_graph`` records the implementation's request
-source, ``impl_output``/``to_graph`` records its response, and the planner
-selects one immutable transport before ranks are built. The Python decorators
-use this same erased C++ path; Python does not repeat the analysis.
+Keyed-service transport planning also relies on this inlining. Once all
+demanded request/reply and subscription implementations have materialized,
+wiring can inspect the actual native dependency graph rather than infer
+behavior from a decorator or an API signature. ``impl_input``/``from_graph``
+records the implementation's request source, ``impl_output``/``to_graph``
+records its response, and the planner selects one immutable transport before
+ranks are built. The Python decorators use this same erased C++ path; Python
+does not repeat the analysis.
 
 
 The service and adaptor surfaces are one boundary model
@@ -471,11 +476,11 @@ independent of ``adaptor_wiring.h``.
 
 For new code, prefer a service whenever its contract fits. A reference service
 covers source-only publication, a reply-less request/reply service covers a
-keyed sink, and a reply-full request/reply service now covers a correlated
-external exchange without imposing feedback on a decoupled implementation.
-The plain adaptor spelling remains useful for an unkeyed merged stream or for
-compatibility with existing adaptor APIs; it is no longer required merely to
-obtain the direct external-transport path.
+keyed sink, and reply-full request/reply or subscription services cover
+correlated external exchanges without imposing feedback on a decoupled
+implementation. The plain adaptor spelling remains useful for an unkeyed
+merged stream or for compatibility with existing adaptor APIs; it is no longer
+required merely to obtain the direct external-transport path.
 
 Adaptors
 --------
@@ -660,9 +665,10 @@ second implementation for the same service kind + path throws
 reads the implementation output by reference (no copy); paths keep shared
 outputs separate; a subscription client's key transitions reach the
 implementation in order and the response flows back keyed with Python timing;
-request/reply replies remain keyed by the client's request id; decoupled,
-self-coupled, and service-dependent implementations select direct,
-request-deferred, and full-feedback transport respectively; two clients'
+request/reply replies remain keyed by the client's request id; decoupled and
+self-coupled implementations select direct and request-deferred transport;
+service-dependent request/reply selects full feedback while subscription keeps
+its direct selected-response path; two clients'
 requests reach the implementation as one cumulative delta.
 
 

--- a/docs/source/rfc/rfc_0014_request_reply_transport_planning.rst
+++ b/docs/source/rfc/rfc_0014_request_reply_transport_planning.rst
@@ -1,17 +1,17 @@
-RFC 0014: Automatic Request/Reply Transport Planning
+RFC 0014: Automatic Keyed-Service Transport Planning
 ====================================================
 
 :Status: Accepted
 :Author: Howard Henson
 :Created: 2026-08-04
-:Target: Request/reply service wiring, scheduling, and Python compatibility
+:Target: Request/reply and subscription service wiring, scheduling, and Python compatibility
 
 Summary
 -------
 
-Reply-full request/reply services no longer unconditionally insert one
-next-cycle request hand-off and one response feedback hand-off. After lazy
-service materialization, native wiring selects the least costly transport that
+Reply-full request/reply and subscription services no longer unconditionally
+pay their conservative request and response hand-offs. After lazy service
+materialization, native wiring selects the least costly transport that
 preserves the implementation's dependency structure:
 
 .. list-table::
@@ -40,15 +40,24 @@ registration, ``get_service_inputs``/``set_service_output``, and
 ``from_graph``/``to_graph`` APIs do not gain a policy argument. The plan is
 fixed before graph ranking and introduces no per-tick policy branch.
 
+The two flavours differ only in correlation shape. Request/reply uses a stable
+integer request id and publishes ``TSD<int, response>``. A subscription request
+is only the service key, represented by ``TSS<key>``, and its response is
+selected from ``TSD<key, value>`` by that same key. Subscription full feedback
+therefore remains after per-client key selection; feeding back the shared
+dictionary itself would change the identity and lifetime of mapped/reference
+children.
+
 Motivation
 ----------
 
 The old reply-full transport assumed that the implementation output could feed
 back, directly or through another boundary, to its request input. That was the
 safest universal choice and permits recursion, but it charged two cycles to
-every implementation.
+every implementation. Subscription wiring similarly imposed one response-gate
+cycle even when its key sink and response source were completely independent.
 
-An external request/reply transport has a different shape. A Kafka-backed
+An external keyed transport has a different shape. A Kafka-backed
 implementation, for example, can sink client requests to an outbound channel
 and publish independently received correlated responses through a push source.
 There is no graph edge from that response source to the request dictionary.
@@ -57,30 +66,32 @@ this shape; both are artificial latency.
 
 RFC 0011 made services and adaptors share one boundary model, and RFC 0012 made
 reply-less request/reply use the direct keyed-sink relay. This RFC completes
-the keyed exchange: a normal request/reply service can now provide the direct
-external-transport behavior that previously encouraged users to choose an
-adaptor solely for scheduling reasons.
+the keyed exchange: normal request/reply and subscription services can now
+provide the direct external-transport behavior that previously encouraged
+users to choose an adaptor solely for scheduling reasons.
 
 User contract
 -------------
 
 No existing user-facing signature changes. Python code continues to declare
-``@request_reply_service`` and ``@service_impl`` and may expose implementation
-boundaries with either:
+``@request_reply_service`` or ``@subscription_service`` with
+``@service_impl`` and may expose implementation boundaries with either:
 
 * a conventional implementation argument and return value;
 * ``get_service_inputs`` and ``set_service_output``; or
 * ``from_graph`` and ``to_graph``.
 
 The native equivalents remain ``register_request_reply_service``,
-``service::impl_input``/``impl_output``, and the service aliases of
-``from_graph``/``to_graph``. All routes lower to the same C++ planner.
+``register_subscription_service``, ``service::impl_input``/``impl_output``,
+and the service aliases of ``from_graph``/``to_graph``. All routes lower to the
+same C++ planner.
 
-A decoupled implementation may send the keyed request dictionary to an
-external sink and provide a keyed response dictionary from a push source. The
-stable client request id remains the correlation key. External concurrency and
-wall-clock timing are not made deterministic by this RFC; the engine preserves
-the ordering presented by the constructed graph and the external transport.
+A decoupled implementation may send requests to an external sink and provide a
+keyed response dictionary from a push source. Request/reply retains its stable
+client request id; subscription uses the requested subscription key directly.
+External concurrency and wall-clock timing are not made deterministic by this
+RFC; the engine preserves the ordering presented by the constructed graph and
+the external transport.
 
 Planning model
 --------------
@@ -89,7 +100,7 @@ Planning occurs after ``Wiring::build_services()`` has materialized every
 demanded implementation and before service-rank dependencies are applied. A
 wiring-lifetime planner records:
 
-* each pending reply-full client capture;
+* each pending request/reply or subscription client capture;
 * the implementation-owned request source for each concrete service path;
 * the implementation response port and shared response source; and
 * whether the active implementation wired any service or adaptor client.
@@ -103,17 +114,19 @@ followed so bundles and generic wiring do not hide a dependency.
 The decision for one concrete service path is:
 
 ``FullFeedback``
-   The implementation calls any service or adaptor. The request remains
-   next-cycle and the response crosses a feedback pair before entering the
-   same-cycle shared-output relay. This conservative rule preserves direct and
-   indirect recursion without requiring inter-service whole-graph cycle
-   speculation.
+   A request/reply implementation calls any service or adaptor. The request
+   remains next-cycle and the response crosses a feedback pair before entering
+   the same-cycle shared-output relay. This conservative request/reply rule
+   preserves direct and indirect recursion without requiring inter-service
+   whole-graph cycle speculation.
 
 ``RequestDeferred``
-   The response causally depends on the implementation's own request source
-   and the implementation has no boundary dependency. Deferring the request
-   breaks that cycle; the computed response then publishes directly in the
-   implementation cycle.
+   The response causally depends on the implementation's own request source,
+   or a subscription implementation calls another service/adaptor. Deferring
+   the request breaks that input cycle; the computed response then publishes
+   directly in the implementation cycle. Subscription never adds a second
+   selected-response delay: its key is both request and response identity, and
+   delaying a transient selected value can move it beyond that key's lifetime.
 
 ``Direct``
    The response has no causal path from the request source and the
@@ -135,6 +148,11 @@ when the owning implementation selected ``Direct``. The child does not create
 or own a response feedback pair; the root implementation plan remains the
 single owner of response transport.
 
+A subscription's direct freshness gate is wired immediately and only its key
+capture waits for the implementation plan. The public response is therefore a
+concrete port during composition, so it can be published as context or imported
+by ``switch_``, ``map_``, and other nested graphs before outer finalization.
+
 Consequences
 ------------
 
@@ -142,8 +160,8 @@ Consequences
 required. A request captured in the owning graph can reach its sink in that
 cycle, and an externally supplied response can publish in its arrival cycle.
 
-**Self-coupled services lose one artificial cycle.** The observable sequence
-for a conventional request-driven implementation changes from
+**Self-coupled request/reply loses one artificial cycle.** The observable sequence
+for a conventional request/reply implementation changes from
 ``[None, None, response]`` to ``[None, response]``. The request boundary still
 breaks the graph cycle. Differential testing against released hgraph 0.5.34
 tracks this as an exact one-cycle response advance: payloads, ordering, and all
@@ -152,17 +170,26 @@ already accepted transient map-removal behavior on a request/reply switch
 flip; the issue-175 response-versus-new-key collision remains an exact pinned
 corpus divergence so a lost or reordered response is never accepted broadly.
 
-**Service-dependent and recursive behavior is retained.** Such an
-implementation continues to observe the full two-boundary sequence. The rule
-is deliberately conservative: a service call that does not happen to feed the
-response still selects full feedback because the referenced implementation may
-complete a wider cycle.
+For a self-coupled subscription, the one required break moves from the first
+fresh response to the key relay. Its public output sequence remains
+tick-for-tick compatible, while the response can publish in the implementation
+cycle and the freshness gate no longer needs a scheduler. Re-add protection,
+rapid key-transition ordering, and immediate sampling of a key already kept
+live by another subscriber remain unchanged.
+
+**Service-dependent behavior retains each flavour's lifetime semantics.** A
+request/reply implementation continues to use the conservative two-boundary
+sequence because the referenced implementation may complete a wider cycle.
+A subscription defers only its key relay and keeps the selected response
+direct. This is tick-for-tick compatible with released hgraph for rapid key
+replacement and avoids publishing a short-lived response after its key is no
+longer the active subscription.
 
 **Adaptor scope narrows without a disruptive deprecation.** New keyed,
-correlated external exchanges should use request/reply services. Plain
-adaptors remain supported for existing APIs and unkeyed merged streams. This
-RFC does not emit a deprecation warning; removing or formally deprecating an
-adaptor decorator requires a separate compatibility decision.
+correlated external exchanges should use request/reply or subscription
+services. Plain adaptors remain supported for existing APIs and unkeyed merged
+streams. This RFC does not emit a deprecation warning; removing or formally
+deprecating an adaptor decorator requires a separate compatibility decision.
 
 C++ ownership
 -------------
@@ -173,9 +200,11 @@ contract. Python does not classify the implementation or build a parallel
 transport, preserving the repository's C++-first ownership rule.
 
 The reusable erased contract lives in
-``include/hgraph/types/request_reply_transport.h``. Its concrete planner and
-feedback representation stay under ``src/hgraph/types/impl``. Semantic service
-owners depend on the contract and do not name the concrete strategy.
+``include/hgraph/types/keyed_service_transport.h``. The original
+``request_reply_transport.h`` names remain as compatibility aliases. The
+concrete planner and feedback representations stay under
+``src/hgraph/types/impl``. Semantic service owners depend on the contract and
+do not name the concrete strategy.
 
 Alternatives considered
 -----------------------
@@ -202,10 +231,10 @@ Always use deferred request and direct response
 Acceptance criteria
 -------------------
 
-* Public typed C++ wiring proves all three transport selections.
-* Matching Python tests prove self-coupled and service-dependent timing and a
-  real-time Kafka-style sink/push-source exchange through the existing public
-  API.
+* Public typed C++ wiring proves all three transport selections for both keyed
+  service flavours.
+* Matching Python tests prove self-coupled and service-dependent timing and
+  Kafka-style sink/source exchanges through the existing public API.
 * Recursive, mapped, meshed, switch, cumulative-delta, removal, and teardown
   behavior remains valid.
 * Repeated wiring snapshots do not duplicate synthesized nodes or plans.

--- a/include/hgraph/runtime/service_node.h
+++ b/include/hgraph/runtime/service_node.h
@@ -45,20 +45,23 @@ namespace hgraph
      */
     [[nodiscard]] HGRAPH_EXPORT NodeBuilder make_subscription_key_capture_node(
         std::string path,
-        const ValueTypeMetaData &key_schema);
+        const ValueTypeMetaData &key_schema,
+        bool same_cycle = true);
 
     /**
      * Build the response boundary for one subscription client.
      *
      * A newly-live service key immediately invalidates any response sampled
      * through the shared dictionary. The first fresh implementation value is
-     * published one cycle after it arrives, matching Python's keyed-child
-     * lifecycle and preventing cached values from leaking on re-add. A client
-     * joining a key already kept live by another client samples it immediately.
+     * published either immediately or one cycle after it arrives, according to
+     * the immutable wiring-time transport. Both forms prevent cached values
+     * from leaking on re-add. A client joining a key already kept live by
+     * another client samples it immediately.
      */
     [[nodiscard]] HGRAPH_EXPORT NodeBuilder make_subscription_response_gate_node(
         const ValueTypeMetaData &key_schema,
-        const TSValueTypeMetaData &response_schema);
+        const TSValueTypeMetaData &response_schema,
+        bool response_same_cycle = false);
 
     /**
      * Build a source node that owns a request/reply service request dictionary.

--- a/include/hgraph/types/keyed_service_transport.h
+++ b/include/hgraph/types/keyed_service_transport.h
@@ -1,0 +1,77 @@
+#ifndef HGRAPH_TYPES_KEYED_SERVICE_TRANSPORT_H
+#define HGRAPH_TYPES_KEYED_SERVICE_TRANSPORT_H
+
+#include <hgraph/hgraph_export.h>
+#include <hgraph/types/graph_wiring.h>
+
+#include <cstdint>
+#include <string>
+#include <typeindex>
+
+namespace hgraph
+{
+    /**
+     * Immutable wiring-time transport selected for one concrete keyed service
+     * implementation (RFC 0014). No policy dispatch occurs at runtime.
+     */
+    enum class KeyedServiceTransportPlan : std::uint8_t
+    {
+        Direct,          ///< ranked request relay and direct response relay
+        RequestDeferred, ///< next-cycle request relay and direct response relay
+        FullFeedback,    ///< next-cycle request relay and feedback response relay
+    };
+
+    namespace keyed_service_transport
+    {
+        /** Defer a request/reply client capture until its implementation plan is known. */
+        HGRAPH_EXPORT void defer_request_reply_client(
+            Wiring &w, std::string base_path, std::string request_path,
+            std::string response_path, const TSValueTypeMetaData &request_schema,
+            WiringPortRef request, WiringPortRef request_source,
+            WiringPortRef request_id, WiringPortRef response_source,
+            std::type_index capture_role);
+
+        /**
+         * Wire the subscription response gate immediately and defer only the
+         * key capture until its implementation plan is known. The returned
+         * value is therefore a concrete port that can cross nested wiring and
+         * context boundaries before final planning.
+         */
+        [[nodiscard]] HGRAPH_EXPORT WiringPortRef defer_subscription_client(
+            Wiring &w, std::string base_path, std::string request_path,
+            std::string response_path, const ValueTypeMetaData &key_schema,
+            const TSValueTypeMetaData &response_schema, WiringPortRef key,
+            WiringPortRef request_source, WiringPortRef response,
+            WiringPortRef response_source, std::type_index capture_role,
+            std::type_index gate_role);
+
+        /** Record the implementation-owned request source used for causality analysis. */
+        HGRAPH_EXPORT void register_implementation_input(
+            Wiring &w, std::string base_path, const WiringInstance *request_source);
+
+        /**
+         * Defer publication of one implementation output. The active
+         * implementation scope is retained so later service/adaptor calls in
+         * the same graph conservatively select full feedback.
+         */
+        HGRAPH_EXPORT void defer_request_reply_implementation_output(
+            Wiring &w, std::string base_path, std::string response_path,
+            const TSValueTypeMetaData &response_dict_schema,
+            WiringPortRef output, WiringPortRef response_source,
+            std::type_index capture_role);
+
+        /**
+         * Defer publication of a subscription implementation dictionary.
+         * Subscription coupling is broken by deferring the key relay; the
+         * shared keyed response and per-client selection remain direct so a
+         * short-lived response cannot be hidden by a second boundary.
+         */
+        HGRAPH_EXPORT void defer_subscription_implementation_output(
+            Wiring &w, std::string base_path, std::string response_path,
+            const TSValueTypeMetaData &response_dict_schema,
+            WiringPortRef output, WiringPortRef response_source,
+            std::type_index capture_role);
+    }  // namespace keyed_service_transport
+}  // namespace hgraph
+
+#endif

--- a/include/hgraph/types/request_reply_transport.h
+++ b/include/hgraph/types/request_reply_transport.h
@@ -1,47 +1,51 @@
 #ifndef HGRAPH_TYPES_REQUEST_REPLY_TRANSPORT_H
 #define HGRAPH_TYPES_REQUEST_REPLY_TRANSPORT_H
 
-#include <hgraph/hgraph_export.h>
-#include <hgraph/types/graph_wiring.h>
+#include <hgraph/types/keyed_service_transport.h>
 
-#include <cstdint>
-#include <string>
-#include <typeindex>
+#include <utility>
 
 namespace hgraph
 {
-    /**
-     * Immutable wiring-time transport selected for one concrete request/reply
-     * implementation (RFC 0014). No policy dispatch occurs at runtime.
-     */
-    enum class RequestReplyTransportPlan : std::uint8_t
-    {
-        Direct,          ///< ranked request relay and direct response relay
-        RequestDeferred, ///< next-cycle request relay and direct response relay
-        FullFeedback,    ///< next-cycle request relay and feedback response relay
-    };
+    /** Compatibility name retained for the original RFC 0014 contract. */
+    using RequestReplyTransportPlan = KeyedServiceTransportPlan;
 
     namespace request_reply_transport
     {
         /** Defer a reply-full client capture until its implementation plan is known. */
-        HGRAPH_EXPORT void defer_client(Wiring &w, std::string base_path, std::string request_path,
-                                        std::string response_path, const TSValueTypeMetaData &request_schema,
-                                        WiringPortRef request, WiringPortRef request_source, WiringPortRef request_id,
-                                        WiringPortRef response_source, std::type_index capture_role);
+        inline void defer_client(Wiring &w, std::string base_path, std::string request_path,
+                                 std::string response_path, const TSValueTypeMetaData &request_schema,
+                                 WiringPortRef request, WiringPortRef request_source, WiringPortRef request_id,
+                                 WiringPortRef response_source, std::type_index capture_role)
+        {
+            keyed_service_transport::defer_request_reply_client(
+                w, std::move(base_path), std::move(request_path), std::move(response_path), request_schema,
+                std::move(request), std::move(request_source), std::move(request_id),
+                std::move(response_source), capture_role);
+        }
 
         /** Record the implementation-owned request source used for causality analysis. */
-        HGRAPH_EXPORT void register_implementation_input(Wiring &w, std::string base_path,
-                                                         const WiringInstance *request_source);
+        inline void register_implementation_input(Wiring &w, std::string base_path,
+                                                  const WiringInstance *request_source)
+        {
+            keyed_service_transport::register_implementation_input(
+                w, std::move(base_path), request_source);
+        }
 
         /**
          * Defer publication of one implementation output. The active
          * implementation scope is retained so later service/adaptor calls in
          * the same graph conservatively select full feedback.
          */
-        HGRAPH_EXPORT void defer_implementation_output(Wiring &w, std::string base_path, std::string response_path,
-                                                       const TSValueTypeMetaData &response_dict_schema,
-                                                       WiringPortRef output, WiringPortRef response_source,
-                                                       std::type_index capture_role);
+        inline void defer_implementation_output(Wiring &w, std::string base_path, std::string response_path,
+                                                const TSValueTypeMetaData &response_dict_schema,
+                                                WiringPortRef output, WiringPortRef response_source,
+                                                std::type_index capture_role)
+        {
+            keyed_service_transport::defer_request_reply_implementation_output(
+                w, std::move(base_path), std::move(response_path), response_dict_schema,
+                std::move(output), std::move(response_source), capture_role);
+        }
     }  // namespace request_reply_transport
 }  // namespace hgraph
 

--- a/include/hgraph/types/service_wiring.h
+++ b/include/hgraph/types/service_wiring.h
@@ -7,6 +7,7 @@
 #include <hgraph/runtime/shared_output_node.h>
 #include <hgraph/types/metadata/type_registry.h>
 #include <hgraph/types/graph_wiring.h>
+#include <hgraph/types/keyed_service_transport.h>
 #include <hgraph/types/operator_dispatch.h>
 #include <hgraph/types/request_reply_transport.h>
 #include <hgraph/types/static_schema.h>
@@ -837,38 +838,6 @@ namespace hgraph::service
             return Port<REF<output_schema>>{w, std::move(port)};
         }
 
-        template <typename Service>
-        const WiringInstance *capture_subscription_key(Wiring &w,
-                                                       Port<TS<key_type_t<Service>>> key,
-                                                       Port<TSS<key_type_t<Service>>> subscriptions,
-                                                       const ServicePath &user_path)
-        {
-            using key_type = key_type_t<Service>;
-
-            std::array<WiringPortRef, 2> sources{key.erased(), subscriptions.erased()};
-            std::array<WiringInputRef, 2> inputs{{
-                WiringInputRef{.source = sources[0]},
-                WiringInputRef{.source = sources[1], .rank_dependency = false},
-            }};
-            const auto *key_meta = resolved_scalar_meta<key_type>(
-                user_path.resolution, "subscription service key");
-            NodeBuilder builder = make_subscription_key_capture_node(
-                subscriptions_path<Service>(user_path), *key_meta);
-            builder.input_endpoint(graph_wiring_detail::input_endpoint_for_sources(
-                builder.type().schema()->input_schema,
-                std::span<const WiringPortRef>{sources.data(), sources.size()}));
-
-            WiringPortRef capture = w.add_node(std::type_index(typeid(subscription_capture_marker)),
-                                               std::move(builder),
-                                               std::span<const WiringInputRef>{inputs.data(), inputs.size()},
-                                               Value{});
-            // Root captures rank before the shared key source and publish in
-            // the same cycle. A dynamically-started nested capture defers its
-            // outer hand-off one cycle; observed-time batches keep successive
-            // transitions distinct.
-            return capture.peered_node();
-        }
-
         template <typename Service, typename RequestSchema>
         const WiringInstance *capture_request_input(Wiring &w,
                                                     Port<RequestSchema> request,
@@ -923,40 +892,6 @@ namespace hgraph::service
             return boundary_detail::shared_output_relay_capture(
                 w, std::type_index(typeid(reference_output_capture_marker)), output_meta,
                 reference_output_path<Service>(user_path), output.erased(), shared_output.erased());
-        }
-
-        template <typename Service, typename Impl>
-        const WiringInstance *capture_service_output(Wiring &w,
-                                                     Port<output_schema_t<Service>> output,
-                                                     Port<REF<output_schema_t<Service>>> shared_output,
-                                                     const ServicePath &user_path)
-        {
-            std::array<WiringPortRef, 2> sources{output.erased(), shared_output.erased()};
-            std::array<WiringInputRef, 2> inputs{{
-                WiringInputRef{.source = sources[0]},
-                WiringInputRef{.source = sources[1], .rank_dependency = false},
-            }};
-            const auto *output_meta = output.erased().schema;
-            if (output_meta == nullptr)
-            {
-                const auto *key_meta = resolved_scalar_meta<key_type_t<Service>>(
-                    user_path.resolution, "subscription service key");
-                const auto *value_meta = resolved_schema_meta<value_schema_t<Service>>(
-                    user_path.resolution, "subscription service value");
-                output_meta = TypeRegistry::instance().tsd(key_meta, value_meta);
-            }
-            NodeBuilder builder = make_shared_output_capture_node(
-                output_path<Service>(user_path), *output_meta);
-            builder.input_endpoint(graph_wiring_detail::input_endpoint_for_sources(
-                builder.type().schema()->input_schema,
-                std::span<const WiringPortRef>{sources.data(), sources.size()}));
-
-            WiringPortRef capture = w.add_node(std::type_index(typeid(shared_output_capture_marker)),
-                                               std::move(builder),
-                                               std::span<const WiringInputRef>{inputs.data(), inputs.size()},
-                                               Value{});
-            w.add_same_cycle_pair(capture.peered_node(), shared_output.node());
-            return capture.peered_node();
         }
 
         template <typename Impl, typename... Args>
@@ -1050,6 +985,8 @@ namespace hgraph::service
         w.register_service_implementation_stub(endpoint, "subscription service");
         auto source = detail::subscription_source<Service>(w, user_path);
         w.register_service_rank_anchor(detail::subscriptions_path<Service>(user_path), source.node());
+        keyed_service_transport::register_implementation_input(
+            w, detail::subscription_base_path<Service>(user_path), source.node());
         return source;
     }
 
@@ -1085,10 +1022,6 @@ namespace hgraph::service
         return impl_input<Service>(w, detail::default_service_path<Service>());
     }
 
-    struct explicit_impl_output_marker
-    {
-    };
-
     template <typename Service>
         requires detail::reference_service_interface<Service>
     void impl_output(Wiring &w,
@@ -1123,9 +1056,19 @@ namespace hgraph::service
             user_path.resolution, w.service_implementation_stub_resolution(endpoint));
         w.register_service_implementation_stub(endpoint, "subscription service");
         auto shared_output = detail::shared_output_source<Service>(w, user_path);
-        const WiringInstance *capture = detail::capture_service_output<Service, explicit_impl_output_marker>(
-            w, std::move(output), shared_output, user_path);
-        w.register_service_rank_anchor(detail::output_path<Service>(user_path), capture);
+        const auto *key_meta = detail::resolved_scalar_meta<detail::key_type_t<Service>>(
+            user_path.resolution, "subscription service key");
+        const auto *response_meta = detail::resolved_schema_meta<detail::value_schema_t<Service>>(
+            user_path.resolution, "subscription service response");
+        const auto *output_meta = TypeRegistry::instance().tsd(key_meta, response_meta);
+        keyed_service_transport::defer_subscription_implementation_output(
+            w,
+            detail::subscription_base_path<Service>(user_path),
+            detail::output_path<Service>(user_path),
+            *output_meta,
+            output.erased(),
+            shared_output.erased(),
+            std::type_index(typeid(detail::shared_output_capture_marker)));
     }
 
     template <typename Service>
@@ -1312,33 +1255,26 @@ namespace hgraph::service
         [[nodiscard]] Port<value_schema> operator()(Port<TS<key_type>> key) const
         {
             if (wiring_ == nullptr) { throw std::logic_error("subscription service handle is not bound"); }
-            const WiringInstance *capture =
-                detail::capture_subscription_key<Service>(*wiring_, key, subscriptions_, path_);
-            wiring_->register_service_client_rank(
-                detail::subscriptions_path<Service>(path_), "subscription service", capture, false);
             auto sampled = wire<stdlib::getitem_>(
                 *wiring_, output_.template as<output_schema>(), key)
                 .template as<value_schema>();
-            std::array<WiringPortRef, 3> sources{
-                sampled.erased(), key.erased(), subscriptions_.erased()};
-            std::array<WiringInputRef, 3> inputs{{
-                WiringInputRef{.source = sources[0]},
-                WiringInputRef{.source = sources[1]},
-                WiringInputRef{.source = sources[2]},
-            }};
             const auto *key_meta = detail::resolved_scalar_meta<key_type>(
                 path_.resolution, "subscription service key");
             const auto *response_meta = detail::resolved_schema_meta<value_schema>(
                 path_.resolution, "subscription service response");
-            NodeBuilder builder = make_subscription_response_gate_node(
-                *key_meta, *response_meta);
-            builder.input_endpoint(graph_wiring_detail::input_endpoint_for_sources(
-                builder.type().schema()->input_schema,
-                std::span<const WiringPortRef>{sources.data(), sources.size()}));
-            WiringPortRef gated = wiring_->add_node(
-                std::type_index(typeid(detail::subscription_response_gate_marker)),
-                std::move(builder),
-                std::span<const WiringInputRef>{inputs.data(), inputs.size()}, Value{});
+            WiringPortRef gated = keyed_service_transport::defer_subscription_client(
+                *wiring_,
+                detail::subscription_base_path<Service>(path_),
+                detail::subscriptions_path<Service>(path_),
+                detail::output_path<Service>(path_),
+                *key_meta,
+                *response_meta,
+                key.erased(),
+                subscriptions_.erased(),
+                sampled.erased(),
+                output_.erased(),
+                std::type_index(typeid(detail::subscription_capture_marker)),
+                std::type_index(typeid(detail::subscription_response_gate_marker)));
             return Port<value_schema>{*wiring_, std::move(gated)};
         }
 
@@ -1356,8 +1292,6 @@ namespace hgraph::service
         auto subscriptions = detail::subscription_source<Service>(w, user_path);
         auto shared_output = detail::shared_output_source<Service>(w, user_path);
         w.register_service_rank_anchor(detail::subscriptions_path<Service>(user_path), subscriptions.node());
-        w.register_service_client_rank(
-            detail::output_path<Service>(user_path), "subscription service", shared_output.node(), true);
         return SubscriptionService<Service>{w, subscriptions, shared_output, std::move(user_path)};
     }
 
@@ -1382,15 +1316,30 @@ namespace hgraph::service
                 auto shared_output = detail::shared_output_source<Service>(target, user_path);
                 target.register_service_rank_anchor(
                     detail::subscriptions_path<Service>(user_path), subscriptions.node());
+                auto scope = target.service_implementation_scope(
+                    "subscription service " + base_path,
+                    std::vector<WiringServiceImplementationEndpoint>{}, false);
+                keyed_service_transport::register_implementation_input(
+                    target, base_path, subscriptions.node());
                 auto output = std::apply(
                     [&](const auto &...stored) {
                         return detail::wire_service_impl<Impl, output_schema>(
                             target, user_path, detail::service_input_arg<Impl>(subscriptions), stored...);
                     }, stored_args);
-                const WiringInstance *capture = detail::capture_service_output<Service, Impl>(
-                    target, output, shared_output, user_path);
-                target.register_service_rank_anchor(
-                    detail::output_path<Service>(user_path), capture);
+                const auto *key_meta = detail::resolved_scalar_meta<detail::key_type_t<Service>>(
+                    user_path.resolution, "subscription service key");
+                const auto *response_meta = detail::resolved_schema_meta<detail::value_schema_t<Service>>(
+                    user_path.resolution, "subscription service response");
+                const auto *output_meta = TypeRegistry::instance().tsd(key_meta, response_meta);
+                keyed_service_transport::defer_subscription_implementation_output(
+                    target,
+                    base_path,
+                    detail::output_path<Service>(user_path),
+                    *output_meta,
+                    output.erased(),
+                    shared_output.erased(),
+                    std::type_index(typeid(detail::shared_output_capture_marker)));
+                scope.complete();
             });
     }
 

--- a/python/tests/test_service_timing_semantics.py
+++ b/python/tests/test_service_timing_semantics.py
@@ -82,6 +82,78 @@ def test_subscription_replacement_waits_for_fresh_value_and_preserves_transition
     assert calls == {"rates": 2, "fx": 1}
 
 
+def test_decoupled_subscription_from_to_graph_is_same_cycle():
+    """An external response source does not pay a synthetic subscription cycle."""
+    transitions = []
+
+    @hg.subscription_service
+    def quote(symbol: TS[str], path: str = "direct-quotes") -> TS[int]: ...
+
+    @hg.reference_service
+    def transport_ready(path: str = "direct-quotes") -> TS[bool]: ...
+
+    @hg.sink_node
+    def observe(symbols: TSS[str]):
+        transitions.append((sorted(symbols.added()), sorted(symbols.removed())))
+
+    @hg.service_impl(interfaces=(quote, transport_ready))
+    def quote_transport(path: str):
+        symbols = hg.from_graph(quote, path)
+        observe(symbols)
+        hg.to_graph(
+            quote,
+            hg.const({"rates": 70}, TSD[str, TS[int]]),
+            path,
+        )
+        hg.to_graph(transport_ready, hg.const(True), path)
+
+    @graph
+    def app(symbol: TS[str]) -> TS[int]:
+        hg.register_service("direct-quotes", quote_transport)
+        return quote(symbol, path="direct-quotes")
+
+    assert eval_node(
+        app,
+        ["rates"],
+        __end_time__=hg.MIN_ST + 3 * hg.MIN_TD,
+    ) == [70]
+    assert transitions == [(["rates"], [])]
+
+
+def test_service_dependent_subscription_defers_only_its_key_relay():
+    @hg.reference_service
+    def offset(path: str = "subscription-offset") -> TS[int]: ...
+
+    @hg.service_impl(interfaces=offset)
+    def offset_impl(path: str = "subscription-offset") -> TS[int]:
+        return hg.const(10)
+
+    @hg.subscription_service
+    def quote(symbol: TS[str], path: str = "dependent-quotes") -> TS[int]: ...
+
+    @hg.service_impl(interfaces=quote)
+    def quote_impl(symbols: TSS[str]) -> TSD[str, TS[int]]:
+        amount = offset(path="subscription-offset")
+        return hg.map_(
+            lambda symbol, value: hg.len_(symbol) * 10 + value,
+            __keys__=symbols,
+            __key_arg__="symbol",
+            value=amount,
+        )
+
+    @graph
+    def app(symbol: TS[str]) -> TS[int]:
+        hg.register_service("subscription-offset", offset_impl)
+        hg.register_service("dependent-quotes", quote_impl)
+        return quote(symbol, path="dependent-quotes")
+
+    assert eval_node(
+        app,
+        ["rates"],
+        __end_time__=hg.MIN_ST + 5 * hg.MIN_TD,
+    ) == [None, 60]
+
+
 def test_request_reply_inside_a_mapped_switch_keeps_late_keys():
     @hg.request_reply_service
     def adjust(path: str, request: TS[int]) -> TS[int]: ...

--- a/src/hgraph/runtime/service_node.cpp
+++ b/src/hgraph/runtime/service_node.cpp
@@ -17,6 +17,7 @@
 #include <atomic>
 #include <cstddef>
 #include <memory>
+#include <optional>
 #include <stdexcept>
 #include <string>
 #include <string_view>
@@ -91,6 +92,13 @@ namespace hgraph
         {
             std::string path{};
             std::size_t storage_offset{0};
+            bool        same_cycle{true};
+        };
+
+        struct SubscriptionResponseGateContext
+        {
+            std::size_t storage_offset{0};
+            bool        response_same_cycle{false};
         };
 
         struct SubscriptionResponseGateStorage
@@ -99,6 +107,7 @@ namespace hgraph
             Value pending_response{};
             bool  has_previous{false};
             bool  awaiting_fresh_response{false};
+            bool  awaiting_subscription{false};
         };
 
         struct RequestInputSourceContext
@@ -172,19 +181,53 @@ namespace hgraph
 
         [[nodiscard]] const SubscriptionKeyCaptureContext &register_subscription_key_capture_context(
             std::string path,
-            std::size_t storage_offset)
+            std::size_t storage_offset,
+            bool same_cycle)
         {
             auto &contexts = subscription_key_capture_contexts();
             const auto existing = std::ranges::find_if(
                 contexts,
                 [&](const auto &context) {
-                    return context->path == path && context->storage_offset == storage_offset;
+                    return context->path == path && context->storage_offset == storage_offset
+                        && context->same_cycle == same_cycle;
                 });
             if (existing != contexts.end()) { return **existing; }
             auto context = std::make_unique<SubscriptionKeyCaptureContext>(SubscriptionKeyCaptureContext{
                 .path           = std::move(path),
                 .storage_offset = storage_offset,
+                .same_cycle     = same_cycle,
             });
+            const auto *result = context.get();
+            contexts.push_back(std::move(context));
+            return *result;
+        }
+
+        [[nodiscard]] std::vector<std::unique_ptr<SubscriptionResponseGateContext>> &
+        subscription_response_gate_contexts() noexcept
+        {
+            static auto *contexts =
+                new std::vector<std::unique_ptr<SubscriptionResponseGateContext>>;
+            return *contexts;
+        }
+
+        [[nodiscard]] const SubscriptionResponseGateContext &
+        register_subscription_response_gate_context(
+            std::size_t storage_offset,
+            bool response_same_cycle)
+        {
+            auto &contexts = subscription_response_gate_contexts();
+            const auto existing = std::ranges::find_if(
+                contexts,
+                [&](const auto &context) {
+                    return context->storage_offset == storage_offset
+                        && context->response_same_cycle == response_same_cycle;
+                });
+            if (existing != contexts.end()) { return **existing; }
+            auto context = std::make_unique<SubscriptionResponseGateContext>(
+                SubscriptionResponseGateContext{
+                    .storage_offset = storage_offset,
+                    .response_same_cycle = response_same_cycle,
+                });
             const auto *result = context.get();
             contexts.push_back(std::move(context));
             return *result;
@@ -699,9 +742,12 @@ namespace hgraph
             auto key    = storage.input.borrowed_ref(evaluation_time);
             auto source = NodeView{storage.source}.as<SubscriptionKeySourceView>();
             static_cast<void>(start_phase);
-            const DateTime schedule_time = view.graph().is_nested()
-                                               ? evaluation_time + MIN_TD
-                                               : evaluation_time;
+            const DateTime schedule_time = context.same_cycle
+                                               ? (view.graph().is_nested()
+                                                      ? evaluation_time + MIN_TD
+                                                      : evaluation_time)
+                                               : request_stub_forward_time(
+                                                     view, evaluation_time, start_phase);
             record_subscription_key(source, storage, key, schedule_time, evaluation_time);
         }
 
@@ -725,7 +771,7 @@ namespace hgraph
         }
 
         void evaluate_subscription_response_gate(
-            std::size_t storage_offset,
+            const SubscriptionResponseGateContext &context,
             const NodeView &view,
             DateTime evaluation_time)
         {
@@ -735,9 +781,13 @@ namespace hgraph
             auto key   = input.at(1);
             auto subscriptions_input = input.at(2);
             auto subscriptions = subscriptions_input.as_set();
-            auto &storage = response_gate_storage_of(view, storage_offset);
-            NodeScheduler scheduler{
-                view.scheduler_state(), view.graph_value(), view.node_index(), evaluation_time};
+            auto &storage = response_gate_storage_of(view, context.storage_offset);
+            std::optional<NodeScheduler> scheduler;
+            if (!context.response_same_cycle)
+            {
+                scheduler.emplace(
+                    view.scheduler_state(), view.graph_value(), view.node_index(), evaluation_time);
+            }
             auto output = view.output(evaluation_time);
 
             const auto key_was_added = [&]() {
@@ -747,19 +797,49 @@ namespace hgraph
                     [&](const ValueView &added) { return added.equals(key.value()); });
             };
 
+            const auto key_is_live = [&]() {
+                return key.valid() && subscriptions.contains(key.value());
+            };
+
             const auto stage_fresh_response = [&]() {
                 if (!value.valid() || !value.modified()) { return; }
+                if (context.response_same_cycle)
+                {
+                    apply_current_value(output, value.value());
+                    storage.pending_response = Value{};
+                    storage.awaiting_fresh_response = false;
+                    return;
+                }
                 storage.pending_response = Value{value.value()};
-                scheduler.schedule(MIN_TD);
+                scheduler->schedule(MIN_TD);
             };
 
             if (response_key_changed(storage, key))
             {
                 storage.pending_response = Value{};
-                storage.awaiting_fresh_response = key_was_added();
+                storage.awaiting_subscription = false;
+                storage.awaiting_fresh_response = false;
                 auto mutation = output.begin_mutation(evaluation_time);
                 static_cast<void>(mutation.invalidate());
                 if (!key.valid()) { return; }
+                if (!key_is_live())
+                {
+                    storage.awaiting_subscription = true;
+                    return;
+                }
+                storage.awaiting_fresh_response = key_was_added();
+                if (storage.awaiting_fresh_response)
+                {
+                    stage_fresh_response();
+                    return;
+                }
+            }
+
+            if (storage.awaiting_subscription)
+            {
+                if (!key_is_live()) { return; }
+                storage.awaiting_subscription = false;
+                storage.awaiting_fresh_response = key_was_added();
                 if (storage.awaiting_fresh_response)
                 {
                     stage_fresh_response();
@@ -769,7 +849,8 @@ namespace hgraph
 
             if (storage.awaiting_fresh_response)
             {
-                if (scheduler.is_scheduled_now() && storage.pending_response.has_value())
+                if (!context.response_same_cycle && scheduler->is_scheduled_now()
+                    && storage.pending_response.has_value())
                 {
                     if (!value.valid())
                     {
@@ -872,7 +953,9 @@ namespace hgraph
             auto source = NodeView{storage.source}.as<SubscriptionKeySourceView>();
             source.enqueue(
                 std::move(storage.previous_key), false,
-                view.graph().is_nested() ? evaluation_time + MIN_TD : evaluation_time,
+                context->same_cycle && !view.graph().is_nested()
+                    ? evaluation_time
+                    : evaluation_time + MIN_TD,
                 evaluation_time);
             storage.previous_key = Value{};
             storage.has_previous = false;
@@ -976,7 +1059,8 @@ namespace hgraph
         return builder;
     }
 
-    NodeBuilder make_subscription_key_capture_node(std::string path, const ValueTypeMetaData &key_schema)
+    NodeBuilder make_subscription_key_capture_node(
+        std::string path, const ValueTypeMetaData &key_schema, bool same_cycle)
     {
         path = subscription_key_path(std::move(path));
 
@@ -1001,7 +1085,8 @@ namespace hgraph
         descriptor.storage_plan = &node_storage_plan_for(descriptor.schema, fields);
 
         const auto *context = &register_subscription_key_capture_context(
-            path, descriptor.storage_plan->component(subscription_key_capture_storage_field).offset);
+            path, descriptor.storage_plan->component(subscription_key_capture_storage_field).offset,
+            same_cycle);
 
         descriptor.callbacks.start = [context](const NodeView &view, DateTime evaluation_time) {
             capture_subscription_key(*context, view, evaluation_time, true);
@@ -1018,7 +1103,8 @@ namespace hgraph
 
     NodeBuilder make_subscription_response_gate_node(
         const ValueTypeMetaData &key_schema,
-        const TSValueTypeMetaData &response_schema)
+        const TSValueTypeMetaData &response_schema,
+        bool response_same_cycle)
     {
         auto &registry = TypeRegistry::instance();
         const auto *key_ts_schema = registry.ts(&key_schema);
@@ -1032,8 +1118,8 @@ namespace hgraph
         });
         descriptor.schema.output_schema = &response_schema;
         descriptor.schema.node_kind = NodeKind::Compute;
-        descriptor.schema.uses_scheduler = true;
-        descriptor.schema.active_inputs = std::vector<std::size_t>{0, 1};
+        descriptor.schema.uses_scheduler = !response_same_cycle;
+        descriptor.schema.active_inputs = std::vector<std::size_t>{0, 1, 2};
         descriptor.schema.valid_inputs = std::vector<std::size_t>{};
 
         const std::array fields{NodeStorageField{
@@ -1041,17 +1127,17 @@ namespace hgraph
             .plan = &MemoryUtils::plan_for<SubscriptionResponseGateStorage>(),
         }};
         descriptor.storage_plan = &node_storage_plan_for(descriptor.schema, fields);
-        const std::size_t storage_offset =
-            descriptor.storage_plan->component(subscription_response_gate_storage_field).offset;
-        const auto *canonical_context = descriptor.storage_plan;
+        const auto *context = &register_subscription_response_gate_context(
+            descriptor.storage_plan->component(subscription_response_gate_storage_field).offset,
+            response_same_cycle);
 
-        descriptor.callbacks.evaluate = [storage_offset](
+        descriptor.callbacks.evaluate = [context](
             const NodeView &view, DateTime evaluation_time) {
-            evaluate_subscription_response_gate(storage_offset, view, evaluation_time);
+            evaluate_subscription_response_gate(*context, view, evaluation_time);
         };
 
         NodeBuilder builder = NodeBuilder::from_canonical_descriptor(
-            std::move(descriptor), canonical_context);
+            std::move(descriptor), context);
         builder.label("subscription_response_gate");
         return builder;
     }

--- a/src/hgraph/types/impl/request_reply_transport.cpp
+++ b/src/hgraph/types/impl/request_reply_transport.cpp
@@ -1,4 +1,4 @@
-#include <hgraph/types/request_reply_transport.h>
+#include <hgraph/types/keyed_service_transport.h>
 
 #include <hgraph/runtime/feedback_node.h>
 #include <hgraph/runtime/service_node.h>
@@ -13,7 +13,7 @@
 #include <utility>
 #include <vector>
 
-namespace hgraph::request_reply_transport
+namespace hgraph::keyed_service_transport
 {
     namespace
     {
@@ -23,6 +23,18 @@ namespace hgraph::request_reply_transport
 
         struct request_reply_feedback_sink_marker
         {
+        };
+
+        struct PendingSubscriptionClient
+        {
+            std::string                    base_path{};
+            std::string                    request_path{};
+            std::string                    response_path{};
+            const ValueTypeMetaData       *key_schema{nullptr};
+            WiringPortRef                  key{};
+            WiringPortRef                  request_source{};
+            WiringPortRef                  response_source{};
+            std::type_index                capture_role{typeid(void)};
         };
 
         struct PendingClient
@@ -47,15 +59,18 @@ namespace hgraph::request_reply_transport
             WiringPortRef               response_source{};
             std::type_index             capture_role{typeid(void)};
             std::shared_ptr<const bool> boundary_dependency{};
+            bool                        full_feedback_on_boundary_dependency{true};
         };
 
         struct Planner
         {
             std::unordered_map<std::string, const WiringInstance *>    implementation_inputs{};
-            std::unordered_map<std::string, RequestReplyTransportPlan> plans{};
+            std::unordered_map<std::string, KeyedServiceTransportPlan> plans{};
             std::vector<PendingClient>                                 clients{};
+            std::vector<PendingSubscriptionClient>                     subscription_clients{};
             std::vector<PendingOutput>                                 outputs{};
             std::size_t                                                finalized_clients{0};
+            std::size_t                                                finalized_subscription_clients{0};
             std::size_t                                                finalized_outputs{0};
 
             void finalize(Wiring &w);
@@ -143,11 +158,16 @@ namespace hgraph::request_reply_transport
         }
 
         [[nodiscard]] const WiringInstance *publish_response(Wiring &w, const PendingOutput &pending,
-                                                             RequestReplyTransportPlan plan)
+                                                             KeyedServiceTransportPlan plan)
         {
             WiringPortRef output = pending.output;
-            if (plan == RequestReplyTransportPlan::FullFeedback)
+            if (plan == KeyedServiceTransportPlan::FullFeedback)
             {
+                if (!pending.full_feedback_on_boundary_dependency)
+                {
+                    throw std::logic_error(
+                        "subscription transport cannot select response feedback");
+                }
                 output = response_feedback(w, std::move(output), *pending.response_dict_schema);
             }
             else
@@ -171,9 +191,9 @@ namespace hgraph::request_reply_transport
             return capture.peered_node();
         }
 
-        void publish_request(Wiring &w, const PendingClient &pending, RequestReplyTransportPlan plan)
+        void publish_request(Wiring &w, const PendingClient &pending, KeyedServiceTransportPlan plan)
         {
-            const bool                    direct = plan == RequestReplyTransportPlan::Direct;
+            const bool                    direct = plan == KeyedServiceTransportPlan::Direct;
             std::array<WiringPortRef, 3>  sources{pending.request, pending.request_source, pending.request_id};
             std::array<WiringInputRef, 3> inputs{{
                 WiringInputRef{.source = sources[0]},
@@ -191,11 +211,46 @@ namespace hgraph::request_reply_transport
                 w.register_service_client_rank(pending.request_path, "request/reply service", capture.peered_node(),
                                                false);
             }
-            if (plan != RequestReplyTransportPlan::FullFeedback)
+            if (plan != KeyedServiceTransportPlan::FullFeedback)
             {
                 w.register_service_client_rank(pending.response_path, "request/reply service",
                                                pending.response_source.peered_node(), true);
             }
+        }
+
+        void publish_subscription_request(
+            Wiring &w, PendingSubscriptionClient &pending,
+            KeyedServiceTransportPlan plan)
+        {
+            const bool direct = plan == KeyedServiceTransportPlan::Direct;
+            std::array<WiringPortRef, 2> capture_sources{
+                pending.key, pending.request_source};
+            std::array<WiringInputRef, 2> capture_inputs{{
+                WiringInputRef{.source = capture_sources[0]},
+                WiringInputRef{
+                    .source = capture_sources[1], .rank_dependency = false},
+            }};
+            NodeBuilder capture_builder = make_subscription_key_capture_node(
+                pending.request_path, *pending.key_schema, direct);
+            capture_builder.input_endpoint(
+                graph_wiring_detail::input_endpoint_for_sources(
+                    capture_builder.type().schema()->input_schema,
+                    std::span<const WiringPortRef>{
+                        capture_sources.data(), capture_sources.size()}));
+            WiringPortRef capture = w.add_node(
+                pending.capture_role, std::move(capture_builder),
+                std::span<const WiringInputRef>{
+                    capture_inputs.data(), capture_inputs.size()},
+                Value{});
+            if (direct)
+            {
+                w.register_service_client_rank(
+                    pending.request_path, "subscription service",
+                    capture.peered_node(), false);
+            }
+            w.register_service_client_rank(
+                pending.response_path, "subscription service",
+                pending.response_source.peered_node(), true);
         }
 
         void Planner::finalize(Wiring &w)
@@ -206,23 +261,27 @@ namespace hgraph::request_reply_transport
                 const auto           input = implementation_inputs.find(pending.base_path);
                 if (input == implementation_inputs.end() || input->second == nullptr)
                 {
-                    throw std::logic_error("request/reply implementation '" + pending.base_path +
+                    throw std::logic_error("keyed service implementation '" + pending.base_path +
                                            "' published an output without its request input");
                 }
 
-                RequestReplyTransportPlan plan = RequestReplyTransportPlan::Direct;
-                if (pending.boundary_dependency != nullptr && *pending.boundary_dependency)
+                KeyedServiceTransportPlan plan = KeyedServiceTransportPlan::Direct;
+                if (pending.full_feedback_on_boundary_dependency
+                    && pending.boundary_dependency != nullptr
+                    && *pending.boundary_dependency)
                 {
-                    plan = RequestReplyTransportPlan::FullFeedback;
+                    plan = KeyedServiceTransportPlan::FullFeedback;
                 }
-                else if (output_depends_on(pending.output, input->second))
+                else if ((pending.boundary_dependency != nullptr
+                          && *pending.boundary_dependency)
+                         || output_depends_on(pending.output, input->second))
                 {
-                    plan = RequestReplyTransportPlan::RequestDeferred;
+                    plan = KeyedServiceTransportPlan::RequestDeferred;
                 }
                 auto [it, inserted] = plans.try_emplace(pending.base_path, plan);
                 if (!inserted && it->second != plan)
                 {
-                    throw std::logic_error("request/reply implementation '" + pending.base_path +
+                    throw std::logic_error("keyed service implementation '" + pending.base_path +
                                            "' produced conflicting transport plans");
                 }
                 static_cast<void>(publish_response(w, pending, plan));
@@ -242,10 +301,30 @@ namespace hgraph::request_reply_transport
                     // A child externalizes the service. Both request modes hand
                     // off to the owner on the next tick, so retain the
                     // conservative unranked capture in the compiled child.
-                    publish_request(w, pending, RequestReplyTransportPlan::RequestDeferred);
+                    publish_request(w, pending, KeyedServiceTransportPlan::RequestDeferred);
                     continue;
                 }
                 publish_request(w, pending, selected->second);
+            }
+
+            while (finalized_subscription_clients < subscription_clients.size())
+            {
+                PendingSubscriptionClient &pending =
+                    subscription_clients[finalized_subscription_clients++];
+                const auto selected = plans.find(pending.base_path);
+                if (selected == plans.end())
+                {
+                    if (w.kind() == WiringKind::TopLevel)
+                    {
+                        throw std::logic_error(
+                            "subscription implementation '" + pending.base_path
+                            + "' did not publish a response transport");
+                    }
+                    publish_subscription_request(
+                        w, pending, KeyedServiceTransportPlan::RequestDeferred);
+                    continue;
+                }
+                publish_subscription_request(w, pending, selected->second);
             }
         }
 
@@ -253,7 +332,8 @@ namespace hgraph::request_reply_transport
         {
             auto state = std::static_pointer_cast<Planner>(w.acquire_extension_state(
                 std::type_index(typeid(Planner)), [] { return std::make_shared<Planner>(); }));
-            if (state->clients.empty() && state->outputs.empty() && state->implementation_inputs.empty())
+            if (state->clients.empty() && state->subscription_clients.empty()
+                && state->outputs.empty() && state->implementation_inputs.empty())
             {
                 std::weak_ptr<Planner> weak = state;
                 w.register_pre_rank_finalizer(
@@ -269,9 +349,12 @@ namespace hgraph::request_reply_transport
         }
     }  // namespace
 
-    void defer_client(Wiring &w, std::string base_path, std::string request_path, std::string response_path,
-                      const TSValueTypeMetaData &request_schema, WiringPortRef request, WiringPortRef request_source,
-                      WiringPortRef request_id, WiringPortRef response_source, std::type_index capture_role)
+    void defer_request_reply_client(
+        Wiring &w, std::string base_path, std::string request_path,
+        std::string response_path, const TSValueTypeMetaData &request_schema,
+        WiringPortRef request, WiringPortRef request_source,
+        WiringPortRef request_id, WiringPortRef response_source,
+        std::type_index capture_role)
     {
         planner_for(w)->clients.push_back(PendingClient{
             .base_path = std::move(base_path),
@@ -286,37 +369,108 @@ namespace hgraph::request_reply_transport
         });
     }
 
+    WiringPortRef defer_subscription_client(
+        Wiring &w, std::string base_path, std::string request_path,
+        std::string response_path, const ValueTypeMetaData &key_schema,
+        const TSValueTypeMetaData &response_schema, WiringPortRef key,
+        WiringPortRef request_source, WiringPortRef response,
+        WiringPortRef response_source, std::type_index capture_role,
+        std::type_index gate_role)
+    {
+        std::array<WiringPortRef, 3> gate_sources{
+            std::move(response), key, request_source};
+        std::array<WiringInputRef, 3> gate_inputs{{
+            WiringInputRef{.source = gate_sources[0]},
+            WiringInputRef{.source = gate_sources[1]},
+            WiringInputRef{.source = gate_sources[2]},
+        }};
+        NodeBuilder gate_builder = make_subscription_response_gate_node(
+            key_schema, response_schema, /*response_same_cycle=*/true);
+        gate_builder.input_endpoint(
+            graph_wiring_detail::input_endpoint_for_sources(
+                gate_builder.type().schema()->input_schema,
+                std::span<const WiringPortRef>{
+                    gate_sources.data(), gate_sources.size()}));
+        WiringPortRef gated = w.add_node(
+            gate_role, std::move(gate_builder),
+            std::span<const WiringInputRef>{
+                gate_inputs.data(), gate_inputs.size()},
+            Value{});
+        planner_for(w)->subscription_clients.push_back(PendingSubscriptionClient{
+            .base_path       = std::move(base_path),
+            .request_path    = std::move(request_path),
+            .response_path   = std::move(response_path),
+            .key_schema      = &key_schema,
+            .key             = std::move(key),
+            .request_source  = std::move(request_source),
+            .response_source = std::move(response_source),
+            .capture_role    = capture_role,
+        });
+        return gated;
+    }
+
     void register_implementation_input(Wiring &w, std::string base_path, const WiringInstance *request_source)
     {
         if (request_source == nullptr)
         {
-            throw std::invalid_argument("request/reply implementation input must name a source");
+            throw std::invalid_argument("keyed service implementation input must name a source");
         }
         auto planner = planner_for(w);
         auto [it, inserted] = planner->implementation_inputs.try_emplace(std::move(base_path), request_source);
         if (!inserted && it->second != request_source)
         {
-            throw std::invalid_argument("duplicate request/reply implementation input for '" + it->first + "'");
+            throw std::invalid_argument("duplicate keyed service implementation input for '" + it->first + "'");
         }
     }
 
-    void defer_implementation_output(Wiring &w, std::string base_path, std::string response_path,
-                                     const TSValueTypeMetaData &response_dict_schema, WiringPortRef output,
-                                     WiringPortRef response_source, std::type_index capture_role)
+    namespace
     {
-        auto dependency = w.service_implementation_boundary_dependency();
-        if (dependency == nullptr)
+        void defer_output(
+            Wiring &w, std::string base_path, std::string response_path,
+            const TSValueTypeMetaData &response_dict_schema,
+            WiringPortRef output, WiringPortRef response_source,
+            std::type_index capture_role,
+            bool full_feedback_on_boundary_dependency)
         {
-            throw std::logic_error("request/reply output must be wired inside its implementation scope");
+            auto dependency = w.service_implementation_boundary_dependency();
+            if (dependency == nullptr)
+            {
+                throw std::logic_error(
+                    "keyed service output must be wired inside its implementation scope");
+            }
+            planner_for(w)->outputs.push_back(PendingOutput{
+                .base_path                = std::move(base_path),
+                .response_path            = std::move(response_path),
+                .response_dict_schema     = &response_dict_schema,
+                .output                   = std::move(output),
+                .response_source          = std::move(response_source),
+                .capture_role             = capture_role,
+                .boundary_dependency      = std::move(dependency),
+                .full_feedback_on_boundary_dependency =
+                    full_feedback_on_boundary_dependency,
+            });
         }
-        planner_for(w)->outputs.push_back(PendingOutput{
-            .base_path = std::move(base_path),
-            .response_path = std::move(response_path),
-            .response_dict_schema = &response_dict_schema,
-            .output = std::move(output),
-            .response_source = std::move(response_source),
-            .capture_role = capture_role,
-            .boundary_dependency = std::move(dependency),
-        });
+    }  // namespace
+
+    void defer_request_reply_implementation_output(
+        Wiring &w, std::string base_path, std::string response_path,
+        const TSValueTypeMetaData &response_dict_schema, WiringPortRef output,
+        WiringPortRef response_source, std::type_index capture_role)
+    {
+        defer_output(
+            w, std::move(base_path), std::move(response_path),
+            response_dict_schema, std::move(output), std::move(response_source),
+            capture_role, true);
     }
-}  // namespace hgraph::request_reply_transport
+
+    void defer_subscription_implementation_output(
+        Wiring &w, std::string base_path, std::string response_path,
+        const TSValueTypeMetaData &response_dict_schema, WiringPortRef output,
+        WiringPortRef response_source, std::type_index capture_role)
+    {
+        defer_output(
+            w, std::move(base_path), std::move(response_path),
+            response_dict_schema, std::move(output), std::move(response_source),
+            capture_role, false);
+    }
+}  // namespace hgraph::keyed_service_transport

--- a/src/hgraph/types/service_runtime.cpp
+++ b/src/hgraph/types/service_runtime.cpp
@@ -1,6 +1,7 @@
 #include <hgraph/types/service_runtime.h>
 
 #include <hgraph/types/graph_wiring.h>
+#include <hgraph/types/keyed_service_transport.h>
 #include <hgraph/types/operator_dispatch.h>
 #include <hgraph/types/adaptor_wiring.h>
 #include <hgraph/types/request_reply_transport.h>
@@ -367,29 +368,11 @@ namespace hgraph
             w, std::type_index(typeid(service::detail::shared_output_source_marker)), dict_meta, out_path);
 
         w.register_service_rank_anchor(subs_path, subscriptions.peered_node());
-        w.register_service_client_rank(out_path, "subscription service", shared.peered_node(), true);
-
         // Subscription keys use the same input adaptation as request/reply
         // payloads. In particular, a concrete Bundle leaf is materialized in
         // the service interface's closed base union before capture.
         WiringPortRef adapted_key = graph_wiring_detail::adapt_source_for_input(
             w, TypeRegistry::instance().ts(descriptor.key_type), key);
-        // Root captures rank before the shared key source and publish in the
-        // same cycle. Nested hand-offs retain their one-cycle temporal boundary.
-        std::array<WiringPortRef, 2>  sources{adapted_key, subscriptions};
-        std::array<WiringInputRef, 2> inputs{{
-            WiringInputRef{.source = sources[0]},
-            WiringInputRef{.source = sources[1], .rank_dependency = false},
-        }};
-        NodeBuilder builder = make_subscription_key_capture_node(subs_path, *descriptor.key_type);
-        builder.input_endpoint(graph_wiring_detail::input_endpoint_for_sources(
-            builder.type().schema()->input_schema,
-            std::span<const WiringPortRef>{sources.data(), sources.size()}));
-        WiringPortRef capture = w.add_node(
-            std::type_index(typeid(service::detail::subscription_capture_marker)), std::move(builder),
-            std::span<const WiringInputRef>{inputs.data(), inputs.size()}, Value{});
-        w.register_service_client_rank(subs_path, "subscription service", capture.peered_node(), false);
-
         // The subscribed value: the shared TSD (descriptive-schema patched,
         // as Port::as does) keyed at the subscribed key.
         WiringPortRef dict = shared;
@@ -406,22 +389,19 @@ namespace hgraph
         WiringPortRef output =
             resolved.impl->wire(w, resolved.map, resolved.args, resolved.kwargs).output;
         output.schema = descriptor.value_schema;
-        std::array<WiringPortRef, 3> gate_sources{
-            output, adapted_key, subscriptions};
-        std::array<WiringInputRef, 3> gate_inputs{{
-            WiringInputRef{.source = gate_sources[0]},
-            WiringInputRef{.source = gate_sources[1]},
-            WiringInputRef{.source = gate_sources[2]},
-        }};
-        NodeBuilder gate_builder = make_subscription_response_gate_node(
-            *descriptor.key_type, *descriptor.value_schema);
-        gate_builder.input_endpoint(graph_wiring_detail::input_endpoint_for_sources(
-            gate_builder.type().schema()->input_schema,
-            std::span<const WiringPortRef>{gate_sources.data(), gate_sources.size()}));
-        WiringPortRef gated = w.add_node(
-            std::type_index(typeid(service::detail::subscription_response_gate_marker)),
-            std::move(gate_builder),
-            std::span<const WiringInputRef>{gate_inputs.data(), gate_inputs.size()}, Value{});
+        WiringPortRef gated = keyed_service_transport::defer_subscription_client(
+            w,
+            base,
+            subs_path,
+            out_path,
+            *descriptor.key_type,
+            *descriptor.value_schema,
+            std::move(adapted_key),
+            subscriptions,
+            std::move(output),
+            shared,
+            std::type_index(typeid(service::detail::subscription_capture_marker)),
+            std::type_index(typeid(service::detail::subscription_response_gate_marker)));
         gated.schema = descriptor.value_schema;
         return gated;
     }
@@ -457,16 +437,26 @@ namespace hgraph
                     target, std::type_index(typeid(service::detail::shared_output_source_marker)),
                     dict_meta, out_path);
                 target.register_service_rank_anchor(subs_path, subscriptions.peered_node());
+                auto scope = target.service_implementation_scope(
+                    "subscription service " + requested_base,
+                    std::vector<WiringServiceImplementationEndpoint>{}, false);
+                keyed_service_transport::register_implementation_input(
+                    target, requested_base, subscriptions.peered_node());
                 std::array<WiringPortRef, 1> transport{subscriptions};
                 const auto impl_inputs = combine_impl_inputs(
                     *descriptor_ptr, impl, transport, stored_inputs);
                 WiringPortRef output = describe_service_output(
                     *descriptor_ptr, dict_meta,
                     wire_impl(target, *descriptor_ptr, impl, impl_inputs));
-                const WiringInstance *capture = shared_output_capture_node(
-                    target, std::type_index(typeid(service::detail::shared_output_capture_marker)),
-                    dict_meta, out_path, output, shared);
-                target.register_service_rank_anchor(out_path, capture);
+                keyed_service_transport::defer_subscription_implementation_output(
+                    target,
+                    requested_base,
+                    out_path,
+                    *dict_meta,
+                    std::move(output),
+                    std::move(shared),
+                    std::type_index(typeid(service::detail::shared_output_capture_marker)));
+                scope.complete();
             };
         if (default_fallback)
         {
@@ -757,6 +747,8 @@ namespace hgraph
                         return make_subscription_key_source_node(endpoint, *key_meta);
                     });
                 w.register_service_rank_anchor(endpoint, source.peered_node());
+                keyed_service_transport::register_implementation_input(
+                    w, subscription_base(descriptor, path), source.peered_node());
                 return source;
             }
             case ServiceFlavour::RequestReply: {
@@ -805,10 +797,14 @@ namespace hgraph
                     TypeRegistry::instance().tsd(descriptor.key_type, descriptor.value_schema);
                 WiringPortRef shared = shared_output_source_node(
                     w, std::type_index(typeid(service::detail::shared_output_source_marker)), dict_meta, endpoint);
-                const WiringInstance *capture = shared_output_capture_node(
-                    w, std::type_index(typeid(service::detail::shared_output_capture_marker)),
-                    out.schema != nullptr ? out.schema : dict_meta, endpoint, out, shared);
-                w.register_service_rank_anchor(endpoint, capture);
+                keyed_service_transport::defer_subscription_implementation_output(
+                    w,
+                    subscription_base(descriptor, path),
+                    endpoint,
+                    *dict_meta,
+                    out,
+                    std::move(shared),
+                    std::type_index(typeid(service::detail::shared_output_capture_marker)));
                 return;
             }
             case ServiceFlavour::RequestReply: {

--- a/tests/cpp/test_service_wiring.cpp
+++ b/tests/cpp/test_service_wiring.cpp
@@ -6,6 +6,7 @@
 #include <hgraph/lib/testing/check_output.h>
 #include <hgraph/lib/testing/eval_node.h>
 #include <hgraph/types/adaptor_wiring.h>
+#include <hgraph/types/context_wiring.h>
 #include <hgraph/types/service_wiring.h>
 #include <hgraph/types/static_node.h>
 #include <hgraph/types/value/value_builder.h>
@@ -383,6 +384,31 @@ namespace
             {
                 Value key_value{key};
                 Value price{key * Int{10}};
+                mutation.set(key_value.view(), price.view());
+            }
+        }
+    };
+
+    struct OffsetPricesImplNode
+    {
+        static constexpr auto name = "offset_prices_impl_node";
+
+        static void eval(
+            In<"keys", TSS<Int>, InputValidity::Unchecked> keys,
+            In<"offset", TS<Int>> offset,
+            Out<TSD<Int, TS<Int>>> out)
+        {
+            if (!keys.valid()) { return; }
+
+            auto mutation = out.begin_mutation(out.evaluation_time());
+            for (Int removed : keys.removed())
+            {
+                static_cast<void>(mutation.erase(Value{removed}.view()));
+            }
+            for (Int key : keys.values())
+            {
+                Value key_value{key};
+                Value price{key * Int{10} + offset.value()};
                 mutation.set(key_value.view(), price.view());
             }
         }
@@ -832,6 +858,19 @@ namespace
         }
     };
 
+    struct ServiceDependentPricesImpl
+    {
+        [[maybe_unused]] static constexpr auto name =
+            "service_dependent_prices_impl";
+
+        static Port<TSD<Int, TS<Int>>> compose(Wiring &w, Port<TSS<Int>> keys)
+        {
+            auto offset = wire<BaseValueService>(w, service::path("subscription_offset"));
+            return wire<OffsetPricesImplNode>(w, keys, offset)
+                .as<TSD<Int, TS<Int>>>();
+        }
+    };
+
     inline std::vector<std::pair<std::vector<Int>, std::vector<Int>>> observed_subscription_keys;
 
     struct ObserveSubscriptionKeysNode
@@ -983,6 +1022,56 @@ namespace
         {
             service::register_subscription_service<PricesService, PricesImpl>(w);
             return wire<PricesService>(w, instrument);
+        }
+    };
+
+    struct ServiceDependentPriceClientGraph
+    {
+        [[maybe_unused]] static constexpr auto name =
+            "service_dependent_price_client_graph";
+
+        static Port<TS<Int>> compose(Wiring &w, Port<TS<Int>> instrument)
+        {
+            service::register_reference_service<BaseValueService, BaseValueImpl>(
+                w, service::path("subscription_offset"));
+            service::register_subscription_service<
+                PricesService, ServiceDependentPricesImpl>(
+                w, service::path("dependent_prices"));
+            return wire<PricesService>(
+                w, service::path("dependent_prices"), instrument);
+        }
+    };
+
+    struct SubscriptionContextBranch
+    {
+        [[maybe_unused]] static constexpr auto name =
+            "subscription_context_branch";
+
+        static Port<TS<Int>> compose(Wiring &w, Port<TS<Int>>)
+        {
+            return context::get<TS<Int>>(w, "subscription_price");
+        }
+    };
+
+    struct SubscriptionContextSwitchGraph
+    {
+        [[maybe_unused]] static constexpr auto name =
+            "subscription_context_switch_graph";
+
+        static Port<TS<Int>> compose(
+            Wiring &w, Port<TS<Int>> instrument, Port<TS<Str>> selector)
+        {
+            service::register_subscription_service<PricesService, PricesImpl>(w);
+            auto price = wire<PricesService>(w, instrument);
+            context::scope<"subscription_price"> context_scope{w, price};
+            return wire<stdlib::switch_>(
+                       w, selector,
+                       stdlib::switch_cases({
+                           {Value{Str{"left"}}, fn<SubscriptionContextBranch>()},
+                           {Value{Str{"right"}}, fn<SubscriptionContextBranch>()},
+                       }),
+                       instrument)
+                .as<TS<Int>>();
         }
     };
 
@@ -1286,6 +1375,41 @@ namespace
             auto requests = service::from_graph<AddOneService>(w, custom);
             static_cast<void>(wire<ObserveReplylessRequestsNode>(w, requests));
             service::to_graph<AddOneService>(w, custom, responses);
+        }
+    };
+
+    struct DecoupledSubscriptionImplGraph
+    {
+        [[maybe_unused]] static constexpr auto name =
+            "decoupled_subscription_impl_graph";
+
+        static void compose(
+            Wiring &w,
+            Port<TSD<Int, TS<Int>>> responses,
+            Scalar<"path", Str> path)
+        {
+            const auto custom = service::path(path.value());
+            auto keys = service::from_graph<PricesService>(w, custom);
+            static_cast<void>(wire<ObserveSubscriptionKeysNode>(w, keys));
+            service::to_graph<PricesService>(w, custom, responses);
+        }
+    };
+
+    struct DecoupledSubscriptionClientGraph
+    {
+        [[maybe_unused]] static constexpr auto name =
+            "decoupled_subscription_client_graph";
+
+        static Port<TS<Int>> compose(
+            Wiring &w,
+            Port<TS<Int>> key,
+            Port<TSD<Int, TS<Int>>> responses)
+        {
+            const auto custom = service::path("decoupled_prices");
+            service::register_services<
+                DecoupledSubscriptionImplGraph, PricesService>(
+                w, custom, responses);
+            return wire<PricesService>(w, custom, key);
         }
     };
 
@@ -2275,6 +2399,88 @@ TEST_CASE("service wiring: subscription client reads implementation output by re
 
     CHECK_OUTPUT(eval_node<PriceClientGraph>(values<Int>(7, none, 8)),
                  values<Int>(none, 70, none, 80));
+}
+
+TEST_CASE("service wiring: decoupled subscription transport is direct")
+{
+    hgraph::stdlib::register_standard_operators();
+    observed_subscription_keys.clear();
+
+    CHECK_OUTPUT(
+        eval_node<DecoupledSubscriptionClientGraph>(
+            values<Int>(7),
+            values<Value>(dict_delta<Int, TS<Int>>({{7, 70}}))),
+        values<Int>(70));
+    CHECK(observed_subscription_keys ==
+          std::vector<std::pair<std::vector<Int>, std::vector<Int>>>{
+              {{7}, {}}});
+}
+
+TEST_CASE("service wiring: self-coupled subscription defers only its key relay")
+{
+    hgraph::stdlib::register_standard_operators();
+
+    Wiring wiring;
+    auto key = ts_harness<TS<Int>>::wire_replay(
+        wiring, "subscription_direct_response_owner");
+    static_cast<void>(PriceClientGraph::compose(wiring, key));
+    const GraphBuilder graph = std::move(wiring).finish();
+
+    std::size_t scheduled_gates = 0;
+    std::size_t feedback_sources = 0;
+    std::size_t feedback_sinks = 0;
+    for (const NodeBuilder &node : graph.nodes())
+    {
+        const NodeTypeMetaData *meta = node.type().schema();
+        if (meta == nullptr || meta->display_name == nullptr) { continue; }
+        const std::string_view name{meta->display_name};
+        scheduled_gates += name == "subscription_response_gate"
+                           && meta->uses_scheduler
+                               ? 1
+                               : 0;
+        feedback_sources += name == "feedback_source" ? 1 : 0;
+        feedback_sinks += name == "feedback_sink" ? 1 : 0;
+    }
+    CHECK(scheduled_gates == 0);
+    CHECK(feedback_sources == 0);
+    CHECK(feedback_sinks == 0);
+}
+
+TEST_CASE("service wiring: service-dependent subscription defers only its key relay")
+{
+    hgraph::stdlib::register_standard_operators();
+
+    CHECK_OUTPUT(
+        eval_node<ServiceDependentPriceClientGraph>(values<Int>(7)),
+        values<Int>(none, 80));
+
+    Wiring wiring;
+    auto key = ts_harness<TS<Int>>::wire_replay(
+        wiring, "subscription_plan_owner");
+    static_cast<void>(ServiceDependentPriceClientGraph::compose(wiring, key));
+    const GraphBuilder graph = std::move(wiring).finish();
+    std::size_t scheduled_gates = 0;
+    for (const NodeBuilder &node : graph.nodes())
+    {
+        const NodeTypeMetaData *meta = node.type().schema();
+        if (meta == nullptr || meta->display_name == nullptr) { continue; }
+        scheduled_gates += std::string_view{meta->display_name}
+                               == "subscription_response_gate"
+                           && meta->uses_scheduler
+                               ? 1
+                               : 0;
+    }
+    CHECK(scheduled_gates == 0);
+}
+
+TEST_CASE("service wiring: subscription response crosses a nested context boundary")
+{
+    hgraph::stdlib::register_standard_operators();
+
+    CHECK_OUTPUT(
+        eval_node<SubscriptionContextSwitchGraph>(
+            values<Int>(7), values<Str>(Str{"left"})),
+        values<Int>(none, 70));
 }
 
 TEST_CASE("service wiring: successive subscription keys are published in order")

--- a/tools/parity/catalog.py
+++ b/tools/parity/catalog.py
@@ -923,26 +923,56 @@ def _service_subscription(hg, recipe):
 
     multiplier = recipe.parameters.get("multiplier", 10)
     path = recipe.parameters.get("path", "quotes")
+    dependency = recipe.parameters.get("dependency", False)
 
     @hg.subscription_service
     def quote(path: str, symbol: hg.TS[str]) -> hg.TS[int]: ...
 
-    @hg.graph
-    def quote_value(symbol: hg.TS[str]) -> hg.TS[int]:
-        return hg.len_(symbol) * multiplier
+    if dependency:
+        dependency_path = f"{path}-offset"
 
-    @hg.service_impl(interfaces=quote)
-    def quote_values(
-        symbol: hg.TSS[str],
-    ) -> hg.TSD[str, hg.TS[int]]:
-        return hg.map_(
-            quote_value,
-            __keys__=symbol,
-            __key_arg__="symbol",
-        )
+        @hg.reference_service
+        def offset(path: str = dependency_path) -> hg.TS[int]: ...
+
+        @hg.service_impl(interfaces=offset)
+        def offset_impl(path: str = dependency_path) -> hg.TS[int]:
+            return hg.const(1)
+
+        @hg.graph
+        def quote_value(
+            symbol: hg.TS[str], amount: hg.TS[int]
+        ) -> hg.TS[int]:
+            return hg.len_(symbol) * multiplier + amount
+
+        @hg.service_impl(interfaces=quote)
+        def quote_values(
+            symbol: hg.TSS[str],
+        ) -> hg.TSD[str, hg.TS[int]]:
+            return hg.map_(
+                quote_value,
+                __keys__=symbol,
+                __key_arg__="symbol",
+                amount=offset(path=dependency_path),
+            )
+    else:
+        @hg.graph
+        def quote_value(symbol: hg.TS[str]) -> hg.TS[int]:
+            return hg.len_(symbol) * multiplier
+
+        @hg.service_impl(interfaces=quote)
+        def quote_values(
+            symbol: hg.TSS[str],
+        ) -> hg.TSD[str, hg.TS[int]]:
+            return hg.map_(
+                quote_value,
+                __keys__=symbol,
+                __key_arg__="symbol",
+            )
 
     @hg.graph
     def parity_graph(symbol: hg.TS[str]) -> hg.TS[int]:
+        if dependency:
+            hg.register_service(dependency_path, offset_impl)
         hg.register_service(path, quote_values)
         symbol = _via_non_peered_ref(hg, symbol)
         return quote(path, symbol)
@@ -951,7 +981,7 @@ def _service_subscription(hg, recipe):
     return eval_node(
         parity_graph,
         inputs["symbol"],
-        __end_time__=hg.MIN_ST + (recipe.tick_count + 3) * hg.MIN_TD,
+        __end_time__=hg.MIN_ST + (recipe.tick_count + 4) * hg.MIN_TD,
     )
 
 
@@ -1793,6 +1823,8 @@ def validate_recipe(recipe):
             recipe, "multiplier", 10, minimum=-20, maximum=20
         )
         _validate_path_parameter(recipe, "quotes")
+        if not isinstance(recipe.parameters.get("dependency", False), bool):
+            raise RecipeError("service_subscription dependency must be a boolean")
     elif recipe.template == "adaptor_loopback":
         _validate_bounded_int_parameter(
             recipe, "factor", 2, minimum=-20, maximum=20

--- a/tools/parity/corpus/service-subscription-dependent.json
+++ b/tools/parity/corpus/service-subscription-dependent.json
@@ -1,0 +1,24 @@
+{
+  "schema_version": 1,
+  "id": "service-subscription-dependent",
+  "description": "A subscription implementation that calls another service defers its key relay without delaying the selected response.",
+  "template": "service_subscription",
+  "inputs": {
+    "symbol": ["rates", null, "fx", "rates"]
+  },
+  "parameters": {
+    "dependency": true,
+    "multiplier": 4,
+    "path": "dependent-quotes"
+  },
+  "features": [
+    "framework:service",
+    "service:subscription",
+    "service:reference",
+    "lifecycle:keyed",
+    "lifecycle:transport-delay",
+    "topology:service-dependent",
+    "reference:REF",
+    "binding:non-peered"
+  ]
+}


### PR DESCRIPTION
## Summary

- generalize RFC 0014's request/reply transport planner into a shared keyed-service transport contract
- apply automatic planning to typed and erased subscription-service wiring
- wire decoupled subscriptions directly and defer only the subscription key when the implementation is causally or structurally coupled
- keep the response gate direct and concrete so nested context/switch consumers can wire immediately
- retain the existing request/reply public contract through a compatibility wrapper

## Why

A subscription key is both the request and the response identity. Treating a coupled subscription like full request/reply feedback adds an unnecessary second boundary and can lose transient responses during rapid key churn. Deferring only the key breaks the causal cycle while preserving the existing response lifetime and API behavior.

This is the subscription-service follow-up to #270.

## User impact

Existing subscription and request/reply APIs remain unchanged. Decoupled implementations avoid feedback overhead, while coupled subscription implementations retain the required one-cycle request boundary without delaying responses again.

## Validation

- macOS fresh native suite: 1,448 passed
- macOS Python 3.14 non-WIP suite from a Python 3.12 stable-ABI wheel: 1,897 passed, 11 skipped
- Ubuntu/OrbStack GCC 14 native suite: 1,448 passed
- Ubuntu/OrbStack GCC 14 wheel on Python 3.14 with `polars[rtcompat]`: 1,897 passed, 11 skipped
- 57 parity recipes validated
- released-hgraph subscription dependency replay matches exactly: `[None, 21, None, None, 21]`
