### PR TITLE
Align released hgraph public API and parity evidence

### DIFF
--- a/docs/source/developer_guide/parity_matrix.rst
+++ b/docs/source/developer_guide/parity_matrix.rst
@@ -211,8 +211,23 @@ authoring gaps, both fixed without changing native execution: anonymous
 ``to_dict``/``from_dict``, and ``with_columns[RowSchema](...)`` lowers that
 released shorthand to the native ``TS[Frame[RowSchema]]`` output constraint.
 Against released hgraph 0.5.36, the resulting 1,870-test audit records 1,092
-exact matches, 757 evidence-backed conversions, 21 reference-unverified
+exact matches, 762 evidence-backed conversions, 16 reference-unverified
 tests, and no review-required, confirmed-gap, or ambiguous outcomes.
+
+The 2026-08-05 evidence-frontier refresh installs Pydantic in both audit
+environments, where the unchanged public compound-scalar case passes on both
+engines.  Four upstream logging tests that are explicitly XFAIL because of
+full-suite capture pollution XPASS in isolated reference processes; their
+candidate module imports a retired private TSL implementation, so the report
+retains the suite and isolated outcomes and accepts the existing public Python
+and native logger coverage.  The exact real-time scheduler test's 90--110 ms
+upper window was also observed to fail intermittently in the reference engine.
+Its converted counterpart retains ordered values, tagged rescheduling,
+not-before bounds, and the graph end-time while allowing wall-clock jitter.
+The remaining 16 cases have no executable reference oracle: optional C++
+memory/debug tests, timezone cases, the upstream multi-client adaptor XFAIL,
+and skipped nested-graph, Kafka, and inspector cases.  They remain unverified
+rather than being classified as candidate gaps or accepted conversions.
 
 The remaining broad-suite differences are conversions of already recorded
 design decisions, not unimplemented user behaviour:
@@ -239,6 +254,27 @@ design decisions, not unimplemented user behaviour:
 - Arrow stop-hook errors cross the native exception boundary, explicit nodes
   are never pruned merely because their output is unconsumed, and runtime
   graph state is accessed through the ``GlobalState`` injectable.
+
+Public surface refresh (2026-08-05)
+-----------------------------------
+
+The public API probe against released hgraph 0.5.36 compares 54 package and
+adaptor modules, including callable defaults, parameter names, class methods,
+and optional-module importability.  The refresh has no unclassified findings.
+It restored the upstream ``CompoundScalar.from_dict(d=...)`` keyword across
+the root and Tornado schemas, the standard ``TimeSeriesSchema`` reflection
+surface on unspecialised ``RunGraphOutput``, and the ``_global_state``
+injectable spelling on ``publish_output``.
+
+The remaining threaded-graph signature differences are compatible widenings
+or representation boundaries: ``global_state`` and ``params`` may additionally
+be omitted, ``None`` represents the upstream default-output sentinel, and
+service implementations are passive registration tokens in the C++-first
+model.  The upstream-only ``_state`` parameter on ``adaptor_executor`` is a
+hidden generator injectable; executor ownership remains inside the adaptor's
+lifecycle node.  These call paths are pinned by public Python adaptor tests,
+while independent-engine concurrency and runtime reference identification are
+also covered natively.
 
 Compatibility audit: wiring and time-series tiers
 -------------------------------------------------

--- a/docs/source/developer_guide/parity_testing.rst
+++ b/docs/source/developer_guide/parity_testing.rst
@@ -115,6 +115,14 @@ for discovery while rules are being reviewed; the normal command fails while
 review-required, confirmed-gap, ambiguous-rule, or reference-unverified
 entries remain.
 
+An upstream test explicitly marked XFAIL because it is polluted by suite
+context may opt into isolated reference replay through a converted rule.  The
+controller reruns only that exact node id in a fresh reference process, accepts
+only PASS or XPASS, and retains both the suite and isolated results in the
+report.  A failed isolated replay remains reference-unverified.  This mechanism
+does not retry ordinary failures or skips and does not run candidate code in
+the reference process.
+
 ``--reference-python`` and ``--candidate-python`` select already-provisioned
 interpreters.  ``--candidate-wheel`` installs a pre-built stable-ABI wheel,
 which is how CI reuses the wheel already built by the distribution workflow.

--- a/python/hgraph/_compat.py
+++ b/python/hgraph/_compat.py
@@ -198,13 +198,13 @@ class CompoundScalar:
         return result
 
     @classmethod
