### PR TITLE
Refine parity audit scope and temporal ingress

### DIFF
--- a/docs/source/developer_guide/parity_matrix.rst
+++ b/docs/source/developer_guide/parity_matrix.rst
@@ -210,8 +210,8 @@ authoring gaps, both fixed without changing native execution: anonymous
 ``compound_scalar(...)`` schemas once again allow omitted fields and retain
 ``to_dict``/``from_dict``, and ``with_columns[RowSchema](...)`` lowers that
 released shorthand to the native ``TS[Frame[RowSchema]]`` output constraint.
-Against released hgraph 0.5.36, the resulting 1,870-test audit records 1,092
-exact matches, 762 evidence-backed conversions, 16 reference-unverified
+Against released hgraph 0.5.36, the resulting 1,862-test audit records 1,092
+exact matches, 765 evidence-backed conversions, 5 reference-unverified
 tests, and no review-required, confirmed-gap, or ambiguous outcomes.
 
 The 2026-08-05 evidence-frontier refresh installs Pydantic in both audit
@@ -224,10 +224,22 @@ and native logger coverage.  The exact real-time scheduler test's 90--110 ms
 upper window was also observed to fail intermittently in the reference engine.
 Its converted counterpart retains ordered values, tagged rescheduling,
 not-before bounds, and the graph end-time while allowing wall-clock jitter.
-The remaining 16 cases have no executable reference oracle: optional C++
-memory/debug tests, timezone cases, the upstream multi-client adaptor XFAIL,
-and skipped nested-graph, Kafka, and inspector cases.  They remain unverified
-rather than being classified as candidate gaps or accepted conversions.
+The upstream ``GraphBuilder.memory_size`` and arena-canary module is excluded
+from the audit: those diagnostics were experimental and were never part of the
+supported user API or behavior contract.  The four skipped timezone bodies
+are also not a released oracle: two call an
+undefined, non-public helper, ``TS[datetime].tzname`` does not wire in released
+hgraph, and the remaining expected normalization fails when its body is run on
+0.5.36.  RFC 0002 supplies the supported replacement through distinct civil,
+instant, zone, and resolved-zoned types.  The bridge now rejects every
+timezone-bearing standalone ``time`` at both inferred and typed graph ingress
+instead of silently losing a ``ZoneInfo`` whose offset needs a date.
+
+Four stable cases remain without executable reference evidence: the upstream
+multi-client adaptor XFAIL and skipped nested-graph, Kafka, and inspector
+cases.  The latest audit reports five because the already-documented
+real-time scheduler test failed in the reference engine during that run;
+the controller deliberately does not retry ordinary reference failures.
 
 The remaining broad-suite differences are conversions of already recorded
 design decisions, not unimplemented user behaviour:

--- a/docs/source/developer_guide/parity_testing.rst
+++ b/docs/source/developer_guide/parity_testing.rst
@@ -100,13 +100,18 @@ A changed failure diagnostic falls out of the rule and returns to review.
 There is no blanket private-internal exclusion: a test coupled to a non-ported
 concept such as ``HgTypeMetaData`` must be converted to the public reflection
 and type-resolution surface with equivalent evidence, or the required concept
-must be ported.
+must be ported.  A manifest exclusion is reserved for a whole upstream module
+whose subject has been explicitly ruled experimental and outside the supported
+user contract.  Each exclusion names one exact test file, its reason, and its
+review date; the file is not collected and does not contribute to audit totals.
 
 A test skipped by the released reference can only be converted when a rule
 names ``skipped`` explicitly and matches the reference's exact skip diagnostic
-as well as the candidate diagnostic.  This is reserved for upstream internal
-contracts whose public Python and native C++ replacement tests are named as
-evidence; other skips remain reference-unverified.
+as well as the candidate diagnostic.  This is reserved for a source test whose
+supported contract is established independently and whose public Python and
+native C++ replacement tests are named as evidence; other skips remain
+reference-unverified.  Executing a skipped body may establish that it is not a
+released oracle, but does not by itself supply reference behavior.
 
 Reference collection failures and nondeterministic/platform-disabled tests are
 reported as unverified evidence, never candidate noncompliance.  Reports and

