### PR TITLE
Add exact upstream hgraph conformance validation

### DIFF
--- a/docs/source/developer_guide/parity_matrix.rst
+++ b/docs/source/developer_guide/parity_matrix.rst
@@ -275,6 +275,14 @@ model.
        inspect the old private ``_build_map_wiring`` structures and are not
        portable. Keyed-map error capture is covered by the error-handling
        runtime and public ``eval_node`` tests.
+       **Accepted filter correction:** when a keyed input reopens after being
+       filtered, hg_cpp reconciles the complete currently valid state. It
+       removes every formerly published key that is now absent or invalid and
+       does not republish unchanged values. Released hgraph 0.5.34 instead
+       republishes unchanged values and omits an invalidated key; its own test
+       marks that omission as a feature needing reconsideration. The corrected
+       behavior is pinned by ``test_filter_str_tsd`` in the ported Python and
+       native map suites.
    * - ``test_mesh.py``
      - 7
      - Named and anonymous meshes, dependency ordering/cycles, on-demand

--- a/docs/source/developer_guide/parity_testing.rst
+++ b/docs/source/developer_guide/parity_testing.rst
@@ -51,6 +51,63 @@ Useful focused commands are:
    python -m tools.parity coverage --inventory
    python -m tools.parity catalogue
 
+Upstream conformance suite
+--------------------------
+
+Generated recipes cannot prove that existing applications will continue to
+wire: the generator exercises only its trusted catalogue.  The upstream
+conformance tier therefore checks out the tag matching the installed reference
+distribution and stages its exact ``hgraph_unit_tests`` and ``examples`` trees
+without the upstream ``hgraph`` package.  The same unmodified test sources then
+run in separate reference and candidate environments:
+
+.. code-block:: bash
+
+   python -m tools.parity conformance --profile operators
+   python -m tools.parity conformance --profile core --exit-zero
+   python -m tools.parity conformance --profile all --with-extras --exit-zero
+
+``operators`` is the focused public-operator tier.  ``core`` adds runtime,
+types, wiring, nodes, test helpers, and direct time-series tests.  ``all`` also
+collects the adaptor, Arrow, NumPy, debug, and example suites; use
+``--with-extras`` so optional-import results are meaningful.  An existing clean
+checkout of the exact release tag may be supplied with ``--upstream-source``.
+The report records the reference version, tag, commit, in-tree declared
+version, and digest of the staged test and example trees.  The declared version
+is evidence rather than the source selector: hgraph release automation may tag
+the release commit before its follow-up ``pyproject.toml`` version bump, so the
+exact release tag remains authoritative and any discrepancy stays visible.
+The controller installs one explicit conformance dependency set into both
+environments, verifies every version is identical, and records that package
+inventory in the report before it runs either suite.
+
+An upstream test failure is not automatically an ``hg_cpp`` defect.  The
+runner first requires the released reference to pass the test.  A candidate
+difference is then classified using ``tools/parity/upstream_conformance.json``:
+
+* an unmatched difference is **review required**, not a confirmed problem;
+* ``expected-change`` records an approved public semantic difference;
+* ``converted`` records an upstream internal test whose contract is exercised
+  through named public Python and native C++ replacement evidence;
+* ``confirmed-gap`` is used only after review has established a compatibility
+  defect.
+
+Accepted rules are deliberately narrow.  They name the upstream node-id shape,
+allowed candidate outcome, expected diagnostic, reason, decision record, and
+review date.  A converted rule additionally names existing replacement tests.
+A changed failure diagnostic falls out of the rule and returns to review.
+There is no blanket private-internal exclusion: a test coupled to a non-ported
+concept such as ``HgTypeMetaData`` must be converted to the public reflection
+and type-resolution surface with equivalent evidence, or the required concept
+must be ported.
+
+Reference collection failures and nondeterministic/platform-disabled tests are
+reported as unverified evidence, never candidate noncompliance.  Reports and
+raw pytest output are written below ``.parity/results``.  Use ``--exit-zero``
+for discovery while rules are being reviewed; the normal command fails while
+review-required, confirmed-gap, ambiguous-rule, or reference-unverified
+entries remain.
+
 ``--reference-python`` and ``--candidate-python`` select already-provisioned
 interpreters.  ``--candidate-wheel`` installs a pre-built stable-ABI wheel,
 which is how CI reuses the wheel already built by the distribution workflow.

--- a/python/hgraph/_wiring/_core.py
+++ b/python/hgraph/_wiring/_core.py
@@ -441,14 +441,15 @@ class IncorrectTypeBinding(WiringError):
 class RequirementsNotMetWiringError(WiringError):
     """An overload's requires= predicate rejected the call."""
 
-_published_contexts = []   # [(port, ts_type_handle, frame)] most recent last
+_published_contexts = []   # [(port, ts_type_handle, frame, owning_wiring)] newest last
 
 
 def _port_enter(self):
     import sys
 
     frame = sys._getframe(1)
-    _published_contexts.append((self, self._port.ts_type, frame))
+    _published_contexts.append(
+        (self, self._port.ts_type, frame, _current_wiring()))
     return self
 
 
@@ -490,7 +491,7 @@ def _resolve_context(ctx_expr, name=None, resolution_scope=None):
     wanted = getattr(ctx_expr.ts, "handle", None)
     pattern = _pattern_of(ctx_expr.ts) if isinstance(
         ctx_expr.ts, (_GenericTsExpr, _TypeVarSentinel)) else None
-    for port, ts_type, frame in reversed(_published_contexts):
+    for port, ts_type, frame, owning_wiring in reversed(_published_contexts):
         if name is not None and _context_name_of(port, frame) != name:
             continue
         matches = wanted is not None and ts_type == wanted
@@ -518,5 +519,16 @@ def _resolve_context(ctx_expr, name=None, resolution_scope=None):
             )
         if not matches:
             continue
-        return port
+        current_wiring = _current_wiring()
+        # Nested graph/service callbacks receive borrowed Python wrappers for
+        # their native Wiring.  Wrapper identity therefore cannot establish a
+        # graph boundary: compare the underlying Wiring objects instead.
+        if _hgraph.same_wiring(current_wiring, owning_wiring):
+            return port
+        # A context can cross multiple nested compilation boundaries. Make
+        # each boundary explicit through the same C++ capture protocol used
+        # by native Context inputs; carrying the parent's boundary placeholder
+        # directly would leave the inner nested node with no material input.
+        return WiringPort(
+            _hgraph.capture_outer_source(current_wiring, _unwrap(port)))
     return None

--- a/python/hgraph/_wiring/_node.py
+++ b/python/hgraph/_wiring/_node.py
@@ -651,22 +651,30 @@ class _PyNode:
                 scalar_values[param.name] = logger
                 continue
             if isinstance(param.annotation, _ContextExpr):
-                # Context-injected: resolved from the published stack by
-                # type (and name); never supplied positionally.
-                requirement = bound.arguments.get(param.name, param.default)
-                name = None
-                required = False
-                if isinstance(requirement, _Required):
-                    required, name = True, requirement.name
-                elif isinstance(requirement, str):
-                    name = requirement
-                resolved = _resolve_context(param.annotation, name, scope)
-                if resolved is None:
-                    where = f" with name {name}" if name else ""
-                    if required:
-                        raise WiringError(
-                            f"no context published for '{param.name}'{where} of '{self.__name__}'")
-                    continue   # optional and absent: the fn sees its None default
+                # A caller-supplied port overrides ambient context, matching
+                # the native Context input contract. Requirement/name marker
+                # values still select from the published context stack.
+                supplied = bound.arguments.get(param.name, _MISSING)
+                if isinstance(supplied, WiringPort):
+                    context_param = param.replace(annotation=param.annotation.ts)
+                    self._check_binding(scope, context_param, supplied)
+                    resolved = supplied
+                else:
+                    requirement = (
+                        supplied if supplied is not _MISSING else param.default)
+                    name = None
+                    required = False
+                    if isinstance(requirement, _Required):
+                        required, name = True, requirement.name
+                    elif isinstance(requirement, str):
+                        name = requirement
+                    resolved = _resolve_context(param.annotation, name, scope)
+                    if resolved is None:
+                        where = f" with name {name}" if name else ""
+                        if required:
+                            raise WiringError(
+                                f"no context published for '{param.name}'{where} of '{self.__name__}'")
+                        continue   # optional and absent: the fn sees its None default
                 is_active = active_policy is None or param.name in active_policy
                 layout.append("C" if is_active else "P")
                 _note(param.name)

--- a/python/hgraph/_wiring/_runner.py
+++ b/python/hgraph/_wiring/_runner.py
@@ -315,16 +315,35 @@ def _evaluate_graph(graph_fn, config, args, kwargs):
 
 
 def _resolve_generic_annotation(annotation, samples):
-    """Resolve a generic annotation whose only free variable is SIZE.
+    """Resolve a generic collection annotation from eval-node samples.
 
     ``TSL[X, SIZE]`` (nested children included) becomes the concrete TSL by
     inferring the outer size from the samples (int-keyed dict → max key + 1;
-    list/tuple → length). Any annotation the size binding cannot fully
-    resolve (free scalar/ts variables, SIGNAL, ...) returns None and the
-    caller falls back to sample-scalar inference."""
+    list/tuple → length). A bare ``TSS[tuple]`` is represented by a
+    homogeneous tuple of Python objects: the native set remains the owner of
+    delta and lifetime semantics while the eval harness supplies the concrete
+    scalar storage that a C++ graph requires. Any annotation that still cannot
+    resolve returns None and the caller falls back to sample-scalar inference."""
     pattern = getattr(annotation, "pattern", None)
     if pattern is None:
         return None
+
+    if pattern.ts_kind == _hgraph.TS_KIND_TSS:
+        from .._types import TSS
+        from ._sentinels import Removed
+
+        elements = (
+            item.item if isinstance(item, Removed) else item
+            for sample in samples
+            if isinstance(sample, (set, frozenset))
+            for item in sample
+        )
+        if any(isinstance(item, tuple) for item in elements):
+            concrete = TSS[tuple[object, ...]]
+            scope = _hgraph.ResolutionScope()
+            if scope.match(pattern, concrete.handle):
+                return concrete
+
     size = 0
     for sample in samples:
         if sample is None:

--- a/python/hgraph/_wiring/_services.py
+++ b/python/hgraph/_wiring/_services.py
@@ -331,7 +331,7 @@ class _GetContext:
         else:
             from ._core import _context_name_of, _published_contexts
 
-            for port, _, frame in reversed(_published_contexts):
+            for port, _, frame, _ in reversed(_published_contexts):
                 if _context_name_of(port, frame) == name:
                     published = port
                     break
@@ -1244,10 +1244,18 @@ class _ServiceImpl:
         self._bound_impl_cache = {}
         if interfaces is None:
             raise TypeError(f"@service_impl '{self.__name__}' requires interfaces=")
-        self.manual_adaptor = isinstance(interfaces, (tuple, list))
-        if not isinstance(interfaces, (tuple, list)):
+        interfaces_were_sequence = isinstance(interfaces, (tuple, list))
+        if not interfaces_were_sequence:
             interfaces = (interfaces,)
         self.interfaces = tuple(self._resolve(stub) for stub in interfaces)
+        # Sequence spelling is the legacy opt-in for manual ADAPTOR
+        # implementations only. Upstream also spells ordinary one-interface
+        # service implementations as ``interfaces=(service,)``; treating that
+        # request port as registration configuration drops the transport.
+        self.manual_adaptor = (
+            interfaces_were_sequence
+            and all(stub.flavour == "adaptor" for stub in self.interfaces)
+        )
         self.target = getattr(fn, "fn", fn)   # unwrap @graph/@compute_node wrappers
         self.signature = inspect.signature(self.target, eval_str=True)
         self.ts_parameters = tuple(
@@ -1520,7 +1528,7 @@ def _bind_registered_impl(implementation, path, config):
                         frame = SimpleNamespace(
                             f_locals={context_name: context} if context_name else {})
                         _published_contexts.append(
-                            (context, _unwrap(context).ts_type, frame))
+                            (context, _unwrap(context).ts_type, frame, wiring))
                     else:
                         stack.enter_context(context)
                 return impl_fn(**arguments)

--- a/python/py_nodes.cpp
+++ b/python/py_nodes.cpp
@@ -622,7 +622,7 @@ struct PyFastComputeStateRef {
       break;
     }
     case 'c':
-      call_args.append(nb::cast(PyEvalClock{engine.evaluation_clock()}));
+      call_args.append(nb::cast(PyEvalClock{engine.evaluation_clock(), lease}));
       break;
     case 'd':
       call_args.append(nb::cast(PyScheduler{scheduler}));
@@ -778,7 +778,7 @@ void py_assemble_lifecycle_args(std::string_view layout,
           recordable_state->handle(), now, lease}));
       break;
     case 'c':
-      call_args.append(nb::cast(PyEvalClock{engine.evaluation_clock()}));
+      call_args.append(nb::cast(PyEvalClock{engine.evaluation_clock(), lease}));
       break;
     case 'd':
       call_args.append(nb::cast(PyScheduler{scheduler}));

--- a/python/py_runtime.h
+++ b/python/py_runtime.h
@@ -99,20 +99,6 @@ namespace hgraph::python_bridge
         friend bool operator==(const PyStateRef &, const PyStateRef &) noexcept = default;
     };
 
-    struct PyEvalClock
-    {
-        DateTime evaluation_time{};
-        DateTime now{};
-        TimeDelta cycle_time{};
-        DateTime next_cycle_evaluation_time{};
-
-        explicit PyEvalClock(EvaluationClockView clock) noexcept
-            : evaluation_time(clock.evaluation_time()), now(clock.now()), cycle_time(clock.cycle_time()),
-              next_cycle_evaluation_time(clock.next_cycle_evaluation_time())
-        {
-        }
-    };
-
     struct PyScheduler
     {
         NodeScheduler scheduler;
@@ -208,6 +194,53 @@ namespace hgraph::python_bridge
             {
                 guard->alive = false;
             }
+        }
+    };
+
+    /** Python projection over the native live evaluation clock.
+
+        Generator arguments retain their lease for the generator lifetime, so
+        each resumed access observes the current graph cycle. For compatibility
+        with the formerly value-like wrapper, a retained clock falls back to
+        the snapshot captured when it was injected after its lease expires. */
+    struct PyEvalClock
+    {
+        EvaluationClockView clock{};
+        PyTsLease           lease{};
+        DateTime            evaluation_time_snapshot{};
+        DateTime            now_snapshot{};
+        TimeDelta           cycle_time_snapshot{};
+        DateTime            next_cycle_evaluation_time_snapshot{};
+
+        PyEvalClock(EvaluationClockView clock_, PyTsLease lease_) noexcept
+            : clock(clock_)
+            , lease(std::move(lease_))
+            , evaluation_time_snapshot(clock_.evaluation_time())
+            , now_snapshot(clock_.now())
+            , cycle_time_snapshot(clock_.cycle_time())
+            , next_cycle_evaluation_time_snapshot(clock_.next_cycle_evaluation_time())
+        {
+        }
+
+        [[nodiscard]] DateTime evaluation_time() const noexcept
+        {
+            return lease.alive() ? clock.evaluation_time() : evaluation_time_snapshot;
+        }
+
+        [[nodiscard]] DateTime now() const noexcept
+        {
+            return lease.alive() ? clock.now() : now_snapshot;
+        }
+
+        [[nodiscard]] TimeDelta cycle_time() const noexcept
+        {
+            return lease.alive() ? clock.cycle_time() : cycle_time_snapshot;
+        }
+
+        [[nodiscard]] DateTime next_cycle_evaluation_time() const noexcept
+        {
+            return lease.alive() ? clock.next_cycle_evaluation_time()
+                                 : next_cycle_evaluation_time_snapshot;
         }
     };
 

--- a/python/py_state_services.cpp
+++ b/python/py_state_services.cpp
@@ -535,6 +535,12 @@ namespace hgraph::python_bridge
     m.def("get_context", [](PyWiring &w, const std::string &name) {
         return PyPort{graph_wiring_detail::resolve_context_source(w.wiring_ref(), name)};
     });
