### PR TITLE
Audit hgraph compatibility and stop failed Kafka consumers

### DIFF
--- a/docs/source/developer_guide/parity_matrix.rst
+++ b/docs/source/developer_guide/parity_matrix.rst
@@ -210,9 +210,9 @@ authoring gaps, both fixed without changing native execution: anonymous
 ``compound_scalar(...)`` schemas once again allow omitted fields and retain
 ``to_dict``/``from_dict``, and ``with_columns[RowSchema](...)`` lowers that
 released shorthand to the native ``TS[Frame[RowSchema]]`` output constraint.
-Against released hgraph 0.5.36, the resulting 1,862-test audit records 1,092
-exact matches, 765 evidence-backed conversions, 5 reference-unverified
-tests, and no review-required, confirmed-gap, or ambiguous outcomes.
+Against released hgraph 0.5.36, the resulting 1,862-test audit records 1,096
+exact matches, 765 evidence-backed conversions, one reference-unverified
+test, and no review-required, confirmed-gap, or ambiguous outcomes.
 
 The 2026-08-05 evidence-frontier refresh installs Pydantic in both audit
 environments, where the unchanged public compound-scalar case passes on both
@@ -235,11 +235,13 @@ instant, zone, and resolved-zoned types.  The bridge now rejects every
 timezone-bearing standalone ``time`` at both inferred and typed graph ingress
 instead of silently losing a ``ZoneInfo`` whose offset needs a date.
 
-Four stable cases remain without executable reference evidence: the upstream
-multi-client adaptor XFAIL and skipped nested-graph, Kafka, and inspector
-cases.  The latest audit reports five because the already-documented
-real-time scheduler test failed in the reference engine during that run;
-the controller deliberately does not retry ordinary reference failures.
+One stable case remains without executable reference evidence: the upstream
+multi-client adaptor XFAIL.  The skipped generic ``nested_graph`` body is an
+explicit non-requirement, while the skipped Kafka wiring sketch and former
+inspector skip now have deterministic public Python and native C++ evidence.
+The controller deliberately leaves the adaptor XFAIL unclassified because it
+still fails when replayed in isolation and therefore cannot serve as an
+expected-behaviour oracle.
 
 The upstream multi-client service-adaptor XFAIL remains in that direct-audit
 residue: its real-time assertion still fails in isolated released-hgraph runs
@@ -271,9 +273,11 @@ design decisions, not unimplemented user behaviour:
   the private Python ``InputsKey`` cache is likewise replaced by the native
   structural interning key, which compares producer identity, paths, input
   shape, and native scalar values without invoking overloaded port equality;
-- Kafka tests inject consumers through the public ``consumer_factory`` option,
-  and websocket behavior is covered without the upstream module's broad
-  optional-import guard;
+- Kafka tests inject consumers through the public ``consumer_factory`` option.
+  They cover replay/live isolation for both wiring orders, exact recovery
+  handover, and graph shutdown after consumer-thread failure through a native
+  push boundary; websocket behavior is covered without the upstream module's
+  broad optional-import guard;
 - ``cleanup_on_error=False`` defers stop only while the raised exception owns
   the failed executor; releasing it performs mandatory final teardown; and
 - Arrow stop-hook errors cross the native exception boundary, explicit nodes

--- a/python/hgraph/adaptors/kafka/_impl.py
+++ b/python/hgraph/adaptors/kafka/_impl.py
@@ -94,6 +94,8 @@ class _ConsumerSession:
         self.consumer = None
         self.topic_partitions = ()
         self.sender = None
+        self.failure_sender = None
+        self.pending_failure = None
         self.thread = None
         self.stop_event = threading.Event()
         self.start_requested = False
@@ -132,6 +134,23 @@ class _ConsumerSession:
         if launch:
             self._launch()
 