-    def from_dict(cls, values: dict):
+    def from_dict(cls, d: dict):
         """Construct from known fields, recursively adapting nested scalars."""
         from ._types import _compound_python_field_types
 
         field_types = _compound_python_field_types(cls)
         converted = {}
-        for name, value in values.items():
+        for name, value in d.items():
             annotation = field_types.get(name)
             if annotation is None:
                 continue

--- a/python/hgraph/adaptors/run_graph_on_thread/run_graph_on_thread.py
+++ b/python/hgraph/adaptors/run_graph_on_thread/run_graph_on_thread.py
@@ -43,7 +43,7 @@ _OUTPUT_CALLBACK = ":adaptors:run_graph_on_thread:output"
 _RUN_OUTPUT_SCHEMAS = {}
 
 
-class RunGraphOutput:
+class RunGraphOutput(TimeSeriesSchema):
     """The typed result bundle returned by ``run_graph_on_thread[OUT]``."""
 
     def __class_getitem__(cls, output_type):
@@ -84,10 +84,10 @@ _RAW_OUTPUT = TSB[_RawRunGraphOutput]
 def publish_output(
     ts: TIME_SERIES_TYPE,
     delta: bool = True,
-    global_state: GlobalState = None,
+    _global_state: GlobalState = None,
 ):
     """Publish a child graph value to its ``run_graph_on_thread`` client."""
-    callback = global_state.get(_OUTPUT_CALLBACK)
+    callback = _global_state.get(_OUTPUT_CALLBACK)
     if callback is None:
         raise RuntimeError("publish_output must run inside run_graph_on_thread")
     callback(ts.delta_value if delta else ts.value)

--- a/python/tests/adaptors/run_graph_on_thread/test_run_graph_on_thread.py
+++ b/python/tests/adaptors/run_graph_on_thread/test_run_graph_on_thread.py
@@ -1,3 +1,4 @@
+import inspect
 from datetime import datetime, timedelta, timezone
 
 import hgraph as hg
@@ -34,6 +35,8 @@ def test_typed_output_schema_can_be_used_by_eval_node():
 def test_typed_output_schema_supports_standard_scalar_schema_operations():
     schema = RunGraphOutput[hg.TS[int]]
 
