### PR TITLE
Centralize wiring resolver semantics

### DIFF
--- a/include/hgraph/types/operator_type_resolution.h
+++ b/include/hgraph/types/operator_type_resolution.h
@@ -305,14 +305,15 @@ namespace hgraph::operator_type_resolution
     /** True when ``resolution`` already carries the erased graph-output binding. */
     [[nodiscard]] inline bool output_bound(const ResolutionMap &resolution) noexcept
     {
-        return output_schema(resolution) != nullptr;
+        return resolution.is_resolved<ResolutionKind::TimeSeries>("__out__");
     }
 
     /** True when a local output type variable such as ``O`` is already bound. */
     [[nodiscard]] inline bool local_output_bound(const ResolutionMap &resolution,
                                                  std::string_view     local_var) noexcept
     {
-        return !local_var.empty() && resolution.find_ts(local_var) != nullptr;
+        return !local_var.empty() &&
+               resolution.is_resolved<ResolutionKind::TimeSeries>(local_var);
     }
 
     /** Bind ``name`` only when ``schema`` is non-null and the name is still unbound. */
@@ -320,7 +321,11 @@ namespace hgraph::operator_type_resolution
                                 std::string_view name,
                                 const TSValueTypeMetaData *schema)
     {
-        if (schema != nullptr && resolution.find_ts(name) == nullptr) { resolution.bind_ts(name, schema); }
+        if (schema != nullptr &&
+            !resolution.is_resolved<ResolutionKind::TimeSeries>(name))
+        {
+            resolution.bind_ts(name, schema);
+        }
     }
 
     /**

--- a/include/hgraph/types/type_resolution.h
+++ b/include/hgraph/types/type_resolution.h
@@ -19,6 +19,15 @@
 
 namespace hgraph
 {
+    /** The three disjoint binding stores carried by ``ResolutionMap``. */
+    enum class ResolutionKind
+    {
+        TimeSeries,
+        Scalar,
+        Size,
+        Any
+    };
+
     /**
      * Wiring-time resolution of type variables (``TsVar`` / ``ScalarVar``) to concrete
      * registry metadata. A generic node is authored once over deferred schemas; at the
@@ -36,6 +45,39 @@ namespace hgraph
         std::unordered_map<std::string, const TSValueTypeMetaData *> ts_vars;
         std::unordered_map<std::string, const ValueTypeMetaData *>   scalar_vars;
         std::unordered_map<std::string, std::size_t>                 size_vars;
+
+        /**
+         * Whether ``name`` already has a concrete wiring-time resolution.
+         *
+         * Keep the store-specific distinction here, rather than making each
+         * resolver front end repeat three subtly different lookups. Dynamic
+         * authoring bridges normally use ``Any`` because a resolver target's
+         * kind is determined by the value it returns; typed C++ wiring can ask
+         * for the exact store at compile time.
+         */
+        template <ResolutionKind Kind = ResolutionKind::Any>
+        [[nodiscard]] bool is_resolved(std::string_view name) const
+        {
+            if constexpr (Kind == ResolutionKind::TimeSeries)
+            {
+                return ts_vars.contains(std::string{name});
+            }
+            else if constexpr (Kind == ResolutionKind::Scalar)
+            {
+                return scalar_vars.contains(std::string{name});
+            }
+            else if constexpr (Kind == ResolutionKind::Size)
+            {
+                return size_vars.contains(std::string{name});
+            }
+            else
+            {
+                static_assert(Kind == ResolutionKind::Any);
+                return is_resolved<ResolutionKind::TimeSeries>(name) ||
+                       is_resolved<ResolutionKind::Scalar>(name) ||
+                       is_resolved<ResolutionKind::Size>(name);
+            }
+        }
 
         /** Bind time-series variable ``name``; re-binding to a different meta is an error. */
         void bind_ts(std::string_view name, const TSValueTypeMetaData *meta)

