### PR TITLE
Add TSB and TSL dereference support

### DIFF
--- a/include/hgraph/lib/std/operators/container.h
+++ b/include/hgraph/lib/std/operators/container.h
@@ -52,6 +52,13 @@ namespace hgraph::stdlib
     struct is_empty : Operator<"is_empty", In<"ts", TsVar<"S">>, Out<TS<Bool>>>
     {
     };
+
+    /** ``dereference`` — materialize ``REF[TSB[...]]`` as a bundle whose
+        fields are references to the corresponding fields of the referenced
+        bundle. */
+    struct dereference : Operator<"dereference", In<"tsb", REF<TsVar<"S">>>, Out<TsVar<"O">>>
+    {
+    };
 }  // namespace hgraph::stdlib
 
 #endif  // HGRAPH_LIB_STD_OPERATORS_CONTAINER_H

--- a/include/hgraph/lib/std/operators/container.h
+++ b/include/hgraph/lib/std/operators/container.h
@@ -53,9 +53,9 @@ namespace hgraph::stdlib
     {
     };
 
-    /** ``dereference`` — materialize ``REF[TSB[...]]`` as a bundle whose
-        fields are references to the corresponding fields of the referenced
-        bundle. */
+    /** ``dereference`` — materialize ``REF[TSB[...]]`` or ``REF[TSL[...]]``
+        as the same container shape whose children reference the corresponding
+        children of the referenced container. */
     struct dereference : Operator<"dereference", In<"tsb", REF<TsVar<"S">>>, Out<TsVar<"O">>>
     {
     };

--- a/include/hgraph/lib/std/operators/impl/container_impl.h
+++ b/include/hgraph/lib/std/operators/impl/container_impl.h
@@ -250,6 +250,27 @@ resolve_indexed_reference_target(
   } else if (reference.is_non_peered() && index < reference.items().size()) {
     result = reference[index];
   }
+
+  const auto *actual = result.target_schema();
+  if (actual == nullptr) {
+    if (result.is_empty()) {
+      return TimeSeriesReference::empty(element_type);
+    }
+    throw std::invalid_argument(
+        std::string{operation} + ": " + std::string{subject} + " " +
+        std::string{element_kind} + " '" + std::string{element_label} +
+        "' reference has no target schema");
+  }
+
+  auto &registry = TypeRegistry::instance();
+  if (!time_series_schema_equivalent(registry.dereference(actual),
+                                     registry.dereference(element_type))) {
+    throw std::invalid_argument(
+        std::string{operation} + ": " + std::string{subject} + " " +
+        std::string{element_kind} + " '" + std::string{element_label} +
+        "' reference targets schema '" + std::string{actual->name()} +
+        "' but expected '" + std::string{element_type->name()} + "'");
+  }
   return result;
 }
 

--- a/include/hgraph/lib/std/operators/impl/container_impl.h
+++ b/include/hgraph/lib/std/operators/impl/container_impl.h
@@ -15,6 +15,8 @@
 #include <stdexcept>
 #include <string>
 #include <string_view>
+#include <utility>
+#include <vector>
 
 namespace hgraph::stdlib {
 using namespace hgraph::operator_type_resolution;
@@ -122,6 +124,123 @@ inline void resolve_tsb_field_output(ResolutionMap &resolution,
   }
   bind_output(resolution,
               tsb_field_schema_from_context<Key>(context, key_name));
+}
+
+[[nodiscard]] inline const TSValueTypeMetaData *
+materialized_tsb_reference_schema(const TSValueTypeMetaData &bundle) {
+  std::vector<std::pair<std::string, const TSValueTypeMetaData *>> fields;
+  fields.reserve(bundle.field_count());
+  auto &registry = TypeRegistry::instance();
+  for (std::size_t index = 0; index < bundle.field_count(); ++index) {
+    const TSFieldMetaData &field = bundle.fields()[index];
+    fields.emplace_back(field.name != nullptr ? field.name : "",
+                        registry.ref(field.type));
+  }
+  return registry.un_named_tsb(fields);
+}
+
+/** Resolve one field from the VALUE carried by a REF[TSB]. This is the
+    single runtime path used by both scalar field projection and the
+    all-fields dereference operator. */
+[[nodiscard]] inline TimeSeriesReference project_tsb_reference_field(
+    const TimeSeriesReference &reference,
+    const TSValueTypeMetaData &bundle,
+    std::size_t index,
+    DateTime evaluation_time,
+    std::string_view operation,
+    std::string_view field_label) {
+  if (index >= bundle.field_count()) {
+    throw std::out_of_range(std::string{operation} + ": REF[TSB] field '" +
+                            std::string{field_label} + "' is out of range");
+  }
+
+  const auto *field_type = bundle.fields()[index].type;
+  TimeSeriesReference result = TimeSeriesReference::empty(field_type);
+  if (reference.is_peered() && reference.has_output()) {
+    auto target = reference.target_output().view(evaluation_time);
+    auto slow = target.handle();
+    auto fast = slow;
+    const auto advance_forwarding = [evaluation_time](TSOutputHandle handle) {
+      if (!handle.bound()) {
+        return TSOutputHandle{};
+      }
+      auto view = handle.view(evaluation_time);
+      return view.forwarding() && view.forwarding_bound()
+                 ? view.forwarding_target()
+                 : TSOutputHandle{};
+    };
+    while (target.forwarding() && target.forwarding_bound()) {
+      target = target.forwarding_target().view(evaluation_time);
+      slow = advance_forwarding(std::move(slow));
+      fast = advance_forwarding(advance_forwarding(std::move(fast)));
+      if (slow.bound() && fast.bound() && slow.same_as(fast)) {
+        throw std::logic_error(std::string{operation} +
+                               ": REF[TSB] forwarding cycle");
+      }
+    }
+    const auto *data_schema = target.data_view().schema();
+    if (data_schema != nullptr && data_schema->kind == TSTypeKind::REF) {
+      // A descriptive-schema reference: the surface says TSB but the
+      // underlying DATA is itself a REF output (Port::as /
+      // reference-service pattern). Hop through its from-REF alternative
+      // before projecting the field.
+      const auto *deref = TypeRegistry::instance().dereference(data_schema);
+      target = target.binding_for(*deref).view(evaluation_time);
+    }
+    if (!time_series_schema_equivalent(&bundle, target.schema())) {
+      const auto owner = target.owner_node();
+      throw std::invalid_argument(
+          std::string{operation} + ": REF[TSB] requested schema '" +
+          std::string{bundle.name()} + "' but targets schema '" +
+          (target.schema() != nullptr ? std::string{target.schema()->name()}
+                                      : std::string{"<untyped>"}) +
+          "' from node '" +
+          (owner.valid() ? std::string{owner.label()}
+                         : std::string{"<unknown>"}) +
+          "' at index " +
+          (owner.valid() ? std::to_string(owner.node_index())
+                         : std::string{"<unknown>"}));
+    }
+    const auto child_count = target.data_view().indexed_child_count();
+    if (index >= child_count) {
+      throw std::out_of_range(
+          std::string{operation} + ": REF[TSB] field '" +
+          std::string{field_label} + "' has ordinal " +
+          std::to_string(index) + " in requested schema '" +
+          std::string{bundle.name()} + "', but target schema '" +
+          (target.schema() != nullptr ? std::string{target.schema()->name()}
+                                      : std::string{"<untyped>"}) +
+          "' exposes " + std::to_string(child_count) + " children");
+    }
+    try {
+      auto child = target.indexed_child_at(index);
+      if (child.bound()) {
+        result = TimeSeriesReference::peered(child);
+      }
+    } catch (const std::out_of_range &error) {
+      throw std::out_of_range(
+          std::string{operation} + ": failed to project REF[TSB] field '" +
+          std::string{field_label} + "' at ordinal " +
+          std::to_string(index) + " from requested schema '" +
+          std::string{bundle.name()} + "' through target schema '" +
+          (target.schema() != nullptr ? std::string{target.schema()->name()}
+                                      : std::string{"<untyped>"}) +
+          "': " + error.what());
+    }
+  } else if (reference.is_non_peered() && index < reference.items().size()) {
+    result = reference[index];
+  }
+  return result;
+}
+
+inline void set_reference_if_changed(const TSOutputView &out,
+                                     TimeSeriesReference reference) {
+  Value value{std::move(reference)};
+  if (out.data_view().has_current_value() && out.value().equals(value.view())) {
+    return;
+  }
+  auto mutation = out.data_view().begin_mutation(out.evaluation_time());
+  static_cast<void>(mutation.move_value_from(std::move(value)));
 }
 } // namespace container_impl_detail
 
