### PR TITLE
Close expanded upstream conformance gaps

### DIFF
--- a/docs/source/developer_guide/parity_matrix.rst
+++ b/docs/source/developer_guide/parity_matrix.rst
@@ -201,6 +201,42 @@ Standing residue is limited to recorded deviations:
   through the public surface). Mapped children now publish the final validity
   of projected EMPTY-REF terminals and the corresponding test executes.
 
+Expanded upstream ``all``-suite audit (2026-08-05)
+--------------------------------------------------
+
+The exact upstream tier now includes adaptors, the Arrow combinator package,
+debug tooling, and examples.  Its first broad run exposed two genuine Python
+authoring gaps, both fixed without changing native execution: anonymous
+``compound_scalar(...)`` schemas once again allow omitted fields and retain
+``to_dict``/``from_dict``, and ``with_columns[RowSchema](...)`` lowers that
+released shorthand to the native ``TS[Frame[RowSchema]]`` output constraint.
+Against released hgraph 0.5.35, the resulting 1,856-test audit records 1,088
+exact matches, 640 evidence-backed conversions, 128 reference-unverified
+tests, and no review-required, confirmed-gap, or ambiguous outcomes.
+
+The remaining broad-suite differences are conversions of already recorded
+design decisions, not unimplemented user behaviour:
+
+- dataframe adaptors consume Polars at the boundary but publish canonical
+  PyArrow values; equivalent join, filter, group, column, source, and
+  record/replay assertions use Arrow values in the local Python and C++ suites;
+- the old Python runtime-object ``inspector`` function is replaced by the
+  native ``Inspector`` lifecycle observer and owned inspection snapshots;
+- the ``SimpleArrayReplaySource`` example and process-global output-key
+  builder exercise retired test/runtime infrastructure.  Formal replay APIs
+  and native fixed key construction replace them; graph-specific policy is
+  not stored in an unrelated process global;
+- private ``wire_graph``/``WiringNodeInstance`` builder layouts remain outside
+  the compatibility contract while public graph wiring is covered directly;
+- Kafka tests inject consumers through the public ``consumer_factory`` option,
+  and websocket behavior is covered without the upstream module's broad
+  optional-import guard;
+- ``cleanup_on_error=False`` defers stop only while the raised exception owns
+  the failed executor; releasing it performs mandatory final teardown; and
+- Arrow stop-hook errors cross the native exception boundary, explicit nodes
+  are never pruned merely because their output is unconsumed, and runtime
+  graph state is accessed through the ``GlobalState`` injectable.
+
 Compatibility audit: wiring and time-series tiers
 -------------------------------------------------
 

--- a/docs/source/user_guide/python_compatibility.rst
+++ b/docs/source/user_guide/python_compatibility.rst
@@ -185,6 +185,12 @@ uncaught run error; ``capture_values=True`` includes current input values.
 alive. Once the exception is released, executor destruction performs the
 mandatory final teardown.
 
+``run_graph_on_thread`` preserves publication order within each child.  A
+worker's ``started``, output, and ``finished`` deltas may occupy separate outer
+graph cycles: independently scheduled graph engines have no portable tick or
+wall-clock alignment.  Consumers should observe the ordered fields rather than
+require the released Python implementation's incidental same-tick coalescing.
+
 Runtime callables
 -----------------
 

--- a/python/hgraph/_compat.py
+++ b/python/hgraph/_compat.py
@@ -184,6 +184,36 @@ class CompoundScalar:
         cls.__compound_options__ = dict(options)
         _COMPOUND_SCALAR_CLASSES.append(cls)
 
+    def to_dict(self):
+        """Return populated schema fields using hgraph's public value shape."""
+        from ._types import _compound_python_field_types
+
+        result = {}
+        for name in _compound_python_field_types(type(self)):
+            value = getattr(self, name, None)
+            if isinstance(value, CompoundScalar):
+                value = value.to_dict()
+            if value is not None:
+                result[name] = value
+        return result
+
+    @classmethod
+    def from_dict(cls, values: dict):
+        """Construct from known fields, recursively adapting nested scalars."""
+        from ._types import _compound_python_field_types
+
+        field_types = _compound_python_field_types(cls)
+        converted = {}
+        for name, value in values.items():
+            annotation = field_types.get(name)
+            if annotation is None:
+                continue
+            if (isinstance(value, dict) and isinstance(annotation, type)
+                    and issubclass(annotation, CompoundScalar)):
+                value = annotation.from_dict(value)
+            converted[name] = value
+        return cls(**converted)
+
 @dataclass(frozen=True)
 class NodeError(CompoundScalar, namespace=""):
     """Structured error value emitted by native node and child-graph capture."""