--- a/include/hgraph/types/value/value_ops.h
+++ b/include/hgraph/types/value/value_ops.h
@@ -578,6 +578,12 @@ namespace hgraph
 
         static Time from_python(nb::handle source)
         {
+            if (nb::hasattr(source, "tzinfo") &&
+                !source.attr("tzinfo").is_none())
+            {
+                throw nb::type_error(
+                    "timezone-aware time values require a zoned time scalar");
+            }
             if (nb::hasattr(source, "utcoffset"))
             {
                 nb::object offset = source.attr("utcoffset")();

--- a/python/tests/test_bridge.py
+++ b/python/tests/test_bridge.py
@@ -112,13 +112,18 @@ def test_aware_datetime_is_normalized_to_naive_utc():
 
 def test_aware_time_is_rejected_without_a_zoned_time_scalar():
     import datetime
+    from zoneinfo import ZoneInfo
 
-    try:
-        hg._roundtrip_value(datetime.time(12, 30, tzinfo=datetime.timezone.utc))
-    except TypeError as error:
-        check("timezone-aware time" in str(error), f"unexpected error: {error}")
-    else:
-        raise AssertionError("timezone-aware time was accepted")
+    for source in (
+        datetime.time(12, 30, tzinfo=datetime.timezone.utc),
+        datetime.time(12, 30, tzinfo=ZoneInfo("Africa/Johannesburg")),
+    ):
+        try:
+            hg._roundtrip_value(source)
+        except TypeError as error:
+            check("timezone-aware time" in str(error), f"unexpected error: {error}")
+        else:
+            raise AssertionError(f"timezone-bearing time was accepted: {source!r}")
 
 
 def test_datetime_scalars_through_a_graph():

--- a/python/tests/test_temporal_types.py
+++ b/python/tests/test_temporal_types.py
@@ -1,4 +1,5 @@
 import datetime as dt
+from zoneinfo import ZoneInfo
 
 import pytest
 
@@ -40,6 +41,19 @@ def test_temporal_values_are_immutable_hashable_native_scalars():
         return value.value
 
     assert eval_node(identity, [civil]) == [civil]
+
+
+def test_timezone_bearing_time_is_rejected_at_graph_ingress():
+    @hg.graph
+    def combine(
+        day: hg.TS[dt.date],
+        wall_time: hg.TS[dt.time],
+    ) -> hg.TS[hg.CivilDateTime]:
+        return day + wall_time
+
+    source = dt.time(12, 30, tzinfo=ZoneInfo("Africa/Johannesburg"))
+    with pytest.raises(TypeError, match="timezone-aware time"):
+        eval_node(combine, [dt.date(2026, 8, 5)], [source])
 
 
 def test_temporal_value_arithmetic_matches_graph_operators_inside_compute_nodes():

--- a/python/tests/test_upstream_conformance.py
+++ b/python/tests/test_upstream_conformance.py
@@ -12,6 +12,7 @@ from tools.parity.conformance import (
     UpstreamSource,
     apply_reference_isolation,
     compare_upstream_results,
+    conformance_exclusions,
     install_conformance_dependencies,
     load_conformance_manifest,
     prepare_test_workspace,
@@ -347,6 +348,29 @@ def test_manifest_profiles_reject_paths_outside_upstream_tests(tmp_path):
         load_conformance_manifest(path)
 
 
+def test_manifest_accepts_only_exact_experimental_module_exclusions(tmp_path):
+    path = tmp_path / "manifest.json"
+    manifest = _manifest()
+    manifest["exclusions"] = [
+        {
+            "path": "hgraph_unit_tests/_impl/_builder/test_memory_size.py",
+            "reason": "experimental implementation diagnostic",
+            "review_date": "2026-08-05",
+        }
+    ]
+    path.write_text(json.dumps(manifest))
+
+    loaded = load_conformance_manifest(path)
+    assert conformance_exclusions(loaded) == [
+        "hgraph_unit_tests/_impl/_builder/test_memory_size.py"
+    ]
+
+    manifest["exclusions"][0]["path"] = "hgraph_unit_tests/_impl/**/*.py"
+    path.write_text(json.dumps(manifest))
+    with pytest.raises(ValueError, match="one exact upstream test module"):
+        load_conformance_manifest(path)
+
+
 def test_profile_selectors_reports_available_profiles():
     with pytest.raises(ValueError, match="choose core"):
         profile_selectors(_manifest(), "missing")
@@ -444,3 +468,33 @@ def test_pytest_plugin_records_stable_node_outcomes(tmp_path):
         ]
         == "passed"
     )
+
+
+def test_upstream_suite_does_not_collect_excluded_experimental_modules(tmp_path):
+    workspace = tmp_path / "workspace"
+    tests = workspace / "hgraph_unit_tests"
+    tests.mkdir(parents=True)
+    (workspace / "pytest.ini").write_text(
+        "[pytest]\naddopts = --import-mode=importlib\n"
+    )
+    (tests / "test_supported.py").write_text(
+        "def test_supported():\n    assert True\n"
+    )
+    (tests / "test_experimental.py").write_text(
+        "def test_experimental():\n    assert False\n"
+    )
+
+    result = run_upstream_suite(
+        Path(sys.executable),
+        workspace,
+        ["hgraph_unit_tests"],
+        result_path=tmp_path / "result.json",
+        timeout_seconds=30.0,
+        excluded_paths=["hgraph_unit_tests/test_experimental.py"],
+    )
+
+    assert result["status"] == "complete"
+    assert result["process_returncode"] == 0
+    assert result["collected"] == [
+        "hgraph_unit_tests/test_supported.py::test_supported"
+    ]

--- a/python/value_conversion.cpp
+++ b/python/value_conversion.cpp
@@ -466,17 +466,7 @@ namespace hgraph::python_bridge
         }
         if (nb::isinstance(object, date_time_types.time))
         {
-            nb::object offset = object.attr("utcoffset")();
-            if (!offset.is_none())
-            {
-                throw nb::type_error(
-                    "timezone-aware time values require a zoned time scalar");
-            }
-            const std::int64_t micros = nb::cast<std::int64_t>(object.attr("hour")) * 3'600'000'000LL +
-                                        nb::cast<std::int64_t>(object.attr("minute")) * 60'000'000LL +
-                                        nb::cast<std::int64_t>(object.attr("second")) * 1'000'000LL +
-                                        nb::cast<std::int64_t>(object.attr("microsecond"));
-            return Value{Time{micros}};
+            return Value{python_conversion_traits<Time>::from_python(object)};
         }
         if (nb::isinstance(object, date_time_types.timedelta))
         {

--- a/tools/parity/cli.py
+++ b/tools/parity/cli.py
@@ -28,6 +28,7 @@ from .compare import compare_outcomes
 from .conformance import (
     apply_reference_isolation,
     compare_upstream_results,
+    conformance_exclusions,
     ensure_upstream_source,
     install_conformance_dependencies,
     load_conformance_manifest,
@@ -285,6 +286,7 @@ def command_conformance(args) -> int:
     selectors = validate_selectors(
         args.paths or profile_selectors(manifest, args.profile)
     )
+    excluded_paths = conformance_exclusions(manifest)
     extras = SURFACE_EXTRA_DEPENDENCIES if args.with_extras else ()
     install_conformance_dependencies(
         (environments.reference_python, environments.candidate_python),
@@ -313,6 +315,7 @@ def command_conformance(args) -> int:
         selectors,
         result_path=output_dir / "reference-result.json",
         timeout_seconds=args.timeout,
+        excluded_paths=excluded_paths,
     )
     reference_isolation = []
     for index, nodeid in enumerate(
@@ -324,6 +327,7 @@ def command_conformance(args) -> int:
             [nodeid],
             result_path=output_dir / f"reference-isolated-{index:03d}.json",
             timeout_seconds=args.timeout,
+            excluded_paths=excluded_paths,
         )
         record = apply_reference_isolation(reference, nodeid, isolated)
         record["session"] = _session_report(isolated)
@@ -337,6 +341,7 @@ def command_conformance(args) -> int:
         selectors,
         result_path=output_dir / "candidate-result.json",
         timeout_seconds=args.timeout,
+        excluded_paths=excluded_paths,
     )
     report = compare_upstream_results(reference, candidate, manifest)
     report.update(
@@ -357,6 +362,7 @@ def command_conformance(args) -> int:
         reference_session=_session_report(reference),
         candidate_session=_session_report(candidate),
         reference_isolation=reference_isolation,
+        exclusions=manifest.get("exclusions", []),
     )
     report["summary"]["reference_isolated"] = sum(
         record["applied"] for record in reference_isolation

--- a/tools/parity/conformance.py
+++ b/tools/parity/conformance.py
@@ -300,6 +300,7 @@ def run_upstream_suite(
     *,
     result_path: Path,
     timeout_seconds: float,
+    excluded_paths: list[str] | None = None,
 ) -> dict[str, Any]:
     result_path = result_path.absolute()
     result_path.unlink(missing_ok=True)
@@ -317,8 +318,10 @@ def run_upstream_suite(
         str(workspace),
         "--continue-on-collection-errors",
         "-q",
-        *selectors,
     ]
+    for excluded_path in excluded_paths or ():
+        command.extend(("--ignore", excluded_path))
+    command.extend(selectors)
     try:
         completed = subprocess.run(
             command,
@@ -390,6 +393,40 @@ def load_conformance_manifest(path: Path) -> dict[str, Any]:
             value = _safe_relative(selector, field=f"profile {profile}")
             if not value.startswith("hgraph_unit_tests"):
                 raise ValueError(f"profile selector is outside upstream tests: {value}")
+    exclusions = manifest.get("exclusions", [])
+    if not isinstance(exclusions, list):
+        raise ValueError("conformance manifest exclusions must be a list")
+    excluded_paths: set[str] = set()
+    for exclusion in exclusions:
+        if not isinstance(exclusion, dict):
+            raise ValueError("conformance exclusions must be objects")
+        raw_path = exclusion.get("path")
+        if not isinstance(raw_path, str) or not raw_path:
+            raise ValueError("conformance exclusion requires a path")
+        excluded_path = _safe_relative(raw_path, field="conformance exclusion")
+        if (
+            not excluded_path.startswith("hgraph_unit_tests/")
+            or not excluded_path.endswith(".py")
+            or "::" in excluded_path
+            or any(character in excluded_path for character in "*?[]")
+        ):
+            raise ValueError(
+                "conformance exclusion must name one exact upstream test module: "
+                f"{excluded_path}"
+            )
+        if excluded_path in excluded_paths:
+            raise ValueError(f"duplicate conformance exclusion: {excluded_path}")
+        excluded_paths.add(excluded_path)
+        if not isinstance(exclusion.get("reason"), str) or not exclusion["reason"]:
+            raise ValueError(
+                f"conformance exclusion {excluded_path} requires a reason"
+            )
+        try:
+            date.fromisoformat(exclusion["review_date"])
+        except (KeyError, TypeError, ValueError) as error:
+            raise ValueError(
+                f"conformance exclusion {excluded_path} requires an ISO review_date"
+            ) from error
     rules = manifest.get("rules", [])
     if not isinstance(rules, list):
         raise ValueError("conformance manifest rules must be a list")
@@ -481,6 +518,10 @@ def profile_selectors(manifest: dict[str, Any], profile: str) -> list[str]:
         raise ValueError(
             f"unknown conformance profile {profile!r}; choose {choices}"
         ) from error
+
+
+def conformance_exclusions(manifest: dict[str, Any]) -> list[str]:
+    return [exclusion["path"] for exclusion in manifest.get("exclusions", [])]
 
 
 def validate_selectors(selectors: list[str]) -> list[str]:
@@ -761,6 +802,12 @@ def render_conformance_markdown(report: dict[str, Any]) -> str:
             "",
         ]
     )
+    exclusions = report.get("exclusions", [])
+    if exclusions:
+        lines.extend(["## Excluded experimental modules", ""])
+        for exclusion in exclusions:
+            lines.append(f"- `{exclusion['path']}`: {exclusion['reason']}")
+        lines.append("")
     for heading, key in (
         ("Review required", "review_required"),
         ("Confirmed compatibility gaps", "confirmed_gaps"),

--- a/tools/parity/upstream_conformance.json
+++ b/tools/parity/upstream_conformance.json
@@ -17,6 +17,13 @@
       "hgraph_unit_tests"
     ]
   },
