### PR TITLE
Cover multi-interface service permutations

### DIFF
--- a/python/tests/test_service_timing_semantics.py
+++ b/python/tests/test_service_timing_semantics.py
@@ -14,9 +14,121 @@ becomes transiently invalid, hg_cpp removes its element until the child
 validates again instead of retaining a stale value behind an empty delta.
 """
 
+import pytest
+
 import hgraph as hg
 from hgraph import TS, TSD, TSS, graph
 from hgraph.test import eval_node
+
+
+_MIXED_SERVICE_INTERFACE_ORDERS = (
+    "rR", "Rr", "sS", "Ss", "qQ", "Qq",
+    "rs", "sr", "rq", "qr", "sq", "qs",
+    "rsq", "rqs", "srq", "sqr", "qrs", "qsr",
+)
+
+
+@pytest.mark.parametrize("order", _MIXED_SERVICE_INTERFACE_ORDERS)
+def test_multi_interface_service_flavours_are_order_independent(order):
+    """Every mixed service pack shares one implementation in either order.
+
+    Lowercase codes are reference, subscription, and request/reply; uppercase
+    codes are a second interface of the same flavour. Wiring the implementation
+    stubs and clients in the declared order catches order-sensitive endpoint
+    discovery and transport-planner finalization.
+    """
+    @hg.reference_service
+    def current(path: str = "mixed") -> TS[int]: ...
+
+    @hg.reference_service
+    def previous(path: str = "mixed") -> TS[int]: ...
+
+    @hg.subscription_service
+    def price(key: TS[int], path: str = "mixed") -> TS[int]: ...
+
+    @hg.subscription_service
+    def premium_price(key: TS[int], path: str = "mixed") -> TS[int]: ...
+
+    @hg.request_reply_service
+    def adjust(value: TS[int], path: str = "mixed") -> TS[int]: ...
+
+    @hg.request_reply_service
+    def adjust_ten(value: TS[int], path: str = "mixed") -> TS[int]: ...
+
+    by_flavour = {
+        "r": current, "R": previous,
+        "s": price, "S": premium_price,
+        "q": adjust, "Q": adjust_ten,
+    }
+    compositions = []
+
+    @hg.service_impl(interfaces=tuple(by_flavour[item] for item in order))
+    def impl(path: str):
+        compositions.append(tuple(order))
+        for flavour in order:
+            if flavour == "r":
+                current.wire_impl_out_stub(path, hg.const(10))
+            elif flavour == "R":
+                previous.wire_impl_out_stub(path, hg.const(11))
+            elif flavour == "s":
+                keys = price.wire_impl_inputs_stub(path).key
+                price.wire_impl_out_stub(
+                    path,
+                    hg.map_(lambda key: hg.const(20), __keys__=keys),
+                )
+            elif flavour == "S":
+                keys = premium_price.wire_impl_inputs_stub(path).key
+                premium_price.wire_impl_out_stub(
+                    path,
+                    hg.map_(lambda key: hg.const(21), __keys__=keys),
+                )
+            elif flavour == "q":
+                requests = adjust.wire_impl_inputs_stub(path).value
+                adjust.wire_impl_out_stub(
+                    path,
+                    hg.map_(lambda value: value + 1, requests),
+                )
+            else:
+                requests = adjust_ten.wire_impl_inputs_stub(path).value
+                adjust_ten.wire_impl_out_stub(
+                    path,
+                    hg.map_(lambda value: value + 10, requests),
+                )
+
+    @graph
+    def app(key: TS[int], request: TS[int]) -> TS[int]:
+        hg.register_service("mixed", impl)
+        clients = []
+        for flavour in order:
+            if flavour == "r":
+                clients.append(current(path="mixed"))
+            elif flavour == "R":
+                clients.append(previous(path="mixed"))
+            elif flavour == "s":
+                clients.append(price(key, path="mixed"))
+            elif flavour == "S":
+                clients.append(premium_price(key, path="mixed"))
+            elif flavour == "q":
+                clients.append(adjust(request, path="mixed"))
+            else:
+                clients.append(adjust_ten(request, path="mixed"))
+        result = clients[0]
+        for client in clients[1:]:
+            result = result + client
+        return result
+
+    expected = sum(
+        {"r": 10, "R": 11, "s": 20, "S": 21, "q": 8, "Q": 17}[item]
+        for item in order
+    )
+    expected_trace = (
+        [None, expected] if any(item in "sSqQ" for item in order)
+        else [expected]
+    )
+    assert eval_node(
+        app, [2], [7], __end_time__=hg.MIN_ST + 6 * hg.MIN_TD,
+    ) == expected_trace
+    assert compositions == [tuple(order)]
 
 
 def test_service_adaptor_roundtrip_is_same_cycle():

--- a/tests/cpp/test_service_wiring.cpp
+++ b/tests/cpp/test_service_wiring.cpp
@@ -2120,6 +2120,149 @@ namespace
         }
     };
 
+    template <typename... Interfaces>
+    struct MixedServicePermutationImpl
+    {
+        [[maybe_unused]] static constexpr auto name =
+            "mixed_service_permutation_impl";
+        inline static int compositions = 0;
+
+        template <typename Interface>
+        static void wire_interface(Wiring &w, const service::ServicePath &custom)
+        {
+            if constexpr (std::same_as<Interface, BaseValueService>)
+            {
+                service::impl_output<BaseValueService>(w, custom, wire<TenSourceNode>(w));
+            }
+            else if constexpr (std::same_as<Interface, DerivedValueService>)
+            {
+                service::impl_output<DerivedValueService>(
+                    w, custom,
+                    wire<stdlib::const_>(w, Int{11}).as<TS<Int>>());
+            }
+            else if constexpr (std::same_as<Interface, PricesService>)
+            {
+                auto keys = service::impl_input<PricesService>(w, custom);
+                service::impl_output<PricesService>(
+                    w, custom,
+                    wire<PricesImplNode>(w, keys).as<TSD<Int, TS<Int>>>());
+            }
+            else if constexpr (std::same_as<Interface, DerivedPricesService>)
+            {
+                auto keys = service::impl_input<DerivedPricesService>(w, custom);
+                service::impl_output<DerivedPricesService>(
+                    w, custom,
+                    wire<PricesImplNode>(w, keys).as<TSD<Int, TS<Int>>>());
+            }
+            else if constexpr (std::same_as<Interface, AddOneService>)
+            {
+                auto requests = service::impl_input<AddOneService>(w, custom);
+                service::impl_output<AddOneService>(
+                    w, custom,
+                    wire<AddOneImplNode>(w, requests).as<TSD<Int, TS<Int>>>());
+            }
+            else
+            {
+                static_assert(std::same_as<Interface, AddTenService>);
+                auto requests = service::impl_input<AddTenService>(w, custom);
+                service::impl_output<AddTenService>(
+                    w, custom,
+                    wire<AddTenImplNode>(w, requests).as<TSD<Int, TS<Int>>>());
+            }
+        }
+
+        static void compose(Wiring &w, Scalar<"path", Str> path)
+        {
+            ++compositions;
+            const auto custom = service::path(path.value());
+            // Follow the declared interface order so the matrix also proves
+            // that stub discovery and keyed transport finalization are not
+            // order-dependent.
+            (wire_interface<Interfaces>(w, custom), ...);
+        }
+    };
+
+    template <typename... Interfaces>
+    struct MixedServicePermutationClientGraph
+    {
+        [[maybe_unused]] static constexpr auto name =
+            "mixed_service_permutation_client_graph";
+
+        template <typename Interface>
+        static Port<TS<Int>> add_client(
+            Wiring &w, const service::ServicePath &custom,
+            Port<TS<Int>> key, Port<TS<Int>> request,
+            Port<TS<Int>> total)
+        {
+            Port<TS<Int>> value = [&]() {
+                if constexpr (std::same_as<Interface, BaseValueService>)
+                {
+                    return wire<BaseValueService>(w, custom);
+                }
+                else if constexpr (std::same_as<Interface, DerivedValueService>)
+                {
+                    return wire<DerivedValueService>(w, custom);
+                }
+                else if constexpr (std::same_as<Interface, PricesService>)
+                {
+                    return wire<PricesService>(w, custom, key);
+                }
+                else if constexpr (std::same_as<Interface, DerivedPricesService>)
+                {
+                    return wire<DerivedPricesService>(w, custom, key);
+                }
+                else if constexpr (std::same_as<Interface, AddOneService>)
+                {
+                    return wire<AddOneService>(w, custom, request);
+                }
+                else
+                {
+                    static_assert(std::same_as<Interface, AddTenService>);
+                    return wire<AddTenService>(w, custom, request);
+                }
+            }();
+            return wire<stdlib::add_>(w, total, value).as<TS<Int>>();
+        }
+
+        static Port<TS<Int>> compose(
+            Wiring &w, Port<TS<Int>> key, Port<TS<Int>> request)
+        {
+            const auto custom = service::path("mixed_permutation");
+            service::register_services<
+                MixedServicePermutationImpl<Interfaces...>, Interfaces...>(
+                    w, custom);
+
+            auto total = wire<stdlib::const_>(w, Int{0}).as<TS<Int>>();
+            ((total = add_client<Interfaces>(
+                  w, custom, key, request, std::move(total))), ...);
+            return total;
+        }
+    };
+
+    template <typename... Interfaces>
+    void check_mixed_service_permutation(Int expected)
+    {
+        using Implementation = MixedServicePermutationImpl<Interfaces...>;
+        Implementation::compositions = 0;
+        const auto actual =
+            eval_node<MixedServicePermutationClientGraph<Interfaces...>>(
+                values<Int>(2), values<Int>(7));
+        constexpr bool has_keyed_interface =
+            ((std::same_as<Interfaces, PricesService>
+              || std::same_as<Interfaces, DerivedPricesService>
+              || std::same_as<Interfaces, AddOneService>
+              || std::same_as<Interfaces, AddTenService>) || ...);
+        if constexpr (has_keyed_interface)
+        {
+            CHECK_OUTPUT(actual, values<Int>(none, expected));
+        }
+        else
+        {
+            CHECK_OUTPUT(actual, values<Int>(expected));
+        }
+        CHECK(Implementation::compositions == 1);
+    }
+
     struct ServiceAdaptorTwoClientGraph
     {
         [[maybe_unused]] static constexpr auto name = "service_adaptor_two_client_graph";
@@ -2891,6 +3034,41 @@ TEST_CASE("service wiring: multi-interface implementation graph wires explicit s
     hgraph::stdlib::register_standard_operators();
 
     CHECK_OUTPUT(eval_node<MultiServiceClientGraph>(values<Int>(1)), values<Int>(none, 13));
+}
+
+TEST_CASE("service wiring: every service-interface flavour permutation shares one implementation")
+{
+    hgraph::stdlib::register_standard_operators();
+
+    // Exercise both orders of same-flavour and mixed-flavour pairs, followed
+    // by every ordering of a reference/subscription/request-reply pack.
+    check_mixed_service_permutation<BaseValueService, DerivedValueService>(21);
+    check_mixed_service_permutation<DerivedValueService, BaseValueService>(21);
+    check_mixed_service_permutation<PricesService, DerivedPricesService>(40);
+    check_mixed_service_permutation<DerivedPricesService, PricesService>(40);
+    check_mixed_service_permutation<AddOneService, AddTenService>(25);
+    check_mixed_service_permutation<AddTenService, AddOneService>(25);
+
+    // Reference=10, subscription(key=2)=20, request/reply(7)=8.
+    check_mixed_service_permutation<BaseValueService, PricesService>(30);
+    check_mixed_service_permutation<PricesService, BaseValueService>(30);
+    check_mixed_service_permutation<BaseValueService, AddOneService>(18);
+    check_mixed_service_permutation<AddOneService, BaseValueService>(18);
+    check_mixed_service_permutation<PricesService, AddOneService>(28);
+    check_mixed_service_permutation<AddOneService, PricesService>(28);
+
+    check_mixed_service_permutation<
+        BaseValueService, PricesService, AddOneService>(38);
+    check_mixed_service_permutation<
+        BaseValueService, AddOneService, PricesService>(38);
+    check_mixed_service_permutation<
+        PricesService, BaseValueService, AddOneService>(38);
+    check_mixed_service_permutation<
+        PricesService, AddOneService, BaseValueService>(38);
+    check_mixed_service_permutation<
+        AddOneService, BaseValueService, PricesService>(38);
+    check_mixed_service_permutation<
+        AddOneService, PricesService, BaseValueService>(38);
 }
 
 TEST_CASE("service wiring: a source-only adaptor is unambiguous alongside services")


### PR DESCRIPTION
## Summary

- add a complete 18-order matrix for reference, subscription, and request/reply service interfaces
- cover same-flavour pairs, mixed pairs, and every three-interface ordering in native C++ and Python
- assert aggregate output, current timing, single shared-implementation composition, and declared-order endpoint discovery

## Context

This is a focused test-only follow-up to merged PR #271. It verifies that the recent service transport-planning changes preserve multi-interface implementations across every interface permutation. The Python coverage uses the established implementation-stub APIs, while C++ exercises the first-class native wiring path.

There is no runtime behavior change in this PR. Against released Python hgraph 0.5.34, values and API behavior agree; request/reply combinations retain the already-approved RFC 14 one-cycle timing difference.

## Validation

- macOS native acceptance: 1449/1449 tests passed
- stable-ABI wheel built with Python 3.12; full Python 3.14 suite: 1915 passed, 11 skipped
- Ubuntu GCC 14 focused native matrix: 36 assertions passed
- Ubuntu Python 3.14 focused matrix: 18 passed
- differential campaign: 105/105 cases, 90 matched, 15 known mismatches, 0 new verified mismatches
- parity recipe validation: 57 recipes