+    m.def("capture_outer_source", [](PyWiring &w, const PyPort &port) {
+        return PyPort{w.wiring_ref().capture_outer_source(port.ref)};
+    });
+    m.def("same_wiring", [](PyWiring &lhs, PyWiring &rhs) {
+        return &lhs.wiring_ref() == &rhs.wiring_ref();
+    });
     m.def("has_context", [](PyWiring &w, const std::string &name) {
         return graph_wiring_detail::has_context_source(w.wiring_ref(), name);
     });
@@ -811,11 +817,11 @@ namespace hgraph::python_bridge
     });
 
     nb::class_<PyEvalClock>(m, "EvaluationClock")
-        .def_prop_ro("evaluation_time", [](const PyEvalClock &clock) { return clock.evaluation_time; })
-        .def_prop_ro("now", [](const PyEvalClock &clock) { return clock.now; })
-        .def_prop_ro("cycle_time", [](const PyEvalClock &clock) { return clock.cycle_time; })
+        .def_prop_ro("evaluation_time", [](const PyEvalClock &clock) { return clock.evaluation_time(); })
+        .def_prop_ro("now", [](const PyEvalClock &clock) { return clock.now(); })
+        .def_prop_ro("cycle_time", [](const PyEvalClock &clock) { return clock.cycle_time(); })
         .def_prop_ro("next_cycle_evaluation_time",
-                     [](const PyEvalClock &clock) { return clock.next_cycle_evaluation_time; });
+                     [](const PyEvalClock &clock) { return clock.next_cycle_evaluation_time(); });
     nb::class_<PyEvaluationEngineApi>(m, "EvaluationEngineApi")
         // One-shot cycle-boundary notifications: python sugar over the
         // C++-primary EngineControlView facility (C++-first ruling; the
@@ -837,7 +843,7 @@ namespace hgraph::python_bridge
         .def_prop_ro("start_time", [](const PyEvaluationEngineApi &self) { return self.checked().start_time(); })
         .def_prop_ro("end_time", [](const PyEvaluationEngineApi &self) { return self.checked().end_time(); })
         .def_prop_ro("evaluation_clock", [](const PyEvaluationEngineApi &self) {
-            return PyEvalClock{self.checked().evaluation_clock()};
+            return PyEvalClock{self.checked().evaluation_clock(), self.lease};
         })
         .def_prop_ro("is_stop_requested",
                      [](const PyEvaluationEngineApi &self) { return self.checked().stop_requested(); })