+  "exclusions": [
+    {
+      "path": "hgraph_unit_tests/_impl/_builder/test_memory_size.py",
+      "reason": "The module exercises the experimental upstream GraphBuilder memory-size and arena-canary diagnostics, which were never part of the supported user API or behavior contract.",
+      "review_date": "2026-08-05"
+    }
+  ],
   "rules": [
     {
       "id": "wiring-inputs-key-native-interning-converted",
@@ -357,6 +364,40 @@
       "evidence": [
         "python/tests/ported/_operators/test_to_json.py",
         "tests/cpp/test_std_operators.cpp"
+      ]
+    },
+    {
+      "id": "operators-temporal-explicit-zone-combination-converted",
+      "match": "hgraph_unit_tests/_operators/test_date_operators.py::test_add_date_time*",
+      "classification": "converted",
+      "reference_outcomes": ["skipped"],
+      "reference_diagnostic_regex": "Skipped: Skip as the C\\+\\+ engine only deals with naive datetime objects",
+      "candidate_outcomes": ["skipped"],
+      "diagnostic_regex": "Skipped: Skip as the C\\+\\+ engine only deals with naive datetime objects",
+      "reason": "The skipped bodies do not define released behavior: their timezone-preserving helper is neither imported nor public, and their UTC-normalizing date-plus-time expectation fails when executed on hgraph 0.5.36. RFC 0002 replaces implicit zone retention with CivilDate + CivilTime -> CivilDateTime and explicit ZoneId resolution; timezone-bearing Python time values are rejected rather than silently losing zone identity.",
+      "decision": "docs/source/rfc/rfc_0002_temporal_types.rst",
+      "review_date": "2026-08-05",
+      "evidence": [
+        "python/tests/test_bridge.py",
+        "python/tests/test_temporal_types.py",
+        "tests/cpp/test_temporal_operators.cpp"
+      ]
+    },
+    {
+      "id": "operators-temporal-explicit-zone-name-converted",
+      "match": "hgraph_unit_tests/_operators/test_date_operators.py::test_datetime_tzname",
+      "classification": "converted",
+      "reference_outcomes": ["skipped"],
+      "reference_diagnostic_regex": "Skipped: Skip as the C\\+\\+ engine only deals with naive datetime objects",
+      "candidate_outcomes": ["skipped"],
+      "diagnostic_regex": "Skipped: Skip as the C\\+\\+ engine only deals with naive datetime objects",
+      "reason": "The skipped body is not released behavior: TS[datetime].tzname does not wire when executed on hgraph 0.5.36. RFC 0002 makes zone identity explicit through ZonedDateTime and treats provider-dependent abbreviations as an explicit provider query rather than an Instant field.",
+      "decision": "docs/source/rfc/rfc_0002_temporal_types.rst",
+      "review_date": "2026-08-05",
+      "evidence": [
+        "python/tests/test_temporal_types.py",
+        "tests/cpp/test_temporal.cpp",
+        "tests/cpp/test_temporal_operators.cpp"
       ]
     },
     {


### PR DESCRIPTION
## Summary

- Exclude the upstream experimental GraphBuilder memory-size and arena-canary module from conformance collection using exact, audited manifest exclusions.
- Convert four skipped timezone observations to RFC 0002 evidence after verifying that their bodies do not represent released hgraph 0.5.36 behavior.
- Reject timezone-bearing Python time values consistently at inferred and typed graph ingress, preventing silent ZoneInfo loss.

## Root cause

The broad audit treated an experimental module as compatibility evidence, while schema-free and schema-aware time conversion used separate checks. ZoneInfo on datetime.time can return no offset without a date, so the old utcoffset-only check discarded its timezone identity.

## Validation

- Native C++ acceptance: 1,456/1,456 passed.
- Python 3.14 non-WIP suite from a fresh stable-ABI wheel: 1,951 passed, 9 skipped.
- Focused bridge, temporal, and conformance coverage: 40 passed.
- Parity manifest validation: 59 recipes valid.
- Upstream hgraph 0.5.36 audit: 1,862 collected, 0 review-required, 0 confirmed gaps, and 0 ambiguous; five reference-unverified results comprise four stable observations plus the known reference scheduler flake.
- Strict Sphinx build passed.