### PR TITLE
Classify reduced request/reply timing

### DIFF
--- a/docs/source/developer_guide/parity_matrix.rst
+++ b/docs/source/developer_guide/parity_matrix.rst
@@ -575,10 +575,12 @@ Wiring and node-authoring surface
        family. RFC 0014 additionally makes a self-coupled response observable
        one cycle earlier than released hgraph 0.5.34 by removing its redundant
        response-feedback boundary. Standalone service recipes and the reduced
-       nested-map shape from issue #274 are bounded by
-       ``request-reply-one-cycle-earlier``; the relation permits an unchanged
-       structural prefix but otherwise removes exactly the silence immediately
-       before the first divergent response. The switch/map family admits the
+       nested-map shape from issue #274 are bounded independently by
+       ``request-reply-one-cycle-earlier`` and
+       ``nested-request-reply-one-cycle-earlier``. Only the nested relation
+       permits an unchanged structural prefix, and it additionally proves the
+       request/reply-backed alpha branch is active at the removed cycle. The
+       switch/map family admits the
        same single-cycle advance only when composed with its exact flip, and
        the complete issue-175 outer-input collision remains fingerprint-pinned.
    * - ``dispatch_``

--- a/docs/source/developer_guide/parity_matrix.rst
+++ b/docs/source/developer_guide/parity_matrix.rst
@@ -574,10 +574,13 @@ Wiring and node-authoring surface
        and C++ regressions and the bounded ``switch-flip-map-removal`` parity
        family. RFC 0014 additionally makes a self-coupled response observable
        one cycle earlier than released hgraph 0.5.34 by removing its redundant
-       response-feedback boundary. Standalone service recipes are bounded by
-       ``request-reply-one-cycle-earlier``; the switch/map family admits the
+       response-feedback boundary. Standalone service recipes and the reduced
+       nested-map shape from issue #274 are bounded by
+       ``request-reply-one-cycle-earlier``; the relation permits an unchanged
+       structural prefix but otherwise removes exactly the silence immediately
+       before the first divergent response. The switch/map family admits the
        same single-cycle advance only when composed with its exact flip, and
-       the issue-175 outer-input collision remains fingerprint-pinned.
+       the complete issue-175 outer-input collision remains fingerprint-pinned.
    * - ``dispatch_``
      - Full for Bundle values
      - Native ``dispatch_cases`` / ``dispatch_case`` wiring builds a closed

--- a/docs/source/developer_guide/parity_testing.rst
+++ b/docs/source/developer_guide/parity_testing.rst
@@ -233,7 +233,10 @@ way:
   RFC 0014; the earlier response payload and every other tick must still match;
 * ``request-reply-one-cycle-earlier`` requires a self-coupled request/reply
   candidate trace to equal the complete released-hgraph trace after removing
-  exactly its leading silent response-feedback cycle.
+  exactly the silent response-feedback cycle immediately before the first
+  divergent response. An unchanged structural prefix is permitted so a
+  reducer may remove unrelated later input events without minting a new
+  divergence; every payload and remaining silent cycle must still agree.
 
 An unknown relation, payload corruption, unrelated missing field, candidate
 crash, or status difference does not match and therefore continues through

--- a/docs/source/developer_guide/parity_testing.rst
+++ b/docs/source/developer_guide/parity_testing.rst
@@ -233,10 +233,12 @@ way:
   RFC 0014; the earlier response payload and every other tick must still match;
 * ``request-reply-one-cycle-earlier`` requires a self-coupled request/reply
   candidate trace to equal the complete released-hgraph trace after removing
-  exactly the silent response-feedback cycle immediately before the first
-  divergent response. An unchanged structural prefix is permitted so a
-  reducer may remove unrelated later input events without minting a new
-  divergence; every payload and remaining silent cycle must still agree.
+  exactly its leading silent response-feedback cycle;
+* ``nested-request-reply-one-cycle-earlier`` permits an unchanged structural
+  map prefix before that cycle so a reducer may remove unrelated later input
+  events without minting a new divergence. The request/reply-backed ``alpha``
+  branch must be active at the removed cycle, the advanced tick must carry a
+  mapped response value, and every payload and remaining silence must agree.
 
 An unknown relation, payload corruption, unrelated missing field, candidate
 crash, or status difference does not match and therefore continues through

--- a/python/tests/test_parity_harness.py
+++ b/python/tests/test_parity_harness.py
@@ -1344,6 +1344,87 @@ def test_request_reply_one_cycle_earlier_relation_is_exact():
     assert not classify([None, None], [None])
 
 
