### PR TITLE
Extend parity campaigns for scalar operator arguments

### DIFF
--- a/docs/source/developer_guide/parity_testing.rst
+++ b/docs/source/developer_guide/parity_testing.rst
@@ -101,12 +101,13 @@ operator pipelines, and mesh lifecycle driven by a TSD key set.  TSD key-set
 recipes include value-only updates,
 same-cycle replacement, removal, repopulation, and empty transitions.
 
-Twelve of the thirteen generated families pass their inputs through a fixed
-structural ``TSL`` projection before use.  This intentionally combines a
+Most generated framework families pass their inputs through a fixed structural
+``TSL`` projection before use.  This intentionally combines a
 non-peered container with a ``REF``-producing child projection, so ordinary
 operators and framework boundaries must consume REF-transparent sources.
-The remaining scalar-expression family retains direct inputs to preserve an
-independent baseline.
+The scalar-expression and scalar-operator-argument families retain direct
+inputs to preserve an independent baseline and isolate public overload
+selection from reference projection behavior.
 
 The pull-request profile generates 48 cases of 8--32 ticks in addition to the
 curated corpus.  The nightly profile generates 5,000 cases of 8--64 ticks and
@@ -119,15 +120,18 @@ cardinality, remain corpus-only.
 Generated discovery targets the agreed compatibility contract, not accepted
 deviations.  The fixed corpus permanently retains the latter, but unrestricted
 generation works around them: every reduction supplies its explicit identity
-zero; collection and nested scalar outputs use ``dedup`` to normalize equal
-re-ticks; subscription keys include replacements and re-subscriptions while
-using a non-zero multiplier; nested service-backed invalid windows remain
-fixed-corpus cases while standalone service and service-adaptor generators
-cover their agreed behavior; reference-unsupported temporal method-call
-spellings and cyclic adaptor/outer-switch composition remain ordinary
-compatibility or fixed coverage.  This keeps churn, branch lifecycle, service,
-and reduction coverage while reserving random examples for previously unruled
-behavior.
+zero; scalar operator recipes constrain zero divisors, powers, and
+``DivideByZero`` policies to combinations which complete on released hgraph;
+collection generation excludes operator/shape pairs absent from the released
+public overload set; collection and nested scalar outputs use ``dedup`` to
+normalize equal re-ticks; subscription keys include replacements and
+re-subscriptions while using a non-zero multiplier; nested service-backed
+invalid windows remain fixed-corpus cases while standalone service and
+service-adaptor generators cover their agreed behavior; reference-unsupported
+temporal method-call spellings and cyclic adaptor/outer-switch composition
+remain ordinary compatibility or fixed coverage.  This keeps overload, churn,
+branch lifecycle, service, and reduction coverage while reserving random
+examples for previously unruled behavior.
 
 Coverage is semantic rather than only line-based.  Reports count templates,
 time-series shapes, scalar types, operator families, topology, lifecycle
