### PR TITLE
Resolve upstream conformance audit gaps

### DIFF
--- a/docs/source/developer_guide/parity_matrix.rst
+++ b/docs/source/developer_guide/parity_matrix.rst
@@ -210,8 +210,8 @@ authoring gaps, both fixed without changing native execution: anonymous
 ``compound_scalar(...)`` schemas once again allow omitted fields and retain
 ``to_dict``/``from_dict``, and ``with_columns[RowSchema](...)`` lowers that
 released shorthand to the native ``TS[Frame[RowSchema]]`` output constraint.
-Against released hgraph 0.5.35, the resulting 1,856-test audit records 1,088
-exact matches, 640 evidence-backed conversions, 128 reference-unverified
+Against released hgraph 0.5.36, the resulting 1,870-test audit records 1,092
+exact matches, 757 evidence-backed conversions, 21 reference-unverified
 tests, and no review-required, confirmed-gap, or ambiguous outcomes.
 
 The remaining broad-suite differences are conversions of already recorded
@@ -228,6 +228,9 @@ design decisions, not unimplemented user behaviour:
   not stored in an unrelated process global;
 - private ``wire_graph``/``WiringNodeInstance`` builder layouts remain outside
   the compatibility contract while public graph wiring is covered directly;
+  the private Python ``InputsKey`` cache is likewise replaced by the native
+  structural interning key, which compares producer identity, paths, input
+  shape, and native scalar values without invoking overloaded port equality;
 - Kafka tests inject consumers through the public ``consumer_factory`` option,
   and websocket behavior is covered without the upstream module's broad
   optional-import guard;

--- a/docs/source/developer_guide/parity_testing.rst
+++ b/docs/source/developer_guide/parity_testing.rst
@@ -82,8 +82,9 @@ environments, verifies every version is identical, and records that package
 inventory in the report before it runs either suite.
 
 An upstream test failure is not automatically an ``hg_cpp`` defect.  The
-runner first requires the released reference to pass the test.  A candidate
-difference is then classified using ``tools/parity/upstream_conformance.json``:
+runner first requires the released reference assertion to execute successfully
+(``PASS`` or ``XPASS``).  A candidate difference is then classified using
+``tools/parity/upstream_conformance.json``:
 
 * an unmatched difference is **review required**, not a confirmed problem;
 * ``expected-change`` records an approved public semantic difference;
@@ -100,6 +101,12 @@ There is no blanket private-internal exclusion: a test coupled to a non-ported
 concept such as ``HgTypeMetaData`` must be converted to the public reflection
 and type-resolution surface with equivalent evidence, or the required concept
 must be ported.
+
+A test skipped by the released reference can only be converted when a rule
+names ``skipped`` explicitly and matches the reference's exact skip diagnostic
+as well as the candidate diagnostic.  This is reserved for upstream internal
+contracts whose public Python and native C++ replacement tests are named as
+evidence; other skips remain reference-unverified.
 
 Reference collection failures and nondeterministic/platform-disabled tests are
 reported as unverified evidence, never candidate noncompliance.  Reports and

--- a/python/hgraph/adaptors/data_frame/_data_frame_source.py
+++ b/python/hgraph/adaptors/data_frame/_data_frame_source.py
@@ -30,6 +30,10 @@ def _as_arrow_table(value) -> pa.Table:
 class DataFrameSource(ABC):
     """A wiring-time provider of Arrow tables or record batches."""
 