+    def attach_failure_sender(self, sender):
+        with self.lock:
+            self.failure_sender = sender
+            pending = self.pending_failure
+            self.pending_failure = None
+        if pending is not None:
+            sender(pending)
+
+    def _report_failure(self, error):
+        message = f"{type(error).__name__}: {error}"
+        with self.lock:
+            sender = self.failure_sender
+            if sender is None:
+                self.pending_failure = message
+                return
+        sender(message)
+
     def request_start(self):
         with self.lock:
             self.start_requested = True
@@ -164,9 +183,16 @@ class _ConsumerSession:
                     if self.stop_event.is_set():
                         break
                     self.sender(_record_to_kafka_message(record))
-        except BaseException:
+        except BaseException as error:
             logger.exception(
                 "Failure occurred while reading Kafka topic %s", self.topic)
+            try:
+                self._report_failure(error)
+            except BaseException:
+                logger.exception(
+                    "Failed to report the Kafka consumer failure for topic %s",
+                    self.topic,
+                )
         finally:
             self._close_consumer()
 
@@ -391,6 +417,18 @@ def _message_subscriber_queue(sender, *, session: object):
     session.attach_sender(sender)
 
 
+@push_queue(TS[str])
+def _consumer_failure_queue(sender, *, session: object):
+    session.attach_failure_sender(sender)
+
+
+@sink_node
+def _stop_on_consumer_failure(
+        failure: TS[str], _api: EvaluationEngineApi = None):
+    logger.error("Kafka consumer stopped: %s", failure.value)
+    _api.request_engine_stop()
+
+
 @sink_node
 def _start_realtime_message_subscriber(
         start_real_time_service: TS[bool], session: object):
@@ -415,6 +453,8 @@ def _message_subscriber_impl(path: str, topic: str):
     state = KafkaMessageState.instance()
     session = state.consumer_session(topic)
     _consumer_lifetime(const(True, tp=TS[bool]), session=session)
+    _stop_on_consumer_failure(
+        _consumer_failure_queue(session=session))
 
     if topic in state.history_subscribers:
         historical = _message_subscriber_history_aggregator(session=session)

--- a/python/tests/adaptors/kafka/test_kafka_api.py
+++ b/python/tests/adaptors/kafka/test_kafka_api.py
@@ -5,6 +5,7 @@ from datetime import UTC, timedelta
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
+import pytest
 from frozendict import frozendict
 
 import hgraph as hg