@@ -140,12 +144,17 @@ production triage has actually produced (the 2026-07 batch, issues #74-#92):
 
 - ``scalar_expression`` const arguments exercise scalar auto-const overload
   selection (the #74/#78 exact-matching class);
+- ``scalar_operator_arguments`` calls numeric arithmetic and comparison
+  operators with a raw scalar on either side.  Division, floor division,
+  modulo, and power additionally vary the wiring-time ``DivideByZero`` enum,
+  including reference-valid zero-handling paths;
 - ``temporal_expression`` drives date/datetime arithmetic into the upstream
   ``getattr_`` accessor tables — properties and method-call spellings, the
   ``(date - date).days`` shape included (the #82 class);
-- ``collection_size`` covers ``len_``/``is_empty``/``contains_`` over every
-  upstream-supported sized shape (the #81 class); its no-change re-tick
-  elision is the ruled deviation, bounded by the ``no-change-elision``
+- ``collection_size`` covers the valid ``len_``/``is_empty``/``contains_``
+  pairs over every upstream-supported sized shape (the #81 class); its
+  no-change re-tick elision is the ruled deviation, bounded by the
+  ``no-change-elision``
   relation in ``known_divergences.json``;
 - ``lifecycle_state`` generates start/stop lifecycle functions across the
   accepted signature spellings — strict, bare-injectable, and unannotated

--- a/python/tests/test_parity_harness.py
+++ b/python/tests/test_parity_harness.py
@@ -45,6 +45,31 @@ def _scalar_recipe(ticks=None):
     )
 
 
+def _scalar_operator_recipe(**parameter_updates):
+    parameters = {
+        "operation": "div",
+        "input_type": "int",
+        "scalar_type": "int",
+        "scalar_side": "rhs",
+        "scalar_value": 0,
+        "divide_by_zero": "ZERO",
+    }
+    parameters.update(parameter_updates)
+    if parameters.get("divide_by_zero") is None:
+        parameters.pop("divide_by_zero", None)
+    return Recipe.from_dict(
+        {
+            "schema_version": 1,
+            "id": "test-scalar-operator-recipe",
+            "description": "test",
+            "template": "scalar_operator_arguments",
+            "inputs": {"value": [1, None, -2, 3]},
+            "parameters": parameters,
+            "features": ["argument:scalar", "shape:TS"],
+        }
+    )
+
+
 def test_committed_parity_corpus_is_valid_and_unique():
     recipes = load_corpus(CORPUS)
     assert len(recipes) >= 19
@@ -71,6 +96,58 @@ def test_recipe_rejects_unbounded_or_unsafe_shapes():
     }
     with pytest.raises(RecipeError, match="unsupported expression"):
         validate_recipe(Recipe.from_dict(raw))
+
+
+def test_scalar_operator_arguments_validate_reference_safe_public_overloads():
+    validate_recipe(_scalar_operator_recipe())
+    validate_recipe(_scalar_operator_recipe(
+        operation="pow",
+        scalar_value=3,
+        divide_by_zero="ERROR",
+    ))
+
+    with pytest.raises(RecipeError, match="does not accept divide_by_zero"):
+        validate_recipe(_scalar_operator_recipe(
+            operation="add",
+            divide_by_zero="ZERO",
+        ))
+    with pytest.raises(RecipeError, match="zero divisor requires"):
+        validate_recipe(_scalar_operator_recipe(
+            operation="floordiv",
+            divide_by_zero="ONE",
+        ))
+    with pytest.raises(RecipeError, match="integer pow requires non-negative"):
+        validate_recipe(_scalar_operator_recipe(
+            operation="pow",
+            scalar_value=-1,
+            divide_by_zero="NONE",
+        ))
+    with pytest.raises(RecipeError, match="comparison operands must have matching"):
+        validate_recipe(_scalar_operator_recipe(
+            operation="ge",
+            scalar_type="float",
+            scalar_value=1.0,
+            divide_by_zero=None,
+        ))
+
+
+def test_collection_size_rejects_reference_unsupported_string_is_empty():
+    recipe = Recipe.from_dict(
+        {
+            "schema_version": 1,
+            "id": "test-invalid-string-is-empty",
+            "template": "collection_size",
+            "inputs": {"ts": ["", "value"]},
+            "parameters": {
+                "shape": "str",
+                "operation": "is_empty",
+                "normalize_output": True,
+            },
+            "features": ["shape:TS"],
+        }
+    )
+    with pytest.raises(RecipeError, match=r"is_empty.*TS\[str\]"):
+        validate_recipe(recipe)
 
 
 def test_recipe_fingerprint_is_independent_of_json_key_order():
@@ -208,8 +285,60 @@ def test_generated_framework_recipes_prioritize_ref_and_non_peered_paths():
     )
 
 
+def test_generator_covers_scalar_operator_arguments_and_valid_reference_space():
+    pytest.importorskip("hypothesis")
+    from tools.parity.generate import generate_recipes
+
+    scalar_arguments = generate_recipes(
+        256,
+        seed=41,
+        templates=("scalar_operator_arguments",),
+    )
+    assert {
+        "add", "sub", "mul", "div", "floordiv", "mod", "pow",
+        "eq", "ne", "lt", "le", "gt", "ge",
+    } == {recipe.parameters["operation"] for recipe in scalar_arguments}
+    assert {"lhs", "rhs"} == {
+        recipe.parameters["scalar_side"] for recipe in scalar_arguments
+    }
+    assert {"ERROR", "NAN", "INF", "NONE", "ZERO", "ONE"} == {
+        policy
+        for recipe in scalar_arguments
+        if (policy := recipe.parameters.get("divide_by_zero")) is not None
+    }
+    assert any(
+        recipe.parameters["operation"] in {"div", "floordiv", "mod"}
+        and recipe.parameters["scalar_value"] == 0
+        and recipe.parameters["scalar_side"] == "rhs"
+        for recipe in scalar_arguments
+    )
+    assert all(
+        "argument:scalar" in recipe.features
+        for recipe in scalar_arguments
+    )
+    assert all(
+        recipe.parameters["input_type"] == recipe.parameters["scalar_type"]
+        for recipe in scalar_arguments
+        if recipe.parameters["operation"] in {
+            "eq", "ne", "lt", "le", "gt", "ge",
+        }
+    )
+
+    collection_sizes = generate_recipes(
+        256,
+        seed=43,
+        templates=("collection_size",),
+    )
+    assert not any(
+        recipe.parameters["shape"] == "str"
+        and recipe.parameters["operation"] == "is_empty"
+        for recipe in collection_sizes
+    )
+
+
 def test_campaign_profiles_scale_nightly_breadth_and_tick_depth():
     assert CAMPAIGN_PROFILES["pr"]["examples"] == 48
+    assert "scalar_operator_arguments" in CAMPAIGN_PROFILES["pr"]["templates"]
     assert CAMPAIGN_PROFILES["nightly"]["examples"] == 5000
     assert CAMPAIGN_PROFILES["nightly"]["max_ticks"] == 64
     assert CAMPAIGN_PROFILES["nightly"]["time_budget"] == 3600.0
@@ -1503,9 +1632,11 @@ def test_generated_subscription_recipes_include_resubscriptions():
     pytest.importorskip("hypothesis")
     from tools.parity.generate import generate_recipes
 
-    recipes = generate_recipes(240, seed=29)
-    subs = [r for r in recipes if r.template == "service_subscription"]
-    assert subs, "expected generated service_subscription recipes"
+    subs = generate_recipes(
+        240,
+        seed=29,
+        templates=("service_subscription",),
+    )
     assert any(
         len(symbols := [s for s in recipe.inputs["symbol"] if s is not None])
         != len(set(symbols))
@@ -1584,6 +1715,7 @@ def test_coverage_corpus_recipes_execute_on_the_candidate():
     from tools.parity.runner import run_recipe
 
     for name in (
+        "coverage-scalar-operator-arguments",
         "coverage-temporal-accessors",
         "coverage-collection-sizes",
         "coverage-lifecycle-spellings",

--- a/tools/parity/catalog.py
+++ b/tools/parity/catalog.py
@@ -26,6 +26,25 @@ _BINARY_OPS = {
 }
 _UNARY_OPS = {"neg", "pos", "abs", "dedup"}
 
+_SCALAR_ARGUMENT_OPERATIONS = {
+    "add": "add_",
+    "sub": "sub_",
+    "mul": "mul_",
+    "div": "div_",
+    "floordiv": "floordiv_",
+    "mod": "mod_",
+    "pow": "pow_",
+    "eq": "eq_",
+    "ne": "ne_",
+    "lt": "lt_",
+    "le": "le_",
+    "gt": "gt_",
+    "ge": "ge_",
+}
+_COMPARISON_OPERATIONS = {"eq", "ne", "lt", "le", "gt", "ge"}
+_DIVIDE_POLICY_OPERATIONS = {"div", "floordiv", "mod", "pow"}
+_DIVIDE_BY_ZERO_POLICIES = {"ERROR", "NAN", "INF", "NONE", "ZERO", "ONE"}
+
 
 @dataclass(frozen=True)
 class TemplateSpec:
@@ -225,6 +244,165 @@ def _scalar_expression(hg, recipe):
     )
 
 
+def _scalar_argument_output_type(operation, input_type, scalar_type):
+    if operation in _COMPARISON_OPERATIONS:
+        return "bool"
+    if operation == "div":
+        return "float"
+    return "float" if "float" in (input_type, scalar_type) else "int"
+
+
+def _validate_scalar_operator_arguments(recipe):
+    parameters = recipe.parameters
+    operation = parameters.get("operation")
+    if operation not in _SCALAR_ARGUMENT_OPERATIONS:
+        raise RecipeError(
+            "scalar_operator_arguments operation must name a supported "
+            "numeric binary operator"
+        )
+    input_type = parameters.get("input_type")
+    scalar_type = parameters.get("scalar_type")
+    if input_type not in _NUMERIC_TYPES or scalar_type not in _NUMERIC_TYPES:
+        raise RecipeError(
+            "scalar_operator_arguments input_type and scalar_type must be int or float"
+        )
+    if operation in _COMPARISON_OPERATIONS and input_type != scalar_type:
+        raise RecipeError(
+            "scalar_operator_arguments comparison operands must have matching types"
+        )
+    scalar_side = parameters.get("scalar_side")
+    if scalar_side not in {"lhs", "rhs"}:
+        raise RecipeError(
+            "scalar_operator_arguments scalar_side must be lhs or rhs"
+        )
+
+    expected_input = _SCALAR_TYPES[input_type]
+    for tick in recipe.inputs["value"]:
+        if tick is not None and type(tick) is not expected_input:
+            raise RecipeError(
+                f"scalar_operator_arguments {input_type} input contains "
+                f"{type(tick).__name__}"
+            )
+    if not any(tick is not None for tick in recipe.inputs["value"]):
+        raise RecipeError("scalar_operator_arguments requires a valid input tick")
+
+    scalar_value = parameters.get("scalar_value")
+    if type(scalar_value) is not _SCALAR_TYPES[scalar_type]:
+        raise RecipeError(
+            f"scalar_operator_arguments scalar_value must be {scalar_type}"
+        )
+
+    has_policy = "divide_by_zero" in parameters
+    policy = parameters.get("divide_by_zero")
+    if operation in _DIVIDE_POLICY_OPERATIONS:
+        if has_policy and policy not in _DIVIDE_BY_ZERO_POLICIES:
+            raise RecipeError(
+                "scalar_operator_arguments divide_by_zero must name a "
+                "DivideByZero value"
+            )
+    elif has_policy:
+        raise RecipeError(
+            f"scalar_operator_arguments {operation} does not accept divide_by_zero"
+        )
+
+    if operation in {"div", "floordiv", "mod"}:
+        denominators = (
+            [scalar_value]
+            if scalar_side == "rhs"
+            else [tick for tick in recipe.inputs["value"] if tick is not None]
+        )
+        if any(value == 0 for value in denominators):
+            output_type = _scalar_argument_output_type(
+                operation, input_type, scalar_type
+            )
+            allowed = (
+                {"NAN", "INF", "NONE", "ZERO", "ONE"}
+                if operation == "div"
+                else {"NONE", "ZERO"}
+                if operation == "floordiv" and output_type == "int"
+                else {"NAN", "INF", "NONE", "ZERO", "ONE"}
+                if operation == "floordiv"
+                else {"NONE"}
+                if output_type == "int"
+                else {"NAN", "INF", "NONE"}
+            )
+            if policy not in allowed:
+                raise RecipeError(
+                    f"scalar_operator_arguments {operation} zero divisor "
+                    f"requires one of {sorted(allowed)}"
+                )
+
+    if operation == "pow":
+        bases = (
+            [scalar_value]
+            if scalar_side == "lhs"
+            else [tick for tick in recipe.inputs["value"] if tick is not None]
+        )
+        exponents = (
+            [scalar_value]
+            if scalar_side == "rhs"
+            else [tick for tick in recipe.inputs["value"] if tick is not None]
+        )
+        output_type = _scalar_argument_output_type(
+            operation, input_type, scalar_type
+        )
+        if output_type == "int" and any(value < 0 for value in exponents):
+            raise RecipeError(
+                "scalar_operator_arguments integer pow requires non-negative exponents"
+            )
+        if any(base == 0 for base in bases) and any(
+            exponent < 0 for exponent in exponents
+        ):
+            allowed = (
+                {"NONE"}
+                if output_type == "int"
+                else {"NAN", "INF", "NONE", "ZERO", "ONE"}
+            )
+            if policy not in allowed:
+                raise RecipeError(
+                    "scalar_operator_arguments zero to a negative power "
+                    f"requires one of {sorted(allowed)}"
+                )
+        if any(base < 0 for base in bases) and any(
+            isinstance(exponent, float) and not exponent.is_integer()
+            for exponent in exponents
+        ):
+            raise RecipeError(
+                "scalar_operator_arguments fractional powers require non-negative bases"
+            )
+
+
+def _scalar_operator_arguments(hg, recipe):
+    from hgraph.test import eval_node
+
+    parameters = recipe.parameters
+    operation = parameters["operation"]
+    input_type = parameters["input_type"]
+    scalar_type = parameters["scalar_type"]
+    scalar_side = parameters["scalar_side"]
+    scalar_value = parameters["scalar_value"]
+    output_type = _scalar_argument_output_type(
+        operation, input_type, scalar_type
+    )
+    value = "value"
+    scalar = repr(scalar_value)
+    lhs, rhs = (scalar, value) if scalar_side == "lhs" else (value, scalar)
+    policy = parameters.get("divide_by_zero")
+    policy_argument = (
+        f", divide_by_zero=hg.DivideByZero.{policy}" if policy else ""
+    )
+    source = (
+        "@hg.graph\n"
+        f"def parity_graph(value: hg.TS[{input_type}]) -> hg.TS[{output_type}]:\n"
+        f"    return hg.{_SCALAR_ARGUMENT_OPERATIONS[operation]}("
+        f"{lhs}, {rhs}{policy_argument})\n"
+    )
+    namespace = {"hg": hg}
+    exec(compile(source, f"<parity:{recipe.id}>", "exec"), namespace)
+    inputs = decoded_inputs(hg, recipe)
+    return eval_node(namespace["parity_graph"], inputs["value"])
+
+
 # --------------------------------------------------------------------------
 # Temporal accessor expressions (issue #82 class): date/datetime arithmetic
 # feeding the upstream getattr_ property/method tables.
@@ -377,6 +555,10 @@ def _validate_collection_size(recipe):
     if operation not in _COLLECTION_OPERATIONS:
         raise RecipeError(
             f"collection_size operation must be one of {_COLLECTION_OPERATIONS}")
+    if shape == "str" and operation == "is_empty":
+        raise RecipeError(
+            "collection_size is_empty is not supported for TS[str] by released hgraph"
+        )
     if shape == "tsl":
         if operation != "len":
             raise RecipeError("collection_size tsl covers len only")
@@ -1386,6 +1568,17 @@ CATALOG = {
         ),
         execute=_scalar_expression,
     ),
+    "scalar_operator_arguments": TemplateSpec(
+        name="scalar_operator_arguments",
+        required_inputs=("value",),
+        features=(
+            "shape:TS",
+            "topology:operator-overload",
+            "argument:scalar",
+        ),
+        operators=tuple(sorted(_SCALAR_ARGUMENT_OPERATIONS.values())),
+        execute=_scalar_operator_arguments,
+    ),
     "feedback_accumulate": TemplateSpec(
         name="feedback_accumulate",
         required_inputs=("value",),
@@ -1789,6 +1982,8 @@ def validate_recipe(recipe):
         )
     if recipe.template == "scalar_expression":
         _validate_scalar_expression(recipe)
+    elif recipe.template == "scalar_operator_arguments":
+        _validate_scalar_operator_arguments(recipe)
     elif recipe.template == "temporal_expression":
         _validate_temporal_expression(recipe)
     elif recipe.template == "collection_size":

--- a/tools/parity/cli.py
+++ b/tools/parity/cli.py
@@ -45,6 +45,7 @@ CAMPAIGN_PROFILES = {
         "max_ticks": 32,
         "templates": (
             "scalar_expression",
+            "scalar_operator_arguments",
             "feedback_accumulate",
             "switch_arithmetic",
         ),

--- a/tools/parity/corpus/coverage-scalar-operator-arguments.json
+++ b/tools/parity/corpus/coverage-scalar-operator-arguments.json
@@ -1,0 +1,37 @@
+{
+  "schema_version": 1,
+  "id": "coverage-scalar-operator-arguments",
+  "description": "A raw scalar divisor and wiring-time DivideByZero policy exercise the public div_ overload across sparse ticks.",
+  "template": "scalar_operator_arguments",
+  "inputs": {
+    "value": [
+      6,
+      null,
+      -4,
+      0,
+      9,
+      null,
+      2,
+      -7
+    ]
+  },
+  "parameters": {
+    "operation": "div",
+    "input_type": "int",
+    "scalar_type": "int",
+    "scalar_side": "rhs",
+    "scalar_value": 0,
+    "divide_by_zero": "ZERO"
+  },
+  "features": [
+    "argument:scalar",
+    "argument:scalar-rhs",
+    "operator:div",
+    "policy:divide-by-zero-zero",
+    "shape:TS",
+    "topology:operator-overload",
+    "type:input-int",
+    "type:output-float",
+    "type:scalar-int"
+  ]
+}

--- a/tools/parity/generate.py
+++ b/tools/parity/generate.py
@@ -14,6 +14,9 @@ from .catalog import CATALOG, validate_recipe
 from .model import Recipe, SCHEMA_VERSION
 
 
+_DIVIDE_POLICIES = ("ERROR", "NAN", "INF", "NONE", "ZERO", "ONE")
+
+
 def _recipe_from_payload(payload: dict[str, Any], seed: int) -> Recipe:
     encoded = json.dumps(payload, sort_keys=True, separators=(",", ":"))
     suffix = hashlib.sha256(encoded.encode()).hexdigest()[:12]
@@ -110,6 +113,151 @@ def recipe_payload_strategy(*, min_ticks: int = 8, max_ticks: int = 32,
                 f"ticks:{'long' if count > 16 else 'medium'}",
                 *(f"operator:{operation}" for operation in sorted(operations)),
                 *(("mode:postponed-annotations",) if postponed else ()),
+            ],
+        }
+
+    @st.composite
+    def scalar_operator_arguments(draw):
+        operation = draw(st.sampled_from((
+            "add", "sub", "mul", "div", "floordiv", "mod", "pow",
+            "eq", "ne", "lt", "le", "gt", "ge",
+        )))
+        scalar_side = draw(st.sampled_from(("lhs", "rhs")))
+        input_type = draw(st.sampled_from(("int", "float")))
+        scalar_type = (
+            input_type
+            if operation in {"eq", "ne", "lt", "le", "gt", "ge"}
+            else draw(st.sampled_from(("int", "float")))
+        )
+        count = draw(st.integers(min_value=min_ticks, max_value=max_ticks))
+
+        def numeric(type_name, minimum=-8, maximum=8):
+            values = st.integers(min_value=minimum, max_value=maximum)
+            return values if type_name == "int" else values.map(float)
+
+        def nonzero(type_name):
+            values = st.one_of(
+                st.integers(min_value=-8, max_value=-1),
+                st.integers(min_value=1, max_value=8),
+            )
+            return values if type_name == "int" else values.map(float)
+
+        def sparse_series(values, first=None):
+            initial = draw(values if first is None else st.just(first))
+            return [initial] + [
+                draw(st.one_of(st.none(), values)) for _ in range(count - 1)
+            ]
+
+        divide_by_zero = None
+        output_type = (
+            "bool"
+            if operation in {"eq", "ne", "lt", "le", "gt", "ge"}
+            else "float"
+            if operation == "div" or "float" in (input_type, scalar_type)
+            else "int"
+        )
+
+        if operation in {"div", "floordiv", "mod"}:
+            if operation == "div":
+                zero_policies = ("NAN", "INF", "NONE", "ZERO", "ONE")
+            elif operation == "floordiv" and output_type == "int":
+                zero_policies = ("NONE", "ZERO")
+            elif operation == "floordiv":
+                zero_policies = ("NAN", "INF", "NONE", "ZERO", "ONE")
+            elif output_type == "int":
+                zero_policies = ("NONE",)
+            else:
+                zero_policies = ("NAN", "INF", "NONE")
+            exercise_zero = draw(st.booleans())
+            divide_by_zero = draw(st.sampled_from(
+                zero_policies if exercise_zero else _DIVIDE_POLICIES
+            ))
+            if scalar_side == "rhs":
+                scalar_value = (
+                    0 if scalar_type == "int" else 0.0
+                ) if exercise_zero else draw(nonzero(scalar_type))
+                ticks = sparse_series(numeric(input_type))
+            else:
+                scalar_value = draw(numeric(scalar_type))
+                denominator = numeric(input_type)
+                if exercise_zero:
+                    ticks = sparse_series(
+                        st.one_of(denominator, st.just(
+                            0 if input_type == "int" else 0.0
+                        )),
+                        first=0 if input_type == "int" else 0.0,
+                    )
+                else:
+                    ticks = sparse_series(nonzero(input_type))
+        elif operation == "pow":
+            divide_by_zero = draw(st.sampled_from(_DIVIDE_POLICIES))
+            integer_output = output_type == "int"
+            exercise_zero = not integer_output and draw(st.booleans())
+            if scalar_side == "rhs":
+                if exercise_zero:
+                    scalar_value = -1 if scalar_type == "int" else -1.0
+                    zero = 0 if input_type == "int" else 0.0
+                    ticks = sparse_series(
+                        numeric(input_type, minimum=0, maximum=5), first=zero
+                    )
+                    divide_by_zero = draw(st.sampled_from(
+                        ("NAN", "INF", "NONE", "ZERO", "ONE")
+                    ))
+                else:
+                    scalar_value = draw(numeric(
+                        scalar_type, minimum=0, maximum=4
+                    ))
+                    ticks = sparse_series(numeric(
+                        input_type,
+                        minimum=-5 if integer_output else 0,
+                        maximum=5,
+                    ))
+            else:
+                if exercise_zero:
+                    scalar_value = 0 if scalar_type == "int" else 0.0
+                    negative_one = -1 if input_type == "int" else -1.0
+                    ticks = sparse_series(
+                        numeric(input_type, minimum=-1, maximum=4),
+                        first=negative_one,
+                    )
+                    divide_by_zero = draw(st.sampled_from(
+                        ("NAN", "INF", "NONE", "ZERO", "ONE")
+                    ))
+                else:
+                    scalar_value = draw(numeric(
+                        scalar_type, minimum=0, maximum=5
+                    ))
+                    ticks = sparse_series(numeric(
+                        input_type, minimum=0, maximum=4
+                    ))
+        else:
+            scalar_value = draw(numeric(scalar_type))
+            ticks = sparse_series(numeric(input_type))
+
+        parameters = {
+            "operation": operation,
+            "input_type": input_type,
+            "scalar_type": scalar_type,
+            "scalar_side": scalar_side,
+            "scalar_value": scalar_value,
+        }
+        if divide_by_zero is not None:
+            parameters["divide_by_zero"] = divide_by_zero
+        return {
+            "template": "scalar_operator_arguments",
+            "inputs": {"value": ticks},
+            "parameters": parameters,
+            "features": [
+                *CATALOG["scalar_operator_arguments"].features,
+                f"operator:{operation}",
+                f"argument:scalar-{scalar_side}",
+                f"type:input-{input_type}",
+                f"type:scalar-{scalar_type}",
+                f"type:output-{output_type}",
+                *(
+                    (f"policy:divide-by-zero-{divide_by_zero.lower()}",)
+                    if divide_by_zero is not None else ()
+                ),
             ],
         }
 
@@ -487,8 +635,15 @@ def recipe_payload_strategy(*, min_ticks: int = 8, max_ticks: int = 32,
     @st.composite
     def collection_size(draw):
         shape = draw(st.sampled_from(("str", "tss", "tsd", "tsl")))
-        operation = ("len" if shape == "tsl"
-                     else draw(st.sampled_from(("len", "is_empty", "contains"))))
+        operation = (
+            "len"
+            if shape == "tsl"
+            else draw(st.sampled_from(
+                ("len", "contains")
+                if shape == "str"
+                else ("len", "is_empty", "contains")
+            ))
+        )
         count = draw(st.integers(min_value=min_ticks, max_value=max_ticks))
         parameters = {
             "shape": shape,
@@ -679,6 +834,7 @@ def recipe_payload_strategy(*, min_ticks: int = 8, max_ticks: int = 32,
     # constrained within their individual generators.
     discovery_weighted = (
         ("scalar_expression", scalar_expression),
+        ("scalar_operator_arguments", scalar_operator_arguments),
         ("feedback_accumulate", feedback_accumulate),
         ("switch_arithmetic", switch_arithmetic),
         ("tsd_map_reduce", tsd_map_reduce),


### PR DESCRIPTION
## What changed

- add a bounded `scalar_operator_arguments` recipe family covering raw scalar operands on either side of arithmetic and comparison operators
- generate valid `DivideByZero` policy combinations for division, floor division, modulo, and power
- reject reference-invalid operator/type combinations, including unsupported string `is_empty`
- add curated corpus, controller coverage, PR-profile coverage, and developer documentation

## Why

The campaign should search valid released-hgraph graphs for candidate failures. Public overload arguments were underrepresented, which left scalar operand direction and wiring-time policy parameters largely unexplored and produced avoidable oracle quarantines.

## Validation

- `python -m tools.parity validate` — 58 recipes validated
- focused parity harness — 41 passed
- Linux PR campaign — 106 attempted; 91 matched; 15 known; 0 quarantined; 0 verified failures
- native C++ suite — 1,449 passed
- Python 3.14 non-WIP suite from a Python 3.12 stable-ABI wheel — 1,919 passed, 11 skipped

The new family also exposed an unclassified integer `pow_` result-type mismatch, which is intentionally not suppressed and will be fixed separately.