### PR TITLE
Assert multi-interface service identity

### DIFF
--- a/python/tests/test_service_timing_semantics.py
+++ b/python/tests/test_service_timing_semantics.py
@@ -60,6 +60,7 @@ def test_multi_interface_service_flavours_are_order_independent(order):
         "s": price, "S": premium_price,
         "q": adjust, "Q": adjust_ten,
     }
+    result_type = hg.TSL[hg.TS[int], hg.Size[len(order)]]
     compositions = []
 
     @hg.service_impl(interfaces=tuple(by_flavour[item] for item in order))
@@ -96,7 +97,7 @@ def test_multi_interface_service_flavours_are_order_independent(order):
                 )
 
     @graph
-    def app(key: TS[int], request: TS[int]) -> TS[int]:
+    def app(key: TS[int], request: TS[int]) -> result_type:
         hg.register_service("mixed", impl)
         clients = []
         for flavour in order:
@@ -112,19 +113,26 @@ def test_multi_interface_service_flavours_are_order_independent(order):
                 clients.append(adjust(request, path="mixed"))
             else:
                 clients.append(adjust_ten(request, path="mixed"))
-        result = clients[0]
-        for client in clients[1:]:
-            result = result + client
-        return result
+        return hg.combine[result_type](*clients)
 
-    expected = sum(
-        {"r": 10, "R": 11, "s": 20, "S": 21, "q": 8, "Q": 17}[item]
-        for item in order
-    )
-    expected_trace = (
-        [None, expected] if any(item in "sSqQ" for item in order)
-        else [expected]
-    )
+    expected_values = {"r": 10, "R": 11, "s": 20, "S": 21, "q": 8, "Q": 17}
+    reference_delta = {
+        index: expected_values[item]
+        for index, item in enumerate(order)
+        if item in "rR"
+    }
+    keyed_delta = {
+        index: expected_values[item]
+        for index, item in enumerate(order)
+        if item in "sSqQ"
+    }
+    expected_trace = []
+    if reference_delta:
+        expected_trace.append(reference_delta)
+    elif keyed_delta:
+        expected_trace.append(None)
+    if keyed_delta:
+        expected_trace.append(keyed_delta)
     assert eval_node(
         app, [2], [7], __end_time__=hg.MIN_ST + 6 * hg.MIN_TD,
     ) == expected_trace

--- a/tests/cpp/test_service_wiring.cpp
+++ b/tests/cpp/test_service_wiring.cpp
@@ -14,6 +14,7 @@
 #include <algorithm>
 #include <cstddef>
 #include <concepts>
+#include <optional>
 #include <stdexcept>
 #include <string>
 #include <tuple>