--- a/python/hgraph/_types.py
+++ b/python/hgraph/_types.py
@@ -2714,8 +2714,16 @@ def compound_scalar(**kwargs):
 
     label = "_".join(f"{name}_{tp!r}" for name, tp in kwargs.items())
     digest = hashlib.md5(label.encode()).hexdigest()[:12]
-    cls = type(f"UnNamedCompoundScalar_{digest}", (CompoundScalar,),
-               {"__annotations__": dict(kwargs), "__unnamed_compound__": True})
+    # Upstream's anonymous schemas are commonly used as sparse predicates,
+    # for example ``compound_scalar(a=int, b=int)(a=1)``.  A regular dataclass
+    # would make both fields required; default every anonymous field to None so
+    # an omitted field remains unset at the native Bundle boundary.
+    namespace = {
+        "__annotations__": dict(kwargs),
+        "__unnamed_compound__": True,
+        **{name: None for name in kwargs},
+    }
+    cls = type(f"UnNamedCompoundScalar_{digest}", (CompoundScalar,), namespace)
     return dataclasses.dataclass(frozen=True)(cls)
 
 

--- a/python/hgraph/_wiring/_core.py
+++ b/python/hgraph/_wiring/_core.py
@@ -186,6 +186,16 @@ class _OperatorFunction:
         # inputs). A plain type subscript is the requested output type.
         from .._types import OUT, _type_var_name
 
+        # ``with_columns[RowSchema](...)`` is the released hgraph spelling:
+        # its plain subscript selects the Frame row schema, not a bare Bundle
+        # output.  Keep this as Python syntax adaptation; native dispatch still
+        # receives the complete TS[Frame[RowSchema]] output constraint once.
+        if (self.__name__ == "with_columns" and isinstance(item, type)):
+            from .._compat import CompoundScalar
+            if issubclass(item, CompoundScalar):
+                from .._types import Frame, TS
+                item = TS[Frame[item]]
+
         output_type = None
         sizes = []
         ts_hints = []

--- a/python/hgraph/adaptors/data_frame/_data_frame_operators.py
+++ b/python/hgraph/adaptors/data_frame/_data_frame_operators.py
@@ -261,7 +261,12 @@ def with_columns_typed(ts, _tp_out=None, **columns):
 
 
 def _columns_output_type(mapping, _tp_out):
-    return mapping["ROW"] if _tp_out is AUTO_RESOLVE else _tp_out
+    if _tp_out is not AUTO_RESOLVE:
+        return _tp_out
+    # A bracket-specialized ``with_columns[RowSchema]`` has already bound
+    # ROW_1 from the requested output.  Preserve that authoritative public
+    # constraint; only the unspecialized spelling inherits the input row.
+    return mapping.get("ROW_1", mapping["ROW"])
 
 
 @graph(overloads=with_columns, resolvers={ROW_1: _columns_output_type})

--- a/python/tests/adaptors/data_frame/test_python_data_frame_operators.py
+++ b/python/tests/adaptors/data_frame/test_python_data_frame_operators.py
@@ -59,7 +59,15 @@ def test_join_semi_and_anti():
 def test_filter_variants():
     table = pa.table({"a": [1, 2, 3], "b": [10, 20, 30]})
 