+    def _prepare_for_graph(self) -> "DataFrameSource":
+        """Bind wiring-time dependencies needed by runtime iteration."""
+        return self
+
     @abstractmethod
     def data_frame(
         self, start_time: datetime = None, end_time: datetime = None
@@ -169,9 +173,18 @@ class SqlDataFrameSource(DataFrameSource):
         self._batch_size = batch_size
         self._kwargs = kwargs
         self._frame = None
+        self._bound_connection = None
+
+    def _prepare_for_graph(self) -> "SqlDataFrameSource":
+        self._bound_connection = DataConnectionStore.instance().get_connection(
+            self._connection
+        )
+        return self
 
     @property
     def connection(self):
+        if self._bound_connection is not None:
+            return self._bound_connection
         return DataConnectionStore.instance().get_connection(self._connection)
 
     def _execute(self, query: str = None):

--- a/python/hgraph/adaptors/data_frame/_data_source_generators.py
+++ b/python/hgraph/adaptors/data_frame/_data_source_generators.py
@@ -76,7 +76,7 @@ def schema_from_frame(frame) -> type:
 
 
 def _source(source_type: type[DATA_FRAME_SOURCE]):
-    return DataStore.instance().get_data_source(source_type)
+    return DataStore.instance().get_data_source(source_type)._prepare_for_graph()
 
 
 def _schema_table(source_type: type[DATA_FRAME_SOURCE]) -> pa.Table:

--- a/python/tests/adaptors/data_frame/test_data_frame_source.py
+++ b/python/tests/adaptors/data_frame/test_data_frame_source.py
@@ -389,3 +389,50 @@ def test_sql_source_schema_probe_preserves_batched_streaming():
     assert [row for frame in frames for row in frame.to_pylist()] == [
         {"date": when, "value": value} for when, value in rows
     ]
+
+
+def test_sql_source_binds_connection_before_runtime_iteration():
+    rows = [
+        (date(2026, 1, 1), "Alice", 25),
+        (date(2026, 1, 2), "Bob", 42),
+    ]
+
+    class _Result:
+        description = (("date",), ("name",), ("age",))
+
+        def __init__(self, values):
+            self._values = values
+
+        def fetchall(self):
+            return self._values
+
+    class _Connection:
+        def __init__(self):
+            self.queries = []
+
+        def execute(self, query):
+            self.queries.append(query)
+            return _Result(rows[:1] if query.endswith(" LIMIT 1") else rows)
+
+    class _People(SqlDataFrameSource):
+        def __init__(self):
+            super().__init__("select date, name, age from people", "test")
+
+    connection = _Connection()
+    with DataConnectionStore() as connections, DataStore():
+        connections.set_connection("test", connection)
+        assert eval_node(
+            tsb_from_data_source,
+            _People,
+            "date",
+            __start_time__=datetime(2026, 1, 1),
+            __elide__=True,
+        ) == [
+            frozendict(name="Alice", age=25),
+            frozendict(name="Bob", age=42),
+        ]
+
+    assert connection.queries == [
+        "select date, name, age from people LIMIT 1",
+        "select date, name, age from people",
+    ]

--- a/python/tests/test_python_authoring.py
+++ b/python/tests/test_python_authoring.py
@@ -37,6 +37,19 @@ def test_compute_nodes_mix_with_cpp_and_bind_keywords():
     check(eval_node(app, [2.5, 4.0], [10, 3]) == [51.0, 25.0], "mixed compute pipeline")
 
 
+def test_public_wiring_cache_keeps_distinct_input_ports_separate():
+    @graph
+    def app(lhs: TS[int], rhs: TS[int]) -> TS[int]:
+        lhs_shifted = lhs + 1
+        rhs_shifted = rhs + 1
+        return lhs_shifted * 10 + rhs_shifted
+
+    check(
+        eval_node(app, [1, 2], [3, 4]) == [24, 35],
+        "structurally similar nodes retain their input-port identity",
+    )
+
+
 def test_repeated_python_native_boundary_runs_preserve_type_and_state_lifetimes():
     @hg.compute_node
     def add_bias(value: TS[int], bias: int) -> TS[int]:

--- a/python/tests/test_upstream_conformance.py
+++ b/python/tests/test_upstream_conformance.py
@@ -113,6 +113,56 @@ def test_conformance_reports_reference_failures_as_unverified_not_candidate_gaps
     assert report["summary"]["confirmed_gaps"] == 0
 
 
+def test_conformance_treats_xpass_as_executed_reference_evidence():
+    nodeid = "hgraph_unit_tests/test_reference.py::test_xpass"
+    reference = _result({nodeid: _outcome("xpassed")})
+
+    report = compare_upstream_results(
+        reference, _result({nodeid: _outcome("xpassed")}), _manifest()
+    )
+    assert report["summary"]["matched"] == 1
+    assert report["summary"]["reference_unverified"] == 0
+
+    report = compare_upstream_results(
+        reference,
+        _result({nodeid: _outcome("failed", "AssertionError: candidate defect")}),
+        _manifest(),
+    )
+    assert report["summary"]["review_required"] == 1
+    assert report["summary"]["reference_unverified"] == 0
+
+
+def test_conformance_converts_only_an_exact_skipped_reference_reason():
+    nodeid = "hgraph_unit_tests/_types/test_cpp_bridge.py::test_type"
+    rule = {
+        "id": "retired-cpp-bridge",
+        "match": "hgraph_unit_tests/_types/test_cpp_bridge.py::*",
+        "classification": "converted",
+        "reference_outcomes": ["skipped"],
+        "reference_diagnostic_regex": "Skipped: C\\+\\+ not enabled",
+        "candidate_outcomes": ["collection-error"],
+        "diagnostic_regex": "HgTypeMetaData",
+        "reason": "the upstream bridge internals are replaced by native type tests",
+        "decision": "docs/source/developer_guide/type_reflection.rst",
+        "review_date": "2026-08-05",
+        "evidence": ["tests/cpp/test_schema_examples.cpp"],
+    }
+    candidate = _result(
+        {nodeid: _outcome("collection-error", "ImportError: HgTypeMetaData")}
+    )
+
+    reference = _result(
+        {nodeid: _outcome("skipped", "Skipped: C++ not enabled")}
+    )
+    report = compare_upstream_results(reference, candidate, _manifest([rule]))
+    assert report["summary"]["known_expected"] == 1
+
+    reference["tests"][nodeid]["diagnostic"] = "Skipped: missing database"
+    report = compare_upstream_results(reference, candidate, _manifest([rule]))
+    assert report["summary"]["known_expected"] == 0
+    assert report["summary"]["reference_unverified"] == 1
+
+
 def test_conformance_requires_identical_dependency_versions(monkeypatch):
     import tools.parity.conformance as conformance
 
@@ -178,6 +228,30 @@ def test_manifest_requires_evidence_for_internal_conversions(tmp_path):
     path.write_text(json.dumps(manifest))
 
     with pytest.raises(ValueError, match="requires evidence"):
+        load_conformance_manifest(path)
+
+
+def test_manifest_requires_reference_diagnostic_for_skipped_conversion(tmp_path):
+    path = tmp_path / "manifest.json"
+    manifest = _manifest(
+        [
+            {
+                "id": "unsafe-skipped-conversion",
+                "match": "hgraph_unit_tests/_types/*",
+                "classification": "converted",
+                "reference_outcomes": ["skipped"],
+                "candidate_outcomes": ["collection-error"],
+                "diagnostic_regex": "HgTypeMetaData",
+                "reason": "converted",
+                "decision": "docs/source/developer_guide/type_reflection.rst",
+                "review_date": "2026-08-05",
+                "evidence": ["python/tests/test_reflection.py"],
+            }
+        ]
+    )
+    path.write_text(json.dumps(manifest))
+
+    with pytest.raises(ValueError, match="requires reference_diagnostic_regex"):
         load_conformance_manifest(path)
 
 

--- a/src/hgraph/types/value/table_codec.cpp
+++ b/src/hgraph/types/value/table_codec.cpp
@@ -12,6 +12,7 @@
 
 #include <algorithm>
 #include <chrono>
+#include <limits>
 #include <memory>
 #include <stdexcept>
 #include <unordered_map>
@@ -329,12 +330,47 @@ namespace hgraph
 
         Value read_int(const Column &, const arrow::Array &array, std::int64_t row)
         {
-            return Value{Int{static_cast<const arrow::Int64Array &>(array).Value(row)}};
+            switch (array.type_id())
+            {
+                case arrow::Type::INT8:
+                    return Value{Int{static_cast<const arrow::Int8Array &>(array).Value(row)}};
+                case arrow::Type::INT16:
+                    return Value{Int{static_cast<const arrow::Int16Array &>(array).Value(row)}};
+                case arrow::Type::INT32:
+                    return Value{Int{static_cast<const arrow::Int32Array &>(array).Value(row)}};
+                case arrow::Type::INT64:
+                    return Value{Int{static_cast<const arrow::Int64Array &>(array).Value(row)}};
+                case arrow::Type::UINT8:
+                    return Value{Int{static_cast<const arrow::UInt8Array &>(array).Value(row)}};
+                case arrow::Type::UINT16:
+                    return Value{Int{static_cast<const arrow::UInt16Array &>(array).Value(row)}};
+                case arrow::Type::UINT32:
+                    return Value{Int{static_cast<const arrow::UInt32Array &>(array).Value(row)}};
+                case arrow::Type::UINT64: {
+                    const auto value = static_cast<const arrow::UInt64Array &>(array).Value(row);
+                    if (value > static_cast<std::uint64_t>(std::numeric_limits<Int>::max()))
+                    {
+                        throw std::out_of_range(
+                            "table codec: unsigned integer does not fit native scalar 'int'");
+                    }
+                    return Value{Int{static_cast<Int>(value)}};
+                }
+                default:
+                    throw std::logic_error("table codec: non-integer array reached integer reader");
+            }
         }
 
         Value read_float(const Column &, const arrow::Array &array, std::int64_t row)
         {
-            return Value{Float{static_cast<const arrow::DoubleArray &>(array).Value(row)}};
+            switch (array.type_id())
+            {
+                case arrow::Type::FLOAT:
+                    return Value{Float{static_cast<const arrow::FloatArray &>(array).Value(row)}};
+                case arrow::Type::DOUBLE:
+                    return Value{Float{static_cast<const arrow::DoubleArray &>(array).Value(row)}};
+                default:
+                    throw std::logic_error("table codec: non-floating array reached float reader");
+            }
         }
 
         Value read_str(const Column &, const arrow::Array &array, std::int64_t row)
@@ -671,7 +707,27 @@ namespace hgraph
         {
             const LeafOps ops = leaf_ops_for(leaf);
             const auto actual = array.type();
+            const auto integer_compatible = [&] {
+                if (leaf != scalar_descriptor<Int>::value_meta()) { return false; }
+                switch (actual->id())
+                {
+                    case arrow::Type::INT8:
+                    case arrow::Type::INT16:
+                    case arrow::Type::INT32:
+                    case arrow::Type::INT64:
+                    case arrow::Type::UINT8:
+                    case arrow::Type::UINT16:
+                    case arrow::Type::UINT32:
+                    case arrow::Type::UINT64: return true;
+                    default: return false;
+                }
+            }();
+            const bool floating_compatible =
+                leaf == scalar_descriptor<Float>::value_meta() &&
+                (actual->id() == arrow::Type::FLOAT ||
+                 actual->id() == arrow::Type::DOUBLE);
             const bool compatible = actual->Equals(ops.type) ||
+                                    integer_compatible || floating_compatible ||
                                     (leaf ==
                                          scalar_descriptor<DateTime>::value_meta() &&
                                      actual->Equals(arrow::timestamp(

--- a/tests/cpp/test_data_frame_operators.cpp
+++ b/tests/cpp/test_data_frame_operators.cpp
@@ -43,6 +43,7 @@ namespace
     using ScalarRefFrameRow =
         UnNamedBundle<Field<"date", DateTime>, Field<"key", Str>, Field<"value", Float>>;
     using RefBundle = UnNamedTSB<Field<"a", TS<Int>>, Field<"b", TS<Str>>>;
+    using SqlRow = UnNamedTSB<Field<"name", TS<Str>>, Field<"age", TS<Int>>>;
     using BundleRefFrameRow =
         UnNamedBundle<Field<"date", DateTime>, Field<"key", Str>, Field<"a", Int>,
                       Field<"b", Str>>;
@@ -186,6 +187,31 @@ namespace
                 arrow::field("date", arrow::timestamp(arrow::TimeUnit::MICRO)),
                 arrow::field("value", arrow::list(arrow::int64()))}),
             {std::move(date_array), std::move(list_array)})};
+    }
+
+    [[nodiscard]] Frame sql_integer_frame()
+    {
+        arrow::TimestampBuilder date_builder{
+            arrow::timestamp(arrow::TimeUnit::MICRO),
+            arrow::default_memory_pool()};
+        arrow::StringBuilder name_builder;
+        arrow::Int32Builder age_builder;
+        require_arrow(date_builder.Append(MIN_ST.time_since_epoch().count()));
+        require_arrow(name_builder.Append("Alice"));
+        require_arrow(age_builder.Append(25));
+        std::shared_ptr<arrow::Array> date_array;
+        std::shared_ptr<arrow::Array> name_array;
+        std::shared_ptr<arrow::Array> age_array;
+        require_arrow(date_builder.Finish(&date_array));
+        require_arrow(name_builder.Finish(&name_array));
+        require_arrow(age_builder.Finish(&age_array));
+        return Frame{arrow::Table::Make(
+            arrow::schema({
+                arrow::field("date", arrow::timestamp(arrow::TimeUnit::MICRO)),
+                arrow::field("name", arrow::utf8()),
+                arrow::field("age", arrow::int32())}),
+            {std::move(date_array), std::move(name_array),
+             std::move(age_array)})};
     }
 
     [[nodiscard]] Frame matrix_frame(DateTime when)