@@ -2150,9 +2151,11 @@ namespace
             else if constexpr (std::same_as<Interface, DerivedPricesService>)
             {
                 auto keys = service::impl_input<DerivedPricesService>(w, custom);
+                auto offset = wire<stdlib::const_>(w, Int{1}).as<TS<Int>>();
                 service::impl_output<DerivedPricesService>(
                     w, custom,
-                    wire<PricesImplNode>(w, keys).as<TSD<Int, TS<Int>>>());
+                    wire<OffsetPricesImplNode>(w, keys, offset)
+                        .as<TSD<Int, TS<Int>>>());
             }
             else if constexpr (std::same_as<Interface, AddOneService>)
             {
@@ -2189,12 +2192,11 @@ namespace
             "mixed_service_permutation_client_graph";
 
         template <typename Interface>
-        static Port<TS<Int>> add_client(
+        static Port<TS<Int>> client(
             Wiring &w, const service::ServicePath &custom,
-            Port<TS<Int>> key, Port<TS<Int>> request,
-            Port<TS<Int>> total)
+            Port<TS<Int>> key, Port<TS<Int>> request)
         {
-            Port<TS<Int>> value = [&]() {
+            return [&]() {
                 if constexpr (std::same_as<Interface, BaseValueService>)
                 {
                     return wire<BaseValueService>(w, custom);
@@ -2221,10 +2223,9 @@ namespace
                     return wire<AddTenService>(w, custom, request);
                 }
             }();
-            return wire<stdlib::add_>(w, total, value).as<TS<Int>>();
         }
 
-        static Port<TS<Int>> compose(
+        static Port<TSL<TS<Int>, sizeof...(Interfaces)>> compose(
             Wiring &w, Port<TS<Int>> key, Port<TS<Int>> request)
         {
             const auto custom = service::path("mixed_permutation");
@@ -2232,15 +2233,58 @@ namespace
                 MixedServicePermutationImpl<Interfaces...>, Interfaces...>(
                     w, custom);
 
-            auto total = wire<stdlib::const_>(w, Int{0}).as<TS<Int>>();
-            ((total = add_client<Interfaces>(
-                  w, custom, key, request, std::move(total))), ...);
-            return total;
+            // Tuple list-initialization evaluates left-to-right, preserving the
+            // declared client order before the structural list is assembled.
+            auto clients = std::tuple{
+                client<Interfaces>(w, custom, key, request)...};
+            return std::apply(
+                [&](const auto &...ports) {
+                    return stdlib::to_tsl<
+                        TSL<TS<Int>, sizeof...(Interfaces)>>(w, ports...);
+                },
+                clients);
         }
     };
 
+    template <typename Interface>
+    constexpr Int mixed_service_expected_value()
+    {
+        if constexpr (std::same_as<Interface, BaseValueService>) { return 10; }
+        else if constexpr (std::same_as<Interface, DerivedValueService>) { return 11; }
+        else if constexpr (std::same_as<Interface, PricesService>) { return 20; }
+        else if constexpr (std::same_as<Interface, DerivedPricesService>) { return 21; }
+        else if constexpr (std::same_as<Interface, AddOneService>) { return 8; }
+        else
+        {
+            static_assert(std::same_as<Interface, AddTenService>);
+            return 17;
+        }
+    }
+
+    template <typename Interface>
+    constexpr bool mixed_service_is_reference =
+        std::same_as<Interface, BaseValueService>
+        || std::same_as<Interface, DerivedValueService>;
+
+    template <typename Interface>
+    std::optional<Int> mixed_service_reference_value()
+    {
+        if constexpr (mixed_service_is_reference<Interface>)
+        {
+            return mixed_service_expected_value<Interface>();
+        }
+        else { return std::nullopt; }
+    }
+
+    template <typename Interface>
+    std::optional<Int> mixed_service_keyed_value()
+    {
+        if constexpr (mixed_service_is_reference<Interface>) { return std::nullopt; }
+        else { return mixed_service_expected_value<Interface>(); }
+    }
+
     template <typename... Interfaces>
-    void check_mixed_service_permutation(Int expected)
+    void check_mixed_service_permutation()
     {
         using Implementation = MixedServicePermutationImpl<Interfaces...>;
         Implementation::compositions = 0;
@@ -2252,13 +2296,25 @@ namespace
               || std::same_as<Interfaces, DerivedPricesService>
               || std::same_as<Interfaces, AddOneService>
               || std::same_as<Interfaces, AddTenService>) || ...);
-        if constexpr (has_keyed_interface)
+        constexpr bool has_reference_interface =
+            (mixed_service_is_reference<Interfaces> || ...);
+        auto reference_delta = list_delta<TS<Int>>(
+            std::vector<std::optional<Int>>{
+                mixed_service_reference_value<Interfaces>()...});
+        auto keyed_delta = list_delta<TS<Int>>(
+            std::vector<std::optional<Int>>{
+                mixed_service_keyed_value<Interfaces>()...});
+        if constexpr (has_reference_interface && has_keyed_interface)
         {
-            CHECK_OUTPUT(actual, values<Int>(none, expected));
+            CHECK_OUTPUT(actual, values<Value>(reference_delta, keyed_delta));
+        }
+        else if constexpr (has_keyed_interface)
+        {
+            CHECK_OUTPUT(actual, values<Value>(none, keyed_delta));
         }
         else
         {
-            CHECK_OUTPUT(actual, values<Int>(expected));
+            CHECK_OUTPUT(actual, values<Value>(reference_delta));
         }
         CHECK(Implementation::compositions == 1);
     }