+def test_nested_request_reply_one_cycle_earlier_preserves_structural_prefix():
+    from tools.parity.known import (
+        is_known_family_failure,
+        load_known_divergences,
+        matches_known_family,
+    )
+
+    _fingerprints, families = load_known_divergences()
+    timing_family_name = "nested-mapped-request-reply-one-cycle-earlier"
+    timing_families = [
+        family
+        for family in families
+        if family["family"] == timing_family_name
+    ]
+    assert len(timing_families) == 1
+    recipe = {
+        "template": "nested_higher_order",
+        "inputs": {
+            "selector": ["alpha"],
+            "values": [{"k1": 8}],
+        },
+        "parameters": {
+            "increment": 0,
+            "inner": "request_reply",
+            "outer": "map",
+            "reduce_output": False,
+            "wrap_switch": False,
+        },
+    }
+    assert matches_known_family(recipe, timing_families)
+    for name, value in (
+        ("inner", "arithmetic"),
+        ("outer", "mesh"),
+        ("reduce_output", True),
+        ("wrap_switch", True),
+    ):
+        assert not matches_known_family(
+            {
+                **recipe,
+                "parameters": {**recipe["parameters"], name: value},
+            },
+            timing_families,
+        )
+
+    mapped = lambda entries: {"$map": entries}
+    empty = mapped([])
+    first = mapped([["k1", 8]])
+    second = mapped([["k2", -2]])
+    ok = lambda trace: {"status": "ok", "trace": trace}
+
+    def classify(reference, candidate):
+        difference = compare_outcomes(ok(reference), ok(candidate))
+        assert difference is not None
+        return is_known_family_failure(
+            recipe,
+            difference.to_dict(),
+            ok(reference),
+            ok(candidate),
+            timing_families,
+        )
+
+    # Issue #274: reduction removed the later outer-key collision, leaving
+    # exactly RFC 0014's one-cycle response advance after a stable map prefix.
+    assert classify([empty, None, first], [empty, first])
+    # Payload changes, prefix loss, multiple removed cycles, and trailing
+    # silence removal remain reportable.
+    assert not classify(
+        [empty, None, first],
+        [empty, mapped([["k1", 9]])],
+    )
+    assert not classify([empty, None, first], [first])
+    assert not classify([empty, None, None, first], [empty, first])
+    assert not classify([empty, first, None], [empty, first])
+    # The complete issue-175 collision also changes the map delta at the next
+    # outer-key event, so its existing exact fingerprint remains necessary.
+    assert not classify(
+        [empty, None, first, None, second],
+        [empty, first, empty, second],
+    )
+
+
 def test_nested_no_change_retick_family_is_elision_only():
     from tools.parity.known import (
         is_known_family_failure,

--- a/python/tests/test_parity_harness.py
+++ b/python/tests/test_parity_harness.py
@@ -1340,6 +1340,10 @@ def test_request_reply_one_cycle_earlier_relation_is_exact():
     assert not classify(reference, [None, 8, 11, None, 5])
     assert not classify(reference, [None, 8, 10, 5, None])
     assert not classify(reference, [8, 10, None, 5])
+    assert not classify(
+        [None, None, 8, None, 10, None, 5],
+        [None, None, 8, 10, None, 5],
+    )
     # A trace without a response is not accepted merely because it is shorter.
     assert not classify([None, None], [None])
 
@@ -1394,11 +1398,11 @@ def test_nested_request_reply_one_cycle_earlier_preserves_structural_prefix():
     second = mapped([["k2", -2]])
     ok = lambda trace: {"status": "ok", "trace": trace}
 
-    def classify(reference, candidate):
+    def classify(reference, candidate, *, with_recipe=recipe):
         difference = compare_outcomes(ok(reference), ok(candidate))
         assert difference is not None
         return is_known_family_failure(
-            recipe,
+            with_recipe,
             difference.to_dict(),
             ok(reference),
             ok(candidate),
@@ -1417,6 +1421,30 @@ def test_nested_request_reply_one_cycle_earlier_preserves_structural_prefix():
     assert not classify([empty, None, first], [first])
     assert not classify([empty, None, None, first], [empty, first])
     assert not classify([empty, first, None], [empty, first])
+    assert not classify(
+        [empty, first, None, second],
+        [empty, first, second],
+    )
+    assert not classify([empty, None, empty], [empty, empty])
+    beta_only = {
+        **recipe,
+        "inputs": {**recipe["inputs"], "selector": ["beta"]},
+    }
+    assert matches_known_family(beta_only, timing_families)
+    assert not classify(
+        [empty, None, first],
+        [empty, first],
+        with_recipe=beta_only,
+    )
+    beta_at_removal = {
+        **recipe,
+        "inputs": {**recipe["inputs"], "selector": ["alpha", "beta"]},
+    }
+    assert not classify(
+        [empty, None, first],
+        [empty, first],
+        with_recipe=beta_at_removal,
+    )
     # The complete issue-175 collision also changes the map delta at the next
     # outer-key event, so its existing exact fingerprint remains necessary.
     assert not classify(

--- a/tools/parity/known.py
+++ b/tools/parity/known.py
@@ -327,23 +327,36 @@ def _request_reply_one_cycle_earlier_relation(
     _family: dict[str, Any],
 ) -> bool:
     """RFC 0014 self-coupled request/reply transport removes exactly the
-    released implementation's leading response-feedback cycle.
+    released implementation's response-feedback cycle immediately before the
+    first response which differs between the traces.
 
-    Preserve every payload and silent cycle after that boundary.  This is a
-    sequence relation, not a general tolerance for shifted or missing ticks.
+    Preserve any structural prefix, every payload, and every remaining silent
+    cycle.  This is a sequence relation, not a general tolerance for shifted
+    or missing ticks.
     """
     if difference.get("classification") != "length":
         return False
     reference_trace = reference.get("trace")
     candidate_trace = candidate.get("trace")
-    return (
-        isinstance(reference_trace, list)
-        and isinstance(candidate_trace, list)
-        and len(reference_trace) == len(candidate_trace) + 1
-        and reference_trace[0] is None
-        and any(tick is not None for tick in candidate_trace)
-        and reference_trace[1:] == candidate_trace
-    )
+    if (
+        not isinstance(reference_trace, list)
+        or not isinstance(candidate_trace, list)
+        or len(reference_trace) != len(candidate_trace) + 1
+    ):
+        return False
+
+    for index, (ref, cand) in enumerate(
+        zip(reference_trace, candidate_trace)
+    ):
+        if ref == cand:
+            continue
+        return (
+            ref is None
+            and cand is not None
+            and reference_trace[index + 1 :] == candidate_trace[index:]
+        )
+    # Removing an unrelated trailing silence exposes no earlier response.
+    return False
 
 
 def _switch_flip_map_removal_relation(

--- a/tools/parity/known.py
+++ b/tools/parity/known.py
@@ -31,6 +31,7 @@ NO_CHANGE_ELISION = "no-change-elision"
 VALID_SUBSET_REDUCE = "valid-subset-reduce"
 SWITCH_FLIP_MAP_REMOVAL = "switch-flip-map-removal"
 REQUEST_REPLY_ONE_CYCLE_EARLIER = "request-reply-one-cycle-earlier"
+NESTED_REQUEST_REPLY_ONE_CYCLE_EARLIER = "nested-request-reply-one-cycle-earlier"
 
 
 def load_known_divergences(
@@ -327,12 +328,38 @@ def _request_reply_one_cycle_earlier_relation(
     _family: dict[str, Any],
 ) -> bool:
     """RFC 0014 self-coupled request/reply transport removes exactly the
-    released implementation's response-feedback cycle immediately before the
-    first response which differs between the traces.
+    released implementation's leading response-feedback cycle.
 
-    Preserve any structural prefix, every payload, and every remaining silent
-    cycle.  This is a sequence relation, not a general tolerance for shifted
-    or missing ticks.
+    Preserve every payload and silent cycle after that boundary.  This is a
+    sequence relation, not a general tolerance for shifted or missing ticks.
+    """
+    if difference.get("classification") != "length":
+        return False
+    reference_trace = reference.get("trace")
+    candidate_trace = candidate.get("trace")
+    return (
+        isinstance(reference_trace, list)
+        and isinstance(candidate_trace, list)
+        and len(reference_trace) == len(candidate_trace) + 1
+        and reference_trace[0] is None
+        and any(tick is not None for tick in candidate_trace)
+        and reference_trace[1:] == candidate_trace
+    )
+
+
+def _nested_request_reply_one_cycle_earlier_relation(
+    recipe: dict[str, Any],
+    difference: dict[str, Any],
+    reference: dict[str, Any],
+    candidate: dict[str, Any],
+    _family: dict[str, Any],
+) -> bool:
+    """RFC 0014 response timing under an unreduced nested map.
+
+    A stable structural-map prefix may precede the removed feedback cycle, but
+    the request/reply-backed alpha branch must be active at that cycle and the
+    advanced candidate tick must contain a response value. Everything after
+    that single removal remains exact.
     """
     if difference.get("classification") != "length":
         return False
@@ -345,18 +372,47 @@ def _request_reply_one_cycle_earlier_relation(
     ):
         return False
 
+    removed_index = None
     for index, (ref, cand) in enumerate(
         zip(reference_trace, candidate_trace)
     ):
         if ref == cand:
             continue
-        return (
+        if (
             ref is None
             and cand is not None
             and reference_trace[index + 1 :] == candidate_trace[index:]
-        )
-    # Removing an unrelated trailing silence exposes no earlier response.
-    return False
+        ):
+            removed_index = index
+        break
+    if removed_index is None:
+        # Removing a trailing silence exposes no earlier response.
+        return False
+    if any(
+        tick is not None and _canonical_map_entries(tick) != []
+        for tick in candidate_trace[:removed_index]
+    ):
+        # The prefix may establish the map, but an agreeing response before
+        # the removed cycle proves this is not the first response advance.
+        return False
+
+    active_selector = None
+    selector_ticks = (recipe.get("inputs") or {}).get("selector") or ()
+    for selector in selector_ticks[: removed_index + 1]:
+        if selector is not None:
+            active_selector = selector
+    if active_selector != "alpha":
+        return False
+
+    response_entries = _canonical_map_entries(
+        candidate_trace[removed_index]
+    )
+    return bool(response_entries) and any(
+        isinstance(entry, list)
+        and len(entry) == 2
+        and entry[1] != {"$remove": True}
+        for entry in response_entries
+    )
 
 
 def _switch_flip_map_removal_relation(
@@ -473,6 +529,9 @@ RELATIONS = {
     SWITCH_FLIP_MAP_REMOVAL: _switch_flip_map_removal_relation,
     REQUEST_REPLY_ONE_CYCLE_EARLIER: (
         _request_reply_one_cycle_earlier_relation
+    ),
+    NESTED_REQUEST_REPLY_ONE_CYCLE_EARLIER: (
+        _nested_request_reply_one_cycle_earlier_relation
     ),
     KEY_SET_SIZE_NO_RETICK: _key_set_size_no_retick_relation,
 }

--- a/tools/parity/known_divergences.json
+++ b/tools/parity/known_divergences.json
@@ -37,6 +37,21 @@
       "review_after": "2027-08-04"
     },
     {
+      "family": "nested-mapped-request-reply-one-cycle-earlier",
+      "template": "nested_higher_order",
+      "parameters_equal": {
+        "inner": "request_reply",
+        "outer": "map",
+        "wrap_switch": false,
+        "reduce_output": false
+      },
+      "parameters_not_equal": {},
+      "relation": "request-reply-one-cycle-earlier",
+      "issue": "https://github.com/hhenson/hg_cpp/issues/274",
+      "reason": "RFC 0014 removes the same response-feedback cycle when a self-coupled request/reply client is nested under an unreduced map. A stable structural-map prefix may precede the response; suppress only when deleting the single silence immediately before the first divergent response makes every payload and remaining silence identical. The full issue-175 response-versus-new-key collision remains exact-fingerprint-only.",
+      "review_after": "2027-08-04"
+    },
+    {
       "family": "key-set-size-no-retick",
       "template": "tsd_key_set_pipeline",
       "parameters_not_equal": {

--- a/tools/parity/known_divergences.json
+++ b/tools/parity/known_divergences.json
@@ -46,9 +46,9 @@
         "reduce_output": false
       },
       "parameters_not_equal": {},
-      "relation": "request-reply-one-cycle-earlier",
+      "relation": "nested-request-reply-one-cycle-earlier",
       "issue": "https://github.com/hhenson/hg_cpp/issues/274",
-      "reason": "RFC 0014 removes the same response-feedback cycle when a self-coupled request/reply client is nested under an unreduced map. A stable structural-map prefix may precede the response; suppress only when deleting the single silence immediately before the first divergent response makes every payload and remaining silence identical. The full issue-175 response-versus-new-key collision remains exact-fingerprint-only.",
+      "reason": "RFC 0014 removes the same response-feedback cycle when a self-coupled request/reply client is nested under an unreduced map. A stable structural-map prefix may precede the response; suppress only when the alpha request/reply branch is active at the removed cycle, the advanced tick contains a mapped response value, and deleting that single silence makes every payload and remaining silence identical. The full issue-175 response-versus-new-key collision remains exact-fingerprint-only.",
       "review_after": "2027-08-04"
     },
     {


### PR DESCRIPTION
## Summary

- classify the reduced issue #274 nested `map_` / request-reply trace as RFC 0014's intentional one-cycle response advance
- allow an unchanged structural prefix while still requiring exactly one removed silence and exact payload/suffix equality
- keep the complete issue #175 collision restricted to its existing exact fingerprint
- add positive and negative classifier coverage and document the boundary

This changes parity classification only; it does not change graph runtime behavior or the user API.

Closes #274

## Validation

- `python -m tools.parity validate` — 57 recipes valid
- minimized #274 campaign — 1 documented mismatch, 0 new/quarantined failures
- PR parity campaign — 105/105 attempted, 90 matches, 15 documented mismatches, 0 new/quarantined failures
- parity harness — 38 passed
- fresh native acceptance — 1,449 passed
- Python 3.12 stable-ABI wheel installed under Python 3.14 — 1,916 passed, 11 skipped