@@ -698,6 +724,16 @@ TEST_CASE("data frame operators: from_data_frame preserves shaped array bindings
     REQUIRE(matrix[0]->as_list().size() == 2);
     CHECK(matrix[0]->as_list().at(0).as_list().at(0).checked_as<Int>() == Int{1});
     CHECK(matrix[0]->as_list().at(1).as_list().at(1).checked_as<Int>() == Int{4});
+}
+
+TEST_CASE("data frame operators: SQL-width integers feed native bundle outputs")
+{
+    stdlib::register_standard_operators();
+    CHECK_OUTPUT(
+        (eval_node<stdlib::from_data_frame, SqlRow>(
+            sql_integer_frame(), Str{"date"}, Str{"key"}, Str{"value"},
+            TimeDelta{})),
+        values<Value>(tsb_delta<SqlRow>(Str{"Alice"}, Int{25})));
 }
 
 TEST_CASE("data frame operators: frame batches stream through one native source")

--- a/tests/cpp/test_graph_wiring.cpp
+++ b/tests/cpp/test_graph_wiring.cpp
@@ -1077,6 +1077,29 @@ TEST_CASE("graph wiring: identical nodes are interned to one")
     CHECK(graph.graph().node_count() == 1);   // deduped to a single runtime node
 }
 