@@ -3042,33 +3098,33 @@ TEST_CASE("service wiring: every service-interface flavour permutation shares on
 
     // Exercise both orders of same-flavour and mixed-flavour pairs, followed
     // by every ordering of a reference/subscription/request-reply pack.
-    check_mixed_service_permutation<BaseValueService, DerivedValueService>(21);
-    check_mixed_service_permutation<DerivedValueService, BaseValueService>(21);
-    check_mixed_service_permutation<PricesService, DerivedPricesService>(40);
-    check_mixed_service_permutation<DerivedPricesService, PricesService>(40);
-    check_mixed_service_permutation<AddOneService, AddTenService>(25);
-    check_mixed_service_permutation<AddTenService, AddOneService>(25);
+    check_mixed_service_permutation<BaseValueService, DerivedValueService>();
+    check_mixed_service_permutation<DerivedValueService, BaseValueService>();
+    check_mixed_service_permutation<PricesService, DerivedPricesService>();
+    check_mixed_service_permutation<DerivedPricesService, PricesService>();
+    check_mixed_service_permutation<AddOneService, AddTenService>();
+    check_mixed_service_permutation<AddTenService, AddOneService>();
 
     // Reference=10, subscription(key=2)=20, request/reply(7)=8.
-    check_mixed_service_permutation<BaseValueService, PricesService>(30);
-    check_mixed_service_permutation<PricesService, BaseValueService>(30);
-    check_mixed_service_permutation<BaseValueService, AddOneService>(18);
-    check_mixed_service_permutation<AddOneService, BaseValueService>(18);
-    check_mixed_service_permutation<PricesService, AddOneService>(28);
-    check_mixed_service_permutation<AddOneService, PricesService>(28);
+    check_mixed_service_permutation<BaseValueService, PricesService>();
+    check_mixed_service_permutation<PricesService, BaseValueService>();
+    check_mixed_service_permutation<BaseValueService, AddOneService>();
+    check_mixed_service_permutation<AddOneService, BaseValueService>();
+    check_mixed_service_permutation<PricesService, AddOneService>();
+    check_mixed_service_permutation<AddOneService, PricesService>();
 
     check_mixed_service_permutation<
-        BaseValueService, PricesService, AddOneService>(38);
+        BaseValueService, PricesService, AddOneService>();
     check_mixed_service_permutation<
-        BaseValueService, AddOneService, PricesService>(38);
+        BaseValueService, AddOneService, PricesService>();
     check_mixed_service_permutation<
-        PricesService, BaseValueService, AddOneService>(38);
+        PricesService, BaseValueService, AddOneService>();
     check_mixed_service_permutation<
-        PricesService, AddOneService, BaseValueService>(38);
+        PricesService, AddOneService, BaseValueService>();
     check_mixed_service_permutation<
-        AddOneService, BaseValueService, PricesService>(38);
+        AddOneService, BaseValueService, PricesService>();
     check_mixed_service_permutation<
-        AddOneService, PricesService, BaseValueService>(38);
+        AddOneService, PricesService, BaseValueService>();
 }
 
 TEST_CASE("service wiring: a source-only adaptor is unambiguous alongside services")


### PR DESCRIPTION
## Summary

- preserve each service client result in an ordered structural list instead of reducing the permutation to a commutative sum
- assert interface identity and exact arrival cycle for every reference, subscription, and request/reply permutation
- give the second native subscription implementation a distinct value so endpoint swaps are observable

## Why

Follow-up to the unresolved review on #272. The previous aggregate assertions proved that every interface contributed and that the shared implementation composed once, but addition erased endpoint identity: compatible interfaces could be swapped without changing the expected sum. The native subscription pair was even less discriminating because both implementations produced the same value.

This is a test-only change. It does not alter runtime or user-facing behavior.

## Validation

- fresh macOS native suite: 1449/1449 passed
- stable-ABI wheel built with Python 3.12 and installed into a fresh Python 3.14 environment
- full Python 3.14 compatibility suite: 1915 passed, 11 skipped
- Ubuntu GCC 14 focused native matrix: 36 assertions passed
- focused Python permutation matrix: 18 passed
- parity corpus validation: 57 recipes
- differential PR campaign: 105/105 attempted, 90 matched, 15 known differences, 0 new mismatches