@@ -1215,104 +1334,77 @@ struct tsb_ref_field_node {
     if (!index.has_value()) {
       return;
     }
-    const auto *field_type = bundle->fields()[*index].type;
+    const std::string field_label = [&] {
+      if constexpr (std::same_as<KeyT, Str>) {
+        return key.value();
+      } else {
+        return std::to_string(key.value());
+      }
+    }();
+    const std::string_view operation =
+        KeyName.sv() == std::string_view{"attr"} ? "getattr_" : "getitem_";
+    auto result = container_impl_detail::project_tsb_reference_field(
+        reference, *bundle, *index, erased.evaluation_time(), operation,
+        field_label);
+    container_impl_detail::set_reference_if_changed(erased,
+                                                    std::move(result));
+  }
+};
 
-    TimeSeriesReference result = TimeSeriesReference::empty(field_type);
-    if (reference.is_peered() && reference.has_output()) {
-      auto target = reference.target_output().view(erased.evaluation_time());
-      auto slow = target.handle();
-      auto fast = slow;
-      const auto advance_forwarding = [evaluation_time = erased.evaluation_time()](TSOutputHandle handle) {
-        if (!handle.bound()) {
-          return TSOutputHandle{};
-        }
-        auto view = handle.view(evaluation_time);
-        return view.forwarding() && view.forwarding_bound()
-                   ? view.forwarding_target()
-                   : TSOutputHandle{};
-      };
-      while (target.forwarding() && target.forwarding_bound()) {
-        target = target.forwarding_target().view(erased.evaluation_time());
-        slow = advance_forwarding(std::move(slow));
-        fast = advance_forwarding(advance_forwarding(std::move(fast)));
-        if (slow.bound() && fast.bound() && slow.same_as(fast)) {
-          throw std::logic_error("getattr_: REF[TSB] forwarding cycle");
-        }
-      }
-      const auto *data_schema = target.data_view().schema();
-      if (data_schema != nullptr && data_schema->kind == TSTypeKind::REF) {
-        // A descriptive-schema reference: the surface says TSB but
-        // the underlying DATA is itself a REF output (Port::as /
-        // reference-service pattern) - hop through its from-REF
-        // alternative before the field projection.
-        const auto *deref = TypeRegistry::instance().dereference(data_schema);
-        target = target.binding_for(*deref).view(erased.evaluation_time());
-      }
-      if (!time_series_schema_equivalent(bundle, target.schema())) {
-        const auto owner = target.owner_node();
-        throw std::invalid_argument(
-            std::string{"getattr_: REF[TSB] requested schema '"} +
-            std::string{bundle->name()} + "' but targets schema '" +
-            (target.schema() != nullptr ? std::string{target.schema()->name()}
-                                        : std::string{"<untyped>"}) +
-            "' from node '" +
-            (owner.valid() ? std::string{owner.label()}
-                           : std::string{"<unknown>"}) +
-            "' at index " +
-            (owner.valid() ? std::to_string(owner.node_index())
-                           : std::string{"<unknown>"}));
-      }
-      const auto child_count = target.data_view().indexed_child_count();
-      if (*index >= child_count) {
-        const std::string field_label = [&] {
-          if constexpr (std::same_as<KeyT, Str>) {
-            return key.value();
-          } else {
-            return std::to_string(key.value());
-          }
-        }();
-        throw std::out_of_range(
-            std::string{"getattr_: REF[TSB] field '"} + field_label +
-            "' has ordinal " + std::to_string(*index) +
-            " in requested schema '" + std::string{bundle->name()} +
-            "', but target schema '" +
-            (target.schema() != nullptr ? std::string{target.schema()->name()}
-                                        : std::string{"<untyped>"}) +
-            "' exposes " + std::to_string(child_count) + " children");
-      }
-      try {
-        auto child = target.indexed_child_at(*index);
-        if (child.bound()) {
-          result = TimeSeriesReference::peered(child);
-        }
-      } catch (const std::out_of_range &error) {
-        const std::string field_label = [&] {
-          if constexpr (std::same_as<KeyT, Str>) {
-            return key.value();
-          } else {
-            return std::to_string(key.value());
-          }
-        }();
-        throw std::out_of_range(
-            std::string{"getattr_: failed to project REF[TSB] field '"} +
-            field_label + "' at ordinal " + std::to_string(*index) +
-            " from requested schema '" + std::string{bundle->name()} +
-            "' through target schema '" +
-            (target.schema() != nullptr ? std::string{target.schema()->name()}
-                                        : std::string{"<untyped>"}) +
-            "': " + error.what());
-      }
-    } else if (reference.is_non_peered() && *index < reference.items().size()) {
-      result = reference[*index];
-    }
+/** Materialize REF[TSB] as a peered TSB whose children contain references to
+    the corresponding target fields. The output is intentionally an unnamed
+    schema, matching hgraph's dynamically resolved ``ts_schema`` result. */
+struct dereference_tsb_ref_node {
+  static constexpr auto name = "dereference_tsb_ref";
+  static constexpr bool schedule_on_start = true;
 
-    Value value{std::move(result)};
-    if (erased.data_view().has_current_value() &&
-        erased.value().equals(value.view())) {
+  [[nodiscard]] static const TSValueTypeMetaData *
+  bundle_schema(OperatorCallContext context) {
+    return context.args.size() == 1
+               ? container_impl_detail::ref_tsb_schema(context.args[0])
+               : nullptr;
+  }
+
+  static bool requires_(const ResolutionMap &, OperatorCallContext context) {
+    return bundle_schema(context) != nullptr;
+  }
+
+  static void resolve_default_types(ResolutionMap &resolution,
+                                    OperatorCallContext context) {
+    if (output_bound(resolution)) {
       return;
     }
-    auto mutation = erased.data_view().begin_mutation(erased.evaluation_time());
-    static_cast<void>(mutation.move_value_from(std::move(value)));
+    const auto *bundle = bundle_schema(context);
+    if (bundle != nullptr) {
+      bind_output(
+          resolution,
+          container_impl_detail::materialized_tsb_reference_schema(*bundle));
+    }
+  }
+
+  static void eval(In<"tsb", REF<TsVar<"S">>, InputValidity::Unchecked> tsb,
+                   Out<TsVar<"__out__">> out) {
+    const auto &erased = static_cast<const TSOutputView &>(out);
+    const auto *bundle = TypeRegistry::instance().dereference(tsb.base().schema());
+    if (bundle == nullptr || bundle->kind != TSTypeKind::TSB) {
+      throw std::logic_error("dereference: input is not REF[TSB]");
+    }
+    if (erased.schema() == nullptr || erased.schema()->kind != TSTypeKind::TSB ||
+        erased.schema()->field_count() != bundle->field_count()) {
+      throw std::logic_error("dereference: resolved output does not match the referenced TSB shape");
+    }
+
+    const auto reference = tsb.base().reference();
+    auto output = erased.as_bundle();
+    for (std::size_t index = 0; index < bundle->field_count(); ++index) {
+      const TSFieldMetaData &field = bundle->fields()[index];
+      auto result = container_impl_detail::project_tsb_reference_field(
+          reference, *bundle, index, erased.evaluation_time(), "dereference",
+          field.name != nullptr ? std::string_view{field.name}
+                                : std::string_view{});
+      container_impl_detail::set_reference_if_changed(output.at(index),
+                                                      std::move(result));
+    }
   }
 };
 

--- a/include/hgraph/lib/std/operators/impl/container_impl.h
+++ b/include/hgraph/lib/std/operators/impl/container_impl.h
@@ -10,6 +10,7 @@
 #include <hgraph/types/static_schema.h>
 #include <hgraph/types/subgraph_wiring.h>
 
+#include <algorithm>
 #include <cstddef>
 #include <optional>
 #include <stdexcept>
@@ -50,9 +51,8 @@ direct_tsb_schema(const WiringArg &arg) noexcept {
                                                               : nullptr;
 }
 
-/** REF[TSB] argument: the referenced bundle schema, or null. */
 [[nodiscard]] inline const TSValueTypeMetaData *
-ref_tsb_schema(const WiringArg &arg) noexcept {
+ref_indexed_schema(const WiringArg &arg, TSTypeKind kind) noexcept {
   const TSValueTypeMetaData *surface =
       time_series_schema(arg, SchemaRefMode::Direct);
   if (surface == nullptr || surface->kind != TSTypeKind::REF) {
@@ -60,8 +60,19 @@ ref_tsb_schema(const WiringArg &arg) noexcept {
   }
   const TSValueTypeMetaData *target =
       TypeRegistry::instance().dereference(surface);
-  return target != nullptr && target->kind == TSTypeKind::TSB ? target
-                                                              : nullptr;
+  return target != nullptr && target->kind == kind ? target : nullptr;
+}
+
+/** REF[TSB] argument: the referenced bundle schema, or null. */
+[[nodiscard]] inline const TSValueTypeMetaData *
+ref_tsb_schema(const WiringArg &arg) noexcept {
+  return ref_indexed_schema(arg, TSTypeKind::TSB);
+}
+
+/** REF[TSL] argument: the referenced list schema, or null. */
+[[nodiscard]] inline const TSValueTypeMetaData *
+ref_tsl_schema(const WiringArg &arg) noexcept {
+  return ref_indexed_schema(arg, TSTypeKind::TSL);
 }
 
 [[nodiscard]] inline std::optional<std::size_t>
@@ -127,21 +138,121 @@ inline void resolve_tsb_field_output(ResolutionMap &resolution,
 }
 
 [[nodiscard]] inline const TSValueTypeMetaData *
-materialized_tsb_reference_schema(const TSValueTypeMetaData &bundle) {
-  std::vector<std::pair<std::string, const TSValueTypeMetaData *>> fields;
-  fields.reserve(bundle.field_count());
+materialized_indexed_reference_schema(const TSValueTypeMetaData &container) {
   auto &registry = TypeRegistry::instance();
-  for (std::size_t index = 0; index < bundle.field_count(); ++index) {
-    const TSFieldMetaData &field = bundle.fields()[index];
+  if (container.kind == TSTypeKind::TSL) {
+    return registry.tsl(registry.ref(container.element_ts()),
+                        container.fixed_size());
+  }
+
+  std::vector<std::pair<std::string, const TSValueTypeMetaData *>> fields;
+  fields.reserve(container.field_count());
+  for (std::size_t index = 0; index < container.field_count(); ++index) {
+    const TSFieldMetaData &field = container.fields()[index];
     fields.emplace_back(field.name != nullptr ? field.name : "",
                         registry.ref(field.type));
   }
   return registry.un_named_tsb(fields);
 }
 
-/** Resolve one field from the VALUE carried by a REF[TSB]. This is the
-    single runtime path used by both scalar field projection and the
-    all-fields dereference operator. */
+/** Follow and validate the peered target carried by an indexed-container
+    reference. TSB and TSL projection share this path so forwarding,
+    descriptive-schema references, and schema errors behave identically. */
+[[nodiscard]] inline std::optional<TSOutputView>
+resolve_indexed_reference_target(
+    const TimeSeriesReference &reference,
+    const TSValueTypeMetaData &container,
+    DateTime evaluation_time,
+    std::string_view operation,
+    std::string_view subject) {
+  if (!reference.is_peered() || !reference.has_output()) {
+    return std::nullopt;
+  }
+
+  auto target = reference.target_output().view(evaluation_time);
+  auto slow = target.handle();
+  auto fast = slow;
+  const auto advance_forwarding = [evaluation_time](TSOutputHandle handle) {
+    if (!handle.bound()) {
+      return TSOutputHandle{};
+    }
+    auto view = handle.view(evaluation_time);
+    return view.forwarding() && view.forwarding_bound()
+               ? view.forwarding_target()
+               : TSOutputHandle{};
+  };
+  while (target.forwarding() && target.forwarding_bound()) {
+    target = target.forwarding_target().view(evaluation_time);
+    slow = advance_forwarding(std::move(slow));
+    fast = advance_forwarding(advance_forwarding(std::move(fast)));
+    if (slow.bound() && fast.bound() && slow.same_as(fast)) {
+      throw std::logic_error(std::string{operation} + ": " +
+                             std::string{subject} + " forwarding cycle");
+    }
+  }
+
+  const auto *data_schema = target.data_view().schema();
+  if (data_schema != nullptr && data_schema->kind == TSTypeKind::REF) {
+    // A descriptive-schema reference: the surface says TSB/TSL but the
+    // underlying DATA is itself a REF output (Port::as / reference-service
+    // pattern). Hop through its from-REF alternative before projection.
+    const auto *deref = TypeRegistry::instance().dereference(data_schema);
+    target = target.binding_for(*deref).view(evaluation_time);
+  }
+  if (!time_series_schema_equivalent(&container, target.schema())) {
+    const auto owner = target.owner_node();
+    throw std::invalid_argument(
+        std::string{operation} + ": " + std::string{subject} +
+        " requested schema '" + std::string{container.name()} +
+        "' but targets schema '" +
+        (target.schema() != nullptr ? std::string{target.schema()->name()}
+                                    : std::string{"<untyped>"}) +
+        "' from node '" +
+        (owner.valid() ? std::string{owner.label()}
+                       : std::string{"<unknown>"}) +
+        "' at index " +
+        (owner.valid() ? std::to_string(owner.node_index())
+                       : std::string{"<unknown>"}));
+  }
+  return target;
+}
+
+/** Project one child reference from either a peered indexed-container target
+    or a non-peered composite reference value. */
+[[nodiscard]] inline TimeSeriesReference project_indexed_reference_element(
+    const TimeSeriesReference &reference,
+    const TSOutputView *target,
+    const TSValueTypeMetaData &container,
+    const TSValueTypeMetaData *element_type,
+    std::size_t index,
+    std::string_view operation,
+    std::string_view subject,
+    std::string_view element_kind,
+    std::string_view element_label) {
+  TimeSeriesReference result = TimeSeriesReference::empty(element_type);
+  if (target != nullptr) {
+    const auto child_count = target->data_view().indexed_child_count();
+    if (index >= child_count) {
+      throw std::out_of_range(
+          std::string{operation} + ": " + std::string{subject} + " " +
+          std::string{element_kind} + " '" + std::string{element_label} +
+          "' has ordinal " + std::to_string(index) +
+          " in requested schema '" + std::string{container.name()} +
+          "', but target schema '" +
+          (target->schema() != nullptr ? std::string{target->schema()->name()}
+                                       : std::string{"<untyped>"}) +
+          "' exposes " + std::to_string(child_count) + " children");
+    }
+    auto child = target->indexed_child_at(index);
+    if (child.bound()) {
+      result = TimeSeriesReference::peered(child);
+    }
+  } else if (reference.is_non_peered() && index < reference.items().size()) {
+    result = reference[index];
+  }
+  return result;
+}
+
 [[nodiscard]] inline TimeSeriesReference project_tsb_reference_field(
     const TimeSeriesReference &reference,
     const TSValueTypeMetaData &bundle,
@@ -153,84 +264,12 @@ materialized_tsb_reference_schema(const TSValueTypeMetaData &bundle) {
     throw std::out_of_range(std::string{operation} + ": REF[TSB] field '" +
                             std::string{field_label} + "' is out of range");
   }
-
-  const auto *field_type = bundle.fields()[index].type;
-  TimeSeriesReference result = TimeSeriesReference::empty(field_type);
-  if (reference.is_peered() && reference.has_output()) {
-    auto target = reference.target_output().view(evaluation_time);
-    auto slow = target.handle();
-    auto fast = slow;
-    const auto advance_forwarding = [evaluation_time](TSOutputHandle handle) {
-      if (!handle.bound()) {
-        return TSOutputHandle{};
-      }
-      auto view = handle.view(evaluation_time);
-      return view.forwarding() && view.forwarding_bound()
-                 ? view.forwarding_target()
-                 : TSOutputHandle{};
-    };
-    while (target.forwarding() && target.forwarding_bound()) {
-      target = target.forwarding_target().view(evaluation_time);
-      slow = advance_forwarding(std::move(slow));
-      fast = advance_forwarding(advance_forwarding(std::move(fast)));
-      if (slow.bound() && fast.bound() && slow.same_as(fast)) {
-        throw std::logic_error(std::string{operation} +
-                               ": REF[TSB] forwarding cycle");
-      }
-    }
-    const auto *data_schema = target.data_view().schema();
-    if (data_schema != nullptr && data_schema->kind == TSTypeKind::REF) {
-      // A descriptive-schema reference: the surface says TSB but the
-      // underlying DATA is itself a REF output (Port::as /
-      // reference-service pattern). Hop through its from-REF alternative
-      // before projecting the field.
-      const auto *deref = TypeRegistry::instance().dereference(data_schema);
-      target = target.binding_for(*deref).view(evaluation_time);
-    }
-    if (!time_series_schema_equivalent(&bundle, target.schema())) {
-      const auto owner = target.owner_node();
-      throw std::invalid_argument(
-          std::string{operation} + ": REF[TSB] requested schema '" +
-          std::string{bundle.name()} + "' but targets schema '" +
-          (target.schema() != nullptr ? std::string{target.schema()->name()}
-                                      : std::string{"<untyped>"}) +
-          "' from node '" +
-          (owner.valid() ? std::string{owner.label()}
-                         : std::string{"<unknown>"}) +
-          "' at index " +
-          (owner.valid() ? std::to_string(owner.node_index())
-                         : std::string{"<unknown>"}));
-    }
-    const auto child_count = target.data_view().indexed_child_count();
-    if (index >= child_count) {
-      throw std::out_of_range(
-          std::string{operation} + ": REF[TSB] field '" +
-          std::string{field_label} + "' has ordinal " +
-          std::to_string(index) + " in requested schema '" +
-          std::string{bundle.name()} + "', but target schema '" +
-          (target.schema() != nullptr ? std::string{target.schema()->name()}
-                                      : std::string{"<untyped>"}) +
-          "' exposes " + std::to_string(child_count) + " children");
-    }
-    try {
-      auto child = target.indexed_child_at(index);
-      if (child.bound()) {
-        result = TimeSeriesReference::peered(child);
-      }
-    } catch (const std::out_of_range &error) {
-      throw std::out_of_range(
-          std::string{operation} + ": failed to project REF[TSB] field '" +
-          std::string{field_label} + "' at ordinal " +
-          std::to_string(index) + " from requested schema '" +
-          std::string{bundle.name()} + "' through target schema '" +
-          (target.schema() != nullptr ? std::string{target.schema()->name()}
-                                      : std::string{"<untyped>"}) +
-          "': " + error.what());
-    }
-  } else if (reference.is_non_peered() && index < reference.items().size()) {
-    result = reference[index];
-  }
-  return result;
+  auto target = resolve_indexed_reference_target(
+      reference, bundle, evaluation_time, operation, "REF[TSB]");
+  return project_indexed_reference_element(
+      reference, target ? &*target : nullptr, bundle,
+      bundle.fields()[index].type, index, operation, "REF[TSB]", "field",
+      field_label);
 }
 
 inline void set_reference_if_changed(const TSOutputView &out,
@@ -1351,22 +1390,32 @@ struct tsb_ref_field_node {
   }
 };
 
-/** Materialize REF[TSB] as a peered TSB whose children contain references to
-    the corresponding target fields. The output is intentionally an unnamed
-    schema, matching hgraph's dynamically resolved ``ts_schema`` result. */
-struct dereference_tsb_ref_node {
-  static constexpr auto name = "dereference_tsb_ref";
+/** Materialize REF[TSB]/REF[TSL] as the same indexed container shape whose
+    children contain references to the corresponding target elements. */
+template <TSTypeKind ContainerKind>
+struct dereference_indexed_ref_node {
+  static_assert(ContainerKind == TSTypeKind::TSB ||
+                ContainerKind == TSTypeKind::TSL);
+
+  static constexpr auto name = ContainerKind == TSTypeKind::TSB
+                                   ? "dereference_tsb_ref"
+                                   : "dereference_tsl_ref";
   static constexpr bool schedule_on_start = true;
 
   [[nodiscard]] static const TSValueTypeMetaData *
-  bundle_schema(OperatorCallContext context) {
-    return context.args.size() == 1
-               ? container_impl_detail::ref_tsb_schema(context.args[0])
-               : nullptr;
+  container_schema(OperatorCallContext context) {
+    if (context.args.size() != 1) {
+      return nullptr;
+    }
+    if constexpr (ContainerKind == TSTypeKind::TSB) {
+      return container_impl_detail::ref_tsb_schema(context.args[0]);
+    } else {
+      return container_impl_detail::ref_tsl_schema(context.args[0]);
+    }
   }
 
   static bool requires_(const ResolutionMap &, OperatorCallContext context) {
-    return bundle_schema(context) != nullptr;
+    return container_schema(context) != nullptr;
   }
 
   static void resolve_default_types(ResolutionMap &resolution,
@@ -1374,39 +1423,92 @@ struct dereference_tsb_ref_node {
     if (output_bound(resolution)) {
       return;
     }
-    const auto *bundle = bundle_schema(context);
-    if (bundle != nullptr) {
-      bind_output(
-          resolution,
-          container_impl_detail::materialized_tsb_reference_schema(*bundle));
+    const auto *container = container_schema(context);
+    if (container != nullptr) {
+      bind_output(resolution,
+                  container_impl_detail::materialized_indexed_reference_schema(
+                      *container));
     }
   }
 
-  static void eval(In<"tsb", REF<TsVar<"S">>, InputValidity::Unchecked> tsb,
+  static void eval(In<"tsb", REF<TsVar<"S">>, InputValidity::Unchecked> ts,
                    Out<TsVar<"__out__">> out) {
     const auto &erased = static_cast<const TSOutputView &>(out);
-    const auto *bundle = TypeRegistry::instance().dereference(tsb.base().schema());
-    if (bundle == nullptr || bundle->kind != TSTypeKind::TSB) {
-      throw std::logic_error("dereference: input is not REF[TSB]");
+    const auto *container =
+        TypeRegistry::instance().dereference(ts.base().schema());
+    constexpr std::string_view subject =
+        ContainerKind == TSTypeKind::TSB ? "REF[TSB]" : "REF[TSL]";
+    if (container == nullptr || container->kind != ContainerKind) {
+      throw std::logic_error("dereference: input is not " +
+                             std::string{subject});
     }
-    if (erased.schema() == nullptr || erased.schema()->kind != TSTypeKind::TSB ||
-        erased.schema()->field_count() != bundle->field_count()) {
-      throw std::logic_error("dereference: resolved output does not match the referenced TSB shape");
+    const auto *expected_output =
+        container_impl_detail::materialized_indexed_reference_schema(
+            *container);
+    if (!time_series_schema_equivalent(expected_output, erased.schema())) {
+      throw std::logic_error(
+          "dereference: resolved output does not match the referenced " +
+          std::string{ContainerKind == TSTypeKind::TSB ? "TSB" : "TSL"} +
+          " shape");
     }
 
-    const auto reference = tsb.base().reference();
-    auto output = erased.as_bundle();
-    for (std::size_t index = 0; index < bundle->field_count(); ++index) {
-      const TSFieldMetaData &field = bundle->fields()[index];
-      auto result = container_impl_detail::project_tsb_reference_field(
-          reference, *bundle, index, erased.evaluation_time(), "dereference",
-          field.name != nullptr ? std::string_view{field.name}
-                                : std::string_view{});
-      container_impl_detail::set_reference_if_changed(output.at(index),
-                                                      std::move(result));
+    const auto reference = ts.base().reference();
+    auto target = container_impl_detail::resolve_indexed_reference_target(
+        reference, *container, erased.evaluation_time(), "dereference",
+        subject);
+    const std::size_t source_count =
+        target ? target->data_view().indexed_child_count()
+               : reference.is_non_peered() ? reference.items().size() : 0;
+    const std::size_t count = [&] {
+      if constexpr (ContainerKind == TSTypeKind::TSB) {
+        return container->field_count();
+      } else {
+        const std::size_t fixed_size = container->fixed_size();
+        auto output = erased.as_list();
+        return fixed_size != 0
+                   ? fixed_size
+                   : std::max(output.size(), source_count);
+      }
+    }();
+
+    for (std::size_t index = 0; index < count; ++index) {
+      const TSValueTypeMetaData *element_type = [&] {
+        if constexpr (ContainerKind == TSTypeKind::TSB) {
+          return container->fields()[index].type;
+        } else {
+          return container->element_ts();
+        }
+      }();
+      const std::string element_label = [&] {
+        if constexpr (ContainerKind == TSTypeKind::TSB) {
+          const char *field_name = container->fields()[index].name;
+          return field_name != nullptr ? std::string{field_name} : std::string{};
+        } else {
+          return std::to_string(index);
+        }
+      }();
+      auto result = container_impl_detail::project_indexed_reference_element(
+          reference, target ? &*target : nullptr, *container, element_type,
+          index, "dereference", subject,
+          ContainerKind == TSTypeKind::TSB ? "field" : "element",
+          element_label);
+      if constexpr (ContainerKind == TSTypeKind::TSB) {
+        auto output = erased.as_bundle();
+        container_impl_detail::set_reference_if_changed(output.at(index),
+                                                        std::move(result));
+      } else {
+        auto output = erased.as_list();
+        container_impl_detail::set_reference_if_changed(output.at(index),
+                                                        std::move(result));
+      }
     }
   }
 };
+
+using dereference_tsb_ref_node =
+    dereference_indexed_ref_node<TSTypeKind::TSB>;
+using dereference_tsl_ref_node =
+    dereference_indexed_ref_node<TSTypeKind::TSL>;
 
 struct len_tsb {
   static constexpr auto name = "len_tsb";

--- a/python/tests/ported/_wiring/test_tsb_wiring.py
+++ b/python/tests/ported/_wiring/test_tsb_wiring.py
@@ -30,6 +30,7 @@ from hgraph import (
     SIGNAL,
     TS_SCHEMA,
     REF,
+    dereference,
     nothing,
     TimeSeriesReference,
 )
@@ -309,6 +310,25 @@ def test_tsb_ref_index():
     from hgraph.arrow import eval_, if_then, c, assert_
 
     eval_(True, "") | if_then(c(1) / c("a")) >> g >> assert_(1)
+
+
+def test_dereference_materializes_tsb_field_references():
+    @compute_node
+    def as_reference(tsb: REF[TSB[MyTsb]]) -> REF[TSB[MyTsb]]:
+        return tsb.value
+
+    @graph
+    def g(tsb: TSB[MyTsb]) -> TSB[MyTsb]:
+        fields = dereference(as_reference(tsb))
+        assert fields.p1.output_type == REF[TS[int]]
+        assert fields.p2.output_type == REF[TS[str]]
+        return TSB[MyTsb].from_ts(p1=fields.p1, p2=fields.p2)
+
+    assert eval_node(g, [{"p1": 1}, {"p2": "a"}, {"p1": 2}]) == [
+        {"p1": 1},
+        {"p2": "a"},
+        {"p1": 2},
+    ]
 
 
 def test_tsb_output_access():

--- a/python/tests/ported/_wiring/test_tsb_wiring.py
+++ b/python/tests/ported/_wiring/test_tsb_wiring.py
@@ -331,6 +331,26 @@ def test_dereference_materializes_tsb_field_references():
     ]
 
 
+def test_dereference_rejects_incompatible_non_peered_tsb_child_references():
+    class WrongTsb(TimeSeriesSchema):
+        p1: TS[str]
+        p2: TS[str]
+
+    @compute_node
+    def misdeclare_reference(
+        tsb: REF[TSB[WrongTsb]],
+    ) -> REF[TSB[MyTsb]]:
+        return tsb.value
+
+    @graph
+    def g(p1: TS[str], p2: TS[str]) -> TS[int]:
+        tsb = TSB[WrongTsb].from_ts(p1=p1, p2=p2)
+        return dereference(misdeclare_reference(tsb)).p1
+
+    with pytest.raises(RuntimeError, match="reference targets schema"):
+        eval_node(g, ["wrong"], ["value"])
+
+
 def test_tsb_output_access():
     @compute_node
     def f(tsb: TSB[MyTsb], _output: TSB_OUT[MyTsb] = None) -> TSB[MyTsb]:

--- a/python/tests/ported/_wiring/test_tsl_wiring.py
+++ b/python/tests/ported/_wiring/test_tsl_wiring.py
@@ -139,3 +139,20 @@ def test_dereference_materializes_tsl_element_references():
         {1: 2},
         {0: 3},
     ]
+
+
+def test_dereference_rejects_incompatible_non_peered_tsl_child_references():
+    expected_type = TSL[TS[int], Size[2]]
+    wrong_type = TSL[TS[str], Size[2]]
+
+    @compute_node
+    def misdeclare_reference(tsl: REF[wrong_type]) -> REF[expected_type]:
+        return tsl.value
+
+    @graph
+    def g(first: TS[str], second: TS[str]) -> TS[int]:
+        tsl = TSL.from_ts(first, second)
+        return dereference(misdeclare_reference(tsl))[0]
+
+    with pytest.raises(RuntimeError, match="reference targets schema"):
+        eval_node(g, ["wrong"], ["value"])

--- a/python/tests/ported/_wiring/test_tsl_wiring.py
+++ b/python/tests/ported/_wiring/test_tsl_wiring.py
@@ -2,7 +2,23 @@
 import pytest
 
 from datetime import timedelta
-from hgraph import REF, TS, combine, generator, graph, TSL, Size, SCALAR, compute_node, SIZE, getitem_, const, if_, TimeSeriesReference
+from hgraph import (
+    REF,
+    TS,
+    combine,
+    dereference,
+    generator,
+    graph,
+    TSL,
+    Size,
+    SCALAR,
+    compute_node,
+    SIZE,
+    getitem_,
+    const,
+    if_,
+    TimeSeriesReference,
+)
 from hgraph.nodes import flatten_tsl_values
 from hgraph.test import eval_node
 
@@ -102,4 +118,24 @@ def test_tsl_ref_flipping():
         None,
         {0: 2, 1: 2},
         None,
+    ]
+
+
+def test_dereference_materializes_tsl_element_references():
+    tsl_type = TSL[TS[int], Size[2]]
+
+    @compute_node
+    def as_reference(tsl: REF[tsl_type]) -> REF[tsl_type]:
+        return tsl.value
+
+    @graph
+    def g(tsl: tsl_type) -> tsl_type:
+        elements = dereference(as_reference(tsl))
+        assert elements.output_type == TSL[REF[TS[int]], Size[2]]
+        return TSL.from_ts(elements[0], elements[1])
+
+    assert eval_node(g, [{0: 1}, {1: 2}, {0: 3}]) == [
+        {0: 1},
+        {1: 2},
+        {0: 3},
     ]

--- a/src/hgraph/lib/std/operators/container_impl.cpp
+++ b/src/hgraph/lib/std/operators/container_impl.cpp
@@ -29,6 +29,7 @@ namespace hgraph::stdlib
         register_overload<getitem_, tsb_ref_field_node<Str, "key", "getitem_tsb_ref">>();
         register_overload<getitem_, tsb_ref_field_node<Int, "key", "getitem_tsb_ref_index">>();
         register_overload<dereference, dereference_tsb_ref_node>();
+        register_overload<dereference, dereference_tsl_ref_node>();
 
         register_graph_overload<getitem_, getitem_tsb_by_name>();
         register_graph_overload<getitem_, getitem_tsb_by_index>();

--- a/src/hgraph/lib/std/operators/container_impl.cpp
+++ b/src/hgraph/lib/std/operators/container_impl.cpp
@@ -28,6 +28,7 @@ namespace hgraph::stdlib
         register_overload<getattr_, tsb_ref_field_node<Str, "attr", "getattr_tsb_ref">>();
         register_overload<getitem_, tsb_ref_field_node<Str, "key", "getitem_tsb_ref">>();
         register_overload<getitem_, tsb_ref_field_node<Int, "key", "getitem_tsb_ref_index">>();
+        register_overload<dereference, dereference_tsb_ref_node>();
 
         register_graph_overload<getitem_, getitem_tsb_by_name>();
         register_graph_overload<getitem_, getitem_tsb_by_index>();

--- a/tests/cpp/test_std_operators.cpp
+++ b/tests/cpp/test_std_operators.cpp
@@ -33,6 +33,7 @@
 #include <arrow/api.h>
 
 #include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_string.hpp>
 
 #include <array>
 #include <chrono>
@@ -553,6 +554,56 @@ namespace
         static void eval(Out<REF<Schema>> out)
         {
             out.set(TimeSeriesReference::empty(ts_type<Schema>()));
+        }
+    };
+
+    struct MalformedNonPeeredTsbReferenceSource
+    {
+        static constexpr auto name              = "malformed_non_peered_tsb_reference_source";
+        static constexpr bool schedule_on_start = true;
+
+        static void eval(Out<REF<ContainerAccessBundle>> out)
+        {
+            out.set(TimeSeriesReference::non_peered(
+                ts_type<ContainerAccessBundle>(),
+                {TimeSeriesReference::empty(ts_type<TS<Float>>()),
+                 TimeSeriesReference::empty(ts_type<TS<Str>>())}));
+        }
+    };
+
+    struct MalformedNonPeeredTslReferenceSource
+    {
+        static constexpr auto name              = "malformed_non_peered_tsl_reference_source";
+        static constexpr bool schedule_on_start = true;
+
+        static void eval(Out<REF<IntTslPair>> out)
+        {
+            out.set(TimeSeriesReference::non_peered(
+                ts_type<IntTslPair>(),
+                {TimeSeriesReference::empty(ts_type<TS<Str>>()),
+                 TimeSeriesReference::empty(ts_type<TS<Int>>())}));
+        }
+    };
+
+    struct DereferenceMalformedNonPeeredTsbReferenceGraph
+    {
+        static constexpr auto name = "dereference_malformed_non_peered_tsb_reference_graph";
+
+        static Port<ContainerAccessReferenceBundle> compose(Wiring &w)
+        {
+            return wire<stdlib::dereference>(w, wire<MalformedNonPeeredTsbReferenceSource>(w))
+                .as<ContainerAccessReferenceBundle>();
+        }
+    };
+
+    struct DereferenceMalformedNonPeeredTslReferenceGraph
+    {
+        static constexpr auto name = "dereference_malformed_non_peered_tsl_reference_graph";
+
+        static Port<IntTslPairReferences> compose(Wiring &w)
+        {
+            return wire<stdlib::dereference>(w, wire<MalformedNonPeeredTslReferenceSource>(w))
+                .as<IntTslPairReferences>();
         }
     };
 
@@ -2723,6 +2774,20 @@ TEST_CASE("std operators: dereference materializes REF TSL elements as reference
                                none,
                                list_delta<TS<Int>>({{0, 2}, {1, 20}}),
                                none));
+}
+
+TEST_CASE("std operators: dereference rejects incompatible non-peered child references")
+{
+    stdlib::register_standard_operators();
+
+    CHECK_THROWS_WITH(
+        eval_node<DereferenceMalformedNonPeeredTsbReferenceGraph>(),
+        Catch::Matchers::ContainsSubstring(
+            "dereference: REF[TSB] field 'a' reference targets schema"));
+    CHECK_THROWS_WITH(
+        eval_node<DereferenceMalformedNonPeeredTslReferenceGraph>(),
+        Catch::Matchers::ContainsSubstring(
+            "dereference: REF[TSL] element '0' reference targets schema"));
 }
 
 TEST_CASE("std operators: date component operators extract day month year and explode")

--- a/tests/cpp/test_std_operators.cpp
+++ b/tests/cpp/test_std_operators.cpp
@@ -509,6 +509,7 @@ namespace
                                          Field<"false", REF<TSD<Int, TS<Int>>>>>;
     using RoutedIntRefList      = TSL<REF<TS<Int>>, 3>;
     using IntTslPair            = TSL<TS<Int>, 2>;
+    using IntTslPairReferences  = TSL<REF<TS<Int>>, 2>;
     using IntTsd                = TSD<Int, TS<Int>>;
 
     struct ForwardReference
@@ -577,6 +578,35 @@ namespace
         static Port<TS<Int>> compose(Wiring &, Port<IntTslPair> ts)
         {
             return tsl_element(ts, 0);
+        }
+    };
+
+    struct DereferenceTslReferenceGraph
+    {
+        static constexpr auto name = "dereference_tsl_reference_graph";
+
+        static Port<IntTslPair> compose(Wiring &w,
+                                        Port<IntTslPair> first,
+                                        Port<IntTslPair> second,
+                                        Port<TS<Int>> index)
+        {
+            auto empty = wire<EmptyReferenceSource<IntTslPair>>(w);
+            auto choices = stdlib::to_tsl<TSL<IntTslPair, 3>>(w, first, second, empty);
+            auto selected = wire<stdlib::getitem_>(w, choices, index).as<REF<IntTslPair>>();
+            auto references = wire<stdlib::dereference>(w, selected);
+            if (references.erased().is_structural_source())
+            {
+                throw std::logic_error("dereference did not materialize a node output");
+            }
+            if (references.erased().schema != ts_type<IntTslPairReferences>())
+            {
+                throw std::logic_error("dereference did not resolve a TSL of element references");
+            }
+
+            auto materialized = references.as<IntTslPairReferences>();
+            return stdlib::to_tsl<IntTslPair>(w, tsl_element(materialized, 0),
+                                              tsl_element(materialized, 1))
+                .template as<IntTslPair>();
         }
     };
 
@@ -2673,6 +2703,25 @@ TEST_CASE("std operators: dereference materializes REF TSB fields as references"
                                tsb_delta<ContainerAccessBundle>(std::nullopt, Str{"a"}),
                                none,
                                tsb_delta<ContainerAccessBundle>(Int{2}, Str{"b"}),
+                               none));
+}
+
+TEST_CASE("std operators: dereference materializes REF TSL elements as references")
+{
+    stdlib::register_standard_operators();
+
+    CHECK_OUTPUT(eval_node<DereferenceTslReferenceGraph>(
+                     values<Value>(list_delta<TS<Int>>({{0, 1}}),
+                                   list_delta<TS<Int>>({{1, 10}}),
+                                   none, none, none),
+                     values<Value>(list_delta<TS<Int>>({{0, 2}}),
+                                   list_delta<TS<Int>>({{1, 20}}),
+                                   none, none, none),
+                     values<Int>(0, none, 2, 1, 2)),
+                 values<Value>(list_delta<TS<Int>>({{0, 1}}),
+                               list_delta<TS<Int>>({{1, 10}}),
+                               none,
+                               list_delta<TS<Int>>({{0, 2}, {1, 20}}),
                                none));
 }
 

--- a/tests/cpp/test_std_operators.cpp
+++ b/tests/cpp/test_std_operators.cpp
@@ -495,6 +495,8 @@ namespace
     };
 
     using ContainerAccessBundle = UnNamedTSB<Field<"a", TS<Int>>, Field<"b", TS<Str>>>;
+    using ContainerAccessReferenceBundle =
+        UnNamedTSB<Field<"a", REF<TS<Int>>>, Field<"b", REF<TS<Str>>>>;
     using NamedContainerAccessBundle =
         TSB<"NamedContainerAccessBundle", Field<"a", TS<Int>>, Field<"b", TS<Str>>>;
     using HandlerOutputBundle =
@@ -590,6 +592,35 @@ namespace
             auto empty = wire<EmptyReferenceSource<ContainerAccessBundle>>(w);
             auto choices = stdlib::to_tsl<TSL<ContainerAccessBundle, 3>>(w, first, second, empty);
             return wire<stdlib::getitem_>(w, choices, index).as<ContainerAccessBundle>();
+        }
+    };
+
+    struct DereferenceTsbReferenceGraph
+    {
+        static constexpr auto name = "dereference_tsb_reference_graph";
+
+        static Port<ContainerAccessBundle> compose(Wiring &w,
+                                                   Port<ContainerAccessBundle> first,
+                                                   Port<ContainerAccessBundle> second,
+                                                   Port<TS<Int>> index)
+        {
+            auto empty = wire<EmptyReferenceSource<ContainerAccessBundle>>(w);
+            auto choices = stdlib::to_tsl<TSL<ContainerAccessBundle, 3>>(w, first, second, empty);
+            auto selected = wire<stdlib::getitem_>(w, choices, index).as<REF<ContainerAccessBundle>>();
+            auto references = wire<stdlib::dereference>(w, selected);
+            if (references.erased().is_structural_source())
+            {
+                throw std::logic_error("dereference did not materialize a node output");
+            }
+            if (references.erased().schema != ts_type<ContainerAccessReferenceBundle>())
+            {
+                throw std::logic_error("dereference did not resolve a TSB of field references");
+            }
+
+            auto materialized = references.as<ContainerAccessReferenceBundle>();
+            auto a = wire<stdlib::getattr_>(w, materialized, Str{"a"}).as<REF<TS<Int>>>();
+            auto b = wire<stdlib::getattr_>(w, materialized, Str{"b"}).as<REF<TS<Str>>>();
+            return stdlib::to_tsb<ContainerAccessBundle>(w, a, b);
         }
     };
 
@@ -2621,6 +2652,25 @@ TEST_CASE("std operators: TSB REF composition flips through an empty reference")
                                    none, none),
                      values<Int>(0, 2, 1, 2)),
                  values<Value>(tsb_delta<ContainerAccessBundle>(Int{1}, std::nullopt),
+                               none,
+                               tsb_delta<ContainerAccessBundle>(Int{2}, Str{"b"}),
+                               none));
+}
+
+TEST_CASE("std operators: dereference materializes REF TSB fields as references")
+{
+    stdlib::register_standard_operators();
+
+    CHECK_OUTPUT(eval_node<DereferenceTsbReferenceGraph>(
+                     values<Value>(tsb_delta<ContainerAccessBundle>(Int{1}, std::nullopt),
+                                   tsb_delta<ContainerAccessBundle>(std::nullopt, Str{"a"}),
+                                   none, none, none),
+                     values<Value>(tsb_delta<ContainerAccessBundle>(Int{2}, std::nullopt),
+                                   tsb_delta<ContainerAccessBundle>(std::nullopt, Str{"b"}),
+                                   none, none, none),
+                     values<Int>(0, none, 2, 1, 2)),
+                 values<Value>(tsb_delta<ContainerAccessBundle>(Int{1}, std::nullopt),
+                               tsb_delta<ContainerAccessBundle>(std::nullopt, Str{"a"}),
                                none,
                                tsb_delta<ContainerAccessBundle>(Int{2}, Str{"b"}),
                                none));


### PR DESCRIPTION
## Summary

- add the first-class C++ `dereference` operator for both `REF[TSB]` and `REF[TSL]`
- materialize `REF[TSB]` as an unnamed `TSB` whose fields are references
- materialize `REF[TSL]` as a same-sized `TSL` whose elements are references
- select the two container variants through one wiring-time templated implementation
- centralize indexed-reference target resolution and projection, including forwarding, descriptive-schema references, schema validation, empty references, and retargeting
- add matching native C++ and Python compatibility coverage

## Root cause

The compatibility surface was missing dereference materialization. Stripping the outer `REF` type is insufficient: callers need a concrete container whose children hold references to the corresponding children of the referenced container.

Python hgraph currently defines this explicitly for TSB. This change also supports TSL because both TSB and TSL expose child access at wiring time and should have consistent materialization behavior.

## Validation

- focused native TSB and TSL dereference regressions
- focused Python TSB and TSL dereference regressions through a stable-ABI wheel
- `cmake --preset cpp --fresh`
- `cmake --build --preset cpp --target clean`
- `cmake --build --preset cpp --parallel`
- `ctest --preset cpp --parallel 2` — 1,470 passed
- stable-ABI wheel built with Python 3.12
- full non-WIP compatibility suite run from a fresh Python 3.14 environment — 1,978 passed, 9 skipped
- `git diff --check`

Fixes #289