### PR TITLE
Fix integer pow result parity

### DIFF
--- a/docs/source/user_guide/authoring_graphs_cpp.rst
+++ b/docs/source/user_guide/authoring_graphs_cpp.rst
@@ -332,9 +332,9 @@ Arithmetic
      - Uses Python-style modulo semantics. Optional ``DivideByZero`` policy.
    * - ``pow_`` / ``pow(lhs, rhs)``
      - ``Int ** Int``; ``Float ** Float``; ``Int ** Float``; ``Float ** Int``
-     - ``Float``
-     - Numeric power is explicitly float-valued in C++. Optional ``DivideByZero``
-       policy for ``0 ** negative``.
+     - ``Int`` for ``Int ** Int``; otherwise ``Float``
+     - Integer power requires a non-negative exponent. Optional ``DivideByZero``
+       policy for ``0 ** negative``; ``NoTick`` remains valid for integer power.
    * - ``neg_`` / unary ``-``
      - ``Int``; ``Float``; ``TimeDelta``
      - same type

--- a/include/hgraph/lib/std/lifted_kernels.h
+++ b/include/hgraph/lib/std/lifted_kernels.h
@@ -55,6 +55,10 @@ namespace hgraph::stdlib
         using modulo_result_t = floor_div_result_t<L, R>;
 
         template <typename L, typename R>
+        using pow_result_t = std::conditional_t<
+            std::is_same_v<L, Int> && std::is_same_v<R, Int>, Int, Float>;
+
+        template <typename L, typename R>
         struct ordered_result
         {
             using type = std::conditional_t<std::is_same_v<L, R>, L, Float>;
@@ -91,6 +95,37 @@ namespace hgraph::stdlib
         [[nodiscard]] inline Int modulo_int(Int lhs, Int rhs)
         {
             return lhs - floor_divide_int(lhs, rhs) * rhs;
+        }
+
+        [[nodiscard]] inline Int checked_multiply_int(Int lhs, Int rhs)
+        {
+            constexpr Int min = std::numeric_limits<Int>::min();
+            constexpr Int max = std::numeric_limits<Int>::max();
+            if (lhs == 0 || rhs == 0) { return 0; }
+            if ((lhs > 0 && rhs > 0 && lhs > max / rhs) ||
+                (lhs > 0 && rhs < 0 && rhs < min / lhs) ||
+                (lhs < 0 && rhs > 0 && lhs < min / rhs) ||
+                (lhs < 0 && rhs < 0 && lhs < max / rhs))
+            {
+                throw std::overflow_error("pow_: integer result overflow");
+            }
+            return lhs * rhs;
+        }
+
+        [[nodiscard]] inline Int integer_power(Int base, Int exponent)
+        {
+            if (exponent < 0)
+            {
+                throw std::domain_error("pow_: negative exponent cannot produce an integer result");
+            }
+            Int result = 1;
+            while (exponent != 0)
+            {
+                if ((exponent & 1) != 0) { result = checked_multiply_int(result, base); }
+                exponent /= 2;
+                if (exponent != 0) { base = checked_multiply_int(base, base); }
+            }
+            return result;
         }
 
         [[nodiscard]] inline Float floor_divide_float(Float lhs, Float rhs)
@@ -225,16 +260,26 @@ namespace hgraph::stdlib
     template <typename L, typename R = L>
     struct scalar_pow
     {
+        using result_type = lifted_kernel_detail::pow_result_t<L, R>;
+
         static constexpr const char *name = "scalar_pow";
         static constexpr std::array<std::string_view, 2> parameter_names{"lhs", "rhs"};
 
-        [[nodiscard]] static Float apply(const L &lhs, const R &rhs)
+        [[nodiscard]] static result_type apply(const L &lhs, const R &rhs)
         {
-            if (static_cast<Float>(lhs) == Float{0} && static_cast<Float>(rhs) < Float{0})
+            if constexpr (std::is_same_v<result_type, Int>)
             {
-                throw std::domain_error("pow_: zero cannot be raised to a negative power");
+                static_assert(std::is_same_v<L, Int> && std::is_same_v<R, Int>);
+                return lifted_kernel_detail::integer_power(lhs, rhs);
             }
-            return std::pow(static_cast<Float>(lhs), static_cast<Float>(rhs));
+            else
+            {
+                if (static_cast<Float>(lhs) == Float{0} && static_cast<Float>(rhs) < Float{0})
+                {
+                    throw std::domain_error("pow_: zero cannot be raised to a negative power");
+                }
+                return std::pow(static_cast<Float>(lhs), static_cast<Float>(rhs));
+            }
         }
     };
 

--- a/include/hgraph/lib/std/operators/impl/arithmetic_impl.h
+++ b/include/hgraph/lib/std/operators/impl/arithmetic_impl.h
@@ -317,12 +317,30 @@ namespace hgraph::stdlib
     template <typename L, typename R>
     struct pow_numbers
     {
+        using result_type = lifted_kernel_detail::pow_result_t<L, R>;
+
         static void eval(In<"lhs", TS<L>> lhs, In<"rhs", TS<R>> rhs,
-                         Scalar<"divide_by_zero", DivideByZero> on_zero, Out<TS<Float>> out)
+                         Scalar<"divide_by_zero", DivideByZero> on_zero, Out<TS<result_type>> out)
         {
-            if (const std::optional<Float> result = pow_with_policy(static_cast<Float>(lhs.value()),
-                                                                    static_cast<Float>(rhs.value()),
-                                                                    on_zero.value()))
+            if constexpr (std::is_same_v<result_type, Int>)
+            {
+                const Int base     = lhs.value();
+                const Int exponent = rhs.value();
+                if (exponent < 0)
+                {
+                    if (base == 0 && on_zero.value() == DivideByZero::NoTick) { return; }
+                    if (base == 0)
+                    {
+                        throw std::domain_error("pow_: zero cannot be raised to a negative power");
+                    }
+                    throw std::domain_error("pow_: negative exponent cannot produce an integer result");
+                }
+                out.set(lifted_kernel_detail::integer_power(base, exponent));
+            }
+            else if (const std::optional<Float> result =
+                         pow_with_policy(static_cast<Float>(lhs.value()),
+                                         static_cast<Float>(rhs.value()),
+                                         on_zero.value()))
             {
                 out.set(*result);
             }

--- a/python/tests/ported/_operators/test_number_operators.py
+++ b/python/tests/ported/_operators/test_number_operators.py
@@ -95,7 +95,11 @@ def test_divmod_int_float():
     ],
 )
 def test_pow_numbers(lhs, rhs, expected):