-    assert eval_node(filter_cs, [table], AB(a=2, b=None), resolution_dict={"ts": TS[Frame[AB]]})[0].equals(
+    predicate = compound_scalar(a=int, b=int)
+    sparse_condition = predicate(a=2)
+    assert sparse_condition.b is None
+    assert eval_node(
+        filter_cs,
+        [table],
+        sparse_condition,
+        resolution_dict={"ts": TS[Frame[predicate]]},
+    )[0].equals(
         table.slice(1, 1)
     )
     assert eval_node(filter_exp, [table], pc.field("a") > 1, resolution_dict={"ts": TS[Frame[AB]]})[0].equals(
@@ -157,7 +165,7 @@ def test_with_columns_replace_and_project():
 
     @graph
     def project(ts: TS[Frame[AB]], c: TS[int]) -> TS[Frame[projected]]:
-        return with_columns(ts, _tp_out=projected, c=c)
+        return with_columns[projected](ts, c=c)
 
     assert eval_node(replace, [table], [99])[0].equals(pa.table({"a": [1, 2], "b": [99, 99]}))
     assert eval_node(project, [table], [7])[0].equals(pa.table({"a": [1, 2], "c": [7, 7]}))

--- a/python/tests/ported/arrow/test_arrow.py
+++ b/python/tests/ported/arrow/test_arrow.py
@@ -5,8 +5,8 @@
 #  - test_assert_insufficient_args / test_assert_too_many_args: node/stop-hook
 #    exceptions cross the C++ boundary as NodeException (RuntimeError) rather
 #    than the original AssertionError (deviation: error-type translation).
-#  - test_side_effects: skipped - deviation: hg_cpp does not prune sink-less
-#    nodes at wiring, so an un-flagged side-effect node still evaluates
+#  - test_side_effects: converted - hg_cpp retains explicitly wired nodes, so
+#    an un-flagged side-effect node evaluates even when its output is unused
 #    (upstream discards nodes unreachable from a sink).
 import pytest
 from frozendict import frozendict as fd
@@ -302,8 +302,6 @@ def test_debug_():
     eval_([1, 2], [1, None, 2]) | debug_("Test value {}") >> assert_((1, 1), (2, 1), (2, 2))
 
 
-@pytest.mark.skip(reason="deviation: hg_cpp does not prune sink-less nodes at "
-                         "wiring; the un-flagged side-effect node still evaluates")
 def test_side_effects():
 
     @compute_node
@@ -318,7 +316,9 @@ def test_side_effects():
 
     with GlobalState():
         eval_node(g)
-        assert GlobalState.instance().get("t", None) == None
+        # hg_cpp retains every explicitly wired node.  Side-effect retention is
+        # a graph-construction property rather than an opt-in Python flag.
+        assert GlobalState.instance().get("t", None) == 1
 
     @graph
     def h():

--- a/python/tests/test_compound_scalar_hierarchy.py
+++ b/python/tests/test_compound_scalar_hierarchy.py
@@ -6,7 +6,25 @@ from typing import Callable, Generic, Optional, TypeVar
 import _hgraph
 import hgraph as hg
 import pytest
-from hgraph import CompoundScalar, TS, TSB, TSD, TSW, TimeSeriesSchema, WindowSize, combine, compute_node, const, default, from_json_builder, graph, mesh_, operator, to_json_builder
+from hgraph import (
+    CompoundScalar,
+    TS,
+    TSB,
+    TSD,
+    TSW,
+    TimeSeriesSchema,
+    WindowSize,
+    combine,
+    compound_scalar,
+    compute_node,
+    const,
+    default,
+    from_json_builder,
+    graph,
+    mesh_,
+    operator,
+    to_json_builder,
+)
 # White-box: these tests assert on the interned C++ value-type metadata
 # (qualified names, generic specialisation identity), which has no public
 # introspection surface — the module under test is imported directly.
@@ -42,6 +60,37 @@ def test_compound_scalar_default_namespace_includes_enclosing_scope():
     meta = _value_type(Local)
     assert meta.namespace == f"{__name__}.test_compound_scalar_default_namespace_includes_enclosing_scope.<locals>"
     assert meta.local_name == "Local"
+
+
+def test_compound_scalar_dictionary_conversion_and_sparse_anonymous_values():
+    @dataclass(frozen=True)
+    class Inner(CompoundScalar):
+        value: int
+
+    @dataclass(frozen=True)
+    class Outer(CompoundScalar):
+        amount: float
+        inner: Inner
+        label: Optional[str] = None
+        internal: str = field(
+            default="implementation detail", init=False,
+            metadata={"hidden": True},
+        )
+
+    value = Outer(amount=2.0, inner=Inner(value=1))
+    assert value.to_dict() == {"amount": 2.0, "inner": {"value": 1}}
+    assert Outer.from_dict({
+        "amount": 2.0,
+        "inner": {"value": 1},
+        "internal": "ignored because it is not part of the logical schema",
+        "ignored": "unknown fields retain upstream's filtering behavior",
+    }) == value
+
+    predicate = compound_scalar(a=int, b=int)
+    sparse = predicate(a=1)
+    assert sparse.b is None
+    assert sparse.to_dict() == {"a": 1}
+    assert predicate.from_dict({"a": 1, "ignored": 2}) == sparse
 
 
 def test_compound_scalar_generic_specializations_are_invariant():

--- a/tests/cpp/test_std_nodes.cpp
+++ b/tests/cpp/test_std_nodes.cpp
@@ -139,6 +139,31 @@ namespace
         }
     };
 