+TEST_CASE("graph wiring: node interning keeps distinct input ports separate")
+{
+    using namespace hgraph;
+
+    Wiring w;
+    auto   first  = wire<ScaledSource>(w, Int{7});
+    auto   second = wire<ScaledSource>(w, Int{8});
+
+    auto first_pair       = wire<Sum>(w, first, second);
+    auto repeated_pair    = wire<Sum>(w, first, second);
+    auto reversed_pair    = wire<Sum>(w, second, first);
+    auto repeated_source  = wire<Sum>(w, first, first);
+
+    CHECK(first_pair.node() == repeated_pair.node());
+    CHECK(first_pair.node() != reversed_pair.node());
+    CHECK(first_pair.node() != repeated_source.node());
+    CHECK(reversed_pair.node() != repeated_source.node());
+
+    GraphBuilder           graph_builder = std::move(w).finish();
+    testing::MockRootGraph graph{graph_builder};
+    CHECK(graph.graph().node_count() == 5);   // two sources + three distinct sums
+}
+
 TEST_CASE("graph wiring: push sources form the runtime prefix across implementations")
 {
     using namespace hgraph;

--- a/tests/cpp/test_table.cpp
+++ b/tests/cpp/test_table.cpp
@@ -13,6 +13,9 @@
 
 #include <catch2/catch_test_macros.hpp>
 
+#include <cstdint>
+#include <limits>
+
 // Step 3 of the record/replay/table design record: the Arrow-backed Frame
 // value kind + the interned per-schema TableConverter (bitemporal
 // [date, as_of, *columns] rows written directly into Arrow builders) and the
@@ -182,6 +185,33 @@ TEST_CASE("table codec: Arrow utf8_view arrays decode as native strings")
     const Value decoded =
         array_cell(*values, scalar_descriptor<Str>::value_meta(), 0);
     CHECK(decoded.view().checked_as<Str>() == expected);
+}
+
+TEST_CASE("table codec: Arrow numeric widths widen to Python-compatible native scalars")
+{
+    arrow::Int32Builder int_builder;
+    REQUIRE(int_builder.Append(42).ok());
+    std::shared_ptr<arrow::Array> integers;
+    REQUIRE(int_builder.Finish(&integers).ok());
+    CHECK(array_cell(*integers, scalar_descriptor<Int>::value_meta(), 0)
+              .view()
+              .checked_as<Int>() == Int{42});
+
+    arrow::FloatBuilder float_builder;
+    REQUIRE(float_builder.Append(1.25F).ok());
+    std::shared_ptr<arrow::Array> floats;
+    REQUIRE(float_builder.Finish(&floats).ok());
+    CHECK(array_cell(*floats, scalar_descriptor<Float>::value_meta(), 0)
+              .view()
+              .checked_as<Float>() == Float{1.25});
+
+    arrow::UInt64Builder overflow_builder;
+    REQUIRE(overflow_builder.Append(std::numeric_limits<std::uint64_t>::max()).ok());
+    std::shared_ptr<arrow::Array> overflow;
+    REQUIRE(overflow_builder.Finish(&overflow).ok());
+    CHECK_THROWS_AS(
+        array_cell(*overflow, scalar_descriptor<Int>::value_meta(), 0),
+        std::out_of_range);
 }
 
 TEST_CASE("table codec: bytes and variadic tuples are Arrow leaf values")