-    assert eval_node(pow_, lhs, rhs) == expected
+    actual = eval_node(pow_, lhs, rhs)
+    assert actual == expected
+    assert [type(value) if value is not None else None for value in actual] == [
+        type(value) if value is not None else None for value in expected
+    ]
 
 
 @pytest.mark.parametrize(

--- a/python/tests/test_parity_harness.py
+++ b/python/tests/test_parity_harness.py
@@ -1716,6 +1716,7 @@ def test_coverage_corpus_recipes_execute_on_the_candidate():
 
     for name in (
         "coverage-scalar-operator-arguments",
+        "regression-integer-pow-result-type",
         "coverage-temporal-accessors",
         "coverage-collection-sizes",
         "coverage-lifecycle-spellings",

--- a/src/hgraph/lib/std/operators/arithmetic_impl.cpp
+++ b/src/hgraph/lib/std/operators/arithmetic_impl.cpp
@@ -181,7 +181,7 @@ namespace hgraph::stdlib
         register_overload<divmod_, divmod_numbers<Int, Float>>();
         register_overload<divmod_, divmod_numbers<Float, Int>>();
 
-        // pow_ — numeric power is explicitly Float-valued in C++.
+        // pow_ — homogeneous integer power remains Int; mixed/float power is Float.
         register_overload<pow_, lift<scalar_pow<Int>>>();
         register_overload<pow_, lift<scalar_pow<Float>>>();
         register_overload<pow_, lift<scalar_pow<Int, Float>>>();

--- a/tests/cpp/lift/test_lift.cpp
+++ b/tests/cpp/lift/test_lift.cpp
@@ -178,7 +178,13 @@ TEST_CASE("lift: standard arithmetic kernels expose scalar operator semantics")
 
     CHECK(value_as_int(eval_binary<stdlib::scalar_floordiv<Int>>(Int{-3}, Int{2})) == Int{-2});
     CHECK(value_as_int(eval_binary<stdlib::scalar_mod<Int>>(Int{-3}, Int{2})) == Int{1});
-    CHECK(value_as_float(eval_binary<stdlib::scalar_pow<Int>>(Int{2}, Int{3})) == Float{8.0});
+    CHECK(value_as_int(eval_binary<stdlib::scalar_pow<Int>>(Int{2}, Int{3})) == Int{8});
+    CHECK(value_as_int(eval_binary<stdlib::scalar_pow<Int>>(Int{-2}, Int{3})) == Int{-8});
+    CHECK(value_as_int(eval_binary<stdlib::scalar_pow<Int>>(Int{0}, Int{0})) == Int{1});
+    CHECK(value_as_float(eval_binary<stdlib::scalar_pow<Int, Float>>(Int{4}, Float{0.5})) == Float{2.0});
+    CHECK_THROWS_AS((eval_binary<stdlib::scalar_pow<Int>>(Int{2}, Int{-1})), std::domain_error);
+    CHECK_THROWS_AS((eval_binary<stdlib::scalar_pow<Int>>(std::numeric_limits<Int>::max(), Int{2})),
+                    std::overflow_error);
     CHECK(value_as_int(eval_unary<stdlib::scalar_neg<Int>>(Int{5})) == Int{-5});
     CHECK(value_as_int(eval_unary<stdlib::scalar_abs<Int>>(Int{-5})) == Int{5});
     CHECK(value_as_int(eval_unary<stdlib::scalar_sign<Int>>(Int{-5})) == Int{-1});

--- a/tests/cpp/test_std_operators.cpp
+++ b/tests/cpp/test_std_operators.cpp
@@ -1519,11 +1519,14 @@ TEST_CASE("std operators: divmod_ returns quotient and remainder as a two-elemen
                  values<Value>(list_delta<TS<Float>>({{0, 2.0}, {1, 1.0}})));
 }
 
-TEST_CASE("std operators: pow_ is Float-valued for numeric operands")
+TEST_CASE("std operators: pow_ preserves homogeneous integer results")
 {
     stdlib::register_standard_operators();
-    CHECK_OUTPUT(eval_node<stdlib::pow_>(values<Int>(2, 9), values<Int>(3, 2)), values<Float>(8.0, 81.0));
+    CHECK_OUTPUT(eval_node<stdlib::pow_>(values<Int>(2, 9), values<Int>(3, 2)), values<Int>(8, 81));
+    CHECK_OUTPUT(eval_node<stdlib::pow_>(values<Int>(2, 3), Int{3}), values<Int>(8, 27));
+    CHECK_OUTPUT(eval_node<stdlib::pow_>(Int{2}, values<Int>(3, 4)), values<Int>(8, 16));
     CHECK_OUTPUT(eval_node<stdlib::pow_>(values<Float>(4.0, 9.0), values<Float>(0.5, 0.5)), values<Float>(2.0, 3.0));
+    CHECK_OUTPUT(eval_node<stdlib::pow_>(values<Int>(4), values<Float>(0.5)), values<Float>(2.0));
 }
 
 TEST_CASE("std operators: pow_ takes divide-by-zero policy for zero raised to a negative power")
@@ -1531,13 +1534,15 @@ TEST_CASE("std operators: pow_ takes divide-by-zero policy for zero raised to a 
     using DBZ = stdlib::DivideByZero;
     stdlib::register_standard_operators();
 
-    CHECK_OUTPUT(eval_node<stdlib::pow_>(values<Int>(0, 2), values<Int>(-1, 3), DBZ::Inf),
+    CHECK_OUTPUT(eval_node<stdlib::pow_>(values<Float>(0.0, 2.0), values<Int>(-1, 3), DBZ::Inf),
                  values<Float>(std::numeric_limits<Float>::infinity(), 8.0));
-    CHECK_OUTPUT(eval_node<stdlib::pow_>(values<Int>(0, 2), values<Int>(-1, 3), DBZ::NoTick),
+    CHECK_OUTPUT(eval_node<stdlib::pow_>(values<Float>(0.0, 2.0), values<Int>(-1, 3), DBZ::NoTick),
                  values<Float>(none, 8.0));
-    CHECK_OUTPUT(eval_node<stdlib::pow_>(values<Int>(0), values<Int>(-1), DBZ::Zero), values<Float>(0.0));
-    CHECK_OUTPUT(eval_node<stdlib::pow_>(values<Int>(0), values<Int>(-1), DBZ::One), values<Float>(1.0));
-    REQUIRE_THROWS(eval_node<stdlib::pow_>(values<Int>(0), values<Int>(-1)));
+    CHECK_OUTPUT(eval_node<stdlib::pow_>(values<Float>(0.0), values<Int>(-1), DBZ::Zero), values<Float>(0.0));
+    CHECK_OUTPUT(eval_node<stdlib::pow_>(values<Float>(0.0), values<Int>(-1), DBZ::One), values<Float>(1.0));
+    CHECK_OUTPUT(eval_node<stdlib::pow_>(values<Int>(0), values<Int>(-1), DBZ::NoTick), values<Int>(none));
+    REQUIRE_THROWS(eval_node<stdlib::pow_>(values<Float>(0.0), values<Int>(-1)));
+    REQUIRE_THROWS(eval_node<stdlib::pow_>(values<Int>(2), values<Int>(-1)));
 }
 
 TEST_CASE("std operators: unary numeric operators support neg pos abs sign and ln")
@@ -1582,7 +1587,7 @@ TEST_CASE("std operators: fixed TSL arithmetic maps elementwise")
     CHECK_OUTPUT((eval_node<stdlib::pow_, TSL<TS<Int>, 3>, TSL<TS<Int>, 3>>(
                      values<Value>(list_delta<TS<Int>>({{0, 3}, {1, 4}, {2, 5}})),
                      values<Value>(list_delta<TS<Int>>({{0, 3}, {1, 0}, {2, 1}})))),
-                 values<Value>(list_delta<TS<Float>>({{0, 27.0}, {1, 1.0}, {2, 5.0}})));
+                 values<Value>(list_delta<TS<Int>>({{0, 27}, {1, 1}, {2, 5}})));
 }
 
 TEST_CASE("std operators: fixed TSL arithmetic broadcasts scalar time-series")
@@ -1612,7 +1617,7 @@ TEST_CASE("std operators: fixed TSL arithmetic broadcasts scalar time-series")
                  values<Value>(list_delta<TS<Int>>({{0, 1}, {1, 0}})));
     CHECK_OUTPUT((eval_node<stdlib::pow_, TSL<TS<Int>, 2>>(
                      values<Value>(list_delta<TS<Int>>({{0, 3}, {1, 2}})), values<Int>(2))),
-                 values<Value>(list_delta<TS<Float>>({{0, 9.0}, {1, 4.0}})));
+                 values<Value>(list_delta<TS<Int>>({{0, 9}, {1, 4}})));
     CHECK_OUTPUT((eval_node<stdlib::div_, TSL<TS<Int>, 2>>(
                      values<Int>(12), values<Value>(list_delta<TS<Int>>({{0, 3}, {1, 4}})))),
                  values<Value>(list_delta<TS<Float>>({{0, 4.0}, {1, 3.0}})));