+    inline std::int32_t retained_unconsumed_evaluations{};
+
+    struct RetainedUnconsumedNode
+    {
+        static constexpr auto name = "retained_unconsumed_node";
+
+        static void eval(In<"in", TS<Int>> in, Out<TS<Int>> out)
+        {
+            ++retained_unconsumed_evaluations;
+            out.set(in.value());
+        }
+    };
+
+    struct RetainedUnconsumedGraph
+    {
+        static constexpr auto name = "retained_unconsumed_graph";
+
+        static Port<TS<Int>> compose(Wiring &w)
+        {
+            auto value = wire<stdlib::const_>(w, 1_i).as<TS<Int>>();
+            static_cast<void>(wire<RetainedUnconsumedNode>(w, value));
+            return value;
+        }
+    };
+
     struct PolymorphicTsdConstGraph
     {
         static constexpr auto name = "polymorphic_tsd_const_graph";
@@ -773,6 +798,17 @@ TEST_CASE("stdlib::debug_print runs over a tick")
 
     GraphExecutorValue executor = testing::run_graph(build_graph<DebugPrintGraph>());
     CHECK(executor.view().graph().node_count() == 2);
+}
+
+TEST_CASE("explicitly wired nodes are retained when their output is unconsumed")
+{
+    using namespace hgraph;
+    using namespace hgraph::testing;
+    stdlib::register_standard_operators();
+
+    retained_unconsumed_evaluations = 0;
+    CHECK_OUTPUT(eval_node<RetainedUnconsumedGraph>(), values<Int>(1));
+    CHECK(retained_unconsumed_evaluations == 1);
 }
 
 namespace

--- a/tools/parity/upstream_conformance.json
+++ b/tools/parity/upstream_conformance.json
@@ -955,6 +955,220 @@
         "python/tests/ported/_operators/test_stream_operators.py",
         "tests/cpp/test_map.cpp"
       ]