--- a/python/hgraph/_wiring/__init__.py
+++ b/python/hgraph/_wiring/__init__.py
@@ -29,8 +29,11 @@ from ._core import (
     _port_getattr, _port_getitem, _port_iter, _port_keys, _port_len, _port_reduce,
     _published_contexts, _resolve_context, _unwrap, _wiring_stack, operator_function, wire
 )
+from ._resolution import (
+    _BindingsMap, _apply_resolvers, _bind_resolution, _invoke_resolution_callable
+)
 from ._operator import (
-    _BindingsMap, _DISPATCH_KEYS_NODE, _DISPATCH_KEY_NODE, _Dispatch, _Operator,
+    _DISPATCH_KEYS_NODE, _DISPATCH_KEY_NODE, _Dispatch, _Operator,
     _declared_dispatch_class, _declared_dispatch_classes, _dispatch_branch, _dispatch_key_node,
     _dispatch_keys_node, _dispatch_specificity, _overload_registry_name,
     _overload_wire_trampoline, _register_overload, _requires_bridge, _run_requires, dispatch,
@@ -76,7 +79,7 @@ __all__ = [
     "_RecordReplayModes", "_RecordableStateExpr", "_RecordableStateMarker", "_Removed",
     "_ResolvedSize", "_ServiceAdaptorStub", "_ServiceImpl", "_ServiceInputs", "_ServiceStub",
     "_SetDelta", "_TSW_KIND", "_TsExprFor", "_TsOutMarker", "_UNBOUNDED_TUPLE_KIND",
-    "_annotation_ts_kind", "_as_wired", "_bind_registered_impl", "_bind_switch_scalar_args",
+    "_annotation_ts_kind", "_apply_resolvers", "_as_wired", "_bind_registered_impl", "_bind_resolution", "_bind_switch_scalar_args",
     "_combine_compound_scalars", "_context_name_of", "_current_wiring",
     "_declared_dispatch_class", "_declared_dispatch_classes", "_dispatch_branch",
     "_dispatch_key_node", "_dispatch_keys_node", "_dispatch_specificity",
@@ -85,7 +88,7 @@ __all__ = [
     "_enter_runtime", "_exit_runtime", "_overload_wire_trampoline", "_port_enter", "_port_exit",
     "_port_getattr", "_port_getitem", "_port_iter", "_port_keys", "_port_len", "_port_reduce",
     "_published_contexts", "_register_overload",
-    "_requires_bridge", "_resolve_context", "_resolve_requested_target", "_run_requires",
+    "_invoke_resolution_callable", "_requires_bridge", "_resolve_context", "_resolve_requested_target", "_run_requires",
     "_simplify_delta", "_times_for", "_tsw_kind", "_type_pattern_for_target",
     "_unbounded_tuple_kind", "_unwrap", "_wiring_stack", "_wrap_graph_fn", "adaptor",
     "adaptor_impl", "cast_", "collect", "combine", "comparison_summary", "component",

--- a/python/hgraph/_wiring/_graph.py
+++ b/python/hgraph/_wiring/_graph.py
@@ -12,6 +12,7 @@ from ._markers import _INJECTABLE_MARKERS
 from ._node import (_PyNode, _is_time_series_annotation,
                     _lift_time_series_argument, _warn_deprecated)
 from ._operator import _register_overload, _run_requires
+from ._resolution import _apply_resolvers
 from ._state import GlobalState
 
 def _wrap_graph_fn(gfn, *, input_names=None, scalar_bindings=None):
@@ -269,12 +270,7 @@ def _graph_auto_resolve(signature, arguments, resolvers=None, requires=None,
         name: value for name, value in arguments.items()
         if not isinstance(value, WiringPort)
     }
-    if resolvers:
-        for sentinel, resolver in resolvers.items():
-            params = list(inspect.signature(resolver, eval_str=True).parameters)
-            call = {name: scalar_values.get(name) for name in params[1:]}
-            _PyNode._bind_resolved(
-                scope, _type_var_name(sentinel), resolver(scope.bindings, **call))
+    _apply_resolvers(scope, resolvers, scalar_values)
     if requires is not None:
         verdict = _run_requires(requires, scope.bindings, scalar_values)
         if verdict is not True:

--- a/python/hgraph/_wiring/_node.py
+++ b/python/hgraph/_wiring/_node.py
@@ -18,6 +18,8 @@ from ._markers import (LOGGER, STATE, _INJECTABLE_MARKERS, _MISSING,
                        _RecordableStateExpr, _StateExpr, _annotation_ts_kind,
                        _is_object_vt, _tsw_kind, _unbounded_tuple_kind)
 from ._operator import _register_overload, _run_requires
+from ._resolution import (_apply_resolvers as _apply_wiring_resolvers,
+                          _bind_resolution, _invoke_resolution_callable)
 from ._state import (GlobalState, _GRAPH_LOGGER_FORMATTER_KEY,
                      _GRAPH_LOGGER_KEY)
 
@@ -275,24 +277,13 @@ class _PyNode:
         """Seed a pinned/resolved type variable into the C++ scope: a ts
         expression binds the ts var, a fixed-size value binds the size var,
         and a python scalar type binds the scalar var of the same name."""
-        from .._types import _TsExpr, _value_type
-
-        if isinstance(resolved, _TsExpr):
-            scope.bind_ts(name, resolved.handle)
-        elif isinstance(resolved, _hgraph.TsType):
-            scope.bind_ts(name, resolved)
-        elif isinstance(resolved, int) and not isinstance(resolved, bool):
-            scope.bind_size(name, resolved)
-        else:
-            scope.bind_scalar(name, _value_type(resolved))
+        _bind_resolution(scope, name, resolved)
 
     @staticmethod
     def _eval_policy(policy, fn, scope, scalar_values):
         """Evaluate a wiring-time active=/valid= callable: (m, **scalars) ->
         None (all inputs) / iterable of input names."""
-        params = list(inspect.signature(fn, eval_str=True).parameters)
-        call = {name: scalar_values.get(name) for name in params[1:]}
-        result = fn(scope.bindings, **call)
+        result = _invoke_resolution_callable(fn, scope.bindings, scalar_values)
         if result is None:
             return None
         return frozenset(result)
@@ -418,12 +409,7 @@ class _PyNode:
     def _apply_resolvers(self, scope, scalar_values):
         """resolvers={TYPEVAR: lambda mapping, <scalars...>: type}: bind the
         computed types into the scope (mapping = the scope's bindings)."""
-        for sentinel, resolver in self._resolvers.items():
-            params = list(inspect.signature(resolver, eval_str=True).parameters)
-            call = {name: scalar_values.get(name) for name in params[1:]}
-            resolved = resolver(scope.bindings, **call)
-            name = _type_var_name(sentinel)
-            self._bind_resolved(scope, name, resolved)
+        _apply_wiring_resolvers(scope, self._resolvers, scalar_values)
 
     @staticmethod
     def _resolve_recordable_state(annotation, scope):
@@ -1021,12 +1007,7 @@ class _Generator:
         bound_call.apply_defaults()
         scalar_values = dict(bound_call.arguments)
         scope = _hgraph.ResolutionScope()
-        if self._resolvers:
-            for name, resolver in self._resolvers.items():
-                params = list(inspect.signature(resolver, eval_str=True).parameters)
-                call = {key: scalar_values.get(key) for key in params[1:]}
-                _PyNode._bind_resolved(
-                    scope, _type_var_name(name), resolver(scope.bindings, **call))
+        _apply_wiring_resolvers(scope, self._resolvers, scalar_values)
         if self._requires is not None:
             verdict = _run_requires(self._requires, scope.bindings, scalar_values)
             if verdict is not True:
@@ -1148,12 +1129,7 @@ class _PushQueue:
         bound_call.apply_defaults()
         scalar_values = dict(bound_call.arguments)
         scope = _hgraph.ResolutionScope()
-        if self._resolvers:
-            for name, resolver in self._resolvers.items():
-                params = list(inspect.signature(resolver, eval_str=True).parameters)
-                call = {key: scalar_values.get(key) for key in params[1:]}
-                _PyNode._bind_resolved(
-                    scope, _type_var_name(name), resolver(scope.bindings, **call))
+        _apply_wiring_resolvers(scope, self._resolvers, scalar_values)
         if self._requires is not None:
             verdict = _run_requires(self._requires, scope.bindings, scalar_values)
             if verdict is not True:

--- a/python/hgraph/_wiring/_operator.py
+++ b/python/hgraph/_wiring/_operator.py
@@ -12,6 +12,8 @@ from ._core import (WiringError, WiringPort, _OperatorFunction, _unwrap,
                     _wiring_stack, wire)
 from ._markers import (LOGGER, _INJECTABLE_MARKERS, _RecordableStateExpr,
                        _StateExpr, _is_object_vt)
+from ._resolution import (_BindingsMap, _apply_resolvers,
+                          _invoke_resolution_callable)
 
 
 def _is_hidden_node_parameter(parameter):
@@ -105,39 +107,16 @@ def _overload_registry_name(target):
     raise TypeError(f"overloads= target {target!r} is not an @operator or a registered operator")
 
 
-class _BindingsMap:
-    """The ``m`` argument of hgraph's ``requires=``/resolver lambdas: the
-    resolution scope's bindings, keyed by TYPE VARIABLE (or its name)."""
-
-    __slots__ = ("_bindings",)
-
-    def __init__(self, bindings):
-        self._bindings = bindings
-
-    def __getitem__(self, key):
-        return self._bindings[_type_var_name(key)]
-
-    def __contains__(self, key):
-        return _type_var_name(key) in self._bindings
-
-    def get(self, key, default=None):
-        return self._bindings.get(_type_var_name(key), default)
-
-    def keys(self):
-        return self._bindings.keys()
-
 def _run_requires(user_requires, bindings, scalar_values):
     """Evaluate a ``requires=lambda m[, <scalar names...>]`` predicate.
     Returns True to accept; False or an explanation string rejects."""
-    names = list(inspect.signature(user_requires).parameters)[1:]
     scalar_values = {
         name: (value._python_callable
                if isinstance(value, _hgraph.WiredFn) and value._python_callable is not None
                else value)
         for name, value in scalar_values.items()
     }
-    return user_requires(_BindingsMap(bindings),
-                         **{name: scalar_values.get(name) for name in names})
+    return _invoke_resolution_callable(user_requires, bindings, scalar_values)
 
 
 def _requires_bridge(user_requires):
@@ -165,16 +144,7 @@ def _resolvers_bridge(user_resolvers):
         return None
 
     def _resolve(scope, scalars):
-        from ._node import _PyNode
-
-        scalar_values = dict(scalars)
-        for sentinel, resolver in user_resolvers.items():
-            names = list(inspect.signature(resolver).parameters)[1:]
-            resolved = resolver(
-                scope.bindings,
-                **{name: scalar_values.get(name) for name in names},
-            )
-            _PyNode._bind_resolved(scope, _type_var_name(sentinel), resolved)
+        _apply_resolvers(scope, user_resolvers, dict(scalars))
         return scope
 
     return _resolve

--- a/python/hgraph/_wiring/_resolution.py
+++ b/python/hgraph/_wiring/_resolution.py
@@ -38,7 +38,10 @@ class _BindingsMap(Mapping):
 
 def _invoke_resolution_callable(fn, bindings, scalar_values):
     """Invoke a wiring callable as ``fn(mapping, **declared_scalars)``."""
-    parameters = list(inspect.signature(fn, eval_str=True).parameters)
+    # Resolver annotations do not participate in argument selection. Avoid
+    # evaluating postponed annotations here: a valid resolver may annotate
+    # its parameters with function-local types that are absent from globals.
+    parameters = list(inspect.signature(fn).parameters)
     scalars = dict(scalar_values or {})
     return fn(
         _BindingsMap(bindings),

--- a/python/hgraph/_wiring/_resolution.py
+++ b/python/hgraph/_wiring/_resolution.py
@@ -1,0 +1,77 @@
+"""Shared wiring-time type-resolution behavior.
+
+All Python authoring surfaces delegate resolver scheduling and result binding
+to this module. The C++ ``ResolutionMap`` remains the source of truth for
+whether a variable is already resolved and for consistent re-binding checks.
+"""
+import inspect
+from collections.abc import Mapping
+
+import _hgraph
+
+from .._types import _TsExpr, _type_var_name, _value_type
+
+
+class _BindingsMap(Mapping):
+    """Resolver/requires view keyed by either a type variable or its name."""
+
+    __slots__ = ("_bindings",)
+
+    def __init__(self, bindings):
+        self._bindings = bindings
+
+    def __getitem__(self, key):
+        return self._bindings[_type_var_name(key)]
+
+    def __contains__(self, key):
+        return _type_var_name(key) in self._bindings
+
+    def get(self, key, default=None):
+        return self._bindings.get(_type_var_name(key), default)
+
+    def __iter__(self):
+        return iter(self._bindings)
+
+    def __len__(self):
+        return len(self._bindings)
+
+
+def _invoke_resolution_callable(fn, bindings, scalar_values):
+    """Invoke a wiring callable as ``fn(mapping, **declared_scalars)``."""
+    parameters = list(inspect.signature(fn, eval_str=True).parameters)
+    scalars = dict(scalar_values or {})
+    return fn(
+        _BindingsMap(bindings),
+        **{name: scalars.get(name) for name in parameters[1:]},
+    )
+
+
+def _bind_resolution(scope, name, resolved):
+    """Bind one dynamically authored result into the native resolution map."""
+    if isinstance(resolved, _TsExpr):
+        scope.bind_ts(name, resolved.handle)
+    elif isinstance(resolved, _hgraph.TsType):
+        scope.bind_ts(name, resolved)
+    elif isinstance(resolved, int) and not isinstance(resolved, bool):
+        scope.bind_size(name, resolved)
+    else:
+        scope.bind_scalar(name, _value_type(resolved))
+
+
+def _apply_resolvers(scope, resolvers, scalar_values=None):
+    """Apply only resolvers whose target is not already resolved.
+
+    This is the common hgraph compatibility rule for nodes, graphs, operator
+    overloads, sources, services, and adaptors. A concrete Python type in a
+    resolver table is a literal resolution (not a callable resolver), matching
+    service specialization behavior.
+    """
+    for sentinel, resolver in (resolvers or {}).items():
+        name = _type_var_name(sentinel)
+        if scope.is_resolved(name):
+            continue
+        resolved = resolver if isinstance(resolver, type) else _invoke_resolution_callable(
+            resolver, scope.bindings, scalar_values
+        )
+        _bind_resolution(scope, name, resolved)
+    return scope

--- a/python/hgraph/_wiring/_services.py
+++ b/python/hgraph/_wiring/_services.py
@@ -20,6 +20,7 @@ from ._core import (
 from ._graph import _wrap_graph_fn
 from ._markers import _INJECTABLE_MARKERS
 from ._node import _PyNode, _warn_deprecated
+from ._resolution import _apply_resolvers
 
 
 _TS_ANNOTATIONS = (_TsExpr, _GenericTsExpr)
@@ -315,16 +316,7 @@ def _resolved_implementation_path(stub, path):
 def _apply_service_resolvers(resolution, resolvers):
     if resolution is None:
         resolution = _hgraph.ResolutionScope()
-    for sentinel, resolver in (resolvers or {}).items():
-        name = _type_var_name(sentinel)
-        if name in resolution.bindings:
-            continue
-        # A concrete Python type is itself callable, but in a resolver table
-        # it denotes that type. Only resolver functions consume the current
-        # bindings mapping.
-        resolved = resolver if isinstance(resolver, type) else resolver(resolution.bindings)
-        _PyNode._bind_resolved(resolution, name, resolved)
-    return resolution
+    return _apply_resolvers(resolution, resolvers)
 
 
 def _specialization_label(resolution):

--- a/python/hgraph/adaptors/data_frame/_data_frame_operators.py
+++ b/python/hgraph/adaptors/data_frame/_data_frame_operators.py
@@ -208,14 +208,29 @@ def _explicit_output_type(mapping, _tp_out):
     return _tp_out
 
 
-@graph(overloads=ungroup, resolvers={ROW_1: _explicit_output_type})
+def _explicit_output_requested(mapping, _tp_out):
+    # This adapter exists for the legacy third scalar argument. Bracket/output
+    # specialization already matches the native overload directly; selecting
+    # this adapter there would recurse back into itself.
+    return _tp_out is not AUTO_RESOLVE
+
+
+@graph(
+    overloads=ungroup,
+    resolvers={ROW_1: _explicit_output_type},
+    requires=_explicit_output_requested,
+)
 def _ungroup_typed(
     ts: TSD[KEYABLE_SCALAR, TS[Frame[ROW]]], key_col: str, _tp_out: type[ROW_1] = AUTO_RESOLVE
 ) -> TS[Frame[ROW_1]]:
     return ungroup[TS[Frame[_tp_out]]](ts, key_col)
 
 
-@graph(overloads=ungroup, resolvers={ROW_1: _explicit_output_type})
+@graph(
+    overloads=ungroup,
+    resolvers={ROW_1: _explicit_output_type},
+    requires=_explicit_output_requested,
+)
 def _ungroup_typed_tuple(
     ts: TSD[KEYABLE_SCALAR, TS[Frame[ROW]]], key_col: tuple[str, ...], _tp_out: type[ROW_1] = AUTO_RESOLVE
 ) -> TS[Frame[ROW_1]]:

--- a/python/py_type_system.cpp
+++ b/python/py_type_system.cpp
@@ -1047,6 +1047,9 @@ namespace hgraph::python_bridge
             .def("bind_size", [](PyResolutionScope &self, const std::string &name, std::size_t size) {
                 self.map.bind_size(name, size);
             })
+            .def("is_resolved", [](const PyResolutionScope &self, const std::string &name) {
+                return self.map.is_resolved(name);
+            })
             .def("find_ts",
                  [](const PyResolutionScope &self, const std::string &name) -> std::optional<PyTsType> {
                      const auto *meta = self.map.find_ts(name);

--- a/python/tests/test_signature_compatibility.py
+++ b/python/tests/test_signature_compatibility.py
@@ -280,6 +280,63 @@ def test_resolvers_only_run_for_unresolved_targets_across_wiring_surfaces():
     assert calls == []
 
 
+def test_resolution_callables_ignore_postponed_local_annotations():
+    class LocalAnnotation:
+        pass
+
+    def operator_resolver(
+            mapping: "LocalAnnotation",
+            scalar_type: "LocalAnnotation") -> "LocalAnnotation":
+        return scalar_type
+
+    def operator_requires(
+            mapping: "LocalAnnotation",
+            scalar_type: "LocalAnnotation") -> "LocalAnnotation":
+        return scalar_type is int
+
+    def service_resolver(
+            mapping: "LocalAnnotation") -> "LocalAnnotation":
+        return int
+
+    @hg.operator
+    def annotated_operator(
+            ts: hg.TS[int], scalar_type: type) -> hg.TS[hg.SCALAR]: ...
+
+    @hg.compute_node(
+        overloads=annotated_operator,
+        resolvers={hg.SCALAR: operator_resolver},
+        requires=operator_requires,
+    )
+    def annotated_operator_impl(
+            ts: hg.TS[int], scalar_type: type) -> hg.TS[hg.SCALAR]:
+        return ts.value
+
+    @hg.request_reply_service(resolvers={hg.SCALAR: service_resolver})
+    def annotated_service(request: hg.TS[int]) -> hg.TS[hg.SCALAR]: ...
+
+    @hg.service_impl(interfaces=annotated_service)
+    def annotated_service_impl(
+            requests: hg.TSD[int, hg.TS[int]],
+    ) -> hg.TSD[int, hg.TS[int]]:
+        return requests
+
+    @hg.graph
+    def operator_app(ts: hg.TS[int]) -> hg.TS[int]:
+        return annotated_operator(ts, int)
+
+    @hg.graph
+    def service_app(ts: hg.TS[int]) -> hg.TS[int]:
+        hg.register_service("annotated", annotated_service_impl)
+        return annotated_service(ts, path="annotated")
+
+    assert hg.eval_node(operator_app, [1, 2]) == [1, 2]
+    assert hg.eval_node(
+        service_app,
+        [3],
+        __end_time__=hg.MIN_ST + 4 * hg.MIN_TD,
+    ) == [None, 3]
+
+
 def test_deprecated_node_warns_at_wiring_and_node_impl_is_explicitly_rejected():
     @hg.compute_node(deprecated="use replacement")
     def old_node(ts: hg.TS[int]) -> hg.TS[int]:

--- a/python/tests/test_signature_compatibility.py
+++ b/python/tests/test_signature_compatibility.py
@@ -237,6 +237,49 @@ def test_graph_generator_and_component_resolvers():
     assert hg.eval_node(resolved_component, [1, 2], width=3) == [4, 5]
 
 
+def test_resolvers_only_run_for_unresolved_targets_across_wiring_surfaces():
+    calls = []
+
+    def unexpected(surface):
+        def resolver(mapping):
+            calls.append(surface)
+            raise AssertionError(f"{surface} resolver must not run")
+        return resolver
+
+    @hg.compute_node(resolvers={hg.SCALAR: unexpected("node inference")})
+    def inferred_node(ts: hg.TS[hg.SCALAR]) -> hg.TS[hg.SCALAR]:
+        return ts.value
+
+    @hg.compute_node(resolvers={hg.SCALAR_1: unexpected("node pin")})
+    def pinned_node(ts: hg.TS[hg.SCALAR]) -> hg.TS[hg.SCALAR_1]:
+        return str(ts.value)
+
+    @hg.graph(resolvers={hg.SCALAR: unexpected("graph")})
+    def inferred_graph(ts: hg.TS[hg.SCALAR]) -> hg.TS[hg.SCALAR]:
+        return ts
+
+    @hg.operator
+    def inferred_operator(ts: hg.TS[hg.SCALAR]) -> hg.TS[hg.SCALAR]: ...
+
+    @hg.compute_node(
+        overloads=inferred_operator,
+        resolvers={hg.SCALAR: unexpected("operator")},
+    )
+    def inferred_operator_impl(ts: hg.TS[hg.SCALAR]) -> hg.TS[hg.SCALAR]:
+        return ts.value
+
+    @hg.graph
+    def operator_graph(ts: hg.TS[int]) -> hg.TS[int]:
+        return inferred_operator(ts)
+
+    assert hg.eval_node(inferred_node, [1, 2]) == [1, 2]
+    assert hg.eval_node(
+        pinned_node[hg.SCALAR:int, hg.SCALAR_1:str], [1, 2]) == ["1", "2"]
+    assert hg.eval_node(inferred_graph, [1, 2]) == [1, 2]
+    assert hg.eval_node(operator_graph, [1, 2]) == [1, 2]
+    assert calls == []
+
+
 def test_deprecated_node_warns_at_wiring_and_node_impl_is_explicitly_rejected():
     @hg.compute_node(deprecated="use replacement")
     def old_node(ts: hg.TS[int]) -> hg.TS[int]:

--- a/tests/cpp/test_type_resolution.cpp
+++ b/tests/cpp/test_type_resolution.cpp
@@ -236,6 +236,29 @@ TEST_CASE("type_resolution: a generic node resolves its TS type from the connect
     CHECK_OUTPUT(eval_node<PassthroughGraph>(values<Int>(1, none, 3)), {1, none, 3});
 }
 
+TEST_CASE("type_resolution: resolved-variable queries share one typed contract")
+{
+    ResolutionMap resolution;
+
+    CHECK_FALSE(resolution.is_resolved("S"));
+    CHECK_FALSE(resolution.is_resolved<ResolutionKind::TimeSeries>("S"));
+    CHECK_FALSE(resolution.is_resolved<ResolutionKind::Scalar>("S"));
+    CHECK_FALSE(resolution.is_resolved<ResolutionKind::Size>("S"));
+
+    resolution.bind_ts("S", ts_type<TS<Int>>());
+    CHECK(resolution.is_resolved("S"));
+    CHECK(resolution.is_resolved<ResolutionKind::TimeSeries>("S"));
+    CHECK_FALSE(resolution.is_resolved<ResolutionKind::Scalar>("S"));
+    CHECK_FALSE(resolution.is_resolved<ResolutionKind::Size>("S"));
+
+    resolution.bind_scalar("T", scalar_descriptor<Str>::value_meta());
+    resolution.bind_size("N", 3);
+    CHECK(resolution.is_resolved<ResolutionKind::Scalar>("T"));
+    CHECK(resolution.is_resolved<ResolutionKind::Size>("N"));
+    CHECK(resolution.is_resolved("T"));
+    CHECK(resolution.is_resolved("N"));
+}
+
 TEST_CASE("type_resolution: the same generic node resolves to TSS from a set-valued port")
 {
     (void)TypeRegistry::instance().register_scalar<Int>("int");


### PR DESCRIPTION
## Summary

- add a typed `ResolutionMap::is_resolved<ResolutionKind>()` contract using `if constexpr`
- centralize Python resolver invocation, resolved-target checks, scalar argument handling, and result binding
- route nodes, graphs, operators, generators, push queues, services, and adaptors through the shared resolver path
- preserve mapping compatibility for resolver and `requires` callables
- replace `ungroup`'s implicit resolver-failure dispatch guard with an explicit `requires` predicate
- add native and Python regression coverage for inferred and explicitly pinned resolutions

Fixes #288.

## Root cause

Resolver scheduling and binding were implemented independently across the Python wiring surfaces. Most paths invoked user resolvers unconditionally even when input inference, output constraints, or explicit specialization had already resolved the target. Services had a separate resolved-target guard, so equivalent wiring constructs behaved differently.

The duplicated behavior also concealed an `ungroup` overload dependency: it relied on an unnecessary resolver call failing on `AUTO_RESOLVE` to reject a recursive adapter. The adapter now declares its actual applicability directly.

## Impact

User resolvers now match hgraph behavior: they run only when their target remains unresolved. Store-specific C++ differences remain together in one templated contract, while dynamic Python wiring uses the same native source of truth and one shared invocation pipeline.

## Validation

- `cmake --preset cpp --fresh`
- `cmake --build --preset cpp --target clean`
- `cmake --build --preset cpp --parallel`
- `ctest --preset cpp --parallel 2` — 1,469 tests passed
- stable-ABI wheel built with Python 3.12 and installed into a fresh Python 3.14 environment
- `python -m pytest python/tests -q -m "not wip"` — 1,977 passed, 9 skipped