@@ -877,7 +883,7 @@ namespace hgraph::python_bridge
             return self.checked().evaluating();
         })
         .def_prop_ro("evaluation_clock", [](const PyGraph &self) {
-            return PyEvalClock{self.checked().executor().evaluation_clock()};
+            return PyEvalClock{self.checked().executor().evaluation_clock(), self.lease};
         })
         .def_prop_ro("parent_node", [](const PyGraph &self) -> nb::object {
             const GraphView graph = self.checked();

--- a/python/tests/ported/_wiring/test_context.py
+++ b/python/tests/ported/_wiring/test_context.py
@@ -101,6 +101,44 @@ def test_two_generic_contexts_resolve_by_name():
     ]
 
 
+def test_context_input_accepts_an_explicit_port_override():
+    @hg.compute_node
+    def read_context(
+        value: hg.CONTEXT[hg.TIME_SERIES_TYPE] = hg.REQUIRED["value"],
+    ) -> hg.TS[str]:
+        return f"{value.value}"
+
+    @hg.graph
+    def app(value: hg.TS[str]) -> hg.TS[str]:
+        return read_context(value)
+
+    assert eval_node(app, ["Hello", None]) == ["Hello", None]
+
+
+def test_context_crosses_stacked_try_except_boundaries():
+    @hg.compute_node
+    def read_context(
+        value: hg.CONTEXT[hg.TIME_SERIES_TYPE] = hg.REQUIRED["value"],
+    ) -> hg.TS[str]:
+        return f"{value.value}"
+
+    @hg.graph
+    def inner() -> hg.TS[str]:
+        return read_context()
+
+    @hg.graph
+    def middle(outer: hg.TS[str], inner_value: hg.TS[str]) -> hg.TS[str]:
+        with inner_value as value:
+            return hg.try_except(inner).out
+
+    @hg.graph
+    def app(outer: hg.TS[str], inner_value: hg.TS[str]) -> hg.TS[str]:
+        with outer as value:
+            return hg.try_except(middle, outer, inner_value).out
+
+    assert eval_node(app, ["Hello", None], [None, "World"]) == [None, "World"]
+
+
 def test_graph_context_parameters_resolve_before_composition():
     @hg.graph
     def join_contexts(
@@ -287,3 +325,44 @@ def test_parameterized_dataclass_context_from_service_crosses_switch_boundary():
         "context",
         "context false",
     ]
+
+
+def test_tuple_spelled_subscription_impl_retains_nested_context_transport():
+    @hg.reference_service
+    def inner_service(path: str = "inner") -> hg.TS[str]: ...
+
+    @hg.service_impl(interfaces=(inner_service,))
+    def inner_impl(path: str = "inner") -> hg.TS[str]:
+        selected = hg.get_context[hg.TS[str]]("selected")
+        return hg.switch_(
+            selected,
+            {
+                "selected": lambda value: value,
+                "other": lambda value: hg.nothing[hg.TS[str]](),
+            },
+            selected,
+        )
+
+    @hg.subscription_service
+    def outer_service(request: hg.TS[str], path: str = "outer") -> hg.TS[str]: ...
+
+    @hg.service_impl(interfaces=(outer_service,))
+    def outer_impl(
+        request: hg.TSS[str], path: str = "outer",
+    ) -> hg.TSD[str, hg.TS[str]]:
+        return hg.map_(
+            lambda request: inner_service(),
+            __keys__=request,
+            __key_arg__="request",
+        )
+
+    @hg.graph
+    def app() -> hg.TS[str]:
+        with hg.const("selected") as selected:
+            out = outer_service("x")
+            hg.register_service(None, outer_impl)
+            hg.register_service(None, inner_impl)
+            hg.WiringGraphContext.instance().build_services()
+            return out
+
+    assert eval_node(app, __elide__=True) == ["selected"]

--- a/python/tests/ported/_wiring/test_switch.py
+++ b/python/tests/ported/_wiring/test_switch.py
@@ -4,6 +4,7 @@ from frozendict import frozendict
 
 from hgraph import (
     DEFAULT,
+    EvaluationClock,
     MIN_TD,
     REMOVE,
     Removed,
@@ -118,10 +119,9 @@ def test_stop_start():
 
 
 @generator
-def _generator(key: str) -> TS[str]:
-    # The current bridge expresses generator schedules as relative timedeltas.
+def _generator(key: str, _clock: EvaluationClock = None) -> TS[str]:
     for i in range(5):
-        yield MIN_TD, f"{key}_{i}"
+        yield _clock.next_cycle_evaluation_time, f"{key}_{i}"
 
 
 @graph

--- a/python/tests/ported/_wiring/test_tss.py
+++ b/python/tests/ported/_wiring/test_tss.py
@@ -89,3 +89,11 @@ def test_tss_delta_value_preserves_set_delta_type():
         return isinstance(delta, _SetDelta) and delta.added == frozenset({1}) and not delta.removed
 
     assert eval_node(is_set_delta, [{1}]) == [True]
+
+
+def test_tss_bare_tuple_annotation_accepts_tuple_keys():
+    @compute_node
+    def count_tuples(tss: TSS[tuple]) -> TS[int]:
+        return len(tss.value)
+
+    assert eval_node(count_tuples, [{(1, 2), (3, 4)}]) == [2]

--- a/python/tests/test_python_authoring.py
+++ b/python/tests/test_python_authoring.py
@@ -647,6 +647,20 @@ def test_generator_injects_engine_api_for_its_full_lifetime():
     ]
 
 
+def test_generator_evaluation_clock_advances_with_each_resume():
+    @hg.generator
+    def sequence(_clock: hg.EvaluationClock = None) -> hg.TS[datetime.datetime]:
+        for _ in range(3):
+            yield _clock.next_cycle_evaluation_time, _clock.evaluation_time
+
+    assert eval_node(sequence) == [
+        None,
+        hg.MIN_ST,
+        hg.MIN_ST + hg.MIN_TD,
+        hg.MIN_ST + 2 * hg.MIN_TD,
+    ]
+
+
 def test_generator_rejects_duplicate_or_retrograde_times():
     @hg.generator
     def duplicate() -> TS[int]:

--- a/python/tests/test_upstream_conformance.py
+++ b/python/tests/test_upstream_conformance.py
@@ -1,0 +1,295 @@
+"""Controller tests for exact upstream hgraph conformance execution."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+from tools.parity.conformance import (
+    UpstreamSource,
+    compare_upstream_results,
+    install_conformance_dependencies,
+    load_conformance_manifest,
+    prepare_test_workspace,
+    profile_selectors,
+    require_aligned_conformance_environments,
+    run_upstream_suite,
+    validate_selectors,
+)
+
+
+def _result(tests=None, *, collected=None, collection_errors=None):
+    return {
+        "status": "complete",
+        "tests": tests or {},
+        "collected": collected or list((tests or {}).keys()),
+        "collection_errors": collection_errors or [],
+    }
+
+
+def _outcome(outcome, diagnostic=""):
+    return {
+        "outcome": outcome,
+        "phase": "call",
+        "diagnostic": diagnostic,
+        "duration": 0.01,
+    }
+
+
+def _manifest(rules=None):
+    return {
+        "schema_version": 1,
+        "profiles": {"core": ["hgraph_unit_tests"]},
+        "rules": rules or [],
+    }
+
+
+def test_conformance_classifies_only_narrow_known_outcomes():
+    nodeid = "hgraph_unit_tests/_types/test_metadata.py::test_parse"
+    reference = _result({nodeid: _outcome("passed")})
+    candidate = _result(
+        {
+            nodeid: _outcome(
+                "failed",
+                "ImportError: cannot import name 'HgTypeMetaData' from 'hgraph'",
+            )
+        }
+    )
+    rule = {
+        "id": "metadata-reflection-conversion",
+        "match": "hgraph_unit_tests/_types/test_metadata.py::*",
+        "classification": "converted",
+        "reference_outcomes": ["passed"],
+        "candidate_outcomes": ["failed"],
+        "diagnostic_regex": "HgTypeMetaData",
+        "reason": "the public reflection API replaces private metadata objects",
+        "decision": "docs/source/developer_guide/parity_matrix.rst",
+        "review_date": "2026-08-05",
+        "evidence": ["python/tests/test_reflection.py"],
+    }
+
+    report = compare_upstream_results(reference, candidate, _manifest([rule]))
+    assert report["summary"]["known_expected"] == 1
+    assert report["known_expected"][0]["rule"]["id"] == rule["id"]
+
+    candidate["tests"][nodeid]["diagnostic"] = "AssertionError: wrong value"
+    report = compare_upstream_results(reference, candidate, _manifest([rule]))
+    assert report["summary"]["known_expected"] == 0
+    assert report["summary"]["review_required"] == 1
+
+
+def test_conformance_expands_candidate_collection_errors_to_reference_tests():
+    first = "hgraph_unit_tests/_types/test_metadata.py::test_one"
+    second = "hgraph_unit_tests/_types/test_metadata.py::test_two"
+    reference = _result({first: _outcome("passed"), second: _outcome("passed")})
+    candidate = _result(
+        collection_errors=[
+            {
+                "nodeid": "hgraph_unit_tests/_types/test_metadata.py",
+                "outcome": "collection-error",
+                "diagnostic": "ImportError: HgTypeMetaData",
+            }
+        ]
+    )
+
+    report = compare_upstream_results(reference, candidate, _manifest())
+    assert report["summary"]["review_required"] == 2
+    assert {entry["candidate"]["outcome"] for entry in report["review_required"]} == {
+        "collection-error"
+    }
+
+
+def test_conformance_reports_reference_failures_as_unverified_not_candidate_gaps():
+    nodeid = "hgraph_unit_tests/test_reference.py::test_unstable"
+    reference = _result({nodeid: _outcome("failed", "reference defect")})
+    candidate = _result({nodeid: _outcome("failed", "candidate also failed")})
+
+    report = compare_upstream_results(reference, candidate, _manifest())
+    assert report["summary"]["reference_unverified"] == 1
+    assert report["summary"]["review_required"] == 0
+    assert report["summary"]["confirmed_gaps"] == 0
+
+
+def test_conformance_requires_identical_dependency_versions(monkeypatch):
+    import tools.parity.conformance as conformance
+
+    environments = iter(
+        [
+            {
+                "python": "3.14.1",
+                "implementation": "CPython",
+                "packages": {"pytest": "9.0"},
+            },
+            {
+                "python": "3.14.1",
+                "implementation": "CPython",
+                "packages": {"pytest": "9.1"},
+            },
+        ]
+    )
+    monkeypatch.setattr(
+        conformance,
+        "conformance_environment",
+        lambda interpreter, extras=(): next(environments),
+    )
+
+    with pytest.raises(RuntimeError, match="dependencies are not aligned"):
+        require_aligned_conformance_environments(Path("reference"), Path("candidate"))
+
+
+def test_conformance_installs_reference_resolutions_into_candidate(monkeypatch):
+    import tools.parity.conformance as conformance
+
+    commands = []
+    monkeypatch.setattr(conformance, "_run", lambda command: commands.append(command))
+    monkeypatch.setattr(
+        conformance,
+        "conformance_environment",
+        lambda interpreter, extras=(): {
+            "packages": {"multimethod": "2.0.2", "pytest": "9.1.1"}
+        },
+    )
+
+    install_conformance_dependencies((Path("reference"), Path("candidate")))
+
+    assert commands[0][4] == "reference"
+    assert commands[1][-2:] == ["multimethod==2.0.2", "pytest==9.1.1"]
+
+
+def test_manifest_requires_evidence_for_internal_conversions(tmp_path):
+    path = tmp_path / "manifest.json"
+    manifest = _manifest(
+        [
+            {
+                "id": "unsafe-conversion",
+                "match": "hgraph_unit_tests/_types/*",
+                "classification": "converted",
+                "candidate_outcomes": ["collection-error"],
+                "diagnostic_regex": "HgTypeMetaData",
+                "reason": "converted",
+                "decision": "issue-1",
+                "review_date": "2026-08-05",
+            }
+        ]
+    )
+    path.write_text(json.dumps(manifest))
+
+    with pytest.raises(ValueError, match="requires evidence"):
+        load_conformance_manifest(path)
+
+
+def test_manifest_profiles_reject_paths_outside_upstream_tests(tmp_path):
+    path = tmp_path / "manifest.json"
+    path.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "profiles": {"core": ["../hgraph"]},
+                "rules": [],
+            }
+        )
+    )
+    with pytest.raises(ValueError, match="repository-relative"):
+        load_conformance_manifest(path)
+
+
+def test_profile_selectors_reports_available_profiles():
+    with pytest.raises(ValueError, match="choose core"):
+        profile_selectors(_manifest(), "missing")
+
+
+def test_explicit_selectors_cannot_escape_the_upstream_test_tree():
+    assert validate_selectors(
+        ["hgraph_unit_tests/_operators/test_math.py::test_add"]
+    ) == ["hgraph_unit_tests/_operators/test_math.py::test_add"]
+    with pytest.raises(ValueError, match="repository-relative"):
+        validate_selectors(["../candidate/python/tests"])
+
+
+def test_staged_upstream_tree_is_exact_and_excludes_the_runtime_package(tmp_path):
+    source_root = tmp_path / "source"
+    (source_root / "hgraph_unit_tests").mkdir(parents=True)
+    (source_root / "examples").mkdir()
+    (source_root / "hgraph").mkdir()
+    test = source_root / "hgraph_unit_tests" / "test_sample.py"
+    test.write_text("def test_sample():\n    assert True\n")
+    example = source_root / "examples" / "sample.py"
+    example.write_text("VALUE = 1\n")
+
+    import tools.parity.conformance as conformance
+
+    digest = conformance._tree_digest(  # noqa: SLF001 - verifies staging contract
+        [source_root / "hgraph_unit_tests", source_root / "examples"],
+        root=source_root,
+    )
+    source = UpstreamSource(
+        path=source_root,
+        repository="test",
+        ref="v_1.0.0",
+        revision="test-revision",
+        version="1.0.0",
+        declared_version="1.0.0",
+        test_digest=digest,
+    )
+    old_root = conformance.PARITY_ROOT
+    conformance.PARITY_ROOT = tmp_path / "parity"
+    try:
+        workspace = prepare_test_workspace(source)
+    finally:
+        conformance.PARITY_ROOT = old_root
+
+    assert (
+        workspace / "hgraph_unit_tests" / "test_sample.py"
+    ).read_bytes() == test.read_bytes()
+    assert (workspace / "examples" / "sample.py").read_bytes() == example.read_bytes()
+    assert not (workspace / "hgraph").exists()
+
+
+def test_pytest_plugin_records_stable_node_outcomes(tmp_path):
+    workspace = tmp_path / "workspace"
+    tests = workspace / "hgraph_unit_tests"
+    tests.mkdir(parents=True)
+    (workspace / "pytest.ini").write_text(
+        "[pytest]\naddopts = --import-mode=importlib\n"
+    )
+    (tests / "test_sample.py").write_text(
+        "import pytest\n\n"
+        "def test_passes():\n    assert True\n\n"
+        "def test_fails():\n    assert 1 == 2\n"
+        "\n@pytest.mark.parametrize('value', [1, 2])\n"
+        "def test_parameterized(value):\n    assert value > 0\n"
+    )
+    result_path = tmp_path / "result.json"
+
+    result = run_upstream_suite(
+        Path(sys.executable),
+        workspace,
+        ["hgraph_unit_tests/test_sample.py"],
+        result_path=result_path,
+        timeout_seconds=30.0,
+    )
+
+    assert result["status"] == "complete"
+    assert (
+        result["tests"]["hgraph_unit_tests/test_sample.py::test_passes"]["outcome"]
+        == "passed"
+    )
+    assert (
+        result["tests"]["hgraph_unit_tests/test_sample.py::test_fails"]["outcome"]
+        == "failed"
+    )
+    assert (
+        result["tests"]["hgraph_unit_tests/test_sample.py::test_parameterized[case-0]"][
+            "outcome"
+        ]
+        == "passed"
+    )
+    assert (
+        result["tests"]["hgraph_unit_tests/test_sample.py::test_parameterized[case-1]"][
+            "outcome"
+        ]
+        == "passed"
+    )

--- a/tests/cpp/test_data_frame_operators.cpp
+++ b/tests/cpp/test_data_frame_operators.cpp
@@ -710,6 +710,18 @@ TEST_CASE("data frame operators: frame batches stream through one native source"
                  values<Int>(1, 2, 3));
 }
 
+TEST_CASE("data frame operators: throttle forwards Arrow frame values unchanged")
+{
+    stdlib::register_standard_operators();
+    const auto first  = frame({1}, {10});
+    const auto second = frame({2}, {20});
+    const auto third  = frame({3}, {30});
+
+    CHECK_OUTPUT(eval_node<stdlib::throttle>(values<Frame>(first, second, third),
+                                             MIN_TD * 2),
+                 values<Frame>(first, none, third));
+}
+
 TEST_CASE("data frame operators: from_data_frame skips rows before evaluation start")
 {
     stdlib::register_standard_operators();

--- a/tests/cpp/test_std_operators.cpp
+++ b/tests/cpp/test_std_operators.cpp
@@ -113,6 +113,37 @@ namespace
         return Series{std::move(array)};
     }
 
+    [[nodiscard]] Series float_series(std::initializer_list<std::optional<Float>> values)
+    {
+        arrow::DoubleBuilder builder;
+        for (const auto value : values)
+        {
+            const arrow::Status status = value.has_value() ? builder.Append(*value) : builder.AppendNull();
+            if (!status.ok()) { throw std::runtime_error(status.ToString()); }
+        }
+        std::shared_ptr<arrow::Array> array;
+        const auto status = builder.Finish(&array);
+        if (!status.ok()) { throw std::runtime_error(status.ToString()); }
+        return Series{std::move(array)};
+    }
+
+    void check_series_output(const std::vector<std::optional<Series>> &actual,
+                             const std::vector<std::optional<Series>> &expected)
+    {
+        REQUIRE(actual.size() == expected.size());
+        for (std::size_t index = 0; index < actual.size(); ++index)
+        {
+            INFO("series output index " << index);
+            REQUIRE(actual[index].has_value() == expected[index].has_value());
+            if (actual[index].has_value())
+            {
+                REQUIRE(actual[index]->array != nullptr);
+                REQUIRE(expected[index]->array != nullptr);
+                CHECK(actual[index]->array->Equals(expected[index]->array));
+            }
+        }
+    }
+
     [[nodiscard]] WiringArg scalar_arg(Value value)
     {
         WiringArg arg;
@@ -157,6 +188,56 @@ namespace
         static Port<TS<HomogeneousTuple<Int>>> compose(Wiring &w, Port<TS<SeriesOf<Int>>> ts)
         {
             return wire<stdlib::convert, TS<HomogeneousTuple<Int>>>(w, ts);
+        }
+    };
+
+    struct SeriesAddGraph
+    {
+        static constexpr auto name = "series_add_graph";
+        static Port<TS<SeriesOf<Int>>> compose(Wiring &w, Port<TS<SeriesOf<Int>>> lhs,
+                                               Port<TS<SeriesOf<Int>>> rhs)
+        {
+            return wire<stdlib::add_>(w, lhs, rhs).as<TS<SeriesOf<Int>>>();
+        }
+    };
+
+    struct SeriesMixedAddGraph
+    {
+        static constexpr auto name = "series_mixed_add_graph";
+        static Port<TS<SeriesOf<Float>>> compose(Wiring &w, Port<TS<SeriesOf<Int>>> lhs,
+                                                 Port<TS<Float>> rhs)
+        {
+            return wire<stdlib::add_>(w, lhs, rhs).as<TS<SeriesOf<Float>>>();
+        }
+    };
+
+    struct SeriesDivGraph
+    {
+        static constexpr auto name = "series_div_graph";
+        static Port<TS<SeriesOf<Float>>> compose(Wiring &w, Port<TS<SeriesOf<Int>>> lhs,
+                                                 Port<TS<SeriesOf<Int>>> rhs)
+        {
+            return wire<stdlib::div_>(w, lhs, rhs).as<TS<SeriesOf<Float>>>();
+        }
+    };
+
+    struct SeriesGetItemGraph
+    {
+        static constexpr auto name = "series_get_item_graph";
+        static Port<TS<Int>> compose(Wiring &w, Port<TS<SeriesOf<Int>>> ts,
+                                     Port<TS<Int>> index)
+        {
+            return wire<stdlib::getitem_>(w, ts, index).as<TS<Int>>();
+        }
+    };
+
+    struct SeriesContainsGraph
+    {
+        static constexpr auto name = "series_contains_graph";
+        static Port<TS<Bool>> compose(Wiring &w, Port<TS<SeriesOf<Int>>> ts,
+                                      Port<TS<Int>> item)
+        {
+            return wire<stdlib::contains_>(w, ts, item).as<TS<Bool>>();
         }
     };
 
@@ -2116,6 +2197,31 @@ TEST_CASE("std operators: convert copies an Arrow Series into a native variadic 
                                nullable_int_tuple({Int{2}, std::nullopt, Int{3}})));
 }
 
+TEST_CASE("std operators: Arrow Series arithmetic and access use public typed wiring")
+{
+    stdlib::register_standard_operators();
+
+    check_series_output(
+        eval_node<SeriesAddGraph>(values<Series>(int_series({1, 2, 3})),
+                                  values<Series>(int_series({4, 5, 6}))),
+        values<Series>(int_series({5, 7, 9})));
+    check_series_output(
+        eval_node<SeriesMixedAddGraph>(values<Series>(int_series({1, 2, 3})),
+                                       values<Float>(0.5)),
+        values<Series>(float_series({1.5, 2.5, 3.5})));
+    check_series_output(
+        eval_node<SeriesDivGraph>(values<Series>(int_series({4, 6, 9})),
+                                  values<Series>(int_series({2, 4, 3}))),
+        values<Series>(float_series({2.0, 1.5, 3.0})));
+    CHECK_OUTPUT(eval_node<SeriesGetItemGraph>(values<Series>(int_series({1, 2, 3})),
+                                               values<Int>(2)),
+                 values<Int>(3));
+    CHECK_OUTPUT(eval_node<SeriesContainsGraph>(values<Series>(int_series({1, 2, 3}),
+                                                                int_series({1, 2, 3})),
+                                                values<Int>(2, 4)),
+                 values<Bool>(true, false));
+}
+
 TEST_CASE("std operators: str_ converts scalar time-series values to strings")
 {
     stdlib::register_standard_operators();
@@ -2245,6 +2351,23 @@ TEST_CASE("std operators: stream operators cover sampling filtering slicing and 
     CHECK_OUTPUT(eval_node<stdlib::to_window>(values<Int>(1, 2, 3, 4, 5), MIN_TD * 2),
                  values<Value>(Value{Int{1}}, Value{Int{2}}, Value{Int{3}},
                                Value{Int{4}}, Value{Int{5}}));
+    // rolling_average is a public graph operator in both C++ and Python.  Keep
+    // native coverage for both scalar-policy overloads so the ported upstream
+    // tests do not merely prove the Python facade.
+    CHECK_OUTPUT(eval_node<stdlib::rolling_average>(values<Int>(1, 2, 3, 4, 5),
+                                                     Int{3}),
+                 values<Float>(none, none, none, 3.0, 4.0));
+    CHECK_OUTPUT(eval_node<stdlib::rolling_average>(values<Int>(1, 2, 3, 4, 5),
+                                                     Int{3}, Int{2}),
+                 values<Float>(none, 1.5, 2.0, 3.0, 4.0));
+    auto duration_average =
+        eval_node<stdlib::rolling_average>(values<Int>(1, 2, 3, 4, 5), MIN_TD * 3);
+    REQUIRE(duration_average.size() == 8);
+    REQUIRE(duration_average.back().has_value());
+    CHECK(std::isnan(duration_average.back()->view().checked_as<Float>()));
+    duration_average.pop_back();
+    CHECK_OUTPUT(duration_average,
+                 values<Float>(none, none, none, 3.0, 4.0, 4.5, 5.0));
     CHECK_OUTPUT(eval_node<ResettableTickWindowGraph>(
                      values<Int>(1, 2, none, 3, 4),
                      values<Bool>(none, none, true, none, none)),

--- a/tests/cpp/test_tss_nodes.cpp
+++ b/tests/cpp/test_tss_nodes.cpp
@@ -3,6 +3,7 @@
 // size is read back through a TSS<Int> input.
 
 #include <hgraph/lib/testing/check_output.h>
+#include <hgraph/lib/testing/eval_node.h>
 #include <hgraph/lib/testing/record_replay.h>
 #include <hgraph/runtime/runtime.h>
 #include <hgraph/types/graph_wiring.h>
@@ -43,6 +44,55 @@ namespace
             out.set(static_cast<Int>(s.added().size()));
         }
     };
+
+    struct TupleSetSize
+    {
+        static constexpr auto name = "tuple_set_size";
+
+        static void eval(In<"s", TSS<HomogeneousTuple<Int>>> s, Out<TS<Int>> out)
+        {
+            out.set(static_cast<Int>(s.size()));
+        }
+    };
+
+    [[nodiscard]] Value int_tuple(std::initializer_list<Int> elements)
+    {
+        const auto element_binding =
+            ValuePlanFactory::instance().type_for(scalar_descriptor<Int>::value_meta());
+        const auto *tuple_schema =
+            scalar_descriptor<HomogeneousTuple<Int>>::value_meta();
+        ListBuilder builder{element_binding};
+        for (const Int element : elements) { builder.push_back(element); }
+        ListStorage storage = builder.build_storage();
+        return Value{compact_list_type(element_binding, *tuple_schema), &storage};
+    }
+
+    [[nodiscard]] Value tuple_set_delta(
+        std::initializer_list<std::initializer_list<Int>> added_values)
+    {
+        auto &registry = TypeRegistry::instance();
+        const auto *tuple_schema =
+            scalar_descriptor<HomogeneousTuple<Int>>::value_meta();
+        const auto tuple_binding =
+            ValuePlanFactory::instance().type_for(tuple_schema);
+        const auto *set_schema = registry.set(tuple_schema);
+        const auto *delta_schema = registry.un_named_bundle(
+            {{"added", set_schema}, {"removed", set_schema}});
+        const auto delta_binding =
+            ValuePlanFactory::instance().type_for(delta_schema);
+
+        SetBuilder added{tuple_binding};
+        for (const auto elements : added_values)
+        {
+            const Value tuple = int_tuple(elements);
+            static_cast<void>(added.insert_copy(tuple.view().data()));
+        }
+        SetBuilder removed{tuple_binding};
+        BundleBuilder delta{delta_binding};
+        delta.set("added", added.build());
+        delta.set("removed", removed.build());
+        return delta.build();
+    }
 
     struct TssGraph
     {
@@ -137,4 +187,11 @@ TEST_CASE("tss: In<TSS> typed added() exposes this cycle's added elements")
     ex.view().run();
 
     CHECK_OUTPUT(testing::get_recorded_values<Int>(ex.view().graph().global_state(), "out"), {2, 1, 0});
+}
+
+TEST_CASE("tss: tuple keys execute through the public concrete C++ schema")
+{
+    CHECK_OUTPUT(
+        eval_node<TupleSetSize>(values<Value>(tuple_set_delta({{1, 2}, {3, 4}}))),
+        values<Int>(2));
 }

--- a/tools/parity/cli.py
+++ b/tools/parity/cli.py
@@ -25,6 +25,18 @@ from .surface import (
 )
 from .catalog import catalogue_json, validate_recipe
 from .compare import compare_outcomes
+from .conformance import (
+    compare_upstream_results,
+    ensure_upstream_source,
+    install_conformance_dependencies,
+    load_conformance_manifest,
+    prepare_test_workspace,
+    profile_selectors,
+    require_aligned_conformance_environments,
+    render_conformance_markdown,
+    run_upstream_suite,
+    validate_selectors,
+)
 from .coverage import coverage_json, render_coverage_markdown
 from .environments import PARITY_ROOT, prepare_environments
 from .generate import generate_recipes
@@ -252,6 +264,104 @@ def command_surface(args) -> int:
     return 0 if not report["actionable"] or args.exit_zero else 1
 
 
+def _session_report(result: dict) -> dict:
+    return {
+        key: value
+        for key, value in result.items()
+        if key not in {"tests", "collected", "collection_errors", "stdout", "stderr"}
+    }
+
+
+def command_conformance(args) -> int:
+    environments = _prepare(args)
+    manifest_path = (
+        Path(args.manifest)
+        if args.manifest
+        else Path(__file__).with_name("upstream_conformance.json")
+    )
+    manifest = load_conformance_manifest(manifest_path)
+    selectors = validate_selectors(
+        args.paths or profile_selectors(manifest, args.profile)
+    )
+    extras = SURFACE_EXTRA_DEPENDENCIES if args.with_extras else ()
+    install_conformance_dependencies(
+        (environments.reference_python, environments.candidate_python),
+        extras=extras,
+    )
+    conformance_environment = require_aligned_conformance_environments(
+        environments.reference_python,
+        environments.candidate_python,
+        extras=extras,
+    )
+    source = ensure_upstream_source(
+        environments.reference_identity,
+        source_path=_path(args.upstream_source),
+    )
+    workspace = prepare_test_workspace(source)
+    stamp = dt.datetime.now(dt.timezone.utc).strftime("%Y%m%d-%H%M%S")
+    output_dir = (
+        Path(args.output_dir).absolute()
+        if args.output_dir
+        else PARITY_ROOT / "results" / f"{stamp}-conformance-{args.profile}"
+    )
+    output_dir.mkdir(parents=True, exist_ok=True)
+    reference = run_upstream_suite(
+        environments.reference_python,
+        workspace,
+        selectors,
+        result_path=output_dir / "reference-result.json",
+        timeout_seconds=args.timeout,
+    )
+    candidate = run_upstream_suite(
+        environments.candidate_python,
+        workspace,
+        selectors,
+        result_path=output_dir / "candidate-result.json",
+        timeout_seconds=args.timeout,
+    )
+    report = compare_upstream_results(reference, candidate, manifest)
+    report.update(
+        profile=args.profile,
+        selectors=selectors,
+        reference_identity=environments.reference_identity,
+        candidate_identity=environments.candidate_identity,
+        candidate_fingerprint=environments.candidate_fingerprint,
+        conformance_environment=conformance_environment,
+        source={
+            "repository": source.repository,
+            "ref": source.ref,
+            "revision": source.revision,
+            "version": source.version,
+            "declared_version": source.declared_version,
+            "test_digest": source.test_digest,
+        },
+        reference_session=_session_report(reference),
+        candidate_session=_session_report(candidate),
+    )
+    (output_dir / "reference-pytest.txt").write_text(
+        reference.get("stdout", "") + reference.get("stderr", "")
+    )
+    (output_dir / "candidate-pytest.txt").write_text(
+        candidate.get("stdout", "") + candidate.get("stderr", "")
+    )
+    (output_dir / "report.json").write_text(
+        json.dumps(report, indent=2, sort_keys=True) + "\n"
+    )
+    markdown = render_conformance_markdown(report)
+    (output_dir / "report.md").write_text(markdown)
+    print(markdown)
+    print(f"report: {output_dir / 'report.json'}")
+    incomplete = bool(
+        report["review_required"]
+        or report["confirmed_gaps"]
+        or report["ambiguous_rules"]
+        or report["reference_unverified"]
+        or reference.get("status") != "complete"
+        or candidate.get("status") != "complete"
+    )
+    return 0 if args.exit_zero or not incomplete else 1
+
+
 def command_campaign(args) -> int:
     profile_defaults = CAMPAIGN_PROFILES[args.profile]
     examples = (
@@ -430,6 +540,18 @@ def build_parser() -> argparse.ArgumentParser:
     surface.add_argument("--known")
     _environment_arguments(surface)
     surface.set_defaults(func=command_surface)
+
+    conformance = subparsers.add_parser("conformance")
+    conformance.add_argument("paths", nargs="*")
+    conformance.add_argument("--profile", default="core")
+    conformance.add_argument("--manifest")
+    conformance.add_argument("--upstream-source")
+    conformance.add_argument("--timeout", type=float, default=3600.0)
+    conformance.add_argument("--output-dir")
+    conformance.add_argument("--with-extras", action="store_true")
+    conformance.add_argument("--exit-zero", action="store_true")
+    _environment_arguments(conformance)
+    conformance.set_defaults(func=command_conformance)
 
     publish = subparsers.add_parser("publish-issues")
     publish.add_argument("reports", nargs="+")

--- a/tools/parity/conformance.py
+++ b/tools/parity/conformance.py
@@ -1,0 +1,671 @@
+"""Run an exact upstream hgraph test tree against both distributions.
+
+The released distribution remains the oracle.  Candidate-only failures are
+observations until a narrow manifest rule classifies the exact outcome as an
+approved change, a converted internal contract, or a confirmed gap.
+"""
+
+from __future__ import annotations
+
+import fnmatch
+import hashlib
+import json
+import os
+import re
+import shutil
+import subprocess
+import tomllib
+from dataclasses import dataclass
+from datetime import date
+from pathlib import Path
+from typing import Any
+
+from .environments import PARITY_ROOT, REPO_ROOT
+
+UPSTREAM_REPOSITORY = "https://github.com/hhenson/hgraph.git"
+CONFORMANCE_DEPENDENCIES = (
+    "pytest>=7.4.3",
+    "black>=25.1.0",
+    "duckdb",
+    "frozendict",
+    "multimethod",
+    "ordered-set>=4.1.0",
+    "polars>=1.32",
+    "psutil",
+    "pyarrow>=16.1,<25",
+    "pycurl",
+    "pytz",
+    "sortedcontainers>=2.4.0",
+    "sqlalchemy>=2.0",
+    "typing-extensions",
+)
+_VERSION = re.compile(r"^[0-9]+\.[0-9]+\.[0-9]+(?:[A-Za-z0-9.+-]*)?$")
+_ACCEPTED_CLASSIFICATIONS = {"expected-change", "converted"}
+_CLASSIFICATIONS = _ACCEPTED_CLASSIFICATIONS | {"confirmed-gap"}
+
+
+@dataclass(frozen=True)
+class UpstreamSource:
+    path: Path
+    repository: str
+    ref: str
+    revision: str
+    version: str
+    declared_version: str
+    test_digest: str
+
+
+def _run(
+    command: list[str],
+    *,
+    cwd: Path | None = None,
+    capture: bool = True,
+) -> subprocess.CompletedProcess[str]:
+    completed = subprocess.run(
+        command,
+        cwd=cwd,
+        capture_output=capture,
+        text=True,
+    )
+    if completed.returncode:
+        diagnostic = (completed.stderr or completed.stdout or "")[-4000:]
+        raise RuntimeError(
+            f"upstream conformance command failed ({completed.returncode}): "
+            f"{' '.join(command)}\n{diagnostic}"
+        )
+    return completed
+
+
+def _git(path: Path, *arguments: str) -> str:
+    return _run(["git", "-C", str(path), *arguments]).stdout.strip()
+
+
+def _tree_digest(paths: list[Path], *, root: Path) -> str:
+    digest = hashlib.sha256()
+    for base in paths:
+        if not base.exists():
+            continue
+        for path in sorted(
+            item
+            for item in base.rglob("*")
+            if item.is_file()
+            and "__pycache__" not in item.parts
+            and item.suffix not in {".pyc", ".pyo"}
+        ):
+            relative = path.relative_to(root).as_posix()
+            digest.update(relative.encode())
+            digest.update(b"\0")
+            digest.update(path.read_bytes())
+            digest.update(b"\0")
+    return digest.hexdigest()
+
+
+def _source_version(path: Path) -> str:
+    try:
+        project = tomllib.loads((path / "pyproject.toml").read_text())["project"]
+        return str(project["version"])
+    except (OSError, KeyError, tomllib.TOMLDecodeError) as error:
+        raise ValueError(
+            f"cannot read upstream version from {path}: {error}"
+        ) from error
+
+
+def ensure_upstream_source(
+    reference_identity: dict[str, Any],
+    *,
+    source_path: Path | None = None,
+    repository: str = UPSTREAM_REPOSITORY,
+) -> UpstreamSource:
+    version = str(reference_identity.get("version", ""))
+    if not _VERSION.fullmatch(version):
+        raise ValueError(f"unsafe or unknown reference version: {version!r}")
+    ref = f"v_{version}"
+    if source_path is None:
+        source_path = PARITY_ROOT / "upstream" / f"hgraph-{ref}"
+        if not source_path.exists():
+            source_path.parent.mkdir(parents=True, exist_ok=True)
+            _run(
+                [
+                    "git",
+                    "clone",
+                    "--quiet",
+                    "--depth",
+                    "1",
+                    "--branch",
+                    ref,
+                    repository,
+                    str(source_path),
+                ]
+            )
+    source_path = source_path.absolute()
+    if not (source_path / ".git").exists():
+        raise ValueError(f"upstream source is not a git checkout: {source_path}")
+    if _git(source_path, "status", "--porcelain"):
+        raise ValueError(f"upstream source must be unmodified: {source_path}")
+    revision = _git(source_path, "rev-parse", "HEAD")
+    tags = _git(source_path, "tag", "--points-at", "HEAD").splitlines()
+    if ref not in tags:
+        raise ValueError(f"upstream source revision {revision} is not tagged {ref}")
+    # hgraph's release automation tags the release source before its follow-up
+    # pyproject version bump.  The exact release tag is authoritative; retain
+    # the in-tree declaration as provenance instead of silently selecting a
+    # later commit or rejecting the tagged source.
+    declared_version = _source_version(source_path)
+    test_roots = [source_path / "hgraph_unit_tests", source_path / "examples"]
+    if not test_roots[0].is_dir():
+        raise ValueError(f"upstream tests are missing from {source_path}")
+    return UpstreamSource(
+        path=source_path,
+        repository=repository,
+        ref=ref,
+        revision=revision,
+        version=version,
+        declared_version=declared_version,
+        test_digest=_tree_digest(test_roots, root=source_path),
+    )
+
+
+def prepare_test_workspace(source: UpstreamSource) -> Path:
+    workspace = PARITY_ROOT / "upstream-workspaces" / source.revision
+    marker = workspace / ".test-digest"
+    current = marker.read_text().strip() if marker.exists() else ""
+    if current == source.test_digest:
+        copied_digest = _tree_digest(
+            [workspace / "hgraph_unit_tests", workspace / "examples"],
+            root=workspace,
+        )
+        if copied_digest == source.test_digest:
+            return workspace
+    if workspace.exists():
+        shutil.rmtree(workspace)
+    workspace.mkdir(parents=True)
+    for name in ("hgraph_unit_tests", "examples"):
+        source_path = source.path / name
+        if source_path.exists():
+            shutil.copytree(source_path, workspace / name)
+    (workspace / "pytest.ini").write_text(
+        "[pytest]\n"
+        "addopts = --import-mode=importlib\n"
+        "markers =\n"
+        "    serial: upstream serial test\n"
+        "    smoke: upstream smoke test\n"
+    )
+    copied_digest = _tree_digest(
+        [workspace / "hgraph_unit_tests", workspace / "examples"],
+        root=workspace,
+    )
+    if copied_digest != source.test_digest:
+        raise RuntimeError("staged upstream tests differ from the tagged source")
+    marker.write_text(source.test_digest + "\n")
+    return workspace
+
+
+def install_conformance_dependencies(
+    interpreters: tuple[Path, ...],
+    *,
+    extras: tuple[str, ...] = (),
+) -> None:
+    if not interpreters:
+        return
+    reference = interpreters[0]
+    _run(
+        [
+            "uv",
+            "pip",
+            "install",
+            "--python",
+            str(reference),
+            *CONFORMANCE_DEPENDENCIES,
+            *extras,
+        ]
+    )
+    resolved = conformance_environment(reference, extras=extras)
+    exact = [
+        f"{name}=={version}" for name, version in sorted(resolved["packages"].items())
+    ]
+    for interpreter in interpreters[1:]:
+        _run(
+            [
+                "uv",
+                "pip",
+                "install",
+                "--python",
+                str(interpreter),
+                *exact,
+            ]
+        )
+
+
+def _distribution_name(requirement: str) -> str:
+    return re.split(r"[<>=!~\[]", requirement, maxsplit=1)[0].strip()
+
+
+def conformance_environment(
+    interpreter: Path,
+    *,
+    extras: tuple[str, ...] = (),
+) -> dict[str, Any]:
+    distributions = sorted(
+        {
+            _distribution_name(requirement)
+            for requirement in (*CONFORMANCE_DEPENDENCIES, *extras)
+        }
+    )
+    program = (
+        "import importlib.metadata as m,json,platform,sys;"
+        f"names={distributions!r};"
+        "print(json.dumps({'python':platform.python_version(),"
+        "'implementation':platform.python_implementation(),"
+        "'packages':{name:m.version(name) for name in names}},sort_keys=True))"
+    )
+    completed = _run([str(interpreter), "-c", program])
+    return json.loads(completed.stdout)
+
+
+def require_aligned_conformance_environments(
+    reference_python: Path,
+    candidate_python: Path,
+    *,
+    extras: tuple[str, ...] = (),
+) -> dict[str, Any]:
+    reference = conformance_environment(reference_python, extras=extras)
+    candidate = conformance_environment(candidate_python, extras=extras)
+    if reference != candidate:
+        raise RuntimeError(
+            "reference and candidate conformance dependencies are not aligned: "
+            f"reference={reference}, candidate={candidate}"
+        )
+    return reference
+
+
+def _sanitized_environment() -> dict[str, str]:
+    environment = os.environ.copy()
+    for name in ("HGRAPH_USE_CPP", "PYTHONHOME", "VIRTUAL_ENV"):
+        environment.pop(name, None)
+    environment.update(
+        PYTHONHASHSEED="0",
+        PYTHONNOUSERSITE="1",
+        PYTHONPATH=str(REPO_ROOT),
+        PYTEST_DISABLE_PLUGIN_AUTOLOAD="1",
+        TZ="UTC",
+    )
+    return environment
+
+
+def run_upstream_suite(
+    interpreter: Path,
+    workspace: Path,
+    selectors: list[str],
+    *,
+    result_path: Path,
+    timeout_seconds: float,
+) -> dict[str, Any]:
+    result_path = result_path.absolute()
+    result_path.unlink(missing_ok=True)
+    command = [
+        str(interpreter),
+        "-m",
+        "pytest",
+        "-p",
+        "tools.parity.pytest_plugin",
+        "--hgraph-conformance-report",
+        str(result_path),
+        "-c",
+        str(workspace / "pytest.ini"),
+        "--rootdir",
+        str(workspace),
+        "--continue-on-collection-errors",
+        "-q",
+        *selectors,
+    ]
+    try:
+        completed = subprocess.run(
+            command,
+            cwd=workspace,
+            capture_output=True,
+            text=True,
+            timeout=timeout_seconds,
+            env=_sanitized_environment(),
+        )
+    except subprocess.TimeoutExpired as error:
+        return {
+            "schema_version": 1,
+            "status": "timeout",
+            "timeout_seconds": timeout_seconds,
+            "stdout": error.stdout or "",
+            "stderr": error.stderr or "",
+            "tests": {},
+            "collected": [],
+            "collection_errors": [],
+        }
+    try:
+        result = json.loads(result_path.read_text())
+    except (OSError, json.JSONDecodeError) as error:
+        return {
+            "schema_version": 1,
+            "status": "infrastructure-error",
+            "diagnostic": f"pytest did not produce a result: {error}",
+            "process_returncode": completed.returncode,
+            "stdout": completed.stdout,
+            "stderr": completed.stderr,
+            "tests": {},
+            "collected": [],
+            "collection_errors": [],
+        }
+    result.update(
+        status="complete",
+        process_returncode=completed.returncode,
+        stdout=completed.stdout,
+        stderr=completed.stderr,
+    )
+    return result
+
+
+def _safe_relative(value: str, *, field: str) -> str:
+    path = Path(value)
+    if path.is_absolute() or ".." in path.parts:
+        raise ValueError(f"{field} must be a repository-relative path: {value}")
+    return path.as_posix()
+
+
+def load_conformance_manifest(path: Path) -> dict[str, Any]:
+    try:
+        manifest = json.loads(path.read_text())
+    except (OSError, json.JSONDecodeError) as error:
+        raise ValueError(f"cannot read conformance manifest {path}: {error}") from error
+    if manifest.get("schema_version") != 1:
+        raise ValueError("conformance manifest schema_version must be 1")
+    profiles = manifest.get("profiles")
+    if not isinstance(profiles, dict) or not profiles:
+        raise ValueError("conformance manifest requires profiles")
+    for profile, selectors in profiles.items():
+        if (
+            not isinstance(profile, str)
+            or not isinstance(selectors, list)
+            or not selectors
+        ):
+            raise ValueError("conformance profiles require a name and selectors")
+        for selector in selectors:
+            value = _safe_relative(selector, field=f"profile {profile}")
+            if not value.startswith("hgraph_unit_tests"):
+                raise ValueError(f"profile selector is outside upstream tests: {value}")
+    rules = manifest.get("rules", [])
+    if not isinstance(rules, list):
+        raise ValueError("conformance manifest rules must be a list")
+    ids: set[str] = set()
+    for rule in rules:
+        rule_id = rule.get("id")
+        if not isinstance(rule_id, str) or not rule_id or rule_id in ids:
+            raise ValueError(f"invalid or duplicate conformance rule id: {rule_id!r}")
+        ids.add(rule_id)
+        if rule.get("classification") not in _CLASSIFICATIONS:
+            raise ValueError(f"invalid classification for rule {rule_id}")
+        if not isinstance(rule.get("match"), str) or not rule["match"]:
+            raise ValueError(f"rule {rule_id} requires a node-id match")
+        if not isinstance(rule.get("reason"), str) or not rule["reason"]:
+            raise ValueError(f"rule {rule_id} requires a reason")
+        try:
+            date.fromisoformat(rule["review_date"])
+        except (KeyError, TypeError, ValueError) as error:
+            raise ValueError(f"rule {rule_id} requires an ISO review_date") from error
+        outcomes = rule.get("candidate_outcomes")
+        if not isinstance(outcomes, list) or not outcomes:
+            raise ValueError(f"rule {rule_id} requires candidate_outcomes")
+        if rule["classification"] in _ACCEPTED_CLASSIFICATIONS:
+            if not rule.get("diagnostic_regex"):
+                raise ValueError(f"accepted rule {rule_id} requires diagnostic_regex")
+            try:
+                re.compile(rule["diagnostic_regex"])
+            except re.error as error:
+                raise ValueError(
+                    f"invalid diagnostic_regex for {rule_id}: {error}"
+                ) from error
+            if not rule.get("decision"):
+                raise ValueError(f"accepted rule {rule_id} requires a decision")
+        if rule["classification"] == "converted":
+            evidence = rule.get("evidence")
+            if not isinstance(evidence, list) or not evidence:
+                raise ValueError(f"converted rule {rule_id} requires evidence")
+            for evidence_path in evidence:
+                relative = _safe_relative(
+                    evidence_path, field=f"rule {rule_id} evidence"
+                )
+                if not (REPO_ROOT / relative).exists():
+                    raise ValueError(
+                        f"converted rule {rule_id} evidence does not exist: {relative}"
+                    )
+    return manifest
+
+
+def profile_selectors(manifest: dict[str, Any], profile: str) -> list[str]:
+    try:
+        return list(manifest["profiles"][profile])
+    except KeyError as error:
+        choices = ", ".join(sorted(manifest["profiles"]))
+        raise ValueError(
+            f"unknown conformance profile {profile!r}; choose {choices}"
+        ) from error
+
+
+def validate_selectors(selectors: list[str]) -> list[str]:
+    validated: list[str] = []
+    for selector in selectors:
+        path = selector.split("::", 1)[0]
+        value = _safe_relative(path, field="conformance selector")
+        if not value.startswith("hgraph_unit_tests"):
+            raise ValueError(f"conformance selector is outside upstream tests: {value}")
+        validated.append(selector.replace("\\", "/"))
+    if not validated:
+        raise ValueError("at least one upstream test selector is required")
+    return validated
+
+
+def _normalize_nodeid(nodeid: str) -> str:
+    return nodeid.replace("\\", "/")
+
+
+def _collection_error_for(
+    nodeid: str, errors: list[dict[str, Any]]
+) -> dict[str, Any] | None:
+    file_path = nodeid.split("::", 1)[0]
+    for error in errors:
+        error_node = _normalize_nodeid(str(error.get("nodeid", "")))
+        if error_node == file_path or file_path.startswith(
+            error_node.rstrip("/") + "/"
+        ):
+            return {
+                "outcome": "collection-error",
+                "phase": "collection",
+                "diagnostic": error.get("diagnostic", ""),
+                "duration": 0.0,
+            }
+    return None
+
+
+def _rule_matches(
+    rule: dict[str, Any],
+    *,
+    nodeid: str,
+    reference: dict[str, Any],
+    candidate: dict[str, Any],
+) -> bool:
+    if not fnmatch.fnmatchcase(nodeid, rule["match"]):
+        return False
+    if candidate.get("outcome") not in rule["candidate_outcomes"]:
+        return False
+    reference_outcomes = rule.get("reference_outcomes", ["passed"])
+    if reference.get("outcome") not in reference_outcomes:
+        return False
+    pattern = rule.get("diagnostic_regex")
+    return (
+        not pattern
+        or re.search(pattern, candidate.get("diagnostic", ""), re.DOTALL) is not None
+    )
+
+
+def compare_upstream_results(
+    reference: dict[str, Any],
+    candidate: dict[str, Any],
+    manifest: dict[str, Any],
+) -> dict[str, Any]:
+    report: dict[str, Any] = {
+        "schema_version": 1,
+        "matched": [],
+        "known_expected": [],
+        "review_required": [],
+        "confirmed_gaps": [],
+        "reference_unverified": [],
+        "candidate_only": [],
+        "ambiguous_rules": [],
+    }
+    reference_tests = {
+        _normalize_nodeid(nodeid): value
+        for nodeid, value in reference.get("tests", {}).items()
+    }
+    candidate_tests = {
+        _normalize_nodeid(nodeid): value
+        for nodeid, value in candidate.get("tests", {}).items()
+    }
+    candidate_errors = candidate.get("collection_errors", [])
+    for nodeid in sorted(set(reference_tests) | set(candidate_tests)):
+        ref = reference_tests.get(nodeid)
+        cand = candidate_tests.get(nodeid)
+        if ref is None:
+            report["candidate_only"].append({"nodeid": nodeid, "candidate": cand})
+            continue
+        if cand is None:
+            cand = _collection_error_for(nodeid, candidate_errors) or {
+                "outcome": "not-run",
+                "phase": "unknown",
+                "diagnostic": "candidate did not report this reference test",
+                "duration": 0.0,
+            }
+        entry = {"nodeid": nodeid, "reference": ref, "candidate": cand}
+        if ref.get("outcome") != "passed":
+            report["reference_unverified"].append(entry)
+            continue
+        if cand.get("outcome") == "passed":
+            report["matched"].append(entry)
+            continue
+        matching_rules = [
+            rule
+            for rule in manifest.get("rules", [])
+            if _rule_matches(
+                rule,
+                nodeid=nodeid,
+                reference=ref,
+                candidate=cand,
+            )
+        ]
+        if len(matching_rules) > 1:
+            entry["rules"] = [rule["id"] for rule in matching_rules]
+            report["ambiguous_rules"].append(entry)
+            continue
+        if not matching_rules:
+            report["review_required"].append(entry)
+            continue
+        rule = matching_rules[0]
+        entry["rule"] = rule
+        if rule["classification"] in _ACCEPTED_CLASSIFICATIONS:
+            report["known_expected"].append(entry)
+        else:
+            report["confirmed_gaps"].append(entry)
+    for error in reference.get("collection_errors", []):
+        report["reference_unverified"].append(
+            {
+                "nodeid": _normalize_nodeid(str(error.get("nodeid", "collection"))),
+                "reference": error,
+                "candidate": {"outcome": "not-compared", "diagnostic": ""},
+            }
+        )
+    report["summary"] = {
+        key: len(report[key])
+        for key in (
+            "matched",
+            "known_expected",
+            "review_required",
+            "confirmed_gaps",
+            "reference_unverified",
+            "candidate_only",
+            "ambiguous_rules",
+        )
+    }
+    report["summary"].update(
+        reference_collected=len(reference.get("collected", [])),
+        candidate_collected=len(candidate.get("collected", [])),
+        reference_collection_errors=len(reference.get("collection_errors", [])),
+        candidate_collection_errors=len(candidate.get("collection_errors", [])),
+    )
+    return report
+
+
+def _brief_diagnostic(entry: dict[str, Any]) -> str:
+    diagnostic = entry["candidate"].get("diagnostic", "").strip()
+    if not diagnostic:
+        diagnostic = entry["reference"].get("diagnostic", "").strip()
+    if not diagnostic:
+        return entry["candidate"].get("outcome", "unknown")
+    lines = [line.strip() for line in diagnostic.splitlines() if line.strip()]
+    return (lines[-1] if lines else diagnostic)[:300]
+
+
+def render_conformance_markdown(report: dict[str, Any]) -> str:
+    summary = report["summary"]
+    source = report.get("source", {})
+    lines = ["# Upstream hgraph conformance", ""]
+    lines.append(
+        f"Reference: hgraph {report['reference_identity']['version']}; "
+        f"candidate: hg_cpp {report['candidate_identity']['version']}"
+    )
+    lines.append(
+        f"Upstream source: `{source.get('ref')}` at `{source.get('revision')}` "
+        f"(test digest `{source.get('test_digest')}`)"
+    )
+    environment = report.get("conformance_environment", {})
+    if environment:
+        lines.append(
+            f"Aligned environment: {environment.get('implementation')} "
+            f"{environment.get('python')} with {len(environment.get('packages', {}))} "
+            "pinned conformance dependencies."
+        )
+    if source.get("declared_version") != source.get("version"):
+        lines.append(
+            f"Tagged source declares version `{source.get('declared_version')}`; "
+            f"the installed release and tag identify `{source.get('version')}`."
+        )
+    lines.extend(
+        [
+            "",
+            f"- reference tests collected: {summary['reference_collected']}",
+            f"- exact candidate matches: {summary['matched']}",
+            f"- known expected/converted outcomes: {summary['known_expected']}",
+            f"- review required (not yet classified as defects): {summary['review_required']}",
+            f"- confirmed compatibility gaps: {summary['confirmed_gaps']}",
+            f"- reference-unverified tests: {summary['reference_unverified']}",
+            f"- ambiguous known rules: {summary['ambiguous_rules']}",
+            "",
+        ]
+    )
+    for heading, key in (
+        ("Review required", "review_required"),
+        ("Confirmed compatibility gaps", "confirmed_gaps"),
+        ("Known expected or converted outcomes", "known_expected"),
+        ("Reference-unverified", "reference_unverified"),
+        ("Ambiguous rules", "ambiguous_rules"),
+    ):
+        entries = report.get(key, [])
+        if not entries:
+            continue
+        lines.extend([f"## {heading}", ""])
+        limit = 100
+        for entry in entries[:limit]:
+            detail = _brief_diagnostic(entry)
+            rule = entry.get("rule")
+            suffix = f" — rule `{rule['id']}`" if rule else ""
+            lines.append(f"- `{entry['nodeid']}`: {detail}{suffix}")
+        if len(entries) > limit:
+            lines.append(
+                f"- ... {len(entries) - limit} additional entries are in report.json"
+            )
+        lines.append("")
+    return "\n".join(lines) + "\n"

--- a/tools/parity/pytest_plugin.py
+++ b/tools/parity/pytest_plugin.py
@@ -1,0 +1,145 @@
+"""Minimal pytest result recorder for the upstream conformance runner.
+
+The plugin is loaded into isolated reference and candidate environments.  It
+records stable pytest node ids and phase outcomes without requiring an extra
+reporting dependency in either environment.
+"""
+
+from __future__ import annotations
+
+import json
+import platform
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+_STATE: dict[str, Any] = {}
+
+
+def pytest_addoption(parser) -> None:
+    group = parser.getgroup("hgraph-conformance")
+    group.addoption(
+        "--hgraph-conformance-report",
+        action="store",
+        help="write the upstream conformance result as JSON",
+    )
+
+
+def pytest_configure(config) -> None:
+    global _STATE
+    _STATE = {
+        "aliases": {},
+        "collected": [],
+        "collection_errors": [],
+        "phases": {},
+    }
+
+
+def _diagnostic(report) -> str:
+    longrepr = getattr(report, "longrepr", None)
+    return "" if longrepr is None else str(longrepr)
+
+
+def pytest_collection_finish(session) -> None:
+    case_indexes: dict[str, int] = {}
+    collected: list[str] = []
+    for item in session.items:
+        original_name = getattr(item, "originalname", None)
+        if original_name:
+            definition = f"{item.parent.nodeid}::{original_name}"
+        else:
+            definition = item.nodeid.split("[", 1)[0]
+        if hasattr(item, "callspec"):
+            case_index = case_indexes.get(definition, 0)
+            case_indexes[definition] = case_index + 1
+            stable_nodeid = f"{definition}[case-{case_index}]"
+        else:
+            stable_nodeid = definition
+        _STATE["aliases"][item.nodeid] = stable_nodeid
+        collected.append(stable_nodeid)
+    _STATE["collected"] = collected
+
+
+def pytest_collectreport(report) -> None:
+    if not report.failed:
+        return
+    _STATE["collection_errors"].append(
+        {
+            "nodeid": report.nodeid,
+            "outcome": "collection-error",
+            "diagnostic": _diagnostic(report),
+        }
+    )
+
+
+def pytest_runtest_logreport(report) -> None:
+    nodeid = _STATE["aliases"].get(report.nodeid, report.nodeid)
+    _STATE["phases"].setdefault(nodeid, {})[report.when] = {
+        "outcome": report.outcome,
+        "diagnostic": _diagnostic(report),
+        "duration": getattr(report, "duration", 0.0),
+        "pytest_nodeid": report.nodeid,
+        "wasxfail": str(getattr(report, "wasxfail", "")),
+    }
+
+
+def _test_outcome(phases: dict[str, dict[str, Any]]) -> dict[str, Any]:
+    for phase in ("setup", "call", "teardown"):
+        result = phases.get(phase)
+        if result and result["outcome"] == "failed":
+            return {
+                "outcome": "failed" if phase == "call" else "error",
+                "phase": phase,
+                "diagnostic": result["diagnostic"],
+                "duration": sum(item["duration"] for item in phases.values()),
+                "pytest_nodeid": result["pytest_nodeid"],
+            }
+    for phase in ("setup", "call", "teardown"):
+        result = phases.get(phase)
+        if result and result["outcome"] == "skipped":
+            return {
+                "outcome": "xfailed" if result["wasxfail"] else "skipped",
+                "phase": phase,
+                "diagnostic": result["diagnostic"],
+                "duration": sum(item["duration"] for item in phases.values()),
+                "pytest_nodeid": result["pytest_nodeid"],
+            }
+    call = phases.get("call")
+    if call and call["outcome"] == "passed":
+        return {
+            "outcome": "xpassed" if call["wasxfail"] else "passed",
+            "phase": "call",
+            "diagnostic": "",
+            "duration": sum(item["duration"] for item in phases.values()),
+            "pytest_nodeid": call["pytest_nodeid"],
+        }
+    return {
+        "outcome": "not-run",
+        "phase": "unknown",
+        "diagnostic": "",
+        "duration": sum(item["duration"] for item in phases.values()),
+        "pytest_nodeid": next((item["pytest_nodeid"] for item in phases.values()), ""),
+    }
+
+
+def pytest_sessionfinish(session, exitstatus) -> None:
+    output = session.config.getoption("--hgraph-conformance-report")
+    if not output:
+        return
+    tests = {
+        nodeid: _test_outcome(phases)
+        for nodeid, phases in sorted(_STATE["phases"].items())
+    }
+    payload = {
+        "schema_version": 1,
+        "pytest_version": pytest.__version__,
+        "python_version": platform.python_version(),
+        "exit_status": int(exitstatus),
+        "collected": _STATE["collected"],
+        "tests": tests,
+        "collection_errors": _STATE["collection_errors"],
+    }
+    path = Path(output)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n")

--- a/tools/parity/upstream_conformance.json
+++ b/tools/parity/upstream_conformance.json
@@ -1,0 +1,960 @@
+{
+  "schema_version": 1,
+  "profiles": {
+    "operators": [
+      "hgraph_unit_tests/_operators"
+    ],
+    "core": [
+      "hgraph_unit_tests/_operators",
+      "hgraph_unit_tests/_runtime",
+      "hgraph_unit_tests/_types",
+      "hgraph_unit_tests/_wiring",
+      "hgraph_unit_tests/nodes",
+      "hgraph_unit_tests/test",
+      "hgraph_unit_tests/ts_tests"
+    ],
+    "all": [
+      "hgraph_unit_tests"
+    ]
+  },
+  "rules": [
+    {
+      "id": "operators-const-private-wiring-converted",
+      "match": "hgraph_unit_tests/_operators/test_const.py::*",
+      "classification": "converted",
+      "candidate_outcomes": ["collection-error"],
+      "diagnostic_regex": "No module named 'hgraph[.]_wiring[.]_wiring_node_class'",
+      "reason": "The upstream module imports a private Python wiring-node implementation; const and delayed behavior is retained through public wiring tests.",
+      "decision": "docs/source/developer_guide/parity_matrix.rst",
+      "review_date": "2026-08-05",
+      "evidence": [
+        "python/tests/ported/_operators/test_const.py",
+        "tests/cpp/test_std_nodes.cpp"
+      ]
+    },
+    {
+      "id": "operators-number-private-impl-converted",
+      "match": "hgraph_unit_tests/_operators/test_number_operators.py::*",
+      "classification": "converted",
+      "candidate_outcomes": ["collection-error"],
+      "diagnostic_regex": "No module named 'hgraph[.]_impl'",
+      "reason": "The upstream module imports a concrete Python number overload; the public operator family is covered directly in both languages.",
+      "decision": "docs/source/developer_guide/parity_matrix.rst",
+      "review_date": "2026-08-05",
+      "evidence": [
+        "python/tests/ported/_operators/test_number_operators.py",
+        "tests/cpp/test_std_operators.cpp"
+      ]
+    },
+    {
+      "id": "operators-print-private-tsl-converted",
+      "match": "hgraph_unit_tests/_operators/test_print.py::*",
+      "classification": "converted",
+      "candidate_outcomes": ["collection-error"],
+      "diagnostic_regex": "No module named 'hgraph[.]nodes[.]_tsl_operators'",
+      "reason": "The private Python TSL formatting implementation is not a runtime contract; public print and logger behavior is retained.",
+      "decision": "docs/source/developer_guide/parity_matrix.rst",
+      "review_date": "2026-08-05",
+      "evidence": [
+        "python/tests/ported/_operators/test_print.py",
+        "tests/cpp/test_logger.cpp",
+        "tests/cpp/test_std_nodes.cpp"
+      ]
+    },
+    {
+      "id": "operators-stream-analytics-private-impl-converted",
+      "match": "hgraph_unit_tests/_operators/test_stream_analytical_operators.py::*",
+      "classification": "converted",
+      "candidate_outcomes": ["collection-error"],
+      "diagnostic_regex": "No module named 'hgraph[.]_impl'",
+      "reason": "The upstream test imports private Python analytical implementations; native public operators replace those implementation objects.",
+      "decision": "docs/source/developer_guide/replacement_gap_plan.rst",
+      "review_date": "2026-08-05",
+      "evidence": [
+        "python/tests/ported/_operators/test_stream_analytical_operators.py",
+        "tests/cpp/test_std_operators.cpp"
+      ]
+    },
+    {
+      "id": "operators-to-table-private-operator-converted",
+      "match": "hgraph_unit_tests/_operators/test_to_table.py::*",
+      "classification": "converted",
+      "candidate_outcomes": ["collection-error"],
+      "diagnostic_regex": "No module named 'hgraph[.]_operators'",
+      "reason": "The upstream module imports private table helpers; equivalent schema and round-trip behavior is exercised through the public Arrow table surface.",
+      "decision": "docs/source/developer_guide/parity_matrix.rst",
+      "review_date": "2026-08-05",
+      "evidence": [
+        "python/tests/ported/_operators/test_to_table.py",
+        "tests/cpp/test_table.cpp"
+      ]
+    },
+    {
+      "id": "operators-to-table-dispatch-private-impl-converted",
+      "match": "hgraph_unit_tests/_operators/test_to_table_dispatch.py::*",
+      "classification": "converted",
+      "candidate_outcomes": ["collection-error"],
+      "diagnostic_regex": "No module named 'hgraph[.]_impl'",
+      "reason": "PartialSchema is an upstream private builder layout; its public schema and conversion behavior is owned by the native table codec.",
+      "decision": "docs/source/developer_guide/parity_matrix.rst",
+      "review_date": "2026-08-05",
+      "evidence": [
+        "python/tests/ported/_operators/test_to_table_dispatch.py",
+        "python/tests/ported/_operators/test_to_table.py",
+        "tests/cpp/test_table.cpp"
+      ]
+    },
+    {
+      "id": "operators-tsd-private-operator-converted",
+      "match": "hgraph_unit_tests/_operators/test_tsd_operators.py::*",
+      "classification": "converted",
+      "candidate_outcomes": ["collection-error"],
+      "diagnostic_regex": "No module named 'hgraph[.]_operators'",
+      "reason": "The module's private operator imports were converted to public keyed time-series wiring without changing the tested TSD behavior.",
+      "decision": "docs/source/developer_guide/parity_matrix.rst",
+      "review_date": "2026-08-05",
+      "evidence": [
+        "python/tests/ported/_operators/test_tsd_operators.py",
+        "tests/cpp/test_std_operators.cpp",
+        "tests/cpp/test_collection_nodes.cpp"
+      ]
+    },
+    {
+      "id": "operators-tsw-private-runtime-converted",
+      "match": "hgraph_unit_tests/_operators/test_tsw_operators.py::*",
+      "classification": "converted",
+      "candidate_outcomes": ["collection-error"],
+      "diagnostic_regex": "No module named 'hgraph[.]_runtime[.]_constants'",
+      "reason": "The private Python runtime constant import was removed; the public TSW operator behavior has Python and native coverage.",
+      "decision": "docs/source/developer_guide/parity_matrix.rst",
+      "review_date": "2026-08-05",
+      "evidence": [
+        "python/tests/ported/_operators/test_tsw_operators.py",
+        "tests/cpp/test_std_operators.cpp",
+        "tests/cpp/test_collection_nodes.cpp"
+      ]
+    },
+    {
+      "id": "operators-window-private-node-converted",
+      "match": "hgraph_unit_tests/_operators/test_window_operators.py::*",
+      "classification": "converted",
+      "candidate_outcomes": ["collection-error"],
+      "diagnostic_regex": "No module named 'hgraph[.]nodes[.]_window_operators'",
+      "reason": "rolling_average is a registered public graph operator rather than a Python-private implementation node; tick and duration forms are covered in C++ and Python.",
+      "decision": "docs/source/developer_guide/replacement_gap_plan.rst",
+      "review_date": "2026-08-05",
+      "evidence": [
+        "python/tests/ported/_operators/test_window_operators.py",
+        "tests/cpp/test_std_operators.cpp"
+      ]
+    },
+    {
+      "id": "operators-frame-conversion-arrow-boundary",
+      "match": "hgraph_unit_tests/_operators/_conversion_operators/test_frame_conversion_operators.py::*",
+      "classification": "converted",
+      "candidate_outcomes": ["failed"],
+      "diagnostic_regex": "unexpected input types|no runtime value conversion is registered from frame to frame",
+      "reason": "Frame is canonically Apache Arrow and Polars is a compatibility boundary, so the upstream Polars assertions are converted to Arrow table assertions.",
+      "decision": "docs/source/developer_guide/parity_matrix.rst",
+      "review_date": "2026-08-05",
+      "evidence": [
+        "python/tests/ported/_operators/_conversion_operators/test_frame_conversion_operators.py",
+        "python/tests/test_polars_frames.py",
+        "tests/cpp/test_data_frame_operators.cpp"
+      ]
+    },
+    {
+      "id": "operators-series-arrow-boundary",
+      "match": "hgraph_unit_tests/_operators/test_series_operators.py::*",
+      "classification": "converted",
+      "candidate_outcomes": ["failed"],
+      "diagnostic_regex": "Series.*has no attribute '__arrow_c_array__'",
+      "reason": "Series is canonically an Arrow array rather than a Polars Series; the same arithmetic, access, and membership behavior is tested through Arrow values.",
+      "decision": "docs/source/developer_guide/parity_matrix.rst",
+      "review_date": "2026-08-05",
+      "evidence": [
+        "python/tests/ported/_operators/test_series_operators.py",
+        "tests/cpp/test_std_operators.cpp"
+      ]
+    },
+    {
+      "id": "operators-series-to-tuple-arrow-boundary",
+      "match": "hgraph_unit_tests/_operators/_conversion_operators/test_tuple_conversion_operators.py::test_convert_series_to_tuple",
+      "classification": "converted",
+      "candidate_outcomes": ["failed"],
+      "diagnostic_regex": "Series.*has no attribute '__arrow_c_array__'",
+      "reason": "The upstream case supplies a Polars Series; the retained public conversion consumes the canonical Arrow Series including null elements.",
+      "decision": "docs/source/developer_guide/parity_matrix.rst",
+      "review_date": "2026-08-05",
+      "evidence": [
+        "python/tests/ported/_operators/_conversion_operators/test_tuple_conversion_operators.py",
+        "tests/cpp/test_std_operators.cpp"
+      ]
+    },
+    {
+      "id": "operators-data-frame-output-arrow-boundary",
+      "match": "hgraph_unit_tests/_operators/test_data_frame_operators.py::test_to_data_frame_*",
+      "classification": "converted",
+      "candidate_outcomes": ["failed"],
+      "diagnostic_regex": "did not expect type: 'pyarrow[.]lib[.]Table'",
+      "reason": "to_data_frame returns the canonical Arrow Frame; upstream concatenates Polars values and the ported tests concatenate Arrow tables.",
+      "decision": "docs/source/developer_guide/parity_matrix.rst",
+      "review_date": "2026-08-05",
+      "evidence": [
+        "python/tests/ported/_operators/test_data_frame_operators.py",
+        "tests/cpp/test_data_frame_operators.cpp"
+      ]
+    },
+    {
+      "id": "operators-data-frame-group-arrow-boundary",
+      "match": "hgraph_unit_tests/_operators/test_data_frame_operators.py::test_group_by_*",
+      "classification": "converted",
+      "candidate_outcomes": ["failed"],
+      "diagnostic_regex": "unexpected input types",
+      "reason": "group_by returns keyed canonical Arrow frames; the ported assertions compare Arrow tables instead of Polars DataFrames.",
+      "decision": "docs/source/developer_guide/parity_matrix.rst",
+      "review_date": "2026-08-05",
+      "evidence": [
+        "python/tests/ported/_operators/test_data_frame_operators.py",
+        "tests/cpp/test_data_frame_operators.cpp"
+      ]
+    },
+    {
+      "id": "operators-data-frame-key-schema-validation",
+      "match": "hgraph_unit_tests/_operators/test_data_frame_operators.py::test_from_data_frame_tsd_k_tsb",
+      "classification": "converted",
+      "candidate_outcomes": ["failed"],
+      "diagnostic_regex": "column 'key'.*int64.*expected 'string'.*native scalar 'str'",
+      "reason": "The C++-first table codec rejects a frame key column that contradicts the requested TSD key type; the converted public test pins that validation.",
+      "decision": "docs/source/developer_guide/parity_matrix.rst",
+      "review_date": "2026-08-05",
+      "evidence": [
+        "python/tests/ported/_operators/test_data_frame_operators.py",
+        "tests/cpp/test_data_frame_operators.cpp"
+      ]
+    },
+    {
+      "id": "operators-throttle-arrow-frame-boundary",
+      "match": "hgraph_unit_tests/_operators/test_stream_operators.py::test_throttle_dataframe",
+      "classification": "converted",
+      "candidate_outcomes": ["failed"],
+      "diagnostic_regex": "cannot create expression literal for value of type Table",
+      "reason": "The upstream assertion uses Polars DataFrames; throttle preserves canonical Arrow Frame values and timing unchanged.",
+      "decision": "docs/source/developer_guide/parity_matrix.rst",
+      "review_date": "2026-08-05",
+      "evidence": [
+        "python/tests/ported/_operators/test_stream_operators.py",
+        "tests/cpp/test_data_frame_operators.cpp"
+      ]
+    },
+    {
+      "id": "operators-tsw-public-view-conversion",
+      "match": "hgraph_unit_tests/_operators/test_stream_operators.py::test_to_window_*",
+      "classification": "converted",
+      "candidate_outcomes": ["failed"],
+      "diagnostic_regex": "At index 0 diff: 1 != None|assert False",
+      "reason": "The public C++ TSW view exposes warm-up values and scalar deltas immediately; validity and eviction remain explicit and are tested through public graph consumers.",
+      "decision": "docs/source/developer_guide/parity_matrix.rst",
+      "review_date": "2026-08-05",
+      "evidence": [
+        "python/tests/ported/_operators/test_stream_operators.py",
+        "tests/cpp/test_std_operators.cpp",
+        "tests/cpp/test_collection_nodes.cpp"
+      ]
+    },
+    {
+      "id": "operators-json-rfc3339-instant",
+      "match": "hgraph_unit_tests/_operators/test_to_json.py::test_to_json*case-3*",
+      "classification": "converted",
+      "candidate_outcomes": ["failed"],
+      "diagnostic_regex": "2024-06-13T10:15:30[.]000042Z.*2024-06-13 10:15:30[.]000042",
+      "reason": "RFC 0002 writers emit canonical RFC 3339 UTC instants rather than the legacy timezone-free text.",
+      "decision": "docs/source/developer_guide/parity_matrix.rst",
+      "review_date": "2026-08-05",
+      "evidence": [
+        "python/tests/ported/_operators/test_to_json.py",
+        "tests/cpp/test_std_operators.cpp"
+      ]
+    },
+    {
+      "id": "operators-json-canonical-duration",
+      "match": "hgraph_unit_tests/_operators/test_to_json.py::test_to_json*case-5*",
+      "classification": "converted",
+      "candidate_outcomes": ["failed"],
+      "diagnostic_regex": "864015000042us.*10:0:0:15[.]000042",
+      "reason": "RFC 0002 writers emit canonical signed-microsecond durations while readers retain legacy compatibility.",
+      "decision": "docs/source/developer_guide/parity_matrix.rst",
+      "review_date": "2026-08-05",
+      "evidence": [
+        "python/tests/ported/_operators/test_to_json.py",
+        "tests/cpp/test_std_operators.cpp"
+      ]
+    },
+    {
+      "id": "operators-bool-overload-diagnostics",
+      "match": "hgraph_unit_tests/_operators/test_bool_operators.py::*_booleans_attempt",
+      "classification": "converted",
+      "candidate_outcomes": ["failed"],
+      "diagnostic_regex": "no matching overload for operator '(add_|sub_)'",
+      "reason": "The invalid operations still raise WiringError; the C++ overload resolver supplies structured candidate diagnostics instead of the legacy message text.",
+      "decision": "docs/source/developer_guide/parity_matrix.rst",
+      "review_date": "2026-08-05",
+      "evidence": [
+        "python/tests/ported/_operators/test_bool_operators.py",
+        "tests/cpp/test_std_operators.cpp"
+      ]
+    },
+    {
+      "id": "operators-datetime-overload-diagnostics",
+      "match": "hgraph_unit_tests/_operators/test_datetime_operators.py::test_add_date*attempt",
+      "classification": "converted",
+      "candidate_outcomes": ["failed"],
+      "diagnostic_regex": "no matching overload for operator 'add_'",
+      "reason": "The invalid operations still raise WiringError; the C++ overload resolver supplies structured candidate diagnostics instead of the legacy message text.",
+      "decision": "docs/source/developer_guide/parity_matrix.rst",
+      "review_date": "2026-08-05",
+      "evidence": [
+        "python/tests/ported/_operators/test_datetime_operators.py",
+        "tests/cpp/test_std_operators.cpp"
+      ]
+    },
+    {
+      "id": "operators-frozendict-overload-diagnostics",
+      "match": "hgraph_unit_tests/_operators/test_frozendict_operators.py::test_min_frozendict_multi",
+      "classification": "converted",
+      "candidate_outcomes": ["failed"],
+      "diagnostic_regex": "no matching overload for operator 'min_'",
+      "reason": "The invalid operation still raises WiringError; the C++ overload resolver supplies structured candidate diagnostics instead of the legacy message text.",
+      "decision": "docs/source/developer_guide/parity_matrix.rst",
+      "review_date": "2026-08-05",
+      "evidence": [
+        "python/tests/ported/_operators/test_frozendict_operators.py",
+        "tests/cpp/test_std_operators.cpp"
+      ]
+    },
+    {
+      "id": "operators-scalar-overload-diagnostics",
+      "match": "hgraph_unit_tests/_operators/test_scalar_operators.py::test_add_fail",
+      "classification": "converted",
+      "candidate_outcomes": ["failed"],
+      "diagnostic_regex": "no matching overload for operator 'add_'",
+      "reason": "The invalid operation still raises WiringError; the C++ overload resolver supplies structured candidate diagnostics instead of the legacy message text.",
+      "decision": "docs/source/developer_guide/parity_matrix.rst",
+      "review_date": "2026-08-05",
+      "evidence": [
+        "python/tests/ported/_operators/test_scalar_operators.py",
+        "tests/cpp/test_std_operators.cpp"
+      ]
+    },
+    {
+      "id": "operators-frozendict-variance-precision",
+      "match": "hgraph_unit_tests/_operators/test_frozendict_operators.py::test_var_frozendict_unary",
+      "classification": "converted",
+      "candidate_outcomes": ["failed"],
+      "diagnostic_regex": "33[.]33333333333333 != 33[.]333333333333336",
+      "reason": "The native stable variance accumulator differs only in the last floating-point bit; the public test uses an approximate numeric assertion.",
+      "decision": "docs/source/developer_guide/replacement_gap_plan.rst",
+      "review_date": "2026-08-05",
+      "evidence": [
+        "python/tests/ported/_operators/test_frozendict_operators.py",
+        "tests/cpp/test_std_operators.cpp"
+      ]
+    },
+    {
+      "id": "operators-scalar-standard-deviation-precision",
+      "match": "hgraph_unit_tests/_operators/test_scalar_operators.py::test_std_scalars_unary",
+      "classification": "converted",
+      "candidate_outcomes": ["failed"],
+      "diagnostic_regex": "0[.]816496580927726 != 0[.]8164965809277263",
+      "reason": "The native stable standard-deviation accumulator differs only in the last floating-point bit; the public test uses an approximate numeric assertion.",
+      "decision": "docs/source/developer_guide/replacement_gap_plan.rst",
+      "review_date": "2026-08-05",
+      "evidence": [
+        "python/tests/ported/_operators/test_scalar_operators.py",
+        "tests/cpp/test_std_operators.cpp"
+      ]
+    },
+    {
+      "id": "operators-compound-scalar-native-format",
+      "match": "hgraph_unit_tests/_operators/test_compound_scalar_operators.py::test_str_cs",
+      "classification": "converted",
+      "candidate_outcomes": ["failed"],
+      "diagnostic_regex": "At index 0 diff: '[{]a: 1, b: [}]'",
+      "reason": "CompoundScalar stringification uses the recorded native bundle representation rather than a Python dataclass repr.",
+      "decision": "docs/source/developer_guide/parity_matrix.rst",
+      "review_date": "2026-08-05",
+      "evidence": [
+        "python/tests/ported/_operators/test_compound_scalar_operators.py",
+        "tests/cpp/test_std_operators.cpp"
+      ]
+    },
+    {
+      "id": "types-metadata-hierarchy-converted",
+      "match": "hgraph_unit_tests/_types/test_type_meta_data.py::*",
+      "classification": "converted",
+      "candidate_outcomes": ["collection-error"],
+      "diagnostic_regex": "cannot import name 'HgTsTypeVarTypeMetaData'",
+      "reason": "HgTypeMetaData is the Python runtime's private type model; public annotations and reflection replace user inspection while native schema tests own parsing, identity, and storage metadata.",
+      "decision": "docs/source/developer_guide/type_reflection.rst",
+      "review_date": "2026-08-05",
+      "evidence": [
+        "python/tests/test_reflection.py",
+        "tests/cpp/test_static_schema.cpp",
+        "tests/cpp/test_schema_examples.cpp",
+        "tests/cpp/test_type_registry.cpp"
+      ]
+    },
+    {
+      "id": "types-metadata-resolution-converted",
+      "match": "hgraph_unit_tests/_types/test_type_meta_resolve.py::*",
+      "classification": "converted",
+      "candidate_outcomes": ["collection-error"],
+      "diagnostic_regex": "No module named 'hgraph[.]_types[.]_ts_type'",
+      "reason": "build_resolution_dict and resolve are Python-runtime internals; equivalent recursive type-variable binding is owned and tested by native wiring resolution.",
+      "decision": "docs/source/developer_guide/type_reflection.rst",
+      "review_date": "2026-08-05",
+      "evidence": [
+        "python/tests/test_reflection.py",
+        "tests/cpp/test_type_resolution.cpp",
+        "tests/cpp/test_operators.cpp"
+      ]
+    },
+    {
+      "id": "types-operator-rank-converted",
+      "match": "hgraph_unit_tests/_types/test_operator_rank.py::*",
+      "classification": "converted",
+      "candidate_outcomes": ["collection-error"],
+      "diagnostic_regex": "cannot import name 'HgTypeMetaData'",
+      "reason": "generic_rank and compare_ranks are Python-runtime internals; overload specificity, ties, and recursive pattern ranking execute and are tested in C++.",
+      "decision": "docs/source/developer_guide/type_reflection.rst",
+      "review_date": "2026-08-05",
+      "evidence": [
+        "python/tests/test_dispatch_scalar.py",
+        "python/tests/ported/_wiring/test_dispatch.py",
+        "tests/cpp/test_operators.cpp",
+        "tests/cpp/test_dispatch.cpp"
+      ]
+    },
+    {
+      "id": "types-complex-schema-reflection-converted",
+      "match": "hgraph_unit_tests/_types/test_complex_types.py::*",
+      "classification": "converted",
+      "candidate_outcomes": ["collection-error"],
+      "diagnostic_regex": "cannot import name 'HgTimeSeriesTypeMetaData'",
+      "reason": "Private metadata-object assertions are converted to public fields and type predicates; nominal bundle and CompoundScalar inheritance retain native and Python behavior coverage.",
+      "decision": "docs/source/developer_guide/type_reflection.rst",
+      "review_date": "2026-08-05",
+      "evidence": [
+        "python/tests/test_reflection.py",
+        "python/tests/test_compound_scalar_hierarchy.py",
+        "tests/cpp/test_static_schema.cpp",
+        "tests/cpp/test_type_registry.cpp"
+      ]
+    },
+    {
+      "id": "types-schema-base-converted",
+      "match": "hgraph_unit_tests/_types/test_schema_base.py::*",
+      "classification": "converted",
+      "candidate_outcomes": ["collection-error"],
+      "diagnostic_regex": "cannot import name 'Base'",
+      "reason": "The upstream module couples public schema hierarchy behavior to HgTypeMetaData and private JSON converters; the retained Base, reflection, hierarchy, and discriminator behavior is tested through public APIs.",
+      "decision": "docs/source/developer_guide/type_reflection.rst",
+      "review_date": "2026-08-05",
+      "evidence": [
+        "python/tests/test_compound_scalar_hierarchy.py",
+        "python/tests/test_python_owned_structured_scalar.py",
+        "python/tests/stream/test_stream.py",
+        "tests/cpp/test_type_registry.cpp"
+      ]
+    },
+    {
+      "id": "types-dataclass-scalar-converted",
+      "match": "hgraph_unit_tests/_types/test_dataclass_scalar.py::*",
+      "classification": "converted",
+      "candidate_outcomes": ["collection-error"],
+      "diagnostic_regex": "cannot import name 'HgCompoundScalarType'",
+      "reason": "Plain dataclass values are retained as Python-owned structured scalars, but their schema is inspected through public reflection instead of HgTypeMetaData objects.",
+      "decision": "docs/source/developer_guide/type_reflection.rst",
+      "review_date": "2026-08-05",
+      "evidence": [
+        "python/tests/test_python_owned_structured_scalar.py",
+        "python/tests/test_compound_scalar_hierarchy.py",
+        "tests/cpp/test_type_registry.cpp",
+        "tests/cpp/test_value.cpp"
+      ]
+    },
+    {
+      "id": "types-cpp-native-wrapper-converted",
+      "match": "hgraph_unit_tests/_types/test_cpp_native_compound_scalar.py::*",
+      "classification": "converted",
+      "candidate_outcomes": ["collection-error"],
+      "diagnostic_regex": "No module named 'hgraph[.]_types[.]_scalar_types'",
+      "reason": "CppNative and cpp_native select storage in the optional upstream bridge; hg_cpp is always C++-native and tests storage realization directly.",
+      "decision": "docs/source/developer_guide/type_reflection.rst",
+      "review_date": "2026-08-05",
+      "evidence": [
+        "python/tests/test_compound_scalar_hierarchy.py",
+        "tests/cpp/test_type_registry.cpp",
+        "tests/cpp/test_plan_factories.cpp",
+        "tests/cpp/test_value.cpp"
+      ]
+    },
+    {
+      "id": "types-cpp-bridge-integration-converted",
+      "match": "hgraph_unit_tests/_types/test_cpp_type_integration.py::*",
+      "classification": "converted",
+      "candidate_outcomes": ["collection-error"],
+      "diagnostic_regex": "No module named 'hgraph[.]_types[.]_scalar_type_meta_data'",
+      "reason": "The upstream Python-to-C++ metadata bridge does not exist in a C++-first runtime; scalar schemas, plans, values, and round trips are tested natively.",
+      "decision": "docs/source/developer_guide/type_reflection.rst",
+      "review_date": "2026-08-05",
+      "evidence": [
+        "tests/cpp/test_static_schema.cpp",
+        "tests/cpp/test_type_registry.cpp",
+        "tests/cpp/test_plan_factories.cpp",
+        "tests/cpp/test_value.cpp"
+      ]
+    },
+    {
+      "id": "types-ts-cpp-bridge-converted",
+      "match": "hgraph_unit_tests/_types/test_ts_cpp_type.py::*",
+      "classification": "converted",
+      "candidate_outcomes": ["collection-error"],
+      "diagnostic_regex": "No module named 'hgraph[.]_types[.]_type_meta_data'",
+      "reason": "cpp_type is an upstream bridge property; native time-series schemas and their canonical caching are the primary implementation and test surface.",
+      "decision": "docs/source/developer_guide/type_reflection.rst",
+      "review_date": "2026-08-05",
+      "evidence": [
+        "tests/cpp/test_static_schema.cpp",
+        "tests/cpp/test_ts_schemas.cpp",
+        "tests/cpp/test_ts_type_ref.cpp",
+        "tests/cpp/test_type_registry.cpp"
+      ]
+    },
+    {
+      "id": "types-resolved-reflection-input-converted",
+      "match": "hgraph_unit_tests/_types/test_reflection.py::test_reflection_accepts_resolved_signature_metadata",
+      "classification": "converted",
+      "candidate_outcomes": ["failed"],
+      "diagnostic_regex": "cannot import name 'HgTypeMetaData'",
+      "reason": "Public reflection accepts both public type expressions and the native resolved handle, replacing construction of a private HgTypeMetaData object.",
+      "decision": "docs/source/developer_guide/type_reflection.rst",
+      "review_date": "2026-08-05",
+      "evidence": [
+        "python/tests/test_reflection.py",
+        "tests/cpp/test_type_resolution.cpp"
+      ]
+    },
+    {
+      "id": "wiring-adaptor-private-builder-converted",
+      "match": "hgraph_unit_tests/_wiring/test_adaptor.py::*",
+      "classification": "converted",
+      "candidate_outcomes": ["collection-error"],
+      "diagnostic_regex": "No module named 'hgraph[.]_wiring[.]_decorators'",
+      "reason": "The exact module imports the upstream private adaptor builder. Public adaptor call shapes, automatic registration, scalar configuration, service integration, and lifecycle execute through the native adaptor wiring contract.",
+      "decision": "docs/source/developer_guide/parity_matrix.rst",
+      "review_date": "2026-08-05",
+      "evidence": [
+        "python/tests/test_hgraph_api.py",
+        "python/tests/test_python_authoring.py",
+        "python/tests/test_service_timing_semantics.py",
+        "tests/cpp/test_adaptor_wiring.cpp"
+      ]
+    },
+    {
+      "id": "wiring-node-interning-private-builder-converted",
+      "match": "hgraph_unit_tests/_wiring/test_de_dupping_of_nodes.py::*",
+      "classification": "converted",
+      "candidate_outcomes": ["collection-error"],
+      "diagnostic_regex": "cannot import name 'GraphBuilder'",
+      "reason": "GraphBuilder and WiringNodeInstance are private upstream object layouts. Native graph wiring directly verifies identical-node interning, scalar identity, and sink non-interning.",
+      "decision": "docs/source/developer_guide/parity_matrix.rst",
+      "review_date": "2026-08-05",
+      "evidence": [
+        "tests/cpp/test_graph_wiring.cpp"
+      ]
+    },
+    {
+      "id": "wiring-decorator-private-node-classes-converted",
+      "match": "hgraph_unit_tests/_wiring/test_decorators.py::*",
+      "classification": "converted",
+      "candidate_outcomes": ["collection-error"],
+      "diagnostic_regex": "No module named 'hgraph[.]_wiring[.]_wiring_node_class'",
+      "reason": "The upstream assertions name private Python wiring-node classes. The public decorators and every native node kind are exercised without depending on that representation.",
+      "decision": "docs/source/developer_guide/parity_matrix.rst",
+      "review_date": "2026-08-05",
+      "evidence": [
+        "python/tests/ported/_wiring/test_decorators.py",
+        "python/tests/test_python_authoring.py",
+        "tests/cpp/test_static_node.cpp"
+      ]
+    },
+    {
+      "id": "wiring-error-private-flow-module-converted",
+      "match": "hgraph_unit_tests/_wiring/test_error_handling.py::*",
+      "classification": "converted",
+      "candidate_outcomes": ["collection-error"],
+      "diagnostic_regex": "No module named 'hgraph[.]_operators'",
+      "reason": "The exact module imports an upstream private flow-control module. NodeError, try_except, keyed child capture, trace options, and sink/value forms retain public Python and native behavior coverage.",
+      "decision": "docs/source/developer_guide/parity_matrix.rst",
+      "review_date": "2026-08-05",
+      "evidence": [
+        "python/tests/ported/_wiring/test_error_handling.py",
+        "tests/cpp/test_error_handling.cpp"
+      ]
+    },
+    {
+      "id": "wiring-const-fn-injectable-expected-change",
+      "match": "hgraph_unit_tests/_wiring/test_injectables.py::test_global_state_injectable_for_const_fn_direct_call",
+      "classification": "expected-change",
+      "candidate_outcomes": ["collection-error"],
+      "diagnostic_regex": "cannot import name 'const_fn'",
+      "reason": "const_fn is an accepted design difference: ordinary C++ functions are the wiring-time form and registered const-evaluable operators provide dual eager/wired behavior.",
+      "decision": "docs/source/developer_guide/parity_matrix.rst",
+      "review_date": "2026-08-05"
+    },
+    {
+      "id": "wiring-graph-global-state-injectable-converted",
+      "match": "hgraph_unit_tests/_wiring/test_injectables.py::test_global_state_injectable_for_graph",
+      "classification": "converted",
+      "candidate_outcomes": ["collection-error"],
+      "diagnostic_regex": "cannot import name 'const_fn'",
+      "reason": "The module-wide const_fn import prevents collection, but graph GlobalState injection is retained through the public bridge and native graph configuration contract.",
+      "decision": "docs/source/developer_guide/parity_matrix.rst",
+      "review_date": "2026-08-05",
+      "evidence": [
+        "python/tests/ported/_wiring/test_injectables.py",
+        "python/tests/test_global_state_wiring.py",
+        "tests/cpp/test_static_node.cpp"
+      ]
+    },
+    {
+      "id": "wiring-node-global-state-injectable-converted",
+      "match": "hgraph_unit_tests/_wiring/test_injectables.py::test_global_state_injectable_for_node",
+      "classification": "converted",
+      "candidate_outcomes": ["collection-error"],
+      "diagnostic_regex": "cannot import name 'const_fn'",
+      "reason": "The module-wide const_fn import prevents collection, but node GlobalState injection is retained through public Python nodes and the native injectable contract.",
+      "decision": "docs/source/developer_guide/parity_matrix.rst",
+      "review_date": "2026-08-05",
+      "evidence": [
+        "python/tests/ported/_wiring/test_injectables.py",
+        "tests/cpp/test_static_node.cpp"
+      ]
+    },
+    {
+      "id": "wiring-logger-injectable-converted",
+      "match": "hgraph_unit_tests/_wiring/test_injectables.py::test_logger_injectable",
+      "classification": "converted",
+      "candidate_outcomes": ["collection-error"],
+      "diagnostic_regex": "cannot import name 'const_fn'",
+      "reason": "The module-wide const_fn import prevents collection, while the public LOGGER injectable and executor-owned logger behavior have direct replacement coverage.",
+      "decision": "docs/source/developer_guide/parity_matrix.rst",
+      "review_date": "2026-08-05",
+      "evidence": [
+        "python/tests/ported/_wiring/test_injectables.py",
+        "tests/cpp/test_logger.cpp"
+      ]
+    },
+    {
+      "id": "wiring-lift-metadata-converted",
+      "match": "hgraph_unit_tests/_wiring/test_lift.py::*",
+      "classification": "converted",
+      "candidate_outcomes": ["collection-error"],
+      "diagnostic_regex": "cannot import name 'HgTSLTypeMetaData'",
+      "reason": "The upstream lift tests assert through HgTypeMetaData objects. Public lift, output override, deduplication, and Arrow-native lower behavior are retained without that private metadata representation.",
+      "decision": "docs/source/developer_guide/parity_matrix.rst",
+      "review_date": "2026-08-05",
+      "evidence": [
+        "python/tests/ported/_wiring/test_lift.py",
+        "python/tests/ported/_wiring/test_lower.py",
+        "tests/cpp/lift/test_lift.cpp",
+        "tests/cpp/test_lower.cpp"
+      ]
+    },
+    {
+      "id": "wiring-map-private-operator-import-converted",
+      "match": "hgraph_unit_tests/_wiring/test_map.py::*",
+      "classification": "converted",
+      "candidate_outcomes": ["collection-error"],
+      "diagnostic_regex": "No module named 'hgraph[.]_operators'",
+      "reason": "The exact map module imports a private operator implementation. Public keyed and dynamic-list mapping, argument inference, lifecycle, references, overloads, and child errors are covered through the native map path.",
+      "decision": "docs/source/developer_guide/parity_matrix.rst",
+      "review_date": "2026-08-05",
+      "evidence": [
+        "python/tests/test_hgraph_api.py",
+        "python/tests/test_map_upstream_kwargs.py",
+        "python/tests/ported/_wiring/test_map_regressions.py",
+        "tests/cpp/test_map.cpp"
+      ]
+    },
+    {
+      "id": "wiring-mesh-private-scalar-import-converted",
+      "match": "hgraph_unit_tests/_wiring/test_mesh.py::*",
+      "classification": "converted",
+      "candidate_outcomes": ["collection-error"],
+      "diagnostic_regex": "No module named 'hgraph[.]_types[.]_scalar_types'",
+      "reason": "The exact mesh module imports a private CompoundScalar class path. Named and anonymous meshes, dependency order, cycles, membership, key typing, and removal use the public scalar and mesh surfaces.",
+      "decision": "docs/source/developer_guide/parity_matrix.rst",
+      "review_date": "2026-08-05",
+      "evidence": [
+        "python/tests/test_hgraph_api.py",
+        "python/tests/test_mesh_map_classification.py",
+        "python/tests/test_parity_fixes.py",
+        "tests/cpp/test_mesh.cpp"
+      ]
+    },
+    {
+      "id": "wiring-generic-nested-graph-expected-change",
+      "match": "hgraph_unit_tests/_wiring/test_nested_graph.py::*",
+      "classification": "expected-change",
+      "candidate_outcomes": ["collection-error"],
+      "diagnostic_regex": "cannot import name 'nested_graph'",
+      "reason": "Generic Python nested_graph is deliberately not exposed; nested_ is the first-class C++ authoring primitive and registered higher-order operators own their native child graphs.",
+      "decision": "docs/source/developer_guide/parity_matrix.rst",
+      "review_date": "2026-08-05"
+    },
+    {
+      "id": "wiring-ref-private-implementation-converted",
+      "match": "hgraph_unit_tests/_wiring/test_ref.py::*",
+      "classification": "converted",
+      "candidate_outcomes": ["collection-error"],
+      "diagnostic_regex": "No module named 'hgraph[.]_impl'",
+      "reason": "The upstream module imports a private TSS implementation overload. Reference routing, merge, non-peered structural references, retargeting, and keyed/reference collections are exercised through public wiring.",
+      "decision": "docs/source/developer_guide/parity_matrix.rst",
+      "review_date": "2026-08-05",
+      "evidence": [
+        "python/tests/ported/_wiring/test_ref.py",
+        "tests/cpp/test_time_series_reference.cpp",
+        "tests/cpp/test_graph_wiring.cpp"
+      ]
+    },
+    {
+      "id": "wiring-signature-private-ts-type-converted",
+      "match": "hgraph_unit_tests/_wiring/test_wiring_node_signature.py::*",
+      "classification": "converted",
+      "candidate_outcomes": ["collection-error"],
+      "diagnostic_regex": "No module named 'hgraph[.]_types[.]_ts_type'",
+      "reason": "The old Python signature object and HgTypeMetaData payload are private representations. Public callable signatures and native type resolution preserve the authoring contract.",
+      "decision": "docs/source/developer_guide/type_reflection.rst",
+      "review_date": "2026-08-05",
+      "evidence": [
+        "python/tests/ported/_wiring/test_wiring_node_signature.py",
+        "python/tests/test_signature_compatibility.py",
+        "tests/cpp/test_type_resolution.cpp"
+      ]
+    },
+    {
+      "id": "nodes-polars-recorder-private-api-converted",
+      "match": "hgraph_unit_tests/nodes/analytics/test_polars_recorder_api_impl.py::*",
+      "classification": "converted",
+      "candidate_outcomes": ["collection-error"],
+      "diagnostic_regex": "No module named 'hgraph[.]nodes[.]analytics'",
+      "reason": "PolarsRecorderAPI is an upstream private storage implementation. Public record/replay behavior uses the canonical Arrow frame model while retaining the optional Polars boundary.",
+      "decision": "docs/source/developer_guide/parity_matrix.rst",
+      "review_date": "2026-08-05",
+      "evidence": [
+        "python/tests/test_polars_frames.py",
+        "python/tests/ported/adaptors/data_frame/test_data_frame_record_replay.py",
+        "tests/cpp/test_record_replay_frame.cpp"
+      ]
+    },
+    {
+      "id": "nodes-frame-metadata-converted",
+      "match": "hgraph_unit_tests/nodes/test_frame.py::*",
+      "classification": "converted",
+      "candidate_outcomes": ["collection-error"],
+      "diagnostic_regex": "cannot import name 'HgDataFrameScalarTypeMetaData'",
+      "reason": "Frame metadata is exposed through Arrow schemas and public reflection instead of HgDataFrameScalarTypeMetaData; construction, parsing, operators, and round trips retain coverage.",
+      "decision": "docs/source/developer_guide/type_reflection.rst",
+      "review_date": "2026-08-05",
+      "evidence": [
+        "python/tests/test_frame_metadata.py",
+        "python/tests/test_polars_frames.py",
+        "tests/cpp/test_data_frame_operators.cpp"
+      ]
+    },
+    {
+      "id": "nodes-numpy-private-module-converted",
+      "match": "hgraph_unit_tests/nodes/test_numpy.py::*",
+      "classification": "converted",
+      "candidate_outcomes": ["collection-error"],
+      "diagnostic_regex": "No module named 'hgraph[.]nodes[.]_numpy'",
+      "reason": "NumPy nodes are public registered operators rather than a Python-private node module; rolling-window and quantile behavior use native arrays and schemas.",
+      "decision": "docs/source/developer_guide/parity_matrix.rst",
+      "review_date": "2026-08-05",
+      "evidence": [
+        "python/tests/test_numpy_nodes.py",
+        "tests/cpp/test_numpy_operators.cpp"
+      ]
+    },
+    {
+      "id": "nodes-push-queue-private-recorder-converted",
+      "match": "hgraph_unit_tests/nodes/test_push_queue.py::*",
+      "classification": "converted",
+      "candidate_outcomes": ["collection-error"],
+      "diagnostic_regex": "No module named 'hgraph[.]_impl'",
+      "reason": "The exact push-queue module imports a private in-memory recorder helper. Public queue, batch/elide, keyed queue, realtime ownership, and service-owned source behavior have replacement coverage.",
+      "decision": "docs/source/developer_guide/parity_matrix.rst",
+      "review_date": "2026-08-05",
+      "evidence": [
+        "python/tests/test_hgraph_api.py",
+        "python/tests/test_service_push_sources.py",
+        "tests/cpp/test_service_push_sources.cpp"
+      ]
+    },
+    {
+      "id": "nodes-recorder-private-storage-converted",
+      "match": "hgraph_unit_tests/nodes/test_recorder.py::*",
+      "classification": "converted",
+      "candidate_outcomes": ["collection-error"],
+      "diagnostic_regex": "No module named 'hgraph[.]_impl'",
+      "reason": "The upstream assertion imports private in-memory record storage. Public record scopes, lookup, model selection, and native recording retain behavioral coverage.",
+      "decision": "docs/source/developer_guide/parity_matrix.rst",
+      "review_date": "2026-08-05",
+      "evidence": [
+        "python/tests/test_compat_exports.py",
+        "python/tests/test_hgraph_api.py",
+        "tests/cpp/test_record_replay.cpp"
+      ]
+    },
+    {
+      "id": "nodes-replay-private-storage-converted",
+      "match": "hgraph_unit_tests/nodes/test_replay.py::*",
+      "classification": "converted",
+      "candidate_outcomes": ["collection-error"],
+      "diagnostic_regex": "No module named 'hgraph[.]_impl'",
+      "reason": "The upstream test constructs a private replay source. Public replay wiring, configured histories, windows, and native scheduling replace that implementation-level contract.",
+      "decision": "docs/source/developer_guide/parity_matrix.rst",
+      "review_date": "2026-08-05",
+      "evidence": [
+        "python/tests/test_bridge.py",
+        "python/tests/test_data_frame_replay_window.py",
+        "python/tests/test_hgraph_api.py",
+        "tests/cpp/test_record_replay.cpp"
+      ]
+    },
+    {
+      "id": "test-eval-node-private-module-converted",
+      "match": "hgraph_unit_tests/test/test_eval_node.py::*",
+      "classification": "converted",
+      "candidate_outcomes": ["collection-error"],
+      "diagnostic_regex": "No module named 'hgraph[.]test[.]_node_unit_tester'",
+      "reason": "eval_node remains public from hgraph.test, but its upstream private implementation module is not part of the package layout; public Python suites and native eval_node tests exercise the helper.",
+      "decision": "docs/source/developer_guide/parity_matrix.rst",
+      "review_date": "2026-08-05",
+      "evidence": [
+        "python/tests/test_hgraph_api.py",
+        "tests/cpp/test_eval_node.cpp"
+      ]
+    },
+    {
+      "id": "wiring-request-reply-direct-response-expected-change",
+      "match": "hgraph_unit_tests/_wiring/test_service.py::*",
+      "classification": "expected-change",
+      "candidate_outcomes": ["failed"],
+      "diagnostic_regex": "At index [013] diff: .* != None.*Right contains one more item",
+      "reason": "RFC 0014 removes the redundant response-feedback boundary for self-coupled request/reply services, so the same response sequence is observable one cycle earlier than hgraph 0.5.34.",
+      "decision": "docs/source/developer_guide/parity_matrix.rst",
+      "review_date": "2026-08-05"
+    },
+    {
+      "id": "wiring-reduce-omitted-zero-expected-change",
+      "match": "hgraph_unit_tests/_wiring/test_reduce.py::test_tsd_reduce_no_zero*",
+      "classification": "expected-change",
+      "candidate_outcomes": ["failed"],
+      "diagnostic_regex": "At index [013] diff: None != 0",
+      "reason": "An omitted associative zero is deliberately never inferred: empty input remains invalid instead of publishing upstream's inferred integer zero.",
+      "decision": "docs/source/developer_guide/parity_matrix.rst",
+      "review_date": "2026-08-05"
+    },
+    {
+      "id": "wiring-switch-reduce-omitted-zero-expected-change",
+      "match": "hgraph_unit_tests/_wiring/test_switch.py::test_switch*_reduce",
+      "classification": "expected-change",
+      "candidate_outcomes": ["failed"],
+      "diagnostic_regex": "At index 0 diff: None != 0",
+      "reason": "Switch composition preserves the documented omitted-zero reduce semantics: an empty reduction is invalid rather than an inferred integer zero.",
+      "decision": "docs/source/developer_guide/parity_matrix.rst",
+      "review_date": "2026-08-05"
+    },
+    {
+      "id": "wiring-generic-frame-arrow-converted",
+      "match": "hgraph_unit_tests/_wiring/test_generic_graphs.py::test_constraint_typevar_wiring",
+      "classification": "converted",
+      "candidate_outcomes": ["failed"],
+      "diagnostic_regex": "unsupported operand type.*pyarrow[.]lib[.]ChunkedArray.*float",
+      "reason": "The upstream test body performs Polars arithmetic on Frame values. The generic Frame constraint is retained while the canonical value and arithmetic assertions are converted to Arrow.",
+      "decision": "docs/source/developer_guide/parity_matrix.rst",
+      "review_date": "2026-08-05",
+      "evidence": [
+        "python/tests/ported/_wiring/test_generic_graphs.py",
+        "tests/cpp/test_data_frame_operators.cpp"
+      ]
+    },
+    {
+      "id": "timeseries-bare-container-output-converted",
+      "match": "hgraph_unit_tests/ts_tests/test_ts*_behavior.py::*",
+      "classification": "converted",
+      "candidate_outcomes": ["failed"],
+      "diagnostic_regex": "@compute_node .* needs a TS\\[\\.\\.\\.\\] return annotation",
+      "reason": "These direct-runtime tests use bare container output annotations whose element, key, or value types cannot be resolved from an input. The user-facing behavior is retained through concrete public annotations and native time-series views rather than restoring schema-erasing output signatures.",
+      "decision": "docs/source/developer_guide/parity_matrix.rst",
+      "review_date": "2026-08-05",
+      "evidence": [
+        "python/tests/test_python_authoring.py",
+        "python/tests/test_switch_tsd_delta.py",
+        "python/tests/test_time_series_runtime_api.py",
+        "tests/cpp/test_eval_node.cpp",
+        "tests/cpp/test_ts_input.cpp",
+        "tests/cpp/test_ts_output.cpp"
+      ]
+    },
+    {
+      "id": "timeseries-private-bound-state-converted",
+      "match": "hgraph_unit_tests/ts_tests/test_ts_behavior.py::test_input_bound_when_wired",
+      "classification": "converted",
+      "candidate_outcomes": ["failed"],
+      "diagnostic_regex": "AttributeError: bound",
+      "reason": "The upstream test observes the private Python binding flag. Binding and retargeting are runtime-owned; public input behavior and native endpoint binding replace that introspection.",
+      "decision": "docs/source/developer_guide/parity_matrix.rst",
+      "review_date": "2026-08-05",
+      "evidence": [
+        "python/tests/test_time_series_runtime_api.py",
+        "python/tests/ported/_wiring/test_ref.py",
+        "tests/cpp/test_ts_input.cpp",
+        "tests/cpp/test_time_series_reference.cpp"
+      ]
+    },
+    {
+      "id": "timeseries-private-peer-state-converted",
+      "match": "hgraph_unit_tests/ts_tests/test_ts[bl]_behavior.py::test_*peer*",
+      "classification": "converted",
+      "candidate_outcomes": ["failed"],
+      "diagnostic_regex": "AttributeError: has_peer",
+      "reason": "has_peer exposes the old Python binding topology. Public structural values remain reference-transparent while native wiring explicitly tests peered and non-peered endpoints.",
+      "decision": "docs/source/developer_guide/parity_matrix.rst",
+      "review_date": "2026-08-05",
+      "evidence": [
+        "python/tests/test_time_series_runtime_api.py",
+        "python/tests/ported/_wiring/test_ref.py",
+        "tests/cpp/test_graph_wiring.cpp",
+        "tests/cpp/test_ts_input.cpp"
+      ]
+    },
+    {
+      "id": "operators-filter-keyed-reconciliation-expected-change",
+      "match": "hgraph_unit_tests/_operators/test_stream_operators.py::test_filter_str_tsd",
+      "classification": "expected-change",
+      "candidate_outcomes": ["failed"],
+      "diagnostic_regex": "At index 3 diff: (?=[^\\n]*'1': REMOVE)(?=[^\\n]*'3': REMOVE)(?=[^\\n]*'5': 6)(?=[^\\n]*'9': 10)",
+      "reason": "hg_cpp deliberately performs complete keyed-state reconciliation when a filter reopens: invalid former keys are removed and unchanged live values are not republished. The released upstream assertion itself marks its missing invalid-key removal as behavior needing reconsideration.",
+      "decision": "docs/source/developer_guide/parity_matrix.rst",
+      "review_date": "2026-08-05",
+      "evidence": [
+        "python/tests/ported/_operators/test_stream_operators.py",
+        "tests/cpp/test_map.cpp"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- add an exact upstream hgraph conformance runner that stages tagged upstream tests and executes aligned reference and candidate environments
- require evidence-backed classification of expected changes and converted tests, while promoting unmatched differences for review
- resolve the six initial core observations across context wiring, tuple-spelled service implementations, live generator clocks, and bare tuple TSS inputs
- document keyed filter reconciliation as an intentional hg_cpp correction and add paired native/Python regression coverage

## Validation

- macOS native C++: 1452/1452 passed
- macOS Python 3.14 stable-ABI wheel: 1935 passed, 11 skipped
- Linux GCC 14 native C++: 1452/1452 passed
- Linux GCC 14 Python 3.14 stable-ABI wheel: 1935 passed, 11 skipped
- exact upstream core campaign: 1686 collected; 982 exact; 593 known expected/converted; 0 review-required; 0 confirmed gaps; 111 reference-unverified; 0 ambiguous

The 111 reference-unverified cases are upstream skips, reference failures, or private collection limitations rather than candidate mismatches.