+    },
+    {
+      "id": "impl-graph-builder-private-wire-graph-converted",
+      "match": "hgraph_unit_tests/_impl/_builder/test_graph_builder.py::test_build_graph",
+      "classification": "converted",
+      "candidate_outcomes": ["collection-error"],
+      "diagnostic_regex": "cannot import name 'wire_graph'",
+      "reason": "wire_graph exposes the retired Python GraphBuilder implementation. Public graph construction is owned by native Wiring and is exercised through both authoring surfaces.",
+      "decision": "docs/source/developer_guide/parity_matrix.rst",
+      "review_date": "2026-08-05",
+      "evidence": [
+        "python/tests/test_hgraph_api.py",
+        "tests/cpp/test_graph_wiring.cpp"
+      ]
+    },
+    {
+      "id": "impl-runtime-deferred-cleanup-expected-change",
+      "match": "hgraph_unit_tests/_impl/_runtime/test_graph_runner.py::test_run_no_cleanup",
+      "classification": "expected-change",
+      "candidate_outcomes": ["failed"],
+      "diagnostic_regex": "assert True == False",
+      "reason": "cleanup_on_error=False retains the failed executor only for the lifetime of the raised exception. Releasing that exception performs mandatory final graph teardown instead of leaking a started executor.",
+      "decision": "docs/source/developer_guide/parity_matrix.rst",
+      "review_date": "2026-08-05",
+      "evidence": [
+        "python/tests/test_lifecycle_configuration.py",
+        "tests/cpp/test_lifecycle_observers.cpp"
+      ]
+    },
+    {
+      "id": "adaptors-data-frame-operators-arrow-boundary",
+      "match": "hgraph_unit_tests/adaptors/data_frame/test_data_frame_operators.py::*",
+      "classification": "converted",
+      "candidate_outcomes": ["failed"],
+      "diagnostic_regex": "expected pyarrow[.]lib[.]Table, got DataFrame|object has no attribute 'sort'|unexpected input types",
+      "reason": "The public operator signatures, including sparse compound predicates and with_columns[RowSchema], are retained; results use the approved canonical PyArrow Frame boundary rather than Polars-native values.",
+      "decision": "docs/source/developer_guide/parity_matrix.rst",
+      "review_date": "2026-08-05",
+      "evidence": [
+        "python/tests/adaptors/data_frame/test_python_data_frame_operators.py",
+        "python/tests/adaptors/data_frame/test_upstream_surface_parity.py",
+        "tests/cpp/test_data_frame_operators.cpp"
+      ]
+    },
+    {
+      "id": "adaptors-data-frame-record-replay-arrow-boundary",
+      "match": "hgraph_unit_tests/adaptors/data_frame/test_data_frame_record_replay.py::*",
+      "classification": "converted",
+      "candidate_outcomes": ["failed"],
+      "diagnostic_regex": "pyarrow[.](Int64Scalar|Field)",
+      "reason": "DATA_FRAME record/replay is native Arrow storage; converted assertions observe Arrow scalars and schema fields while retaining record IDs, overrides, and replay behavior.",
+      "decision": "docs/source/developer_guide/parity_matrix.rst",
+      "review_date": "2026-08-05",
+      "evidence": [
+        "python/tests/adaptors/data_frame/test_data_frame_record_replay.py",
+        "tests/cpp/test_record_replay_frame.cpp"
+      ]
+    },
+    {
+      "id": "adaptors-data-frame-source-arrow-boundary",
+      "match": "hgraph_unit_tests/adaptors/data_frame/test_data_source_generators.py::*",
+      "classification": "converted",
+      "candidate_outcomes": ["failed"],
+      "diagnostic_regex": "pyarrow[.](Int64Scalar|TimestampScalar)",
+      "reason": "DataFrameSource preserves the upstream constructor and batching behavior but exposes canonical Arrow scalar values at the frame boundary.",
+      "decision": "docs/source/developer_guide/parity_matrix.rst",
+      "review_date": "2026-08-05",
+      "evidence": [
+        "python/tests/adaptors/data_frame/test_data_frame_source.py",
+        "tests/cpp/test_data_frame_operators.cpp"
+      ]
+    },
+    {
+      "id": "adaptors-data-frame-converters-arrow-boundary",
+      "match": "hgraph_unit_tests/adaptors/data_frame/test_to_data_frame_converters.py::*",
+      "classification": "converted",
+      "candidate_outcomes": ["failed"],
+      "diagnostic_regex": "pyarrow[.](Int64Scalar|Date32Scalar|TimestampScalar)",
+      "reason": "to-frame conversion retains scalar, date, datetime, TSB, inferred-schema, and mapping behavior while returning canonical Arrow scalars rather than Polars/Python scalar projections.",
+      "decision": "docs/source/developer_guide/parity_matrix.rst",
+      "review_date": "2026-08-05",
+      "evidence": [
+        "python/tests/adaptors/data_frame/test_python_data_frame_operators.py",
+        "python/tests/adaptors/data_frame/test_upstream_surface_parity.py",
+        "tests/cpp/test_data_frame_operators.cpp"
+      ]
+    },
+    {
+      "id": "adaptors-kafka-private-consumer-injection-converted",
+      "match": "hgraph_unit_tests/adaptors/kafka/test_kafka_api.py::test_realtime_subscriber",
+      "classification": "converted",
+      "candidate_outcomes": ["failed"],
+      "diagnostic_regex": "has no attribute 'KafkaConsumer'",
+      "reason": "The upstream test monkeypatches a private module import. hg_cpp exposes deterministic consumer injection through register_kafka_adaptor's consumer_factory while preserving the public real-time subscriber behavior.",
+      "decision": "docs/source/developer_guide/parity_matrix.rst",
+      "review_date": "2026-08-05",
+      "evidence": [
+        "python/tests/adaptors/kafka/test_kafka_api.py",
+        "tests/cpp/test_service_wiring.cpp"
+      ]
+    },
+    {
+      "id": "adaptors-run-graph-on-thread-cycle-converted",
+      "match": "hgraph_unit_tests/adaptors/run_graph_on_thread/test_run_graph_on_thread.py::test_run_graph_on_thread_*_mode",
+      "classification": "converted",
+      "candidate_outcomes": ["failed"],
+      "diagnostic_regex": "KeyError: 'out'",
+      "reason": "Independent worker engines preserve started/output/finished order but do not promise same-tick or wall-clock alignment. Converted tests assert the ordered payload sequence instead of upstream's incidental coalescing into one tick.",
+      "decision": "docs/source/user_guide/python_compatibility.rst",
+      "review_date": "2026-08-05",
+      "evidence": [
+        "python/tests/adaptors/run_graph_on_thread/test_run_graph_on_thread.py",
+        "tests/cpp/test_service_push_sources.cpp"
+      ]
+    },
+    {
+      "id": "adaptors-websocket-import-guard-converted",
+      "match": "hgraph_unit_tests/adaptors/websocket_adaptor/test_websocket_adaptor.py::test_single_request_graph_client",
+      "classification": "converted",
+      "candidate_outcomes": ["not-run"],
+      "diagnostic_regex": "candidate did not report this reference test",
+      "reason": "The upstream module's broad optional-import guard skips collection against the C++-first package layout. The public client specialization and request/reply flow are covered without that infrastructure guard.",
+      "decision": "docs/source/developer_guide/tornado_parity.rst",
+      "review_date": "2026-08-05",
+      "evidence": [
+        "python/tests/adaptors/tornado/test_websocket_adaptor.py",
+        "tests/cpp/test_adaptor_wiring.cpp",
+        "tests/cpp/test_service_wiring.cpp"
+      ]
+    },
+    {
+      "id": "arrow-stop-hook-native-exception-converted",
+      "match": "hgraph_unit_tests/arrow/test_arrow.py::test_assert_too_many_args",
+      "classification": "converted",
+      "candidate_outcomes": ["failed"],
+      "diagnostic_regex": "RuntimeError: node.*'_assert'.*stop failed:.*AssertionError: Expected 2 values but got 1 results",
+      "reason": "The assertion behavior is retained, but a Python stop-hook exception crossing the native node boundary is surfaced as NodeException/RuntimeError with the original AssertionError preserved in its diagnostic.",
+      "decision": "docs/source/developer_guide/parity_matrix.rst",
+      "review_date": "2026-08-05",
+      "evidence": [
+        "python/tests/ported/arrow/test_arrow.py",
+        "tests/cpp/test_error_handling.cpp"
+      ]
+    },
+    {
+      "id": "arrow-explicit-node-retention-converted",
+      "match": "hgraph_unit_tests/arrow/test_arrow.py::test_side_effects",
+      "classification": "converted",
+      "candidate_outcomes": ["failed"],
+      "diagnostic_regex": "GlobalState[.]instance[(][)] is wiring-only during graph execution",
+      "reason": "Explicitly wired nodes are retained even when their output is unconsumed, and runtime state is borrowed through the GlobalState injectable rather than a process lookup. Converted tests pin both C++-first contracts.",
+      "decision": "docs/source/developer_guide/parity_matrix.rst",
+      "review_date": "2026-08-05",
+      "evidence": [
+        "python/tests/ported/arrow/test_arrow.py",
+        "tests/cpp/test_std_nodes.cpp"
+      ]
+    },
+    {
+      "id": "debug-inspector-native-snapshot-converted",
+      "match": "hgraph_unit_tests/debug/test_inspector.py::*",
+      "classification": "converted",
+      "candidate_outcomes": ["collection-error"],
+      "diagnostic_regex": "cannot import name 'inspector' from 'hgraph[.]debug'",
+      "reason": "The Python runtime-object walker is replaced by the native Inspector lifecycle observer and owned data-only snapshots, including nested references and keyed graphs.",
+      "decision": "docs/source/developer_guide/parity_matrix.rst",
+      "review_date": "2026-08-05",
+      "evidence": [
+        "python/tests/test_inspector.py",
+        "tests/cpp/test_inspector.cpp"
+      ]
+    },
+    {
+      "id": "examples-legacy-replay-source-converted",
+      "match": "hgraph_unit_tests/test_examples.py::test_examples",
+      "classification": "converted",
+      "candidate_outcomes": ["collection-error"],
+      "diagnostic_regex": "cannot import name 'SimpleArrayReplaySource'",
+      "reason": "The collected example uses retired in-memory test helpers. Formal record/replay configuration, Wiring replay seeds, component modes, and native replay scheduling replace those spellings.",
+      "decision": "docs/source/user_guide/python_compatibility.rst",
+      "review_date": "2026-08-05",
+      "evidence": [
+        "python/tests/ported/_wiring/test_component.py",
+        "python/tests/test_hgraph_api.py",
+        "tests/cpp/test_record_replay.cpp"
+      ]
+    },
+    {
+      "id": "global-keys-process-builder-converted",
+      "match": "hgraph_unit_tests/test_global_keys.py::*",
+      "classification": "converted",
+      "candidate_outcomes": ["collection-error"],
+      "diagnostic_regex": "cannot import name 'set_output_key_builder'",
+      "reason": "The private process-global output-key builder is not restored. Native record/replay and component keys are fixed contracts, while graph-specific configuration remains in GlobalState.",
+      "decision": "docs/source/developer_guide/parity_matrix.rst",
+      "review_date": "2026-08-05",
+      "evidence": [
+        "python/tests/ported/_wiring/test_component.py",
+        "tests/cpp/test_record_replay_config.cpp"
+      ]
+    },
+    {
+      "id": "root-wiring-private-instance-converted",
+      "match": "hgraph_unit_tests/test_wiring.py::*",
+      "classification": "converted",
+      "candidate_outcomes": ["collection-error"],
+      "diagnostic_regex": "cannot import name 'WiringNodeInstance'",
+      "reason": "WiringNodeInstance is the retired Python builder representation. Native Wiring owns resolution and topology while the public graph authoring behavior remains covered in both languages.",
+      "decision": "docs/source/developer_guide/parity_matrix.rst",
+      "review_date": "2026-08-05",
+      "evidence": [
+        "python/tests/test_hgraph_api.py",
+        "tests/cpp/test_graph_wiring.cpp"
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Summary

- follow up on #278 by extending the exact released-hgraph audit across adaptors, Arrow combinators, debug tooling, and examples
- restore sparse anonymous `compound_scalar(...)` construction and schema-aware `to_dict`/`from_dict`, including nested and hidden-field behavior
- restore the released `with_columns[RowSchema](...)` authoring shorthand while retaining the native `TS[Frame[RowSchema]]` execution path
- convert intentional C++-first differences into evidence-backed conformance rules and document threaded child-graph ordering
- add native coverage proving explicitly wired nodes execute even when their outputs are unconsumed

## Why

The expanded upstream suite exposed two genuine public Python authoring gaps: anonymous compound scalars required every field, and `with_columns[RowSchema]` did not lower its row schema to the native Frame output constraint. The remaining observations asserted retired Python runtime internals or behavior that intentionally differs under the C++-first design. This change fixes the user-facing gaps and records the other outcomes narrowly against equivalent native and Python evidence.

## User impact

Existing hgraph code can again use sparse compound-scalar predicates, dictionary conversion, and bracket-specialized dataframe column projection with the released Python spellings. Compound-scalar dictionary conversion now derives fields from the same logical schema used by native registration, so hidden implementation fields do not leak and nested values round-trip correctly.

## Validation

- macOS native C++: 1453/1453 passed after fresh configure and clean build
- stable-ABI wheel built with Python 3.12; Python 3.14 non-WIP suite: 1937 passed, 10 skipped
- released hgraph 0.5.35 exact audit: 1856 collected; 1088 exact; 640 evidence-backed expected/converted; 128 reference-unverified; 0 review-required; 0 confirmed gaps; 0 ambiguous
- generated PR campaign: 107/107 attempted; 92 exact; 15 known; 0 verified mismatches
- parity manifest: 59 recipes validated; 11 conformance-tool tests passed
- `git diff --check`: clean

The reference-unverified cases are upstream skips, reference failures, or collection paths tied to retired private Python metadata rather than observed candidate mismatches.