--- a/tools/parity/corpus/regression-integer-pow-result-type.json
+++ b/tools/parity/corpus/regression-integer-pow-result-type.json
@@ -1,0 +1,30 @@
+{
+  "schema_version": 1,
+  "id": "regression-integer-pow-result-type",
+  "description": "Homogeneous integer pow_ retains the released hgraph TS[int] result type when the rhs is a raw scalar.",
+  "template": "scalar_operator_arguments",
+  "inputs": {
+    "value": [
+      0
+    ]
+  },
+  "parameters": {
+    "operation": "pow",
+    "input_type": "int",
+    "scalar_type": "int",
+    "scalar_side": "rhs",
+    "scalar_value": 0,
+    "divide_by_zero": "NONE"
+  },
+  "features": [
+    "argument:scalar",
+    "argument:scalar-rhs",
+    "operator:pow",
+    "policy:divide-by-zero-none",
+    "shape:TS",
+    "topology:operator-overload",
+    "type:input-int",
+    "type:output-int",
+    "type:scalar-int"
+  ]
+}


### PR DESCRIPTION
## Summary

- preserve `Int` output for homogeneous `Int ** Int`, matching released Python hgraph
- retain `Float` output for mixed and floating operands
- use exact, overflow-checked integer exponentiation and preserve valid `DivideByZero.NONE` silence for `0 ** negative`
- add native, Python bridge, TSL, documentation, and minimized differential-corpus coverage

## Root cause

The native `pow_` overloads forced every numeric combination to `Float`. Released hgraph resolves homogeneous integer operands to `TS[int]`, so valid graphs using raw integer scalar arguments had a user-visible result-type mismatch.

## User impact

Existing hgraph code that expects `pow_` over integer operands to remain integer now wires and evaluates with the same public result type in hg_cpp. Mixed integer/float and float cases retain their existing floating-point behavior.

## Validation

- macOS native suite: 1,449 passed
- macOS Python 3.14 non-WIP suite from the stable-ABI wheel: 1,919 passed, 11 skipped
- installed SDK consumer: passed
- GCC 14 Linux native suite: 1,449 passed
- GCC 14 Linux Python 3.14 non-WIP suite with Polars rtcompat: 1,919 passed, 11 skipped
- minimized differential replay against hgraph 0.5.34: identical `[1]` trace
- PR parity profile: 107 attempted, 92 matched, 15 known divergences, 0 unexpected mismatches