### PR TITLE
Support parameterized multi-client service adaptors

### DIFF
--- a/docs/source/developer_guide/parity_matrix.rst
+++ b/docs/source/developer_guide/parity_matrix.rst
@@ -241,6 +241,18 @@ cases.  The latest audit reports five because the already-documented
 real-time scheduler test failed in the reference engine during that run;
 the controller deliberately does not retry ordinary reference failures.
 
+The upstream multi-client service-adaptor XFAIL remains in that direct-audit
+residue: its real-time assertion still fails in isolated released-hgraph runs
+after the graph's stop counter has observed all 15 input modifications, so the
+async output ordering is not a usable oracle.  A deterministic companion
+recipe nevertheless pins the supported user contract on both engines: mapped
+clients with equal scalar options share one implementation, a direct client
+with a different option at the same logical path materializes a second
+implementation, and a constructed sampling tick observes the same routed
+values.  The Python bridge implements this by expanding configurations to
+native qualified C++ paths; native tests exercise the equivalent explicit path
+spellings.
+
 The remaining broad-suite differences are conversions of already recorded
 design decisions, not unimplemented user behaviour:
 

--- a/docs/source/developer_guide/services.rst
+++ b/docs/source/developer_guide/services.rst
@@ -457,9 +457,13 @@ are two spellings over one. Per :doc:`../rfc/rfc_0011_source_only_adaptor_collap
 * **``from_graph`` / ``to_graph`` work for services**, as the adaptor spelling
   of ``impl_input`` / ``impl_output``. A reference service has no client input
   and therefore no ``from_graph``.
-* **Clients of either family may pass wiring-time scalar options**, with the
-  same cross-client agreement check, and **either may take time-series inputs
-  supplied at registration**.
+* **Clients of either family may pass wiring-time scalar options**. Services
+  and plain adaptors enforce cross-client agreement at one concrete path. A
+  multi-client service adaptor follows released hgraph's more expressive rule:
+  scalar options qualify the native path, so equal configurations share one
+  implementation and differing configurations at the same logical path
+  materialize separate implementations. **Either family may take time-series
+  inputs supplied at registration**.
 * **``register_services`` is lazy** and, with one interface, is the by-stub
   single-interface registration. Its interface pack **may mix services and
   adaptors**, so "a sink-only interface in, a source-only interface out" is one
@@ -629,6 +633,17 @@ Single-interface implementations are registered automatically through
 ``to_graph`` inside the implementation body, matching the C++ explicit-stub
 shape.  Both Python forms delegate to the erased C++ runtime functions; they
 do not implement a second request/reply engine in Python.
+
+Scalar interface arguments are wiring-time configuration. Python lowers each
+distinct configuration to a concrete qualified C++ path while retaining the
+logical path injected into the implementation. Two mapped clients calling
+``stub("route", False, value)`` therefore share one keyed implementation; a
+direct client calling ``stub("route", True, value)`` materializes a second
+implementation under the same logical ``"route"`` path. Native C++ code uses
+the equivalent explicit spellings
+``service_adaptor::path("route", arg<"mode">(Bool{false}))`` and
+``service_adaptor::path("route", arg<"mode">(Bool{true}))``. This is a
+wiring-only expansion onto native paths, not a Python transport runtime.
 
 **Paths.** Services are addressed by ``ServicePath`` (``service::path("…")``;
 the default when omitted, overridable per descriptor via a

--- a/python/hgraph/_wiring/_services.py
+++ b/python/hgraph/_wiring/_services.py
@@ -26,6 +26,19 @@ _TS_ANNOTATIONS = (_TsExpr, _GenericTsExpr)
 _SERVICE_ADAPTOR_CLIENT_TOKENS = itertools.count()
 _CLIENT_CONFIGS = {}
 _CLIENT_CONFIG_CLEANUPS = set()
+_PARAMETERIZED_SERVICE_ADAPTOR_REGISTRATIONS = {}
+
+
+class _ClientConfigRecord(typing.NamedTuple):
+    values: dict
+    logical_path: str
+    variant_path: str
+
+
+class _ParameterizedServiceAdaptorRegistration(typing.NamedTuple):
+    implementation: object
+    config: dict
+    paths: set
 
 
 def _is_ts_annotation(annotation):
@@ -68,10 +81,8 @@ def _flavour_label(flavour):
     return _FLAVOUR_LABELS.get(flavour, flavour.replace("_", " "))
 
 
-def _record_client_config(stub, path, bound):
-    """Record the wiring-time scalar options shared by one service or
-    adaptor path. Flavour-neutral: the key carries ``stub.flavour``."""
-    config = {
+def _client_config_values(stub, bound):
+    return {
         parameter.name: bound.arguments[parameter.name]
         for parameter in stub._signature.parameters.values()
         if parameter.name != "path"
@@ -79,31 +90,92 @@ def _record_client_config(stub, path, bound):
         and not _is_resolution_annotation(parameter.annotation)
         and parameter.annotation not in _INJECTABLE_MARKERS
     }
-    wiring = _wiring_stack[0] if _wiring_stack else _current_wiring()
-    identity = wiring.identity()
-    if identity not in _CLIENT_CONFIG_CLEANUPS:
-        def clear_configs():
-            # The C++ Wiring may outlive this module: at interpreter shutdown
-            # module globals are cleared to None, and the cleanup still fires.
-            # Nothing is left to release at that point, so bail out quietly
-            # rather than raising out of a destructor.
-            if _CLIENT_CONFIGS is None or _CLIENT_CONFIG_CLEANUPS is None:
-                return
-            for existing in tuple(_CLIENT_CONFIGS):
-                if existing[0] == identity:
-                    del _CLIENT_CONFIGS[existing]
-            _CLIENT_CONFIG_CLEANUPS.discard(identity)
 
-        # The C++ Wiring owns this callback. A temporary borrowed PyWiring can
-        # disappear before build_services(), but its underlying Wiring retains
-        # both the config and cleanup for its actual lifetime.
-        wiring._retain_cleanup(clear_configs)
-        _CLIENT_CONFIG_CLEANUPS.add(identity)
-    key = (
+
+def _has_client_config(stub):
+    return any(
+        parameter.name != "path"
+        and not _is_ts_annotation(parameter.annotation)
+        and not _is_resolution_annotation(parameter.annotation)
+        and parameter.annotation not in _INJECTABLE_MARKERS
+        for parameter in stub._signature.parameters.values()
+    )
+
+
+def _client_state_key(identity, stub, path):
+    return (
         identity, stub.flavour, stub.__name__,
         stub._specialization, path,
     )
-    previous = _CLIENT_CONFIGS.setdefault(key, config)
+
+
+def _retain_client_state_cleanup(wiring, identity):
+    if identity in _CLIENT_CONFIG_CLEANUPS:
+        return
+
+    def clear_configs():
+        # The C++ Wiring may outlive this module: at interpreter shutdown
+        # module globals are cleared to None, and the cleanup still fires.
+        # Nothing is left to release at that point, so bail out quietly
+        # rather than raising out of a destructor.
+        if _CLIENT_CONFIGS is None or _CLIENT_CONFIG_CLEANUPS is None:
+            return
+        for existing in tuple(_CLIENT_CONFIGS):
+            if existing[0] == identity:
+                del _CLIENT_CONFIGS[existing]
+        if _PARAMETERIZED_SERVICE_ADAPTOR_REGISTRATIONS is not None:
+            for existing in tuple(_PARAMETERIZED_SERVICE_ADAPTOR_REGISTRATIONS):
+                if existing[0] == identity:
+                    del _PARAMETERIZED_SERVICE_ADAPTOR_REGISTRATIONS[existing]
+        _CLIENT_CONFIG_CLEANUPS.discard(identity)
+
+    # The C++ Wiring owns this callback. A temporary borrowed PyWiring can
+    # disappear before build_services(), but its underlying Wiring retains
+    # both the config and cleanup for its actual lifetime.
+    wiring._retain_cleanup(clear_configs)
+    _CLIENT_CONFIG_CLEANUPS.add(identity)
+
+
+def _record_client_config(stub, path, bound, *, variant_path=None):
+    """Record the wiring-time scalar options shared by one service or
+    adaptor path. Flavour-neutral unless ``variant_path`` is supplied for a
+    service adaptor: released hgraph materializes one native adaptor instance
+    per distinct scalar configuration at the same logical path."""
+    config = _client_config_values(stub, bound)
+    wiring = _wiring_stack[0] if _wiring_stack else _current_wiring()
+    identity = wiring.identity()
+    _retain_client_state_cleanup(wiring, identity)
+
+    if variant_path is not None and config:
+        logical_path = path
+        prefix = (identity, stub.flavour, stub.__name__, stub._specialization)
+        variants = [
+            (existing, record)
+            for existing, record in _CLIENT_CONFIGS.items()
+            if existing[:4] == prefix and record.logical_path == logical_path
+            and record.variant_path == variant_path
+        ]
+        for existing, record in variants:
+            if record.values == config:
+                _materialize_parameterized_service_adaptor(
+                    stub, variant_path, existing[4], wiring)
+                return existing[4]
+
+        # The qualifier is an internal native path identity. Values stay in
+        # the Python-owned wiring record, so arbitrary valid scalar options do
+        # not need a lossy string serialization. Equal configurations reuse
+        # the same concrete C++ path and therefore the same implementation.
+        concrete_path = f"{variant_path}[__config__={len(variants)}]"
+        key = _client_state_key(identity, stub, concrete_path)
+        _CLIENT_CONFIGS[key] = _ClientConfigRecord(
+            config, logical_path, variant_path)
+        _materialize_parameterized_service_adaptor(
+            stub, variant_path, concrete_path, wiring)
+        return concrete_path
+
+    key = _client_state_key(identity, stub, path)
+    previous = _CLIENT_CONFIGS.setdefault(
+        key, _ClientConfigRecord(config, path, path)).values
     if previous != config:
         differences = sorted(
             name for name in previous.keys() | config.keys()
@@ -112,15 +184,21 @@ def _record_client_config(stub, path, bound):
         raise WiringError(
             f"{_flavour_label(stub.flavour)} '{stub.__name__}' clients at "
             f"path {path!r} disagree on wiring-time option(s) {differences!r}")
+    # A generic service adaptor's native path carries its type-specialization
+    # suffix even when it has no scalar configuration. ``path`` is the
+    # suffix-free lookup key used by the implementation binding.
+    return variant_path if variant_path is not None else path
+
+
+def _client_config_record(stub, path):
+    wiring = _wiring_stack[0] if _wiring_stack else _current_wiring()
+    return _CLIENT_CONFIGS.get(
+        _client_state_key(wiring.identity(), stub, path))
 
 
 def _client_config(stub, path):
-    wiring = _wiring_stack[0] if _wiring_stack else _current_wiring()
-    key = (
-        wiring.identity(), stub.flavour, stub.__name__,
-        stub._specialization, path,
-    )
-    return _CLIENT_CONFIGS.get(key, {})
+    record = _client_config_record(stub, path)
+    return record.values if record is not None else {}
 
 
 def _resolved_client_path(stub, path):
@@ -680,7 +758,14 @@ class _AdaptorClientStub:
             stub = self._specialized_stub(resolution, specialization)
         self._materialize_client_registration(stub)
         config_path, path = _resolved_client_path(stub, path)
-        _record_client_config(stub, config_path, bound)
+        configured_path = _record_client_config(
+            stub,
+            config_path,
+            bound,
+            variant_path=path if stub.flavour == "service_adaptor" else None,
+        )
+        if stub.flavour == "service_adaptor":
+            path = configured_path
         request = (
             None if not requests else requests[0]
             if len(requests) == 1 else WiringPort(_hgraph.tsb_port(
@@ -1082,9 +1167,72 @@ def register_adaptor(path, implementation, resolution_dict=None, **kwargs):
     _register_resolved_adaptor(path, implementation, kwargs)
 
 
-def _register_resolved_adaptor(path, implementation, kwargs, wiring=None):
+def _parameterized_service_adaptor_key(wiring, stub, path):
+    return _client_state_key(wiring.identity(), stub, path)
+
+
+def _materialize_parameterized_service_adaptor(
+    stub, base_path, concrete_path, wiring,
+):
+    registration = _PARAMETERIZED_SERVICE_ADAPTOR_REGISTRATIONS.get(
+        _parameterized_service_adaptor_key(wiring, stub, base_path))
+    if registration is None or concrete_path in registration.paths:
+        return
+    registration.paths.add(concrete_path)
+    try:
+        _register_resolved_adaptor(
+            concrete_path,
+            registration.implementation,
+            registration.config,
+            wiring=wiring,
+            _parameterize=False,
+        )
+    except Exception:
+        registration.paths.remove(concrete_path)
+        raise
+
+
+def _register_parameterized_service_adaptor(
+    path, implementation, config, stub, wiring,
+):
+    identity = wiring.identity()
+    _retain_client_state_cleanup(wiring, identity)
+    key = _parameterized_service_adaptor_key(wiring, stub, path)
+    if key in _PARAMETERIZED_SERVICE_ADAPTOR_REGISTRATIONS:
+        raise WiringError(
+            f"duplicate service adaptor implementation at path {path!r}")
+    registration = _ParameterizedServiceAdaptorRegistration(
+        implementation, dict(config), set())
+    _PARAMETERIZED_SERVICE_ADAPTOR_REGISTRATIONS[key] = registration
+
+    prefix = key[:4]
+    for existing, record in tuple(_CLIENT_CONFIGS.items()):
+        if existing[:4] == prefix and record.variant_path == path:
+            _materialize_parameterized_service_adaptor(
+                stub, path, existing[4], wiring)
+
+
+def _register_resolved_adaptor(
+    path, implementation, kwargs, wiring=None, *, _parameterize=True,
+):
     wiring = wiring or _current_wiring()
     default_fallback = path is None
+    if (
+        _parameterize
+        and not default_fallback
+        and len(implementation.interfaces) == 1
+        and implementation.interfaces[0].flavour == "service_adaptor"
+        and _has_client_config(implementation.interfaces[0])
+    ):
+        stub = implementation.interfaces[0]
+        _register_parameterized_service_adaptor(
+            _resolved_service_path(stub, path),
+            implementation,
+            kwargs,
+            stub,
+            wiring,
+        )
+        return
     implementation_inputs, scalar_kwargs = _registration_inputs(
         implementation, kwargs)
     if not implementation.interfaces:
@@ -1464,14 +1612,21 @@ def _bind_registered_impl(implementation, path, config):
             if matched_stub is not None:
                 suffix = f"/{matched_stub.__name__}"
                 effective_path = qualified[:-len(suffix)]
-                specialization = getattr(matched_stub, "_specialization", "")
-                typed_suffix = f"[{specialization}]" if specialization else ""
-                if typed_suffix and effective_path.endswith(typed_suffix):
-                    effective_path = effective_path[:-len(typed_suffix)]
-        if any(param.name == "path" for param in parameters):
-            arguments["path"] = effective_path
         if matched_stub is not None:
-            client_config = _client_config(matched_stub, effective_path)
+            specialization = getattr(matched_stub, "_specialization", "")
+            typed_suffix = f"[{specialization}]" if specialization else ""
+            record = _client_config_record(matched_stub, effective_path)
+            if record is None and typed_suffix \
+                    and effective_path.endswith(typed_suffix):
+                effective_path = effective_path[:-len(typed_suffix)]
+                record = _client_config_record(matched_stub, effective_path)
+            if record is None:
+                client_config = {}
+            else:
+                client_config = record.values
+                effective_path = record.logical_path
+            if typed_suffix and effective_path.endswith(typed_suffix):
+                effective_path = effective_path[:-len(typed_suffix)]
         else:
             # A MULTI-interface implementation has no single stub, and
             # service_materialization_path() is only exposed while
@@ -1494,6 +1649,8 @@ def _bind_registered_impl(implementation, path, config):
                             f"'{candidate.__name__}' says {value!r}")
                     client_config[name] = value
                     sources[name] = candidate
+        if any(param.name == "path" for param in parameters):
+            arguments["path"] = effective_path
         for param in scalar_parameters:
             configured = resolved_config.get(param.name, inspect.Parameter.empty)
             client_value = client_config.get(param.name, inspect.Parameter.empty)

--- a/python/tests/test_hgraph_api.py
+++ b/python/tests/test_hgraph_api.py
@@ -1457,6 +1457,54 @@ def test_service_adaptor_from_python():
         check("missing implementation" in str(e), f"unexpected missing implementation error: {e}")
 
 
+def test_service_adaptor_scalar_options_materialize_native_path_variants():
+    observed = []
+
+    @hg.service_adaptor
+    def routed(
+        path: str, passthrough: bool, value: TS[int],
+    ) -> TS[int]: ...
+
+    @hg.service_adaptor_impl(interfaces=routed)
+    def routed_impl(
+        path: str,
+        passthrough: bool,
+        value: TSD[int, TS[int]],
+    ) -> TSD[int, TS[int]]:
+        observed.append((path, passthrough))
+        delayed = hg.feedback(TSD[int, TS[int]])
+        delayed(value)
+        return hg.map_(
+            lambda item: item if passthrough else item + 1,
+            delayed(),
+        )
+
+    @graph
+    def clients(
+        values: TSD[int, TS[int]], direct: TS[int], trigger: TS[int],
+    ) -> TSL[TS[int], Size[3]]:
+        hg.register_adaptor("shared", routed_impl)
+        mapped = hg.map_(
+            lambda item: routed("shared", False, item),
+            values,
+        )
+        separate = routed("shared", True, direct)
+        return hg.sample(
+            trigger, hg.combine(mapped[0], mapped[1], separate))
+
+    out = eval_node(
+        clients,
+        [{0: 1, 1: 10}, {0: 2, 1: 20}],
+        [100, 200],
+        [None, None, None, 1],
+        __end_time__=hg.MIN_ST + 8 * hg.MIN_TD,
+    )
+    check(out == [None, None, None, {0: 3, 1: 21, 2: 200}],
+          f"parameterized service adaptor clients: {out}")
+    check(sorted(observed) == [("shared", False), ("shared", True)],
+          f"parameterized service adaptor implementations: {observed}")
+
+
 def test_service_adaptor_explicit_request_id_client_split():
     @hg.service_adaptor
     def echo(request: TS[int]) -> TS[int]: ...

--- a/tests/cpp/test_service_wiring.cpp
+++ b/tests/cpp/test_service_wiring.cpp
@@ -2334,6 +2334,41 @@ namespace
         }
     };
 
+    struct ServiceAdaptorParameterizedClientGraph
+    {
+        [[maybe_unused]] static constexpr auto name =
+            "service_adaptor_parameterized_client_graph";
+
+        static Port<TS<Int>> compose(
+            Wiring &w,
+            Port<TS<Int>> lhs_request,
+            Port<TS<Int>> rhs_request,
+            Port<TS<Int>> direct_request)
+        {
+            const auto transformed = service_adaptor::path(
+                "parameterized", arg<"passthrough">(Bool{false}));
+            const auto passthrough = service_adaptor::path(
+                "parameterized", arg<"passthrough">(Bool{true}));
+            service_adaptor::register_service_adaptor_impl<
+                AddTwentyServiceAdaptor, AddTwentyServiceAdaptorImplNode>(
+                    w, transformed);
+            service_adaptor::register_service_adaptor_impl<
+                AddTwentyServiceAdaptor, AddThirtyServiceAdaptorImplNode>(
+                    w, passthrough);
+
+            auto lhs_reply = wire<AddTwentyServiceAdaptor>(
+                w, transformed, lhs_request);
+            auto rhs_reply = wire<AddTwentyServiceAdaptor>(
+                w, transformed, rhs_request);
+            auto direct_reply = wire<AddTwentyServiceAdaptor>(
+                w, passthrough, direct_request);
+            return wire<stdlib::add_>(
+                w,
+                wire<stdlib::add_>(w, lhs_reply, rhs_reply).as<TS<Int>>(),
+                direct_reply).as<TS<Int>>();
+        }
+    };
+
     struct ServiceAdaptorSingleClientGraph
     {
         [[maybe_unused]] static constexpr auto name = "service_adaptor_single_client_graph";
@@ -3211,6 +3246,16 @@ TEST_CASE("service wiring: service adaptors collect multiple client requests")
 
     CHECK_OUTPUT(eval_node<ServiceAdaptorTwoClientGraph>(values<Int>(1), values<Int>(10)),
                  values<Int>(51));
+}
+
+TEST_CASE("service wiring: qualified adaptor paths separate scalar configurations")
+{
+    hgraph::stdlib::register_standard_operators();
+
+    CHECK_OUTPUT(
+        eval_node<ServiceAdaptorParameterizedClientGraph>(
+            values<Int>(1), values<Int>(10), values<Int>(100)),
+        values<Int>(181));
 }
 
 TEST_CASE("service wiring: a dynamically started adaptor branch hands off on the next cycle")

--- a/tools/parity/catalog.py
+++ b/tools/parity/catalog.py
@@ -1218,6 +1218,62 @@ def _service_adaptor_roundtrip(hg, recipe):
     )
 
 
+def _service_adaptor_parameterized_clients(hg, recipe):
+    from hgraph.test import eval_node
+
+    implementations = []
+
+    @hg.service_adaptor
+    def routed(
+        path: str, passthrough: bool, value: hg.TS[int],
+    ) -> hg.TS[int]: ...
+
+    @hg.service_adaptor_impl(interfaces=routed)
+    def routed_impl(
+        path: str,
+        passthrough: bool,
+        value: hg.TSD[int, hg.TS[int]],
+    ) -> hg.TSD[int, hg.TS[int]]:
+        implementations.append((path, passthrough))
+        delayed = hg.feedback(hg.TSD[int, hg.TS[int]])
+        delayed(value)
+        return hg.map_(
+            lambda item: item if passthrough else item + 1,
+            delayed(),
+        )
+
+    @hg.graph
+    def parity_graph(
+        values: hg.TSD[int, hg.TS[int]],
+        direct: hg.TS[int],
+        trigger: hg.TS[int],
+    ) -> hg.TSL[hg.TS[int], hg.Size[3]]:
+        hg.register_adaptor("shared", routed_impl)
+        mapped = hg.map_(
+            lambda item: routed("shared", False, item),
+            values,
+        )
+        separate = routed("shared", True, direct)
+        return hg.sample(
+            trigger, hg.combine(mapped[0], mapped[1], separate))
+
+    inputs = decoded_inputs(hg, recipe)
+    trace = eval_node(
+        parity_graph,
+        inputs["values"],
+        inputs["direct"],
+        inputs["trigger"],
+        __end_time__=hg.MIN_ST + (recipe.tick_count + 4) * hg.MIN_TD,
+    )
+    return {
+        "trace": trace,
+        "implementations": [
+            {"path": path, "passthrough": passthrough}
+            for path, passthrough in sorted(implementations)
+        ],
+    }
+
+
 def _context_switch(hg, recipe):
     from hgraph.test import eval_node
 
@@ -1705,6 +1761,25 @@ CATALOG = {
         operators=("add_", "getitem_", "map_"),
         execute=_service_adaptor_roundtrip,
     ),
+    "service_adaptor_parameterized_clients": TemplateSpec(
+        name="service_adaptor_parameterized_clients",
+        required_inputs=("values", "direct", "trigger"),
+        features=(
+            "shape:TS",
+            "shape:TSD",
+            "shape:TSL",
+            "framework:adaptor",
+            "adaptor:service",
+            "adaptor:multi-client",
+            "configuration:scalar",
+            "implementation:path-injection",
+            "topology:map",
+            "topology:feedback",
+            "lifecycle:multi-cycle",
+        ),
+        operators=("add_", "combine", "feedback", "map_", "sample"),
+        execute=_service_adaptor_parameterized_clients,
+    ),
     "context_switch": TemplateSpec(
         name="context_switch",
         required_inputs=("selector", "value", "offset"),
@@ -2029,6 +2104,10 @@ def validate_recipe(recipe):
         _validate_bounded_int_parameter(
             recipe, "increment", 1, minimum=-20, maximum=20
         )
+    elif recipe.template == "service_adaptor_parameterized_clients":
+        if recipe.parameters:
+            raise RecipeError(
+                "service_adaptor_parameterized_clients takes no parameters")
     elif recipe.template == "operator_pipeline":
         if not isinstance(
             recipe.parameters.get("format_ref", False), bool

--- a/tools/parity/corpus/service-adaptor-parameterized-clients.json
+++ b/tools/parity/corpus/service-adaptor-parameterized-clients.json
@@ -1,0 +1,30 @@
+{
+  "schema_version": 1,
+  "id": "service-adaptor-parameterized-clients",
+  "description": "Two mapped clients share one scalar-qualified service-adaptor implementation while a different scalar configuration materializes a separate implementation at the same logical path.",
+  "template": "service_adaptor_parameterized_clients",
+  "inputs": {
+    "values": [
+      {"$map": [[0, 1], [1, 10]]},
+      {"$map": [[0, 2], [1, 20]]},
+      null,
+      null
+    ],
+    "direct": [100, 200, null, null],
+    "trigger": [null, null, null, 1]
+  },
+  "parameters": {},
+  "features": [
+    "adaptor:multi-client",
+    "adaptor:service",
+    "configuration:scalar",
+    "framework:adaptor",
+    "implementation:path-injection",
+    "lifecycle:multi-cycle",
+    "shape:TS",
+    "shape:TSD",
+    "shape:TSL",
+    "topology:feedback",
+    "topology:map"
+  ]
+}


### PR DESCRIPTION
## Summary

- materialize one native service-adaptor path per distinct wiring-time scalar configuration
- reuse the native implementation when clients at the same logical path have equal scalar options
- preserve the logical path and scalar values exposed to Python implementations
- add equivalent explicit C++ path coverage and a deterministic differential parity recipe

## Why

Released hgraph permits multiple clients at one logical service-adaptor path to use different scalar options. hg_cpp previously applied the ordinary cross-client agreement rule and rejected that valid user API. The upstream asynchronous XFAIL is not a reliable ordering oracle even on released hgraph, so this change validates the supported contract with a constructed sampling tick while leaving that direct audit case classified as reference-unverified.

## User impact

Existing service and plain-adaptor agreement behavior is unchanged. Multi-client service adaptors now match hgraph: equal configurations share an implementation, while differing configurations create separate native implementations without exposing the internal qualified path to user code.

## Validation

- macOS native suite: 1,457 passed
- macOS Python 3.14 stable-ABI wheel suite: 1,948 passed, 10 skipped
- GCC 14.2 Linux native suite: 1,457 passed
- GCC 14.2 Linux Python 3.14 stable-ABI wheel suite: 1,948 passed, 10 skipped
- strict Sphinx build with warnings as errors
- exact differential replay against hgraph 0.5.36
- rebased parity validation: 60 recipes valid; 61 parity/conformance tests passed