+    assert issubclass(RunGraphOutput, hg.TimeSeriesSchema)
+    assert RunGraphOutput.scalar_type() is None
     assert schema.scalar_type() is None
     scalar_schema = schema.to_scalar_schema()
     assert scalar_schema.__annotations__ == {
@@ -46,6 +49,11 @@ def test_typed_output_schema_supports_standard_scalar_schema_operations():
 
 
 def test_publish_output_can_publish_full_values_instead_of_deltas():
+    assert tuple(inspect.signature(publish_output).parameters) == (
+        "ts",
+        "delta",
+        "_global_state",
+    )
     captured = []
 
     @hg.graph

--- a/python/tests/test_compound_scalar_hierarchy.py
+++ b/python/tests/test_compound_scalar_hierarchy.py
@@ -1,3 +1,4 @@
+import inspect
 from dataclasses import InitVar, dataclass, field
 from datetime import timedelta
 from enum import Enum
@@ -79,12 +80,18 @@ def test_compound_scalar_dictionary_conversion_and_sparse_anonymous_values():
 
     value = Outer(amount=2.0, inner=Inner(value=1))
     assert value.to_dict() == {"amount": 2.0, "inner": {"value": 1}}
-    assert Outer.from_dict({
-        "amount": 2.0,
-        "inner": {"value": 1},
-        "internal": "ignored because it is not part of the logical schema",
-        "ignored": "unknown fields retain upstream's filtering behavior",
-    }) == value
+    assert tuple(inspect.signature(CompoundScalar.from_dict).parameters) == ("d",)
+    assert (
+        Outer.from_dict(
+            d={
+                "amount": 2.0,
+                "inner": {"value": 1},
+                "internal": "ignored because it is not part of the logical schema",
+                "ignored": "unknown fields retain upstream's filtering behavior",
+            }
+        )
+        == value
+    )
 
     predicate = compound_scalar(a=int, b=int)
     sparse = predicate(a=1)

--- a/python/tests/test_surface_parity.py
+++ b/python/tests/test_surface_parity.py
@@ -1,0 +1,41 @@
+"""Focused contracts for the public API surface classifier."""
+
+from tools.parity.surface import classify_findings
+
+
+def test_surface_rule_with_exact_signatures_does_not_mask_later_drift():
+    reference = [
+        {"name": "value", "kind": "POSITIONAL_OR_KEYWORD", "default": None},
+    ]
+    candidate = [
+        {"name": "value", "kind": "POSITIONAL_OR_KEYWORD", "default": "None"},
+    ]
+    rule = {
+        "module": "hgraph.example",
+        "name": "example",
+        "kind": "signature-mismatch",
+        "reference": reference,
+        "candidate": candidate,
+        "reason": "the candidate deliberately widens the argument",
+    }
+    finding = {
+        "module": "hgraph.example",
+        "name": "example",
+        "kind": "signature-mismatch",
+        "reference": reference,
+        "candidate": candidate,
+    }
+
+    actionable, accepted = classify_findings([finding], [rule])
+    assert not actionable
+    assert accepted[0]["accepted_reason"] == rule["reason"]
+
+    changed = {
+        **finding,
+        "candidate": [
+            {"name": "renamed", "kind": "POSITIONAL_OR_KEYWORD", "default": "None"},
+        ],
+    }
+    actionable, accepted = classify_findings([changed], [rule])
+    assert actionable == [changed]
+    assert not accepted

--- a/python/tests/test_upstream_conformance.py
+++ b/python/tests/test_upstream_conformance.py
@@ -10,11 +10,13 @@ import pytest
 
 from tools.parity.conformance import (
     UpstreamSource,
+    apply_reference_isolation,
     compare_upstream_results,
     install_conformance_dependencies,
     load_conformance_manifest,
     prepare_test_workspace,
     profile_selectors,
+    reference_isolation_selectors,
     require_aligned_conformance_environments,
     run_upstream_suite,
     validate_selectors,
@@ -123,13 +125,58 @@ def test_conformance_treats_xpass_as_executed_reference_evidence():
     assert report["summary"]["matched"] == 1
     assert report["summary"]["reference_unverified"] == 0
 
+
+def test_conformance_isolates_only_declared_suite_context_xfails():
+    isolated = "hgraph_unit_tests/_operators/test_print.py::test_log_args"
+    failed = "hgraph_unit_tests/_operators/test_print.py::test_log_sample"
+    reference = _result(
+        {
+            isolated: _outcome("xfailed", "suite capture pollution"),
+            failed: _outcome("failed", "reference defect"),
+        }
+    )
+    rule = {
+        "id": "isolated-print",
+        "match": "hgraph_unit_tests/_operators/test_print.py::*",
+        "classification": "converted",
+        "isolate_reference_outcomes": ["xfailed"],
+        "candidate_outcomes": ["collection-error"],
+        "diagnostic_regex": "private import",
+        "reason": "public logging is covered independently",
+        "decision": "docs/source/developer_guide/parity_matrix.rst",
+        "review_date": "2026-08-05",
+        "evidence": ["python/tests/ported/_operators/test_print.py"],
+    }
+
+    assert reference_isolation_selectors(reference, _manifest([rule])) == [
+        isolated
+    ]
+    probe = _result({isolated: _outcome("xpassed")})
+    record = apply_reference_isolation(reference, isolated, probe)
+    assert record["applied"] is True
+    assert reference["tests"][isolated]["outcome"] == "xpassed"
+    assert reference["tests"][isolated]["suite_result"]["outcome"] == "xfailed"
+
+
+def test_conformance_keeps_a_failed_isolated_reference_unverified():
+    nodeid = "hgraph_unit_tests/_operators/test_print.py::test_log_args"
+    reference = _result({nodeid: _outcome("xfailed")})
+    record = apply_reference_isolation(
+        reference,
+        nodeid,
+        _result({nodeid: _outcome("xfailed", "still fails alone")}),
+    )
+
+    assert record["applied"] is False
+    assert reference["tests"][nodeid]["outcome"] == "xfailed"
+
     report = compare_upstream_results(
         reference,
         _result({nodeid: _outcome("failed", "AssertionError: candidate defect")}),
         _manifest(),
     )
-    assert report["summary"]["review_required"] == 1
-    assert report["summary"]["reference_unverified"] == 0
+    assert report["summary"]["review_required"] == 0
+    assert report["summary"]["reference_unverified"] == 1
 
 
 def test_conformance_converts_only_an_exact_skipped_reference_reason():
@@ -252,6 +299,36 @@ def test_manifest_requires_reference_diagnostic_for_skipped_conversion(tmp_path)
     path.write_text(json.dumps(manifest))
 
     with pytest.raises(ValueError, match="requires reference_diagnostic_regex"):
+        load_conformance_manifest(path)
+
+
+@pytest.mark.parametrize(
+    ("classification", "isolated_outcomes"),
+    [("expected-change", ["xfailed"]), ("converted", ["failed"])],
+)
+def test_manifest_limits_isolated_replay_to_converted_xfails(
+    tmp_path, classification, isolated_outcomes
+):
+    path = tmp_path / "manifest.json"
+    manifest = _manifest(
+        [
+            {
+                "id": "unsafe-isolated-replay",
+                "match": "hgraph_unit_tests/_operators/test_print.py::*",
+                "classification": classification,
+                "isolate_reference_outcomes": isolated_outcomes,
+                "candidate_outcomes": ["collection-error"],
+                "diagnostic_regex": "private import",
+                "reason": "public logging is covered independently",
+                "decision": "docs/source/developer_guide/parity_matrix.rst",
+                "review_date": "2026-08-05",
+                "evidence": ["python/tests/ported/_operators/test_print.py"],
+            }
+        ]
+    )
+    path.write_text(json.dumps(manifest))
+
+    with pytest.raises(ValueError, match="only isolate an xfailed converted test"):
         load_conformance_manifest(path)
 
 

--- a/tools/parity/cli.py
+++ b/tools/parity/cli.py
@@ -26,12 +26,14 @@ from .surface import (
 from .catalog import catalogue_json, validate_recipe
 from .compare import compare_outcomes
 from .conformance import (
+    apply_reference_isolation,
     compare_upstream_results,
     ensure_upstream_source,
     install_conformance_dependencies,
     load_conformance_manifest,
     prepare_test_workspace,
     profile_selectors,
+    reference_isolation_selectors,
     require_aligned_conformance_environments,
     render_conformance_markdown,
     run_upstream_suite,
@@ -312,6 +314,23 @@ def command_conformance(args) -> int:
         result_path=output_dir / "reference-result.json",
         timeout_seconds=args.timeout,
     )
+    reference_isolation = []
+    for index, nodeid in enumerate(
+        reference_isolation_selectors(reference, manifest)
+    ):
+        isolated = run_upstream_suite(
+            environments.reference_python,
+            workspace,
+            [nodeid],
+            result_path=output_dir / f"reference-isolated-{index:03d}.json",
+            timeout_seconds=args.timeout,
+        )
+        record = apply_reference_isolation(reference, nodeid, isolated)
+        record["session"] = _session_report(isolated)
+        reference_isolation.append(record)
+        (output_dir / f"reference-isolated-{index:03d}-pytest.txt").write_text(
+            isolated.get("stdout", "") + isolated.get("stderr", "")
+        )
     candidate = run_upstream_suite(
         environments.candidate_python,
         workspace,
@@ -337,6 +356,10 @@ def command_conformance(args) -> int:
         },
         reference_session=_session_report(reference),
         candidate_session=_session_report(candidate),
+        reference_isolation=reference_isolation,
+    )
+    report["summary"]["reference_isolated"] = sum(
+        record["applied"] for record in reference_isolation
     )
     (output_dir / "reference-pytest.txt").write_text(
         reference.get("stdout", "") + reference.get("stderr", "")

--- a/tools/parity/conformance.py
+++ b/tools/parity/conformance.py
@@ -438,6 +438,15 @@ def load_conformance_manifest(path: Path) -> dict[str, Any]:
                 raise ValueError(
                     f"invalid reference_diagnostic_regex for {rule_id}: {error}"
                 ) from error
+        isolation_outcomes = rule.get("isolate_reference_outcomes")
+        if isolation_outcomes is not None:
+            if (
+                rule["classification"] != "converted"
+                or isolation_outcomes != ["xfailed"]
+            ):
+                raise ValueError(
+                    f"rule {rule_id} may only isolate an xfailed converted test"
+                )
         if rule["classification"] in _ACCEPTED_CLASSIFICATIONS:
             if not rule.get("diagnostic_regex"):
                 raise ValueError(f"accepted rule {rule_id} requires diagnostic_regex")
@@ -485,6 +494,73 @@ def validate_selectors(selectors: list[str]) -> list[str]:
     if not validated:
         raise ValueError("at least one upstream test selector is required")
     return validated
+
+
+def reference_isolation_selectors(
+    reference: dict[str, Any], manifest: dict[str, Any]
+) -> list[str]:
+    """Return suite-context XFAILs explicitly approved for isolated replay."""
+
+    selectors: list[str] = []
+    for raw_nodeid, result in reference.get("tests", {}).items():
+        nodeid = _normalize_nodeid(raw_nodeid)
+        outcome = result.get("outcome")
+        if any(
+            outcome in rule.get("isolate_reference_outcomes", ())
+            and fnmatch.fnmatchcase(nodeid, rule["match"])
+            for rule in manifest.get("rules", ())
+        ):
+            selectors.append(nodeid)
+    return sorted(selectors)
+
+
+def apply_reference_isolation(
+    reference: dict[str, Any], nodeid: str, isolated: dict[str, Any]
+) -> dict[str, Any]:
+    """Use a pass-like isolated result while retaining the suite result."""
+
+    normalized = _normalize_nodeid(nodeid)
+    reference_key = next(
+        (
+            key
+            for key in reference.get("tests", {})
+            if _normalize_nodeid(key) == normalized
+        ),
+        None,
+    )
+    isolated_key = next(
+        (
+            key
+            for key in isolated.get("tests", {})
+            if _normalize_nodeid(key) == normalized
+        ),
+        None,
+    )
+    suite_result = (
+        reference.get("tests", {}).get(reference_key) if reference_key else None
+    )
+    isolated_result = (
+        isolated.get("tests", {}).get(isolated_key) if isolated_key else None
+    )
+    applied = bool(
+        reference_key
+        and suite_result
+        and suite_result.get("outcome") == "xfailed"
+        and isolated_result
+        and isolated_result.get("outcome") in _PASS_LIKE_OUTCOMES
+    )
+    if applied:
+        reference["tests"][reference_key] = {
+            **isolated_result,
+            "isolated_reference": True,
+            "suite_result": suite_result,
+        }
+    return {
+        "nodeid": normalized,
+        "applied": applied,
+        "suite_result": suite_result,
+        "isolated_result": isolated_result,
+    }
 
 
 def _normalize_nodeid(nodeid: str) -> str:
@@ -676,6 +752,8 @@ def render_conformance_markdown(report: dict[str, Any]) -> str:
             f"- reference tests collected: {summary['reference_collected']}",
             f"- exact candidate matches: {summary['matched']}",
             f"- known expected/converted outcomes: {summary['known_expected']}",
+            "- reference XFAILs verified by isolated replay: "
+            f"{summary.get('reference_isolated', 0)}",
             f"- review required (not yet classified as defects): {summary['review_required']}",
             f"- confirmed compatibility gaps: {summary['confirmed_gaps']}",
             f"- reference-unverified tests: {summary['reference_unverified']}",

--- a/tools/parity/surface.py
+++ b/tools/parity/surface.py
@@ -29,6 +29,7 @@ SURFACE_EXTRA_DEPENDENCIES: tuple[str, ...] = (
     "perspective-python<5.0.0",
     "requests",
     "pandas>=2.0",
+    "pydantic>=2,<3",
     "kafka-python>=2.1.5",
     "boto3>=1.34",
     "deltalake>=1.0",
@@ -259,6 +260,14 @@ def classify_findings(
             return False
         if "side" in rule and rule["side"] != _finding_side(finding):
             return False
+        for field in (
+            "reference",
+            "candidate",
+            "reference_error",
+            "candidate_error",
+        ):
+            if field in rule and rule[field] != finding.get(field):
+                return False
         return True
 
     actionable: list[dict[str, Any]] = []

--- a/tools/parity/surface_known.json
+++ b/tools/parity/surface_known.json
@@ -866,13 +866,6 @@
     },
     {
       "module": "hgraph",
-      "name": "NodeError.from_dict",
-      "kind": "method-missing",
-      "side": "candidate",
-      "reason": "error capture/serialization is native (error_output/exception_time_series records); dict round-trip helpers are upstream implementation"
-    },
-    {
-      "module": "hgraph",
       "name": "NodeError.to_dict",
       "kind": "method-missing",
       "side": "candidate",
@@ -1962,9 +1955,16 @@
     {
       "module": "hgraph",
       "name": "TimeSeries.is_reference",
-      "kind": "method-missing",
-      "side": "candidate",
-      "reason": "annotation classes are type constructors \u2014 upstream's runtime ABC surface on them is deliberately not replicated (ruling 2026-08-01); instance behaviour lives on the runtime views (activity trio verified by test_input_activity)"
+      "kind": "method-signature-mismatch",
+      "reference": [
+        {
+          "name": "self",
+          "kind": "POSITIONAL_OR_KEYWORD",
+          "default": null
+        }
+      ],
+      "candidate": null,
+      "reason": "the runtime method is a nanobind builtin, so inspect.signature cannot recover its implicit self parameter; reference and value views are behaviorally pinned by test_time_series_runtime_api and the native base-view tests"
     },
     {
       "module": "hgraph",
@@ -2730,6 +2730,99 @@
       "reason": "nanobind builtin: inspect.signature unavailable; keyword calling via nb::arg('fn') and behaviour pinned by test_eval_notifications"
     },
     {
+      "module": "hgraph.adaptors.executor.executor",
+      "name": "adaptor_executor",
+      "kind": "signature-mismatch",
+      "reference": [
+        {
+          "name": "pool_size",
+          "kind": "POSITIONAL_OR_KEYWORD",
+          "default": "50"
+        },
+        {
+          "name": "_state",
+          "kind": "POSITIONAL_OR_KEYWORD",
+          "default": "None"
+        }
+      ],
+      "candidate": [
+        {
+          "name": "pool_size",
+          "kind": "POSITIONAL_OR_KEYWORD",
+          "default": "50"
+        }
+      ],
+      "reason": "the retained user argument is pool_size; upstream's _state parameter is a hidden generator injectable, while hg_cpp owns the same executor lifecycle in the inner compute node (pinned by test_adaptor_executor_runs_work_inside_eval_node)"
+    },
+    {
+      "module": "hgraph.adaptors.run_graph_on_thread*",
+      "name": "run_graph_on_thread",
+      "kind": "signature-mismatch",
+      "reference": [
+        {
+          "name": "fn",
+          "kind": "POSITIONAL_OR_KEYWORD",
+          "default": null
+        },
+        {
+          "name": "global_state",
+          "kind": "POSITIONAL_OR_KEYWORD",
+          "default": null
+        },
+        {
+          "name": "params",
+          "kind": "POSITIONAL_OR_KEYWORD",
+          "default": null
+        },
+        {
+          "name": "out_",
+          "kind": "POSITIONAL_OR_KEYWORD",
+          "default": "<hgraph._types._scalar_types.Default object>"
+        },
+        {
+          "name": "path",
+          "kind": "POSITIONAL_OR_KEYWORD",
+          "default": "'thread_graph_runner'"
+        }
+      ],
+      "candidate": [
+        {
+          "name": "fn",
+          "kind": "POSITIONAL_OR_KEYWORD",
+          "default": null
+        },
+        {
+          "name": "global_state",
+          "kind": "POSITIONAL_OR_KEYWORD",
+          "default": "None"
+        },
+        {
+          "name": "params",
+          "kind": "POSITIONAL_OR_KEYWORD",
+          "default": "None"
+        },
+        {
+          "name": "out_",
+          "kind": "POSITIONAL_OR_KEYWORD",
+          "default": "None"
+        },
+        {
+          "name": "path",
+          "kind": "POSITIONAL_OR_KEYWORD",
+          "default": "'thread_graph_runner'"
+        }
+      ],
+      "reason": "hg_cpp accepts every upstream call shape and additionally allows global_state and params to be omitted; None is the native authoring representation of upstream's default output sentinel, with bracket, out_=, and positional path forms pinned by the threaded-graph adaptor tests"
+    },
+    {
+      "module": "hgraph.adaptors.run_graph_on_thread*",
+      "name": "run_graph_on_thread_impl",
+      "kind": "kind-mismatch",
+      "reference": "callable",
+      "candidate": "_ServiceImpl",
+      "reason": "the implementation is a passive C++-first registration token rather than a directly invoked Python service graph; register_adaptor behavior, per-client publication order, and independent native engine concurrency are pinned by the threaded-graph Python and C++ tests"
+    },
+    {
       "module": "hgraph.adaptors.tornado",
       "kind": "name-missing",
       "side": "candidate",
@@ -2740,13 +2833,6 @@
       "kind": "name-missing",
       "side": "candidate",
       "reason": "issue #215 makes each Tornado module's __all__ authoritative; upstream import leaks and internal managers/handlers/markers are excluded while retained names are pinned by test_public_api"
-    },
-    {
-      "module": "hgraph.adaptors.tornado*",
-      "name": "*.from_dict",
-      "kind": "method-missing",
-      "side": "candidate",
-      "reason": "Tornado CompoundScalar values use the native typed value-conversion contract; upstream inherited dict serialization helpers are a Python representation detail outside issue #215's curated API"
     },
     {
       "module": "hgraph.adaptors.tornado*",

--- a/tools/parity/upstream_conformance.json
+++ b/tools/parity/upstream_conformance.json
@@ -118,6 +118,7 @@
       "id": "operators-print-private-tsl-converted",
       "match": "hgraph_unit_tests/_operators/test_print.py::*",
       "classification": "converted",
+      "isolate_reference_outcomes": ["xfailed"],
       "candidate_outcomes": ["collection-error"],
       "diagnostic_regex": "No module named 'hgraph[.]nodes[.]_tsl_operators'",
       "reason": "The private Python TSL formatting implementation is not a runtime contract; public print and logger behavior is retained.",
@@ -1050,6 +1051,20 @@
       "evidence": [
         "python/tests/test_lifecycle_configuration.py",
         "tests/cpp/test_lifecycle_observers.cpp"
+      ]
+    },
+    {
+      "id": "runtime-wall-clock-reschedule-jitter-converted",
+      "match": "hgraph_unit_tests/_runtime/test_scheduler.py::test_wall_clock_scheduler_reschedule",
+      "classification": "converted",
+      "candidate_outcomes": ["failed"],
+      "diagnostic_regex": "test_scheduler[.]py:140: AssertionError",
+      "reason": "The released test's 90-110 ms wall-clock interval is narrower than scheduler jitter and is unstable in the reference engine itself. The converted test retains payload order, tagged rescheduling, the not-before lower bound, and the graph end-time while allowing non-semantic wall-clock delay.",
+      "decision": "docs/source/developer_guide/parity_matrix.rst",
+      "review_date": "2026-08-05",
+      "evidence": [
+        "python/tests/ported/_runtime/test_scheduler.py",
+        "tests/cpp/test_node_scheduler.cpp"
       ]
     },
     {


### PR DESCRIPTION
## Summary

- restore the released hgraph 0.5.36 public call surface for `CompoundScalar.from_dict(d=...)`, `RunGraphOutput`, and `publish_output(..., _global_state)`
- make accepted surface differences exact-signature fingerprints so later API drift becomes actionable
- execute the optional Pydantic compound-scalar case in both audit environments
- replay only manifest-approved suite-context XFAILs in isolated reference processes, retaining both outcomes
- document and evidence the non-semantic wall-clock scheduler tolerance conversion

## Why

The broad released-hgraph audit still had 21 reference-unverified cases and several stale public-surface allowances. This change works through that evidence frontier without changing native graph semantics or treating unavailable reference behavior as candidate compliance.

## User and developer impact

Existing released Python call shapes now work consistently, including the `d` keyword and standard time-series schema reflection. The parity controller is stricter: an accepted signature difference no longer masks later drift, and isolated replay is limited to converted rules that explicitly declare upstream XFAIL evidence.

No C++ runtime behavior is changed.

## Parity evidence

Released hgraph 0.5.36 full-suite audit:

- 1,870 reference tests
- 1,092 exact candidate matches
- 762 evidence-backed expected or converted outcomes
- 16 reference-unverified tests
- 0 review-required outcomes
- 0 confirmed compatibility gaps
- 0 ambiguous rules
- 4 suite-context XFAILs independently XPASS in the reference engine

The remaining 16 tests lack an executable reference oracle: optional C++ memory/debug cases, timezone cases, the upstream multi-client adaptor XFAIL, and skipped nested-graph, Kafka, and inspector cases.

## Validation

- `cmake --preset cpp --fresh`
- `cmake --build --preset cpp --target clean`
- `cmake --build --preset cpp --parallel`
- `ctest --preset cpp --parallel 2` — 1,456/1,456 passed
- stable-ABI wheel built with Python 3.12
- complete non-WIP suite with Python 3.14 — 1,947 passed, 10 skipped
- `python -m tools.parity validate` — 59 recipes validated
- strict Sphinx HTML build with `-W --keep-going` — passed