@@ -521,6 +522,123 @@ def test_replay_aware_publisher_republishes_history_and_closes_history_consumer(
 
     producer.send.assert_called_once_with("test", b"history")
     assert consumer.close_count == 1
+
+
+@pytest.mark.parametrize("subscriber_replays", [False, True])
+@pytest.mark.parametrize("subscriber_first", [False, True])
+def test_recovering_publisher_shares_topic_without_crossing_recovery_boundary(
+        subscriber_replays, subscriber_first):
+    """The upstream Kafka refactor found two silent sharing failures.
+
+    A subscriber that did not request recovery could receive history requested
+    by another client, while a recovering publisher could receive its own live
+    continuation. Exercise both subscriber contracts in both wiring orders;
+    hg_cpp keeps the streams separate inside one multi-interface service, but
+    must preserve the same externally visible handover.
+    """
+    start_time = hg.utc_now() - timedelta(milliseconds=100)
+    start_ms = int(start_time.replace(tzinfo=UTC).timestamp() * 1000)
+    consumer = _Consumer(
+        [
+            {0: [_record(b"history", start_ms + 10, offset=0)]},
+            {0: [_record(b"live", start_ms + 120, offset=1)]},
+        ],
+        partitions=(0,),
+        start_offsets={0: 0},
+        end_offsets={0: 1},
+    )
+    producer = MagicMock()
+    subscriber_values = []
+
+    @hg.sink_node
+    def capture_and_stop(
+            msg: hg.TS[bytes], _engine: hg.EvaluationEngineApi = None):
+        subscriber_values.append(msg.value)
+        if msg.value == b"live":
+            _engine.request_engine_stop()
+
+    if subscriber_replays:
+        @message_subscriber(topic="test")
+        def subscriber(msg: hg.TS[bytes], recovered: hg.TS[bool]):
+            capture_and_stop(msg)
+    else:
+        @message_subscriber(topic="test")
+        def subscriber(msg: hg.TS[bytes]):
+            capture_and_stop(msg)
+
+    @message_publisher(topic="test")
+    def publisher(
+            msg: hg.TS[bytes], recovered: hg.TS[bool]) -> hg.TS[bytes]:
+        return msg
+
+    @hg.graph
+    def app():
+        register_kafka_adaptor({
+            "consumer_factory": lambda **opts: consumer,
+            "producer": producer,
+        })
+        if subscriber_first:
+            subscriber()
+            publisher()
+        else:
+            publisher()
+            subscriber()
+
+    with hg.GlobalContext(hg.GlobalState()):
+        hg.run_graph(
+            app,
+            run_mode=hg.EvaluationMode.REAL_TIME,
+            start_time=start_time,
+            end_time=hg.utc_now() + timedelta(seconds=5),
+        )
+
+    assert subscriber_values == (
+        [b"history", b"live"] if subscriber_replays else [b"live"])
+    producer.send.assert_called_once_with("test", b"history")
+    assert consumer.close_count == 1
+
+
+def test_consumer_failure_stops_the_graph_through_the_push_boundary(caplog):
+    """A broker failure must not leave a graph running on a dead feed.
+
+    The consumer thread reports through a push source; only the graph-thread
+    sink touches ``EvaluationEngineApi``. This keeps the runtime ownership
+    boundary explicit while matching upstream's stop-on-consumer-failure
+    behavior.
+    """
+
+    class FailingConsumer(_Consumer):
+        def __init__(self):
+            super().__init__([], partitions=(0,))
+
+        def poll(self, **kwargs):
+            del kwargs
+            raise RuntimeError("broker gone")
+
+    consumer = FailingConsumer()
+
+    @message_subscriber(topic="test")
+    def subscriber(msg: hg.TS[bytes]):
+        pass
+
+    @hg.graph
+    def app():
+        register_kafka_adaptor({
+            "consumer_factory": lambda **opts: consumer,
+        })
+        subscriber()
+
+    started = time.monotonic()
+    with hg.GlobalContext(hg.GlobalState()):
+        hg.run_graph(
+            app,
+            run_mode=hg.EvaluationMode.REAL_TIME,
+            end_time=hg.utc_now() + timedelta(seconds=5),
+        )
+
+    assert time.monotonic() - started < 2.0
+    assert consumer.close_count == 1
+    assert "RuntimeError: broker gone" in caplog.text
 
 
 def test_replay_parameters_are_required_together_and_typed():

--- a/tools/parity/upstream_conformance.json
+++ b/tools/parity/upstream_conformance.json
@@ -815,6 +815,23 @@
       ]
     },
     {
+      "id": "wiring-generic-nested-graph-skipped-nonrequirement",
+      "match": "hgraph_unit_tests/_wiring/test_nested_graph.py::test_nested_graph",
+      "classification": "converted",
+      "reference_outcomes": ["skipped"],
+      "candidate_outcomes": ["collection-error"],
+      "diagnostic_regex": "cannot import name 'nested_graph'",
+      "reference_diagnostic_regex": "Skipped: A node with no inputs or outputs gets dropped",
+      "reason": "The released reference skips this body before exercising behavior, and generic Python nested_graph is explicitly outside the compatibility contract. Native nested_ and the registered higher-order operators retain the required internal child-graph construction paths.",
+      "decision": "docs/source/developer_guide/parity_matrix.rst",
+      "review_date": "2026-08-06",
+      "evidence": [
+        "tests/cpp/test_nested_wiring.cpp",
+        "tests/cpp/test_map.cpp",
+        "tests/cpp/test_mesh.cpp"
+      ]
+    },
+    {
       "id": "wiring-generic-nested-graph-expected-change",
       "match": "hgraph_unit_tests/_wiring/test_nested_graph.py::*",
       "classification": "expected-change",
@@ -1181,6 +1198,22 @@
       ]
     },
     {
+      "id": "adaptors-kafka-skipped-subscriber-converted",
+      "match": "hgraph_unit_tests/adaptors/kafka/test_kafka_api.py::test_subscriber",
+      "classification": "converted",
+      "reference_outcomes": ["skipped"],
+      "candidate_outcomes": ["skipped"],
+      "diagnostic_regex": "Skipped: Not patched yet",
+      "reference_diagnostic_regex": "Skipped: Not patched yet",
+      "reason": "The released test is an unexecuted wiring sketch rather than reference evidence. Deterministic public tests cover subscriber signatures, replay/live separation, shared-topic wiring order, recovery handover, consumer failure, and multi-interface native service composition.",
+      "decision": "docs/source/developer_guide/parity_matrix.rst",
+      "review_date": "2026-08-06",
+      "evidence": [
+        "python/tests/adaptors/kafka/test_kafka_api.py",
+        "tests/cpp/test_service_wiring.cpp"
+      ]
+    },
+    {
       "id": "adaptors-run-graph-on-thread-cycle-converted",
       "match": "hgraph_unit_tests/adaptors/run_graph_on_thread/test_run_graph_on_thread.py::test_run_graph_on_thread_*_mode",
       "classification": "converted",
@@ -1214,7 +1247,7 @@
       "match": "hgraph_unit_tests/arrow/test_arrow.py::test_assert_too_many_args",
       "classification": "converted",
       "candidate_outcomes": ["failed"],
-      "diagnostic_regex": "RuntimeError: node.*'_assert'.*stop failed:.*AssertionError: Expected 2 values but got 1 results",
+      "diagnostic_regex": "RuntimeError: node.*_assert.*stop failed:.*AssertionError: Expected 2 values but got 1 results",
       "reason": "The assertion behavior is retained, but a Python stop-hook exception crossing the native node boundary is surfaced as NodeException/RuntimeError with the original AssertionError preserved in its diagnostic.",
       "decision": "docs/source/developer_guide/parity_matrix.rst",
       "review_date": "2026-08-05",


### PR DESCRIPTION
## Summary

- stop a running graph when its Kafka consumer thread fails, reporting the failure through a push-source boundary so only the graph thread touches `EvaluationEngineApi`
- validate replay/live separation, recovery handover, and both subscriber/publisher wiring orders for a shared topic
- refresh the released-hgraph conformance audit and evidence rules

## Root cause

The Kafka consumer loop logged broker failures and closed the consumer, but did not notify the graph. A real-time graph could therefore remain alive while its feed was permanently dead. The upstream Kafka changes also exposed replay/live sharing permutations that were not previously pinned in hg_cpp.

hg_cpp already uses a single consumer session with snapshot offsets and an exact replay-to-live handover. This PR retains that design and adds only the missing failure path through the runtime's push boundary.

## User impact

Kafka graphs stop promptly after a consumer failure instead of silently running without data. Existing publisher/subscriber APIs and valid replay behavior are unchanged.

The released hgraph 0.5.36 audit now records 1,096 exact matches, 765 evidence-backed conversions, no review-required or confirmed gaps, and one deliberately unclassified upstream XFAIL that also fails in isolated reference execution.

## Validation

- macOS: 1,468/1,468 native C++ tests
- macOS Python 3.14 stable-ABI wheel: 1,981 passed, 9 skipped
- GCC 14 Linux: 1,468/1,468 native C++ tests
- GCC 14 Linux Python 3.14 stable-ABI wheel with Polars rtcompat: 1,981 passed, 9 skipped
- parity harness: 41 passed
- parity recipes: 60 validated
- bounded full released-hgraph conformance audit: 1,862 tests, zero review-required or confirmed gaps