--- a/tools/parity/conformance.py
+++ b/tools/parity/conformance.py
@@ -42,6 +42,7 @@ CONFORMANCE_DEPENDENCIES = (
 _VERSION = re.compile(r"^[0-9]+\.[0-9]+\.[0-9]+(?:[A-Za-z0-9.+-]*)?$")
 _ACCEPTED_CLASSIFICATIONS = {"expected-change", "converted"}
 _CLASSIFICATIONS = _ACCEPTED_CLASSIFICATIONS | {"confirmed-gap"}
+_PASS_LIKE_OUTCOMES = {"passed", "xpassed"}
 
 
 @dataclass(frozen=True)
@@ -411,6 +412,32 @@ def load_conformance_manifest(path: Path) -> dict[str, Any]:
         outcomes = rule.get("candidate_outcomes")
         if not isinstance(outcomes, list) or not outcomes:
             raise ValueError(f"rule {rule_id} requires candidate_outcomes")
+        reference_outcomes = rule.get(
+            "reference_outcomes", sorted(_PASS_LIKE_OUTCOMES)
+        )
+        if not isinstance(reference_outcomes, list) or not reference_outcomes:
+            raise ValueError(f"rule {rule_id} requires reference_outcomes")
+        non_passing_reference = set(reference_outcomes) - _PASS_LIKE_OUTCOMES
+        if non_passing_reference:
+            if (
+                rule["classification"] != "converted"
+                or non_passing_reference != {"skipped"}
+            ):
+                raise ValueError(
+                    f"rule {rule_id} may only convert a skipped reference outcome"
+                )
+            reference_pattern = rule.get("reference_diagnostic_regex")
+            if not reference_pattern:
+                raise ValueError(
+                    f"skipped-reference rule {rule_id} requires "
+                    "reference_diagnostic_regex"
+                )
+            try:
+                re.compile(reference_pattern)
+            except re.error as error:
+                raise ValueError(
+                    f"invalid reference_diagnostic_regex for {rule_id}: {error}"
+                ) from error
         if rule["classification"] in _ACCEPTED_CLASSIFICATIONS:
             if not rule.get("diagnostic_regex"):
                 raise ValueError(f"accepted rule {rule_id} requires diagnostic_regex")
@@ -493,14 +520,20 @@ def _rule_matches(
         return False
     if candidate.get("outcome") not in rule["candidate_outcomes"]:
         return False
-    reference_outcomes = rule.get("reference_outcomes", ["passed"])
+    reference_outcomes = rule.get(
+        "reference_outcomes", sorted(_PASS_LIKE_OUTCOMES)
+    )
     if reference.get("outcome") not in reference_outcomes:
         return False
     pattern = rule.get("diagnostic_regex")
-    return (
-        not pattern
-        or re.search(pattern, candidate.get("diagnostic", ""), re.DOTALL) is not None
-    )
+    if pattern and re.search(
+        pattern, candidate.get("diagnostic", ""), re.DOTALL
+    ) is None:
+        return False
+    reference_pattern = rule.get("reference_diagnostic_regex")
+    return not reference_pattern or re.search(
+        reference_pattern, reference.get("diagnostic", ""), re.DOTALL
+    ) is not None
 
 
 def compare_upstream_results(
@@ -541,10 +574,11 @@ def compare_upstream_results(
                 "duration": 0.0,
             }
         entry = {"nodeid": nodeid, "reference": ref, "candidate": cand}
-        if ref.get("outcome") != "passed":
-            report["reference_unverified"].append(entry)
-            continue
-        if cand.get("outcome") == "passed":
+        reference_outcome = ref.get("outcome")
+        if (
+            reference_outcome in _PASS_LIKE_OUTCOMES
+            and cand.get("outcome") in _PASS_LIKE_OUTCOMES
+        ):
             report["matched"].append(entry)
             continue
         matching_rules = [
@@ -560,6 +594,9 @@ def compare_upstream_results(
         if len(matching_rules) > 1:
             entry["rules"] = [rule["id"] for rule in matching_rules]
             report["ambiguous_rules"].append(entry)
+            continue
+        if reference_outcome not in _PASS_LIKE_OUTCOMES and not matching_rules:
+            report["reference_unverified"].append(entry)
             continue
         if not matching_rules:
             report["review_required"].append(entry)

--- a/tools/parity/upstream_conformance.json
+++ b/tools/parity/upstream_conformance.json
@@ -19,6 +19,74 @@
   },
   "rules": [
     {
+      "id": "wiring-inputs-key-native-interning-converted",
+      "match": "hgraph_unit_tests/_wiring/test_inputs_key.py::*",
+      "classification": "converted",
+      "candidate_outcomes": ["collection-error"],
+      "diagnostic_regex": "No module named 'hgraph[.]_wiring[.]_wiring_node_instance'",
+      "reason": "InputsKey is a private Python implementation detail. hg_cpp interns nodes in the native Wiring core with an explicit structural key: time-series sources use producer identity and paths, scalar inputs use native value equality, and input shape is fixed by the public node signature. Public Python and C++ wiring tests cover both reuse and separation without invoking overloaded port equality.",
+      "decision": "docs/source/developer_guide/parity_matrix.rst",
+      "review_date": "2026-08-05",
+      "evidence": [
+        "python/tests/test_python_authoring.py",
+        "tests/cpp/test_graph_wiring.cpp"
+      ]
+    },
+    {
+      "id": "types-cpp-integration-native-contract-converted",
+      "match": "hgraph_unit_tests/_types/test_cpp_type_integration.py::*",
+      "classification": "converted",
+      "reference_outcomes": ["skipped"],
+      "reference_diagnostic_regex": "Skipped: C\\+\\+ not enabled",
+      "candidate_outcomes": ["collection-error"],
+      "diagnostic_regex": "No module named 'hgraph[.]_types[.]_scalar_type_meta_data'",
+      "reason": "The released test is disabled without upstream's optional Python-to-C++ bridge and imports its private metadata hierarchy. hg_cpp resolves every scalar and time-series kind natively and exposes public type expressions and reflection instead of that second runtime representation.",
+      "decision": "docs/source/developer_guide/type_reflection.rst",
+      "review_date": "2026-08-05",
+      "evidence": [
+        "python/tests/test_bridge.py",
+        "python/tests/test_reflection.py",
+        "tests/cpp/test_schema_examples.cpp",
+        "tests/cpp/test_type_registry.cpp"
+      ]
+    },
+    {
+      "id": "types-ts-cpp-bridge-native-contract-converted",
+      "match": "hgraph_unit_tests/_types/test_ts_cpp_type.py::*",
+      "classification": "converted",
+      "reference_outcomes": ["skipped"],
+      "reference_diagnostic_regex": "Skipped: C\\+\\+ not enabled",
+      "candidate_outcomes": ["collection-error"],
+      "diagnostic_regex": "No module named 'hgraph[.]_types[.]_type_meta_data'",
+      "reason": "The released test is disabled without upstream's optional Python-to-C++ bridge and asserts its private metadata-to-storage mapping. Native type construction, identity, predicates, and value round trips replace that bridge contract.",
+      "decision": "docs/source/developer_guide/type_reflection.rst",
+      "review_date": "2026-08-05",
+      "evidence": [
+        "python/tests/test_bridge.py",
+        "python/tests/test_reflection.py",
+        "tests/cpp/test_schema_examples.cpp",
+        "tests/cpp/test_value_types.cpp"
+      ]
+    },
+    {
+      "id": "types-cpp-native-compound-storage-converted",
+      "match": "hgraph_unit_tests/_types/test_cpp_native_compound_scalar.py::*",
+      "classification": "converted",
+      "reference_outcomes": ["skipped"],
+      "reference_diagnostic_regex": "Skipped: C\\+\\+ not enabled",
+      "candidate_outcomes": ["collection-error"],
+      "diagnostic_regex": "No module named 'hgraph[.]_types[.]_scalar_types'",
+      "reason": "The released test is disabled without upstream's optional bridge and selects opaque versus expanded storage through cpp_native flags. hg_cpp compound scalars are always native, with hierarchy and value layout tested through the public bridge and C++ value contract.",
+      "decision": "docs/source/developer_guide/type_reflection.rst",
+      "review_date": "2026-08-05",
+      "evidence": [
+        "python/tests/test_bridge.py",
+        "python/tests/test_compound_scalar_hierarchy.py",
+        "tests/cpp/test_schema_examples.cpp",
+        "tests/cpp/test_value_types.cpp"
+      ]
+    },
+    {
       "id": "operators-const-private-wiring-converted",
       "match": "hgraph_unit_tests/_operators/test_const.py::*",
       "classification": "converted",
@@ -1072,7 +1140,7 @@
     },
     {
       "id": "adaptors-websocket-import-guard-converted",
-      "match": "hgraph_unit_tests/adaptors/websocket_adaptor/test_websocket_adaptor.py::test_single_request_graph_client",
+      "match": "hgraph_unit_tests/adaptors/websocket_adaptor/test_websocket_adaptor.py::test_*",
       "classification": "converted",
       "candidate_outcomes": ["not-run"],
       "diagnostic_regex": "candidate did not report this reference test",


### PR DESCRIPTION
## Summary

- Tighten upstream conformance evidence so XPASS counts as executed and skipped conversions require exact reference diagnostics.
- Convert retired private bridge and wiring contracts only when backed by public Python and native C++ evidence.
- Bind SQL dataframe connections during wiring and accept safe Arrow numeric-width widening in the native table codec.

## Root cause

The broad audit treated XPASS as unverified and could not classify disabled optional bridge tests safely. It also exposed a real SQL adaptor lifecycle defect: runtime iteration reached wiring-only `GlobalState`, followed by an overly strict int64-only Arrow decoder for SQL INTEGER columns.

## User impact

Public Python SQL dataframe source behavior now executes through the C++ runtime without runtime `GlobalState` access, and normal SQL integer and floating-point widths decode to Python-compatible native scalar types. Retired private Python implementation APIs remain unexposed, with their behavior covered through public APIs in both languages.

## Validation

- macOS native C++: 1456/1456 passed
- macOS Python 3.14 non-WIP: 1942 passed, 10 skipped
- GCC 14 Linux native C++: 1456/1456 passed
- GCC 14 Linux Python 3.14 non-WIP: 1942 passed, 10 skipped
- hgraph 0.5.36 conformance: 1092 exact, 757 evidence-backed, 21 reference-unverified, 0 review-required, 0 confirmed gaps, 0 ambiguous rules