### PR TITLE
Compatibility: align service resolution and JSON temporal values

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,10 +92,11 @@ uv pip install --python "$test_env/bin/python" "${wheel_path}[test]"
 
 For large changes, especially runtime, ownership, memory-layout, type-erasure,
 or cross-language changes, run the same full C++ and Python validation in the
-local Linux VM before reporting completion. Use the Ubuntu/OrbStack workflow in
-`docs/source/developer_guide/debugging.rst`; add ASan when lifetime or memory
-safety is involved. macOS is the normal local gate. Windows remains a
-best-effort CI platform, but portable code should still be maintained.
+Linux environment before reporting completion. Use the `hg-linux` SSH host
+when it is available; use the Ubuntu/OrbStack VM only as a fallback. Follow the
+workflow in `docs/source/developer_guide/debugging.rst`; add ASan when lifetime
+or memory safety is involved. macOS is the normal local gate. Windows remains
+a best-effort CI platform, but portable code should still be maintained.
 
 The x86_64 OrbStack VM on Apple Silicon does not expose AVX/AVX2. Standard
 Polars warns about the missing CPU features and then segfaults inside

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -191,11 +191,15 @@ else()
 endif()
 check_cxx_source_compiles([=[
     #include <chrono>
+    #include <sstream>
     int main() {
         const auto &database = std::chrono::get_tzdb();
         const auto *zone = database.locate_zone("UTC");
         (void)zone->get_info(std::chrono::sys_time<std::chrono::microseconds>{});
         (void)zone->get_info(std::chrono::local_time<std::chrono::microseconds>{});
+        std::istringstream input{"2024-06-13T10:15:30"};
+        std::chrono::sys_time<std::chrono::microseconds> parsed{};
+        std::chrono::from_stream(input, "%Y-%m-%dT%H:%M:%S", parsed);
         return database.version.empty();
     }
 ]=] HGRAPH_STD_CHRONO_TZDB_AVAILABLE)

--- a/docs/source/developer_guide/debugging.rst
+++ b/docs/source/developer_guide/debugging.rst
@@ -173,35 +173,54 @@ Linux Python/ASan debugging from macOS
 --------------------------------------
 
 Some lifetime failures only reproduce when the Python bridge is loaded into a
-Linux process. A small Linux VM is useful on an Apple Silicon Mac because it
-exercises the Linux/GCC build without modifying the macOS toolchain. The
-workflow below uses an Ubuntu 24.04 OrbStack machine named ``ubuntu``. Other
-Linux VMs work as long as the repository is shared into the guest and the
-commands are run inside the guest.
+Linux process. The project's preferred Linux system is the native host exposed
+through the ``hg-linux`` SSH alias. Use it whenever it is available. It
+exercises the Linux/GCC build on separate hardware without modifying the macOS
+toolchain. An Ubuntu 24.04 OrbStack machine named ``ubuntu`` is the fallback
+when ``hg-linux`` cannot be reached.
 
 Keep the build directory and virtual environment on the Linux filesystem, not
-in the shared source tree. The examples use ``/tmp`` for both. Replace
-``/Users/<mac-user>/src/hg_cpp`` with the macOS path to the checkout; OrbStack
-mounts that path at the same location in the guest.
+in a macOS-shared source tree. The examples use ``/tmp`` for both.
 
-Prepare the guest
-~~~~~~~~~~~~~~~~~
+Prepare the Linux host
+~~~~~~~~~~~~~~~~~~~~~~
 
-Open a shell in the VM and install a current GCC plus Python development
-support:
+First check the preferred host:
+
+.. code-block:: bash
+
+   ssh -o BatchMode=yes -o ConnectTimeout=10 hg-linux true
+
+When it is available, copy the current checkout, including uncommitted source
+changes, into a disposable directory on that host and open a shell there:
+
+.. code-block:: bash
+
+   remote_root="$(ssh hg-linux 'mktemp -d /tmp/hg_cpp-linux.XXXXXX')"
+   rsync -a \
+       --exclude .git --exclude .venv --exclude '.parity' \
+       --exclude 'cmake-build-*' --exclude '._*' --exclude '.DS_Store' \
+       ./ "hg-linux:${remote_root}/repo/"
+   ssh -t hg-linux "cd '${remote_root}/repo' && exec bash"
+   export REPO="$PWD"
+
+If ``hg-linux`` is unavailable, use the OrbStack VM instead. Install a current
+GCC plus Python development support there when needed. Replace the example
+checkout path below with the macOS path to the checkout; OrbStack mounts that
+path at the same location in the guest:
 
 .. code-block:: bash
 
    orb -m ubuntu bash
    sudo apt update
    sudo apt install -y build-essential git python3-dev python3-venv
+   export REPO=/Users/<mac-user>/src/hg_cpp
 
-Inside that Linux shell, create a disposable Python environment containing the
-binding and test dependencies:
+Inside the selected Linux shell, create a disposable Python environment
+containing the binding and test dependencies:
 
 .. code-block:: bash
 
-   export REPO=/Users/<mac-user>/src/hg_cpp
    export VENV=/tmp/hg_cpp-asan-venv
    export BUILD=/tmp/hg_cpp-linux-asan
 

--- a/docs/source/developer_guide/parity_matrix.rst
+++ b/docs/source/developer_guide/parity_matrix.rst
@@ -136,11 +136,13 @@ after the release-hardening audit; the counts come from comparing
      - 2
      - 0
      - 0
-     - equiv-API: to_json_builder, from_json_builder. **Recorded divergence:**
-       RFC 0002 version-2 writers emit RFC 3339 UTC instants and canonical
-       signed-microsecond durations instead of upstream's legacy text.
-       Schema-directed readers accept both formats and normalize legacy input
-       before any subsequent write.
+     - equiv-API: to_json_builder, from_json_builder,
+       register_json_datetime_format. Temporal input formats are registered in
+       the shared C++ codec and apply equally to builders and wired nodes.
+       **Recorded divergence:** RFC 0002 version-2 writers emit RFC 3339 UTC
+       instants and canonical signed-microsecond durations instead of
+       upstream's legacy text. Schema-directed readers accept both formats and
+       normalize legacy input before any subsequent write.
    * - Table (``to_table``)
      - 3
      - 0

--- a/include/hgraph/types/value/json_codec.h
+++ b/include/hgraph/types/value/json_codec.h
@@ -83,6 +83,18 @@ namespace hgraph
     /** Clear the interned converters (registry reset — see registry_reset.h). */
     HGRAPH_EXPORT void clear_json_converters() noexcept;
 
+    /**
+     * Register an additional Python-``strptime``-style format accepted by
+     * schema-directed JSON temporal reads. Date/datetime formats are shared;
+     * ``time_only`` selects the independent time-of-day list.
+     *
+     * Registration is process-wide, idempotent, and safe to perform while
+     * other threads are reading JSON. ISO 8601 and the built-in compatibility
+     * formats are always tried before registered extensions.
+     */
+    HGRAPH_EXPORT void register_json_datetime_format(
+        std::string format, bool time_only = false);
+
     /** Serialize any value view to a JSON string. */
     [[nodiscard]] HGRAPH_EXPORT std::string to_json_string(const ValueView &view);
 

--- a/python/hgraph/__init__.py
+++ b/python/hgraph/__init__.py
@@ -20,7 +20,7 @@ from ._compat import (CmpResult, DivideByZero, exception_time_series, try_except
                       TryExceptResult, TryExceptTsdMapResult, NodeError,
                       OperatorWiringNodeClass, BoolResult, CompoundScalar, JSON, TimeSeriesReference,
                       NodeException, accumulate, average, center_of_mass_to_alpha, span_to_alpha,
-                      to_json_builder, from_json_builder)
+                      to_json_builder, from_json_builder, register_json_datetime_format)
 from ._wiring import filter_by
 from ._wiring import convert
 from ._wiring import collect

--- a/python/hgraph/_compat.py
+++ b/python/hgraph/_compat.py
@@ -120,6 +120,18 @@ def from_json_builder(tp):
     return _read
 
 
+def register_json_datetime_format(fmt: str, *, time_only: bool = False) -> None:
+    """Register an additional ``strptime``-style temporal JSON input format.
+
+    ISO 8601 and the native compatibility formats remain preferred. The
+    registration is process-wide and is consumed directly by the C++ JSON
+    codec used by both builders and graph nodes.
+    """
+    import _hgraph
+
+    _hgraph.register_json_datetime_format(fmt, time_only)
+
+
 def _window_result():
     """hgraph's window() result schema {buffer, index} (generic over the
     element type; resolves when the window operator lands). Built lazily -

--- a/python/hgraph/_wiring/_services.py
+++ b/python/hgraph/_wiring/_services.py
@@ -313,10 +313,10 @@ def _resolved_implementation_path(stub, path):
     return resolved
 
 
-def _apply_service_resolvers(resolution, resolvers):
+def _apply_service_resolvers(resolution, resolvers, scalar_values=None):
     if resolution is None:
         resolution = _hgraph.ResolutionScope()
-    return _apply_resolvers(resolution, resolvers)
+    return _apply_resolvers(resolution, resolvers, scalar_values)
 
 
 def _specialization_label(resolution):
@@ -327,7 +327,7 @@ def _specialization_label(resolution):
     return ",".join(sorted(segments))
 
 
-def _specialization(item, owner, resolvers=None):
+def _specialization(item, owner, signature, resolvers=None):
     items = item if isinstance(item, tuple) else (item,)
     resolution = _hgraph.ResolutionScope()
     variables = {}
@@ -355,7 +355,8 @@ def _specialization(item, owner, resolvers=None):
             else:
                 meta = concrete
             resolution.bind_ts(name, meta)
-    _apply_service_resolvers(resolution, resolvers)
+    resolution = _resolve_service_signature(
+        signature, resolvers, resolution=resolution)
     return resolution, _specialization_label(resolution), variables
 
 
@@ -382,7 +383,9 @@ def _inferred_specialization(fn, request_annotation, request, resolvers=None):
     if not resolution.match(_pattern_of(request_annotation), actual):
         raise TypeError(
             f"generic adaptor '{fn.__name__}' request does not match its type pattern")
-    _apply_service_resolvers(resolution, resolvers)
+    resolution = _resolve_service_signature(
+        inspect.signature(fn, eval_str=True), resolvers,
+        resolution=resolution)
     specialization = _specialization_label(resolution)
     if not specialization:
         raise TypeError(
@@ -419,16 +422,71 @@ def _apply_service_defaults(signature, resolution):
         sentinel = args[0]
         if not isinstance(sentinel, _TypeVarSentinel):
             continue
+        name = _type_var_name(sentinel)
+        if resolution.is_resolved(name):
+            continue
         default = parameter.default
         if default in (inspect.Parameter.empty, AUTO_RESOLVE):
             continue
         if isinstance(default, _GenericTsExpr):
             resolved = resolution.resolve_ts(_pattern_of(default))
             if resolved is not None:
-                resolution.bind_ts(_type_var_name(sentinel), resolved)
+                resolution.bind_ts(name, resolved)
+        elif isinstance(default, (_TypeVarSentinel, typing.TypeVar)):
+            default_name = _type_var_name(default)
+            if (resolved := resolution.find_scalar(default_name)) is not None:
+                resolution.bind_scalar(name, resolved)
+            elif (resolved := resolution.find_ts(default_name)) is not None:
+                resolution.bind_ts(name, resolved)
+            elif (resolved := resolution.find_size(default_name)) is not None:
+                resolution.bind_size(name, resolved)
         else:
-            _PyNode._bind_resolved(resolution, _type_var_name(sentinel), default)
+            _PyNode._bind_resolved(resolution, name, default)
     return resolution
+
+
+def _service_scalar_values(signature, bound):
+    """Return the bound wiring-time scalars available to resolvers.
+
+    Time-series arguments may still be raw Python values at this point, so
+    select by the declared interface annotation rather than by runtime value.
+    This matches graph/node resolution: supplied values and applied defaults
+    are both visible by their declared parameter name.
+    """
+    return {
+        parameter.name: bound.arguments[parameter.name]
+        for parameter in signature.parameters.values()
+        if parameter.name in bound.arguments
+        and not _is_ts_annotation(parameter.annotation)
+        and parameter.annotation not in _INJECTABLE_MARKERS
+    }
+
+
+def _resolve_service_signature(
+    signature,
+    resolvers,
+    *,
+    resolution=None,
+    request_params=(),
+    requests=(),
+    scalar_values=None,
+    owner="service or adaptor",
+):
+    """Apply the common interface resolution order in one place.
+
+    Explicit bindings or request inference run first, type-valued defaults run
+    second, and only then do unresolved user resolvers receive the bound scalar
+    values. This is the same ordering used by nodes, graphs, and operators.
+    """
+    if resolution is None:
+        resolution = _hgraph.ResolutionScope()
+    for parameter, request in zip(request_params, requests):
+        if not resolution.match(
+                _pattern_of(parameter.annotation), _unwrap(request).ts_type):
+            raise TypeError(
+                f"generic {owner} request does not match its type pattern")
+    _apply_service_defaults(signature, resolution)
+    return _apply_service_resolvers(resolution, resolvers, scalar_values)
 
 
 class context:
@@ -554,9 +612,13 @@ class _ServiceStub:
         self._request_annotation = (
             self._request_params[0].annotation if self._request_params else None
         )
-        self._resolution = _apply_service_defaults(self._signature, resolution)
-        self._resolution = _apply_service_resolvers(
-            self._resolution, self._resolvers
+        # Interface construction is descriptive. Resolution happens only once
+        # explicit bindings, inferred request types, and call scalars are
+        # available; running a resolver here gives services a different order
+        # from nodes, graphs, and adaptors.
+        self._resolution = (
+            resolution if resolution is not None
+            else _hgraph.ResolutionScope()
         )
         out = self._signature.return_annotation
         reply_less = (
@@ -630,7 +692,8 @@ class _ServiceStub:
             item = slice(variables[0], items[0])
 
         resolution, specialization, variables = _specialization(
-            item, f"service '{self.__name__}'", self._resolvers)
+            item, f"service '{self.__name__}'", self._signature,
+            self._resolvers)
         result = _ServiceStub(
             self.fn, self.flavour, resolution=resolution,
             specialization=specialization, resolvers=self._resolvers,
@@ -694,19 +757,17 @@ class _ServiceStub:
         w = _current_wiring()
         stub = self
         if self.descriptor is None:
-            if requests:
-                resolution = _hgraph.ResolutionScope()
-                for parameter, request in zip(self._request_params, requests):
-                    actual = _unwrap(request).ts_type
-                    if not resolution.match(_pattern_of(parameter.annotation), actual):
-                        raise TypeError(
-                            f"generic service '{self.__name__}' request does not match its type pattern")
-                _apply_service_defaults(self._signature, resolution)
-                _apply_service_resolvers(resolution, self._resolvers)
-                _expand_pending_resolution(self, resolution, w)
-            else:
-                resolution = _apply_service_resolvers(
-                    _hgraph.ResolutionScope(), self._resolvers)
+            scalar_values = _service_scalar_values(self._signature, bound)
+            resolution = _resolve_service_signature(
+                self._signature,
+                self._resolvers,
+                request_params=self._request_params,
+                requests=requests,
+                scalar_values=scalar_values,
+                owner=f"service '{self.__name__}'",
+            )
+            _expand_pending_resolution(
+                self, resolution, w, scalar_values=scalar_values)
             resolution = _registered_service_resolution(self, w, path, resolution)
             specialization = _specialization_label(resolution)
             stub = _ServiceStub(
@@ -725,7 +786,9 @@ class _ServiceStub:
                 deprecated=self._deprecated,
                 pending_registrations=self._pending_registrations,
                 registered_resolutions=self._registered_resolutions)
-        _materialize_pending_registrations(self, stub._resolution, w)
+        scalar_values = _service_scalar_values(self._signature, bound)
+        _materialize_pending_registrations(
+            self, stub._resolution, w, scalar_values=scalar_values)
         # Record the client's wiring-time scalar options against the resolved
         # path, exactly as adaptor clients do. The key carries the flavour, and
         # ``_bind_registered_impl`` reads it back through ``_client_config``.
@@ -793,7 +856,7 @@ class _AdaptorClientStub:
             self.fn, resolution=resolution, specialization=specialization,
             resolvers=self._resolvers)
 
-    def _materialize_client_registration(self, stub):
+    def _materialize_client_registration(self, stub, scalar_values=None):
         del stub
 
     def _prepare_client_request(self, args, kwargs):
@@ -826,19 +889,19 @@ class _AdaptorClientStub:
             for value in (bound.arguments[parameter.name],)
         ]
         stub = self
+        scalar_values = _service_scalar_values(self._signature, bound)
         if self.descriptor is None:
-            resolution = _hgraph.ResolutionScope()
-            for parameter, request in zip(self._request_params, requests):
-                if not resolution.match(
-                        _pattern_of(parameter.annotation), _unwrap(request).ts_type):
-                    raise TypeError(
-                        f"generic {_flavour_label(self.flavour)} '{self.__name__}' "
-                        "request does not match its type pattern")
-            _apply_service_defaults(self._signature, resolution)
-            _apply_service_resolvers(resolution, self._resolvers)
+            resolution = _resolve_service_signature(
+                self._signature,
+                self._resolvers,
+                request_params=self._request_params,
+                requests=requests,
+                scalar_values=scalar_values,
+                owner=f"{_flavour_label(self.flavour)} '{self.__name__}'",
+            )
             specialization = _specialization_label(resolution)
             stub = self._specialized_stub(resolution, specialization)
-        self._materialize_client_registration(stub)
+        self._materialize_client_registration(stub, scalar_values)
         config_path, path = _resolved_client_path(stub, path)
         configured_path = _record_client_config(
             stub,
@@ -922,7 +985,8 @@ class _AdaptorStub(_AdaptorClientStub):
         if self.descriptor is not None and not self._specialization:
             raise TypeError(f"adaptor '{self.__name__}' is not generic")
         resolution, specialization, variables = _specialization(
-            item, f"adaptor '{self.__name__}'", self._resolvers)
+            item, f"adaptor '{self.__name__}'", self._signature,
+            self._resolvers)
         result = _AdaptorStub(
             self.fn, resolution=resolution, specialization=specialization,
             resolvers=self._resolvers,
@@ -971,9 +1035,10 @@ class _AdaptorStub(_AdaptorClientStub):
             pending_registrations=self._pending_registrations,
             registered_resolutions=self._registered_resolutions)
 
-    def _materialize_client_registration(self, stub):
+    def _materialize_client_registration(self, stub, scalar_values=None):
         _materialize_pending_registrations(
-            self, stub._resolution, _current_wiring())
+            self, stub._resolution, _current_wiring(),
+            scalar_values=scalar_values)
 
     def __call__(self, *args, **kwargs):
         prepared = self._prepare_client_request(args, kwargs)
@@ -1071,7 +1136,8 @@ class _ServiceAdaptorStub(_AdaptorClientStub):
                     f"to bind; use TYPEVAR: concrete")
             item = slice(variables[0], items[0])
         resolution, specialization, variables = _specialization(
-            item, f"service adaptor '{self.__name__}'", self._resolvers)
+            item, f"service adaptor '{self.__name__}'", self._signature,
+            self._resolvers)
         result = _ServiceAdaptorStub(
             self.fn, resolution=resolution, specialization=specialization,
             resolvers=self._resolvers,
@@ -1106,9 +1172,10 @@ class _ServiceAdaptorStub(_AdaptorClientStub):
             pending_registrations=self._pending_registrations,
             registered_resolutions=self._registered_resolutions)
 
-    def _materialize_client_registration(self, stub):
+    def _materialize_client_registration(self, stub, scalar_values=None):
         _materialize_pending_registrations(
-            self, stub._resolution, _current_wiring())
+            self, stub._resolution, _current_wiring(),
+            scalar_values=scalar_values)
 
     @staticmethod
     def _client_request_id(path, request):
@@ -1937,13 +2004,19 @@ def _implementation_for_stub(implementation, concrete_stub):
     return resolved
 
 
-def _specialize_registered_implementation(implementation, resolution):
+def _specialize_registered_implementation(
+    implementation, resolution, scalar_values=None,
+):
     import copy
 
     for stub in implementation.interfaces:
         if isinstance(stub, _ServiceStub):
-            _apply_service_defaults(stub._signature, resolution)
-            _apply_service_resolvers(resolution, stub._resolvers)
+            _resolve_service_signature(
+                stub._signature,
+                stub._resolvers,
+                resolution=resolution,
+                scalar_values=scalar_values,
+            )
     specialization = _specialization_label(resolution)
     resolved = copy.copy(implementation)
     resolved._resolution = resolution
@@ -2019,7 +2092,9 @@ def _queue_service_registration(path, implementation, config, owners=None,
         stub._pending_registrations.append(pending)
 
 
-def _materialize_pending_registrations(owner, resolution, wiring):
+def _materialize_pending_registrations(
+    owner, resolution, wiring, scalar_values=None,
+):
     if resolution is None:
         return
     root_wiring = _wiring_stack[0] if _wiring_stack else wiring
@@ -2027,7 +2102,7 @@ def _materialize_pending_registrations(owner, resolution, wiring):
         if pending.completed or pending.wiring is not root_wiring:
             continue
         resolved = _specialize_registered_implementation(
-            pending.implementation, resolution)
+            pending.implementation, resolution, scalar_values)
         pending.completed = True
         registered = (pending.wiring, pending.path, resolution)
         newly_registered = []
@@ -2084,15 +2159,21 @@ def _registered_service_resolution(owner, wiring, path, requested):
     return candidates[0]
 
 
-def _expand_pending_resolution(owner, resolution, wiring):
+def _expand_pending_resolution(
+    owner, resolution, wiring, scalar_values=None,
+):
     for pending in tuple(owner._pending_registrations):
         if pending.completed or pending.wiring is not wiring:
             continue
         for stub in pending.implementation.interfaces:
             if not isinstance(stub, _ServiceStub):
                 continue
-            _apply_service_defaults(stub._signature, resolution)
-            _apply_service_resolvers(resolution, stub._resolvers)
+            _resolve_service_signature(
+                stub._signature,
+                stub._resolvers,
+                resolution=resolution,
+                scalar_values=scalar_values,
+            )
 
 
 def _registered_stub_for_path(stub, path, wiring):

--- a/python/hgraph/_wiring/_services.py
+++ b/python/hgraph/_wiring/_services.py
@@ -377,6 +377,44 @@ def _service_type_variables(signature):
     return tuple(found.values())
 
 
+def _copy_service_resolution(resolution):
+    """Return a call-local copy of a native service resolution scope."""
+    copied = _hgraph.ResolutionScope()
+    if resolution is None:
+        return copied
+    for name, value in resolution.bindings.items():
+        if isinstance(value, _hgraph.TsType):
+            copied.bind_ts(name, value)
+        elif isinstance(value, _hgraph.ValueType):
+            copied.bind_scalar(name, value)
+        elif isinstance(value, int) and not isinstance(value, bool):
+            copied.bind_size(name, value)
+        else:  # pragma: no cover - ResolutionScope exposes only these kinds
+            raise TypeError(
+                f"unsupported service resolution binding {name}={value!r}")
+    return copied
+
+
+def _service_needs_resolution(stub):
+    """Whether transport or type-only interface variables remain unresolved.
+
+    A concrete transport descriptor is not sufficient: ``type[T]`` parameters
+    can still require call-time scalar values before a resolver can bind them.
+    Keep that distinction in one predicate for clients and registrations.
+    """
+    if getattr(stub, "descriptor", None) is None:
+        return True
+    signature = getattr(stub, "_signature", None)
+    if signature is None:
+        return False
+    resolution = getattr(stub, "_resolution", None)
+    return any(
+        resolution is None
+        or not resolution.is_resolved(_type_var_name(variable))
+        for variable in _service_type_variables(signature)
+    )
+
+
 def _inferred_specialization(fn, request_annotation, request, resolvers=None):
     resolution = _hgraph.ResolutionScope()
     actual = _unwrap(request).ts_type
@@ -675,7 +713,7 @@ class _ServiceStub:
         _remember_service_resolution(self)
 
     def __getitem__(self, item):
-        if self.descriptor is not None and not self._specialization:
+        if not _service_needs_resolution(self) and not self._specialization:
             raise TypeError(f"service '{self.__name__}' is not generic")
 
         items = item if isinstance(item, tuple) else (item,)
@@ -701,9 +739,9 @@ class _ServiceStub:
             pending_registrations=self._pending_registrations,
             registered_resolutions=self._registered_resolutions,
             resolution_variables=variables)
-        if result.descriptor is None:
+        if _service_needs_resolution(result):
             raise TypeError(
-                f"service '{self.__name__}' specialization leaves an unresolved time-series type")
+                f"service '{self.__name__}' specialization leaves an unresolved type")
         return result
 
     def _require_descriptor(self):
@@ -756,11 +794,12 @@ class _ServiceStub:
             ]
         w = _current_wiring()
         stub = self
-        if self.descriptor is None:
-            scalar_values = _service_scalar_values(self._signature, bound)
+        scalar_values = _service_scalar_values(self._signature, bound)
+        if _service_needs_resolution(self):
             resolution = _resolve_service_signature(
                 self._signature,
                 self._resolvers,
+                resolution=_copy_service_resolution(self._resolution),
                 request_params=self._request_params,
                 requests=requests,
                 scalar_values=scalar_values,
@@ -776,6 +815,9 @@ class _ServiceStub:
                 deprecated=self._deprecated,
                 pending_registrations=self._pending_registrations,
                 registered_resolutions=self._registered_resolutions)
+            if _service_needs_resolution(stub):
+                raise TypeError(
+                    f"generic service '{self.__name__}' has unresolved type variables")
         elif self._registered_resolutions:
             resolution = _registered_service_resolution(
                 self, w, path, self._resolution)
@@ -786,7 +828,6 @@ class _ServiceStub:
                 deprecated=self._deprecated,
                 pending_registrations=self._pending_registrations,
                 registered_resolutions=self._registered_resolutions)
-        scalar_values = _service_scalar_values(self._signature, bound)
         _materialize_pending_registrations(
             self, stub._resolution, w, scalar_values=scalar_values)
         # Record the client's wiring-time scalar options against the resolved
@@ -819,7 +860,7 @@ class _ServiceStub:
         """Register an implementation through this interface specialization."""
         if not isinstance(implementation, _ServiceImpl):
             raise WiringError("register_impl requires an @service_impl-decorated implementation")
-        if self.descriptor is None:
+        if _service_needs_resolution(self):
             _queue_service_registration(path, implementation, kwargs, (self,))
             return
         resolved = _implementation_for_stub(implementation, self)
@@ -890,10 +931,11 @@ class _AdaptorClientStub:
         ]
         stub = self
         scalar_values = _service_scalar_values(self._signature, bound)
-        if self.descriptor is None:
+        if _service_needs_resolution(self):
             resolution = _resolve_service_signature(
                 self._signature,
                 self._resolvers,
+                resolution=_copy_service_resolution(self._resolution),
                 request_params=self._request_params,
                 requests=requests,
                 scalar_values=scalar_values,
@@ -901,6 +943,10 @@ class _AdaptorClientStub:
             )
             specialization = _specialization_label(resolution)
             stub = self._specialized_stub(resolution, specialization)
+            if _service_needs_resolution(stub):
+                raise TypeError(
+                    f"generic {_flavour_label(self.flavour)} '{self.__name__}' "
+                    "has unresolved type variables")
         self._materialize_client_registration(stub, scalar_values)
         config_path, path = _resolved_client_path(stub, path)
         configured_path = _record_client_config(
@@ -982,7 +1028,7 @@ class _AdaptorStub(_AdaptorClientStub):
         _remember_service_resolution(self)
 
     def __getitem__(self, item):
-        if self.descriptor is not None and not self._specialization:
+        if not _service_needs_resolution(self) and not self._specialization:
             raise TypeError(f"adaptor '{self.__name__}' is not generic")
         resolution, specialization, variables = _specialization(
             item, f"adaptor '{self.__name__}'", self._signature,
@@ -993,9 +1039,9 @@ class _AdaptorStub(_AdaptorClientStub):
             pending_registrations=self._pending_registrations,
             registered_resolutions=self._registered_resolutions,
             resolution_variables=variables)
-        if result.descriptor is None:
+        if _service_needs_resolution(result):
             raise TypeError(
-                f"adaptor '{self.__name__}' specialization leaves an unresolved time-series type")
+                f"adaptor '{self.__name__}' specialization leaves an unresolved type")
         return result
 
     def _require_descriptor(self):
@@ -1121,7 +1167,7 @@ class _ServiceAdaptorStub(_AdaptorClientStub):
         _remember_service_resolution(self)
 
     def __getitem__(self, item):
-        if self.descriptor is not None and not self._specialization:
+        if not _service_needs_resolution(self) and not self._specialization:
             raise TypeError(f"service adaptor '{self.__name__}' is not generic")
         items = item if isinstance(item, tuple) else (item,)
         if not all(isinstance(binding, slice) for binding in items):
@@ -1144,9 +1190,9 @@ class _ServiceAdaptorStub(_AdaptorClientStub):
             pending_registrations=self._pending_registrations,
             registered_resolutions=self._registered_resolutions,
             resolution_variables=variables)
-        if result.descriptor is None:
+        if _service_needs_resolution(result):
             raise TypeError(
-                f"service adaptor '{self.__name__}' specialization leaves an unresolved time-series type")
+                f"service adaptor '{self.__name__}' specialization leaves an unresolved type")
         return result
 
     def _require_descriptor(self):
@@ -1316,7 +1362,7 @@ def register_adaptor(path, implementation, resolution_dict=None, **kwargs):
         raise WiringError("register_adaptor requires an @adaptor_impl-decorated implementation")
     unresolved = tuple(
         stub for stub in implementation.interfaces
-        if getattr(stub, "descriptor", None) is None)
+        if _service_needs_resolution(stub))
     if unresolved and not resolution_dict:
         _queue_service_registration(
             path, implementation, kwargs, unresolved,
@@ -1751,6 +1797,11 @@ def _bind_registered_impl(implementation, path, config):
         ts_type = resolution.find_ts(name)
         if ts_type is not None:
             resolved_config[param.name] = _TsExpr(ts_type, f"resolved[{name}]")
+            continue
+        size = resolution.find_size(name)
+        if size is not None:
+            from ._graph import _ResolvedSize
+            resolved_config[param.name] = _ResolvedSize(size)
 
     cache_key = None
     if not registration_contexts:
@@ -1949,7 +2000,7 @@ def _resolve_registered_implementation(implementation, resolution_dict, operatio
     """
     unresolved = [
         stub for stub in implementation.interfaces
-        if getattr(stub, "descriptor", None) is None
+        if _service_needs_resolution(stub)
     ]
     if not unresolved:
         return implementation
@@ -1962,7 +2013,7 @@ def _resolve_registered_implementation(implementation, resolution_dict, operatio
 
     resolved = copy.copy(implementation)
     resolved.interfaces = tuple(
-        stub[entries] if getattr(stub, "descriptor", None) is None else stub
+        stub[entries] if _service_needs_resolution(stub) else stub
         for stub in implementation.interfaces
     )
     return resolved
@@ -2009,8 +2060,9 @@ def _specialize_registered_implementation(
 ):
     import copy
 
+    participants = (_ServiceStub, _AdaptorStub, _ServiceAdaptorStub)
     for stub in implementation.interfaces:
-        if isinstance(stub, _ServiceStub):
+        if isinstance(stub, participants):
             _resolve_service_signature(
                 stub._signature,
                 stub._resolvers,
@@ -2022,21 +2074,21 @@ def _specialize_registered_implementation(
     resolved._resolution = resolution
     interfaces = []
     for stub in implementation.interfaces:
-        if getattr(stub, "descriptor", None) is not None:
-            if len(implementation.interfaces) > 1 and isinstance(stub, _ServiceStub):
-                interfaces.append(_ServiceStub(
-                    stub.fn, stub.flavour, resolution=resolution,
-                    specialization=specialization, resolvers=stub._resolvers,
-                    deprecated=stub._deprecated,
-                    pending_registrations=stub._pending_registrations,
-                    registered_resolutions=stub._registered_resolutions,
-                ))
-            else:
-                interfaces.append(stub)
+        if not isinstance(stub, participants):
+            if getattr(stub, "descriptor", None) is None:
+                raise WiringError(
+                    f"generic registration is not supported for "
+                    f"{stub.flavour} '{stub.__name__}'")
+            interfaces.append(stub)
             continue
-        if not isinstance(stub, (_ServiceStub, _AdaptorStub, _ServiceAdaptorStub)):
-            raise WiringError(
-                f"generic registration is not supported for {stub.flavour} '{stub.__name__}'")
+
+        needs_concrete = (
+            _service_needs_resolution(stub)
+            or (len(implementation.interfaces) > 1 and bool(specialization))
+        )
+        if not needs_concrete:
+            interfaces.append(stub)
+            continue
         if isinstance(stub, _AdaptorStub):
             concrete = _AdaptorStub(
                 stub.fn, resolution=resolution, specialization=specialization,
@@ -2056,7 +2108,7 @@ def _specialize_registered_implementation(
                 deprecated=stub._deprecated,
                 pending_registrations=stub._pending_registrations,
                 registered_resolutions=stub._registered_resolutions)
-        if concrete.descriptor is None:
+        if _service_needs_resolution(concrete):
             raise WiringError(
                 f"service '{stub.__name__}' remains unresolved after request inference")
         interfaces.append(concrete)
@@ -2068,7 +2120,7 @@ def _queue_service_registration(path, implementation, config, owners=None,
                                 registrar=None):
     unresolved = tuple(
         stub for stub in implementation.interfaces
-        if getattr(stub, "descriptor", None) is None
+        if _service_needs_resolution(stub)
     )
     triggers = tuple(owners or unresolved)
     if not triggers:
@@ -2343,7 +2395,7 @@ def register_service(path, implementation, resolution_dict=None, **kwargs):
         raise WiringError("register_service requires an @service_impl-decorated implementation")
     unresolved = tuple(
         stub for stub in implementation.interfaces
-        if getattr(stub, "descriptor", None) is None
+        if _service_needs_resolution(stub)
     )
     if unresolved and not resolution_dict:
         _queue_service_registration(path, implementation, kwargs, unresolved)

--- a/python/py_type_system.cpp
+++ b/python/py_type_system.cpp
@@ -887,6 +887,8 @@ namespace hgraph::python_bridge
         const Value parsed = from_json_string(meta.meta, text);
         return python_bridge::value_to_py(parsed.view());
     });
+    m.def("register_json_datetime_format", &register_json_datetime_format,
+          nb::arg("format"), nb::arg("time_only") = false);
     m.def("enum_vt", [](const std::string &name, nb::list members, nb::object cls) {
         std::vector<std::pair<std::string, long long>> table;
         table.reserve(nb::len(members));

--- a/python/tests/ported/_operators/test_to_json.py
+++ b/python/tests/ported/_operators/test_to_json.py
@@ -172,6 +172,14 @@ def test_register_json_datetime_format_accepts_a_producers_own_format():
     ) == [datetime(2024, 6, 13, 10, 15, 30)]
 
 
+def test_registered_json_datetime_format_translates_fraction_directives():
+    register_json_datetime_format("%Y-%m-%d %H:%M:%S,%f")
+    assert eval_node(
+        from_json[TS[datetime]],
+        ['"2024-06-13 10:15:30,123456"'],
+    ) == [datetime(2024, 6, 13, 10, 15, 30, 123456)]
+
+
 def test_register_json_time_format_accepts_a_producers_own_format():
     register_json_datetime_format("%I.%M.%S %p", time_only=True)
     assert eval_node(
@@ -182,6 +190,13 @@ def test_register_json_time_format_accepts_a_producers_own_format():
         time(0, 0, 0),
         time(12, 0, 0),
     ]
+
+
+def test_registered_json_time_format_translates_fraction_directives():
+    register_json_datetime_format("%H:%M:%S,%f", time_only=True)
+    assert eval_node(
+        from_json[TS[time]], ['"10:15:30,000042"'],
+    ) == [time(10, 15, 30, 42)]
 
 
 def test_to_json_omits_fractional_seconds_when_zero():

--- a/python/tests/ported/_operators/test_to_json.py
+++ b/python/tests/ported/_operators/test_to_json.py
@@ -22,6 +22,7 @@ from hgraph import (
     REMOVE,
     to_json_builder,
     from_json_builder,
+    register_json_datetime_format,
 )
 from hgraph.test import eval_node
 
@@ -104,6 +105,93 @@ def test_from_json_accepts_legacy_temporal_version_1_text():
     ) == [
         timedelta(days=10, seconds=15, microseconds=42),
         timedelta(microseconds=-1),
+    ]
+
+
+@pytest.mark.parametrize(
+    ["text", "expected"],
+    [
+        ['"2024-06-13T10:15:30.000042"', datetime(2024, 6, 13, 10, 15, 30, 42)],
+        ['"2024-06-13T10:15:30"', datetime(2024, 6, 13, 10, 15, 30)],
+        ['"2024-06-13T10:15"', datetime(2024, 6, 13, 10, 15)],
+        ['"2024-06-13"', datetime(2024, 6, 13)],
+        ['"2024-06-13T10:15:30.5"', datetime(2024, 6, 13, 10, 15, 30, 500000)],
+        ['"20240613T101530"', datetime(2024, 6, 13, 10, 15, 30)],
+        ['"20240613101530"', datetime(2024, 6, 13, 10, 15, 30)],
+        ['"20240613101530123456"', datetime(2024, 6, 13, 10, 15, 30, 123456)],
+        ['"2024-06-13 10:15:30.000042"', datetime(2024, 6, 13, 10, 15, 30, 42)],
+        ['"2024-06-13T10:15:30Z"', datetime(2024, 6, 13, 10, 15, 30)],
+        ['"2024-06-13T11:15:30+01:00"', datetime(2024, 6, 13, 10, 15, 30)],
+        ['"2024-06-13T05:15:30-05:00"', datetime(2024, 6, 13, 10, 15, 30)],
+        ['"2024/06/13 10:15:30"', datetime(2024, 6, 13, 10, 15, 30)],
+        ['"13-Jun-2024 10:15:30"', datetime(2024, 6, 13, 10, 15, 30)],
+        ['"13 Jun 2024"', datetime(2024, 6, 13)],
+    ],
+)
+def test_from_json_accepts_many_datetime_formats(text: str, expected: datetime):
+    assert eval_node(from_json[TS[datetime]], [text]) == [expected]
+
+
+@pytest.mark.parametrize(
+    ["text", "expected"],
+    [
+        ['"10:15:30.000042"', time(10, 15, 30, 42)],
+        ['"10:15:30"', time(10, 15, 30)],
+        ['"10:15"', time(10, 15)],
+        ['"101530"', time(10, 15, 30)],
+        ['"101530123456"', time(10, 15, 30, 123456)],
+    ],
+)
+def test_from_json_accepts_many_time_formats(text: str, expected: time):
+    assert eval_node(from_json[TS[time]], [text]) == [expected]
+
+
+@pytest.mark.parametrize(
+    ["text", "expected"],
+    [
+        ['"2024-06-13"', date(2024, 6, 13)],
+        ['"20240613"', date(2024, 6, 13)],
+        ['"2024/06/13"', date(2024, 6, 13)],
+        ['"13-Jun-2024"', date(2024, 6, 13)],
+        ['"2024-06-13T10:15:30"', date(2024, 6, 13)],
+    ],
+)
+def test_from_json_accepts_many_date_formats(text: str, expected: date):
+    assert eval_node(from_json[TS[date]], [text]) == [expected]
+
+
+def test_from_json_rejects_an_unparseable_datetime():
+    with pytest.raises(Exception, match="not a datetime"):
+        eval_node(from_json[TS[datetime]], ['"not a datetime"'])
+
+
+def test_register_json_datetime_format_accepts_a_producers_own_format():
+    register_json_datetime_format("%d/%m/%Y %H:%M:%S")
+    assert eval_node(
+        from_json[TS[datetime]], ['"13/06/2024 10:15:30"'],
+    ) == [datetime(2024, 6, 13, 10, 15, 30)]
+
+
+def test_register_json_time_format_accepts_a_producers_own_format():
+    register_json_datetime_format("%I.%M.%S %p", time_only=True)
+    assert eval_node(
+        from_json[TS[time]],
+        ['"10.15.30 PM"', '"12.00.00 AM"', '"12.00.00 PM"'],
+    ) == [
+        time(22, 15, 30),
+        time(0, 0, 0),
+        time(12, 0, 0),
+    ]
+
+
+def test_to_json_omits_fractional_seconds_when_zero():
+    # RFC 0002 keeps the canonical UTC suffix for an Instant while matching
+    # Python's omission of a zero fractional component.
+    assert eval_node(
+        to_json[TS[datetime]], [datetime(2024, 6, 13, 10, 15, 30)],
+    ) == ['"2024-06-13T10:15:30Z"']
+    assert eval_node(to_json[TS[time]], [time(10, 15, 30)]) == [
+        '"10:15:30"'
     ]
 
 

--- a/python/tests/test_service_resolver_consistency.py
+++ b/python/tests/test_service_resolver_consistency.py
@@ -103,3 +103,44 @@ def test_service_and_adaptor_resolvers_receive_bound_scalar_values():
         eval_node(app, [1])
 
     assert all(values and set(values) == {str} for values in calls.values())
+
+
+def test_type_only_service_and_adaptor_resolvers_run_with_concrete_transports():
+    @hg.reference_service(
+        resolvers={hg.SIZE: lambda mapping, width: width})
+    def sized_reference(
+        width: int,
+        size: type[hg.SIZE] = hg.AUTO_RESOLVE,
+        path: str = "sized-reference",
+    ) -> TS[int]: ...
+
+    @hg.service_impl(interfaces=sized_reference)
+    def sized_reference_impl(
+        size: type[hg.SIZE] = hg.AUTO_RESOLVE,
+    ) -> TS[int]:
+        return hg.const(size.SIZE)
+
+    @hg.adaptor(resolvers={hg.SIZE: lambda mapping, width: width})
+    def sized_adaptor(
+        value: TS[int],
+        width: int,
+        size: type[hg.SIZE] = hg.AUTO_RESOLVE,
+        path: str = "sized-adaptor",
+    ) -> TS[int]: ...
+
+    @hg.adaptor_impl(interfaces=sized_adaptor)
+    def sized_adaptor_impl(
+        value: TS[int],
+        size: type[hg.SIZE] = hg.AUTO_RESOLVE,
+    ) -> TS[int]:
+        return value + size.SIZE
+
+    @graph
+    def app(value: TS[int]) -> TS[int]:
+        hg.register_service("sized-reference", sized_reference_impl)
+        hg.register_adaptor("sized-adaptor", sized_adaptor_impl)
+        reference = sized_reference(3, path="sized-reference")
+        adapted = sized_adaptor(value, 4, path="sized-adaptor")
+        return reference + adapted
+
+    assert eval_node(app, [1, 2]) == [8, 9]

--- a/python/tests/test_service_resolver_consistency.py
+++ b/python/tests/test_service_resolver_consistency.py
@@ -1,0 +1,105 @@
+"""Service and adaptor resolvers follow the shared wiring resolution order."""
+
+import pytest
+
+import hgraph as hg
+from hgraph import TS, graph
+from hgraph.test import eval_node
+
+
+def test_explicit_service_and_adaptor_specializations_skip_bound_resolvers():
+    calls = []
+
+    def unexpected(surface):
+        def resolver(mapping):
+            calls.append(surface)
+            raise AssertionError(f"{surface} resolver must not run")
+
+        return resolver
+
+    @hg.reference_service(resolvers={hg.SCALAR: unexpected("reference")})
+    def reference() -> TS[hg.SCALAR]: ...
+
+    @hg.subscription_service(resolvers={hg.SCALAR: unexpected("subscription")})
+    def subscription(key: TS[int]) -> TS[hg.SCALAR]: ...
+
+    @hg.request_reply_service(resolvers={hg.SCALAR: unexpected("request/reply")})
+    def request_reply(request: TS[int]) -> TS[hg.SCALAR]: ...
+
+    @hg.adaptor(resolvers={hg.SCALAR: unexpected("adaptor")})
+    def adaptor(request: TS[int]) -> TS[hg.SCALAR]: ...
+
+    @hg.service_adaptor(resolvers={hg.SCALAR: unexpected("service adaptor")})
+    def service_adaptor(request: TS[int]) -> TS[hg.SCALAR]: ...
+
+    assert reference[hg.SCALAR:int] is not None
+    assert subscription[hg.SCALAR:int] is not None
+    assert request_reply[hg.SCALAR:int] is not None
+    assert adaptor[hg.SCALAR:int] is not None
+    assert service_adaptor[hg.SCALAR:int] is not None
+    assert calls == []
+
+
+def test_service_and_adaptor_resolvers_receive_bound_scalar_values():
+    calls = {
+        "reference": [],
+        "subscription": [],
+        "request/reply": [],
+        "adaptor": [],
+        "service adaptor": [],
+    }
+
+    def selected_type(surface):
+        def resolver(mapping, response_type):
+            calls[surface].append(response_type)
+            return response_type
+
+        return resolver
+
+    @hg.reference_service(resolvers={hg.SCALAR: selected_type("reference")})
+    def reference(
+        response_type: type, path: str = "missing-reference",
+    ) -> TS[hg.SCALAR]: ...
+
+    @hg.subscription_service(
+        resolvers={hg.SCALAR: selected_type("subscription")})
+    def subscription(
+        key: TS[int], response_type: type,
+        path: str = "missing-subscription",
+    ) -> TS[hg.SCALAR]: ...
+
+    @hg.request_reply_service(
+        resolvers={hg.SCALAR: selected_type("request/reply")})
+    def request_reply(
+        request: TS[int], response_type: type,
+        path: str = "missing-request-reply",
+    ) -> TS[hg.SCALAR]: ...
+
+    @hg.adaptor(resolvers={hg.SCALAR: selected_type("adaptor")})
+    def adaptor(
+        request: TS[int], response_type: type,
+        path: str = "missing-adaptor",
+    ) -> TS[hg.SCALAR]: ...
+
+    @hg.service_adaptor(
+        resolvers={hg.SCALAR: selected_type("service adaptor")})
+    def service_adaptor(
+        request: TS[int], response_type: type,
+        path: str = "missing-service-adaptor",
+    ) -> TS[hg.SCALAR]: ...
+
+    @graph
+    def app(value: TS[int]) -> TS[int]:
+        reference(str, path="missing-reference")
+        subscription(value, str, path="missing-subscription")
+        request_reply(value, str, path="missing-request-reply")
+        adaptor(value, str, path="missing-adaptor")
+        service_adaptor(value, str, path="missing-service-adaptor")
+        return value
+
+    # The missing implementations are intentional: all resolver calls happen
+    # through the public graph wiring surface before service materialization.
+    with pytest.raises((hg.WiringError, ValueError)):
+        eval_node(app, [1])
+
+    assert all(values and set(values) == {str} for values in calls.values())

--- a/src/hgraph/types/value/json_codec.cpp
+++ b/src/hgraph/types/value/json_codec.cpp
@@ -29,6 +29,7 @@
 #include <stdexcept>
 #include <unordered_map>
 #include <utility>
+#include <vector>
 
 namespace hgraph
 {
@@ -374,29 +375,95 @@ namespace hgraph
             ++pos;
         }
 
-        [[nodiscard]] std::string translate_python_datetime_format(
-            std::string_view format)
+        struct TranslatedPythonDateTimeInput
         {
-            std::string translated;
-            translated.reserve(format.size());
-            for (std::size_t position = 0; position < format.size();)
+            std::string              format{};
+            std::vector<std::string> candidates{};
+        };
+
+        [[nodiscard]] TranslatedPythonDateTimeInput
+            translate_python_datetime_input(
+                std::string_view text, std::string_view format)
+        {
+            TranslatedPythonDateTimeInput translated{
+                std::string{format}, {std::string{text}}};
+            const std::size_t fraction = format.find("%f");
+            if (fraction == std::string_view::npos)
             {
-                if (format.substr(position, 5) == "%S.%f")
+                return translated;
+            }
+
+            const std::size_t seconds = format.rfind("%S", fraction);
+            if (seconds == std::string_view::npos)
+            {
+                return translated;
+            }
+            const std::string_view separator = format.substr(
+                seconds + 2, fraction - (seconds + 2));
+            if (separator.find('%') != std::string_view::npos)
+            {
+                return translated;
+            }
+
+            // date::from_stream parses fractional seconds as part of %S,
+            // whereas Python strptime exposes them as a separate %f. Remove
+            // the literal separator and %f from the format, then normalize
+            // that separator in candidate text to the classic locale's '.'.
+            translated.format = std::string{format.substr(0, seconds + 2)};
+            translated.format.append(format.substr(fraction + 2));
+
+            const auto add_candidate = [&](std::string candidate) {
+                if (std::ranges::find(
+                        translated.candidates, candidate) ==
+                    translated.candidates.end())
                 {
-                    // date::from_stream parses the fractional component as
-                    // part of %S; Python strptime spells it as a separate %f.
-                    translated += "%S";
-                    position += 5;
+                    translated.candidates.push_back(std::move(candidate));
                 }
-                else if (format.substr(position, 4) == "%S%f")
+            };
+            const auto is_digit = [](char value) {
+                return std::isdigit(
+                    static_cast<unsigned char>(value)) != 0;
+            };
+
+            if (separator == ".")
+            {
+                return translated;
+            }
+            if (separator.empty())
+            {
+                // For compact %S%f spellings, try each position after a
+                // two-digit seconds field. Full-format parsing selects the
+                // position consistent with the surrounding directives.
+                for (std::size_t position = 2; position < text.size();
+                     ++position)
                 {
-                    translated += "%S";
-                    position += 4;
+                    if (!is_digit(text[position - 2]) ||
+                        !is_digit(text[position - 1]) ||
+                        !is_digit(text[position]))
+                    {
+                        continue;
+                    }
+                    std::string candidate{text};
+                    candidate.insert(position, 1, '.');
+                    add_candidate(std::move(candidate));
                 }
-                else
+                return translated;
+            }
+
+            for (std::size_t position = text.find(separator);
+                 position != std::string_view::npos;
+                 position = text.find(separator, position + separator.size()))
+            {
+                const std::size_t fraction_start =
+                    position + separator.size();
+                if (fraction_start >= text.size() ||
+                    !is_digit(text[fraction_start]))
                 {
-                    translated.push_back(format[position++]);
+                    continue;
                 }
+                std::string candidate{text};
+                candidate.replace(position, separator.size(), ".");
+                add_candidate(std::move(candidate));
             }
             return translated;
         }
@@ -425,8 +492,9 @@ namespace hgraph
         [[nodiscard]] std::optional<TimePoint> parse_datetime_format(
             std::string_view text, std::string_view python_format)
         {
-            const std::string format =
-                translate_python_datetime_format(python_format);
+            const auto translated =
+                translate_python_datetime_input(text, python_format);
+            const std::string &format = translated.format;
             const auto parse = [](std::string_view candidate,
                                   std::string_view candidate_format)
                 -> std::optional<TimePoint> {
@@ -442,7 +510,10 @@ namespace hgraph
                 return value;
             };
 
-            if (auto value = parse(text, format)) { return value; }
+            for (const std::string &candidate : translated.candidates)
+            {
+                if (auto value = parse(candidate, format)) { return value; }
+            }
 
             const bool has_offset =
                 format.find("%z") != std::string::npos ||
@@ -452,11 +523,23 @@ namespace hgraph
             const std::string extended_format = colon_offset_format(format);
             if (extended_format != format)
             {
-                if (auto value = parse(text, extended_format)) { return value; }
+                for (const std::string &candidate : translated.candidates)
+                {
+                    if (auto value = parse(candidate, extended_format))
+                    {
+                        return value;
+                    }
+                }
             }
-            if (!text.empty() && (text.back() == 'Z' || text.back() == 'z'))
+            for (const std::string &candidate : translated.candidates)
             {
-                std::string normalized{text.substr(0, text.size() - 1)};
+                if (candidate.empty() ||
+                    (candidate.back() != 'Z' && candidate.back() != 'z'))
+                {
+                    continue;
+                }
+                std::string normalized{
+                    candidate.substr(0, candidate.size() - 1)};
                 normalized += "+00:00";
                 if (auto value = parse(normalized, extended_format))
                 {
@@ -621,47 +704,54 @@ namespace hgraph
             const auto parse = [](std::string_view candidate,
                                   std::string_view python_format)
                 -> std::optional<CivilTime> {
-                const std::string format =
-                    translate_python_datetime_format(python_format);
-                std::istringstream stream{std::string{candidate}};
-                stream.imbue(std::locale::classic());
-                std::chrono::microseconds value{};
-                json_datetime_from_stream(stream, format.c_str(), value);
-                if (stream.fail() || stream.rdbuf()->in_avail() != 0)
+                const auto translated = translate_python_datetime_input(
+                    candidate, python_format);
+                for (const std::string &normalized : translated.candidates)
                 {
-                    return std::nullopt;
-                }
-                if (format.find("%p") != std::string::npos)
-                {
-                    std::string meridiem{candidate};
-                    std::ranges::transform(
-                        meridiem, meridiem.begin(), [](char value) {
-                            return static_cast<char>(std::toupper(
-                                static_cast<unsigned char>(value)));
-                        });
-                    const bool is_am = meridiem.find("AM") != std::string::npos;
-                    const bool is_pm = meridiem.find("PM") != std::string::npos;
-                    if (is_am == is_pm) { return std::nullopt; }
+                    std::istringstream stream{normalized};
+                    stream.imbue(std::locale::classic());
+                    std::chrono::microseconds value{};
+                    json_datetime_from_stream(
+                        stream, translated.format.c_str(), value);
+                    if (stream.fail() || stream.rdbuf()->in_avail() != 0)
+                    {
+                        continue;
+                    }
+                    if (translated.format.find("%p") != std::string::npos)
+                    {
+                        std::string meridiem{normalized};
+                        std::ranges::transform(
+                            meridiem, meridiem.begin(), [](char value) {
+                                return static_cast<char>(std::toupper(
+                                    static_cast<unsigned char>(value)));
+                            });
+                        const bool is_am =
+                            meridiem.find("AM") != std::string::npos;
+                        const bool is_pm =
+                            meridiem.find("PM") != std::string::npos;
+                        if (is_am == is_pm) { continue; }
 
-                    const auto hour =
-                        std::chrono::duration_cast<std::chrono::hours>(value);
-                    // Howard Hinnant date releases differ in whether parsing
-                    // a duration applies %p. Normalize either result.
-                    if (is_pm && hour < std::chrono::hours{12})
-                    {
-                        value += std::chrono::hours{12};
+                        const auto hour = std::chrono::duration_cast<
+                            std::chrono::hours>(value);
+                        // Howard Hinnant date releases differ in whether
+                        // parsing a duration applies %p. Normalize either.
+                        if (is_pm && hour < std::chrono::hours{12})
+                        {
+                            value += std::chrono::hours{12};
+                        }
+                        else if (is_am && hour >= std::chrono::hours{12})
+                        {
+                            value -= std::chrono::hours{12};
+                        }
                     }
-                    else if (is_am && hour >= std::chrono::hours{12})
+                    if (value < std::chrono::microseconds{0} ||
+                        value >= std::chrono::hours{24})
                     {
-                        value -= std::chrono::hours{12};
+                        continue;
                     }
+                    return CivilTime{value.count()};
                 }
-                if (value < std::chrono::microseconds{0} ||
-                    value >= std::chrono::hours{24})
-                {
-                    return std::nullopt;
-                }
-                return CivilTime{value.count()};
+                return std::nullopt;
             };
             for (const std::string_view format : iso_formats)
             {

--- a/src/hgraph/types/value/json_codec.cpp
+++ b/src/hgraph/types/value/json_codec.cpp
@@ -10,13 +10,21 @@
 
 #include <fmt/format.h>
 
+#if defined(HGRAPH_TIME_ZONE_BACKEND_DATE)
+#include <date/date.h>
+#endif
+
 #include <hgraph/util/scope.h>
 
+#include <algorithm>
+#include <array>
 #include <charconv>
 #include <chrono>
+#include <cctype>
 #include <locale>
 #include <memory>
 #include <mutex>
+#include <optional>
 #include <sstream>
 #include <stdexcept>
 #include <unordered_map>
@@ -24,6 +32,74 @@
 
 namespace hgraph
 {
+    namespace
+    {
+        struct RegisteredJsonDateTimeFormats
+        {
+            std::vector<std::string> datetime{};
+            std::vector<std::string> time{};
+        };
+
+        using JsonDateTimeFormatSnapshot =
+            std::shared_ptr<const RegisteredJsonDateTimeFormats>;
+
+        struct JsonDateTimeFormatRegistry
+        {
+            std::mutex mutex{};
+            JsonDateTimeFormatSnapshot formats{
+                std::make_shared<const RegisteredJsonDateTimeFormats>()};
+        };
+
+#if defined(HGRAPH_TIME_ZONE_BACKEND_DATE)
+        template <typename Duration>
+        using JsonSysTime = date::sys_time<Duration>;
+        template <typename Duration>
+        using JsonLocalTime = date::local_time<Duration>;
+#else
+        template <typename Duration>
+        using JsonSysTime = std::chrono::sys_time<Duration>;
+        template <typename Duration>
+        using JsonLocalTime = std::chrono::local_time<Duration>;
+#endif
+
+        template <typename Stream, typename Value>
+        void json_datetime_from_stream(
+            Stream &stream, const char *format, Value &value)
+        {
+#if defined(HGRAPH_TIME_ZONE_BACKEND_DATE)
+            date::from_stream(stream, format, value);
+#else
+            std::chrono::from_stream(stream, format, value);
+#endif
+        }
+
+        JsonDateTimeFormatRegistry &registered_datetime_formats()
+        {
+            static JsonDateTimeFormatRegistry registry{};
+            return registry;
+        }
+
+        [[nodiscard]] JsonDateTimeFormatSnapshot
+            registered_datetime_format_snapshot()
+        {
+            auto &registry = registered_datetime_formats();
+            std::lock_guard lock{registry.mutex};
+            return registry.formats;
+        }
+
+        constexpr std::array<std::string_view, 8>
+            builtin_json_datetime_formats{
+                "%Y/%m/%d %H:%M:%S.%f",
+                "%Y/%m/%d %H:%M:%S",
+                "%Y/%m/%d",
+                "%d-%b-%Y %H:%M:%S.%f",
+                "%d-%b-%Y %H:%M:%S",
+                "%d-%b-%Y",
+                "%d %b %Y %H:%M:%S",
+                "%d %b %Y",
+            };
+    }  // namespace
+
     namespace json_detail
     {
         // ---------------------------------------------------------------
@@ -67,8 +143,11 @@ namespace hgraph
         void append_time_of_day(std::int64_t micros_since_midnight, std::string &out)
         {
             const auto total_seconds = micros_since_midnight / 1'000'000;
-            out += fmt::format("{:02}:{:02}:{:02}.{:06}", total_seconds / 3'600, (total_seconds / 60) % 60,
-                               total_seconds % 60, micros_since_midnight % 1'000'000);
+            const auto micros = micros_since_midnight % 1'000'000;
+            out += fmt::format("{:02}:{:02}:{:02}", total_seconds / 3'600,
+                               (total_seconds / 60) % 60,
+                               total_seconds % 60);
+            if (micros != 0) { out += fmt::format(".{:06}", micros); }
         }
 
         // ---------------------------------------------------------------
@@ -293,6 +372,350 @@ namespace hgraph
         {
             if (pos >= text.size() || text[pos] != c) { reader.fail("bad date/time separator"); }
             ++pos;
+        }
+
+        [[nodiscard]] std::string translate_python_datetime_format(
+            std::string_view format)
+        {
+            std::string translated;
+            translated.reserve(format.size());
+            for (std::size_t position = 0; position < format.size();)
+            {
+                if (format.substr(position, 5) == "%S.%f")
+                {
+                    // date::from_stream parses the fractional component as
+                    // part of %S; Python strptime spells it as a separate %f.
+                    translated += "%S";
+                    position += 5;
+                }
+                else if (format.substr(position, 4) == "%S%f")
+                {
+                    translated += "%S";
+                    position += 4;
+                }
+                else
+                {
+                    translated.push_back(format[position++]);
+                }
+            }
+            return translated;
+        }
+
+        [[nodiscard]] std::string colon_offset_format(
+            std::string_view format)
+        {
+            std::string translated;
+            translated.reserve(format.size() + 1);
+            for (std::size_t position = 0; position < format.size();)
+            {
+                if (format.substr(position, 2) == "%z")
+                {
+                    translated += "%Ez";
+                    position += 2;
+                }
+                else
+                {
+                    translated.push_back(format[position++]);
+                }
+            }
+            return translated;
+        }
+
+        template <typename TimePoint>
+        [[nodiscard]] std::optional<TimePoint> parse_datetime_format(
+            std::string_view text, std::string_view python_format)
+        {
+            const std::string format =
+                translate_python_datetime_format(python_format);
+            const auto parse = [](std::string_view candidate,
+                                  std::string_view candidate_format)
+                -> std::optional<TimePoint> {
+                std::istringstream stream{std::string{candidate}};
+                stream.imbue(std::locale::classic());
+                TimePoint value{};
+                json_datetime_from_stream(
+                    stream, std::string{candidate_format}.c_str(), value);
+                if (stream.fail() || stream.rdbuf()->in_avail() != 0)
+                {
+                    return std::nullopt;
+                }
+                return value;
+            };
+
+            if (auto value = parse(text, format)) { return value; }
+
+            const bool has_offset =
+                format.find("%z") != std::string::npos ||
+                format.find("%Ez") != std::string::npos;
+            if (!has_offset) { return std::nullopt; }
+
+            const std::string extended_format = colon_offset_format(format);
+            if (extended_format != format)
+            {
+                if (auto value = parse(text, extended_format)) { return value; }
+            }
+            if (!text.empty() && (text.back() == 'Z' || text.back() == 'z'))
+            {
+                std::string normalized{text.substr(0, text.size() - 1)};
+                normalized += "+00:00";
+                if (auto value = parse(normalized, extended_format))
+                {
+                    return value;
+                }
+            }
+            return std::nullopt;
+        }
+
+        template <typename TimePoint, std::size_t N>
+        [[nodiscard]] std::optional<TimePoint> parse_first_datetime_format(
+            std::string_view text,
+            const std::array<std::string_view, N> &formats)
+        {
+            for (const std::string_view format : formats)
+            {
+                if (auto value =
+                        parse_datetime_format<TimePoint>(text, format))
+                {
+                    return value;
+                }
+            }
+            return std::nullopt;
+        }
+
+        template <typename TimePoint>
+        [[nodiscard]] std::optional<TimePoint> parse_json_datetime_value(
+            std::string_view text)
+        {
+            static constexpr std::array<std::string_view, 3> compact_formats{
+                "%Y%m%d", "%Y%m%d%H%M%S", "%Y%m%d%H%M%S"};
+            static constexpr std::array<std::string_view, 12> iso_formats{
+                "%Y-%m-%dT%H:%M:%S%Ez",
+                "%Y-%m-%dT%H:%M%Ez",
+                "%Y-%m-%d %H:%M:%S%Ez",
+                "%Y-%m-%d %H:%M%Ez",
+                "%Y-%m-%dT%H:%M:%S",
+                "%Y-%m-%dT%H:%M",
+                "%Y-%m-%d %H:%M:%S",
+                "%Y-%m-%d %H:%M",
+                "%Y-%m-%d",
+                "%Y%m%d",
+                "%Y-%m-%dT%H",
+                "%Y-%m-%d %H",
+            };
+            const auto digits = [](std::string_view value) {
+                return std::ranges::all_of(
+                    value, [](char character) {
+                        return std::isdigit(
+                            static_cast<unsigned char>(character));
+                    });
+            };
+            // Basic ISO date/time has adjacent variable-width numeric
+            // directives which date::from_stream can partition incorrectly.
+            // Normalize the unambiguous lengths before general parsing.
+            if (text.size() >= 13 && text[8] == 'T' &&
+                digits(text.substr(0, 8)) && digits(text.substr(9, 4)))
+            {
+                const bool has_seconds =
+                    text.size() >= 15 && digits(text.substr(13, 2));
+                std::string normalized;
+                normalized.reserve(text.size() + 5);
+                normalized.append(text.substr(0, 4));
+                normalized.push_back('-');
+                normalized.append(text.substr(4, 2));
+                normalized.push_back('-');
+                normalized.append(text.substr(6, 2));
+                normalized.push_back('T');
+                normalized.append(text.substr(9, 2));
+                normalized.push_back(':');
+                normalized.append(text.substr(11, 2));
+                std::size_t remainder = 13;
+                if (has_seconds)
+                {
+                    normalized.push_back(':');
+                    normalized.append(text.substr(13, 2));
+                    remainder = 15;
+                }
+                normalized.append(text.substr(remainder));
+                const auto local_format = has_seconds ?
+                    "%Y-%m-%dT%H:%M:%S" : "%Y-%m-%dT%H:%M";
+                if (auto value = parse_datetime_format<TimePoint>(
+                        normalized, local_format))
+                {
+                    return value;
+                }
+                const auto offset_format = has_seconds ?
+                    "%Y-%m-%dT%H:%M:%S%Ez" :
+                    "%Y-%m-%dT%H:%M%Ez";
+                if (auto value = parse_datetime_format<TimePoint>(
+                        normalized, offset_format))
+                {
+                    return value;
+                }
+            }
+            const bool digits_only = std::ranges::all_of(
+                text, [](char value) {
+                    return std::isdigit(
+                        static_cast<unsigned char>(value));
+                });
+            if (digits_only)
+            {
+                const std::size_t index =
+                    text.size() == 8 ? 0 : text.size() == 14 ? 1 :
+                    text.size() == 20 ? 2 : compact_formats.size();
+                if (index < compact_formats.size())
+                {
+                    std::string normalized{text};
+                    if (text.size() == 20) { normalized.insert(14, "."); }
+                    if (auto value = parse_datetime_format<TimePoint>(
+                            normalized, compact_formats[index]))
+                    {
+                        return value;
+                    }
+                }
+            }
+            if (auto value =
+                    parse_first_datetime_format<TimePoint>(text, iso_formats))
+            {
+                return value;
+            }
+            if (auto value = parse_first_datetime_format<TimePoint>(
+                    text, builtin_json_datetime_formats))
+            {
+                return value;
+            }
+            const auto registered = registered_datetime_format_snapshot();
+            for (const std::string &format : registered->datetime)
+            {
+                if (auto value =
+                        parse_datetime_format<TimePoint>(text, format))
+                {
+                    return value;
+                }
+            }
+            return std::nullopt;
+        }
+
+        [[nodiscard]] std::optional<CivilTime> parse_json_time_value(
+            std::string_view text)
+        {
+            static constexpr std::array<std::string_view, 3> iso_formats{
+                "%H:%M:%S", "%H:%M", "%H"};
+            const bool digits_only = std::ranges::all_of(
+                text, [](char value) {
+                    return std::isdigit(
+                        static_cast<unsigned char>(value));
+                });
+            if (digits_only && (text.size() == 6 || text.size() == 12))
+            {
+                std::string normalized{text};
+                if (text.size() == 12) { normalized.insert(6, "."); }
+                std::chrono::microseconds value{};
+                std::istringstream stream{normalized};
+                stream.imbue(std::locale::classic());
+                json_datetime_from_stream(stream, "%H%M%S", value);
+                if (!stream.fail() && stream.rdbuf()->in_avail() == 0)
+                {
+                    return CivilTime{value.count()};
+                }
+            }
+            const auto parse = [](std::string_view candidate,
+                                  std::string_view python_format)
+                -> std::optional<CivilTime> {
+                const std::string format =
+                    translate_python_datetime_format(python_format);
+                std::istringstream stream{std::string{candidate}};
+                stream.imbue(std::locale::classic());
+                std::chrono::microseconds value{};
+                json_datetime_from_stream(stream, format.c_str(), value);
+                if (stream.fail() || stream.rdbuf()->in_avail() != 0)
+                {
+                    return std::nullopt;
+                }
+                if (format.find("%p") != std::string::npos)
+                {
+                    std::string meridiem{candidate};
+                    std::ranges::transform(
+                        meridiem, meridiem.begin(), [](char value) {
+                            return static_cast<char>(std::toupper(
+                                static_cast<unsigned char>(value)));
+                        });
+                    const bool is_am = meridiem.find("AM") != std::string::npos;
+                    const bool is_pm = meridiem.find("PM") != std::string::npos;
+                    if (is_am == is_pm) { return std::nullopt; }
+
+                    const auto hour =
+                        std::chrono::duration_cast<std::chrono::hours>(value);
+                    // Howard Hinnant date releases differ in whether parsing
+                    // a duration applies %p. Normalize either result.
+                    if (is_pm && hour < std::chrono::hours{12})
+                    {
+                        value += std::chrono::hours{12};
+                    }
+                    else if (is_am && hour >= std::chrono::hours{12})
+                    {
+                        value -= std::chrono::hours{12};
+                    }
+                }
+                if (value < std::chrono::microseconds{0} ||
+                    value >= std::chrono::hours{24})
+                {
+                    return std::nullopt;
+                }
+                return CivilTime{value.count()};
+            };
+            for (const std::string_view format : iso_formats)
+            {
+                if (auto value = parse(text, format)) { return value; }
+            }
+            const auto registered = registered_datetime_format_snapshot();
+            for (const std::string &format : registered->time)
+            {
+                if (auto value = parse(text, format)) { return value; }
+            }
+            return std::nullopt;
+        }
+
+        [[nodiscard]] CivilDate json_date(
+            std::string_view text, Reader &reader)
+        {
+            using LocalMicros =
+                JsonLocalTime<std::chrono::microseconds>;
+            auto value = parse_json_datetime_value<LocalMicros>(text);
+            if (!value)
+            {
+                reader.fail(fmt::format(
+                    "cannot parse '{}' as a date; it is not ISO 8601 nor any registered format",
+                    text));
+            }
+            const auto day = std::chrono::floor<std::chrono::days>(*value);
+            return CivilDate{std::chrono::sys_days{day.time_since_epoch()}};
+        }
+
+        [[nodiscard]] CivilTime json_time(
+            std::string_view text, Reader &reader)
+        {
+            auto value = parse_json_time_value(text);
+            if (!value)
+            {
+                reader.fail(fmt::format(
+                    "cannot parse '{}' as a time; it is not ISO 8601 nor any registered format",
+                    text));
+            }
+            return *value;
+        }
+
+        [[nodiscard]] Instant json_instant(
+            std::string_view text, Reader &reader)
+        {
+            using SysMicros = JsonSysTime<std::chrono::microseconds>;
+            auto value = parse_json_datetime_value<SysMicros>(text);
+            if (!value)
+            {
+                reader.fail(fmt::format(
+                    "cannot parse '{}' as a datetime; it is not ISO 8601 nor any registered format",
+                    text));
+            }
+            return Instant{value->time_since_epoch()};
         }
 
         [[nodiscard]] Date parse_date_body(std::string_view s, std::size_t &i, Reader &reader)
@@ -611,6 +1034,27 @@ namespace hgraph
         }
     }  // namespace json_detail
 
+    void register_json_datetime_format(std::string format, bool time_only)
+    {
+        if (format.empty())
+        {
+            throw std::invalid_argument(
+                "register_json_datetime_format: format must not be empty");
+        }
+        auto &registry = registered_datetime_formats();
+        std::lock_guard lock{registry.mutex};
+        const auto &current = registry.formats;
+        const auto &formats =
+            time_only ? current->time : current->datetime;
+        if (std::ranges::find(formats, format) != formats.end())
+        {
+            return;
+        }
+        auto next = std::make_shared<RegisteredJsonDateTimeFormats>(*current);
+        (time_only ? next->time : next->datetime).push_back(format);
+        registry.formats = std::move(next);
+    }
+
     namespace
     {
         using json_detail::Reader;
@@ -896,16 +1340,12 @@ namespace hgraph
                     return Value{json_detail::parse_float_token(reader.parse_number_token(), reader)};
                 case AtomicTag::Str: return Value{Str{reader.parse_string()}};
                 case AtomicTag::Date: {
-                    const std::string s = reader.parse_string();
-                    std::size_t       i = 0;
-                    return Value{json_detail::parse_date_body(s, i, reader)};
+                    return Value{json_detail::json_date(
+                        reader.parse_string(), reader)};
                 }
                 case AtomicTag::DateTime: {
-                    const CivilDateTime value =
-                        json_detail::parse_civil_datetime(
-                            reader.parse_string(), reader, true);
-                    return Value{Instant{
-                        Duration{value.epoch_microseconds()}}};
+                    return Value{json_detail::json_instant(
+                        reader.parse_string(), reader)};
                 }
                 case AtomicTag::TimeDelta: {
                     return Value{
@@ -913,9 +1353,8 @@ namespace hgraph
                             reader.parse_string(), reader)};
                 }
                 case AtomicTag::Time: {
-                    const std::string s = reader.parse_string();
-                    std::size_t       i = 0;
-                    return Value{Time{json_detail::parse_time_body_micros(s, i, reader)}};
+                    return Value{json_detail::json_time(
+                        reader.parse_string(), reader)};
                 }
                 case AtomicTag::CivilDateTime:
                     return Value{json_detail::parse_civil_datetime(

--- a/tests/cpp/test_json.cpp
+++ b/tests/cpp/test_json.cpp
@@ -33,6 +33,28 @@ namespace
         CHECK(back.view().template checked_as<T>() == input);
         return text;
     }
+
+    template <typename T>
+    T parse_json_value(std::string_view text)
+    {
+        return from_json_string(
+                   scalar_descriptor<T>::value_meta(), text)
+            .view().template checked_as<T>();
+    }
+
+    DateTime utc_instant(
+        int year, unsigned month, unsigned day, int hour = 0,
+        int minute = 0, int second = 0, int microsecond = 0)
+    {
+        using namespace std::chrono;
+        const Date date{
+            std::chrono::year{year}, std::chrono::month{month},
+            std::chrono::day{day}};
+        return DateTime{
+            duration_cast<microseconds>(sys_days{date}.time_since_epoch()) +
+            hours{hour} + minutes{minute} + seconds{second} +
+            microseconds{microsecond}};
+    }
 }  // namespace
 
 TEST_CASE("json: atomic values round-trip in the Python wire format")
@@ -52,6 +74,7 @@ TEST_CASE("json: atomic values round-trip in the Python wire format")
     CHECK(round_trip(TimeDelta{microseconds{2 * 86'400'000'000 + 3'723'500'000}}) ==
           "\"176523500000us\"");
     CHECK(round_trip(time_of_day(9, 30, 5, 250)) == "\"09:30:05.000250\"");
+    CHECK(round_trip(time_of_day(9, 30, 5)) == "\"09:30:05\"");
 }
 
 TEST_CASE("json: temporal version 2 scalar and range forms round-trip")
@@ -135,6 +158,73 @@ TEST_CASE("json: schema-directed temporal reads accept legacy version 1 text")
         "\"0:0:0:0.-00001\"");
     CHECK(early_native_negative.view().checked_as<TimeDelta>() ==
           TimeDelta{-1});
+}
+
+TEST_CASE("json: temporal reads accept ISO, compact, fallback, and registered formats")
+{
+    CHECK(parse_json_value<DateTime>("\"2024-06-13T10:15\"") ==
+          utc_instant(2024, 6, 13, 10, 15));
+    CHECK(parse_json_value<DateTime>("\"2024-06-13\"") ==
+          utc_instant(2024, 6, 13));
+    CHECK(parse_json_value<DateTime>("\"2024-06-13T10:15:30.5\"") ==
+          utc_instant(2024, 6, 13, 10, 15, 30, 500'000));
+    CHECK(parse_json_value<DateTime>("\"20240613T101530\"") ==
+          utc_instant(2024, 6, 13, 10, 15, 30));
+    CHECK(parse_json_value<DateTime>("\"20240613101530\"") ==
+          utc_instant(2024, 6, 13, 10, 15, 30));
+    CHECK(parse_json_value<DateTime>("\"20240613101530123456\"") ==
+          utc_instant(2024, 6, 13, 10, 15, 30, 123'456));
+    CHECK(parse_json_value<DateTime>("\"2024-06-13T11:15:30+01:00\"") ==
+          utc_instant(2024, 6, 13, 10, 15, 30));
+    CHECK(parse_json_value<DateTime>("\"2024-06-13T05:15:30-05:00\"") ==
+          utc_instant(2024, 6, 13, 10, 15, 30));
+    CHECK(parse_json_value<DateTime>("\"2024/06/13 10:15:30\"") ==
+          utc_instant(2024, 6, 13, 10, 15, 30));
+    CHECK(parse_json_value<DateTime>("\"13-Jun-2024 10:15:30\"") ==
+          utc_instant(2024, 6, 13, 10, 15, 30));
+    CHECK(parse_json_value<DateTime>("\"13 Jun 2024\"") ==
+          utc_instant(2024, 6, 13));
+
+    CHECK(parse_json_value<Time>("\"10:15\"") == time_of_day(10, 15));
+    CHECK(parse_json_value<Time>("\"101530\"") ==
+          time_of_day(10, 15, 30));
+    CHECK(parse_json_value<Time>("\"101530123456\"") ==
+          time_of_day(10, 15, 30, 123'456));
+    CHECK(parse_json_value<Date>("\"20240613\"") ==
+          Date{std::chrono::year{2024}, std::chrono::June,
+               std::chrono::day{13}});
+    CHECK(parse_json_value<Date>("\"2024/06/13\"") ==
+          Date{std::chrono::year{2024}, std::chrono::June,
+               std::chrono::day{13}});
+    CHECK(parse_json_value<Date>("\"13-Jun-2024\"") ==
+          Date{std::chrono::year{2024}, std::chrono::June,
+               std::chrono::day{13}});
+    CHECK(parse_json_value<Date>("\"2024-06-13T10:15:30\"") ==
+          Date{std::chrono::year{2024}, std::chrono::June,
+               std::chrono::day{13}});
+
+    register_json_datetime_format("%d/%m/%Y %H:%M:%S");
+    CHECK(parse_json_value<DateTime>("\"13/06/2024 10:15:30\"") ==
+          utc_instant(2024, 6, 13, 10, 15, 30));
+    register_json_datetime_format("%I.%M.%S %p", true);
+    CHECK(parse_json_value<Time>("\"10.15.30 PM\"") ==
+          time_of_day(22, 15, 30));
+    CHECK(parse_json_value<Time>("\"12.00.00 AM\"") ==
+          time_of_day(0, 0, 0));
+    CHECK(parse_json_value<Time>("\"12.00.00 PM\"") ==
+          time_of_day(12, 0, 0));
+
+    try
+    {
+        static_cast<void>(
+            parse_json_value<DateTime>("\"not a datetime\""));
+        FAIL("invalid datetime text should be rejected");
+    }
+    catch (const std::invalid_argument &error)
+    {
+        CHECK(std::string{error.what()}.find("not a datetime") !=
+              std::string::npos);
+    }
 }
 
 TEST_CASE("json: containers round-trip (list, set, map with string and int keys)")
@@ -229,6 +319,18 @@ namespace
         static Port<TS<Int>> compose(Wiring &w, Port<TS<Str>> ts)
         {
             return wire<stdlib::from_json, TS<Int>>(w, ts).as<TS<Int>>();
+        }
+    };
+
+    struct FromJsonDateTimeGraph
+    {
+        [[maybe_unused]] static constexpr auto name =
+            "from_json_datetime_graph";
+
+        static Port<TS<DateTime>> compose(Wiring &w, Port<TS<Str>> ts)
+        {
+            return wire<stdlib::from_json, TS<DateTime>>(w, ts)
+                .as<TS<DateTime>>();
         }
     };
 
@@ -365,6 +467,19 @@ TEST_CASE("json operators: from_json parses into the resolved output type")
     stdlib::register_standard_operators();
     CHECK_OUTPUT(eval_node<FromJsonGraph>(values<Str>(Str{"3"}, none, Str{"-9"})),
                  values<Int>(3, none, -9));
+}
+
+TEST_CASE("json operators: temporal parsing uses the shared native format registry")
+{
+    stdlib::register_standard_operators();
+    register_json_datetime_format("%d/%m/%Y %H:%M:%S");
+    CHECK_OUTPUT(
+        eval_node<FromJsonDateTimeGraph>(values<Str>(
+            Str{"\"2024-06-13T11:15:30+01:00\""},
+            Str{"\"13/06/2024 10:15:30\""})),
+        values<DateTime>(
+            utc_instant(2024, 6, 13, 10, 15, 30),
+            utc_instant(2024, 6, 13, 10, 15, 30)));
 }
 
 TEST_CASE("json operators: to_json -> from_json round-trips through a graph")

--- a/tests/cpp/test_json.cpp
+++ b/tests/cpp/test_json.cpp
@@ -206,6 +206,10 @@ TEST_CASE("json: temporal reads accept ISO, compact, fallback, and registered fo
     register_json_datetime_format("%d/%m/%Y %H:%M:%S");
     CHECK(parse_json_value<DateTime>("\"13/06/2024 10:15:30\"") ==
           utc_instant(2024, 6, 13, 10, 15, 30));
+    register_json_datetime_format("%Y-%m-%d %H:%M:%S,%f");
+    CHECK(parse_json_value<DateTime>(
+              "\"2024-06-13 10:15:30,123456\"") ==
+          utc_instant(2024, 6, 13, 10, 15, 30, 123'456));
     register_json_datetime_format("%I.%M.%S %p", true);
     CHECK(parse_json_value<Time>("\"10.15.30 PM\"") ==
           time_of_day(22, 15, 30));
@@ -213,6 +217,9 @@ TEST_CASE("json: temporal reads accept ISO, compact, fallback, and registered fo
           time_of_day(0, 0, 0));
     CHECK(parse_json_value<Time>("\"12.00.00 PM\"") ==
           time_of_day(12, 0, 0));
+    register_json_datetime_format("%H:%M:%S,%f", true);
+    CHECK(parse_json_value<Time>("\"10:15:30,000042\"") ==
+          time_of_day(10, 15, 30, 42));
 
     try
     {

--- a/tools/parity/upstream_conformance.json
+++ b/tools/parity/upstream_conformance.json
@@ -343,13 +343,41 @@
       "match": "hgraph_unit_tests/_operators/test_to_json.py::test_to_json*case-3*",
       "classification": "converted",
       "candidate_outcomes": ["failed"],
-      "diagnostic_regex": "2024-06-13T10:15:30[.]000042Z.*2024-06-13 10:15:30[.]000042",
+      "diagnostic_regex": "2024-06-13T10:15:30[.]000042Z.*2024-06-13T10:15:30[.]000042",
       "reason": "RFC 0002 writers emit canonical RFC 3339 UTC instants rather than the legacy timezone-free text.",
       "decision": "docs/source/developer_guide/parity_matrix.rst",
-      "review_date": "2026-08-05",
+      "review_date": "2026-08-08",
       "evidence": [
         "python/tests/ported/_operators/test_to_json.py",
-        "tests/cpp/test_std_operators.cpp"
+        "tests/cpp/test_json.cpp"
+      ]
+    },
+    {
+      "id": "operators-json-rfc3339-instant-zero-fraction",
+      "match": "hgraph_unit_tests/_operators/test_to_json.py::test_to_json_omits_fractional_seconds_when_zero",
+      "classification": "converted",
+      "candidate_outcomes": ["failed"],
+      "diagnostic_regex": "2024-06-13T10:15:30Z.*2024-06-13T10:15:30",
+      "reason": "RFC 0002 omits a zero fractional component but retains the canonical RFC 3339 UTC suffix for an Instant.",
+      "decision": "docs/source/developer_guide/parity_matrix.rst",
+      "review_date": "2026-08-08",
+      "evidence": [
+        "python/tests/ported/_operators/test_to_json.py",
+        "tests/cpp/test_json.cpp"
+      ]
+    },
+    {
+      "id": "operators-json-native-datetime-format-registry",
+      "match": "hgraph_unit_tests/_operators/test_to_json.py::test_register_json_datetime_format_accepts_a_producers_own_format",
+      "classification": "converted",
+      "candidate_outcomes": ["failed"],
+      "diagnostic_regex": "No module named 'hgraph[.]_impl'",
+      "reason": "The public format-registration behavior is implemented by the shared C++ JSON codec and covered through public Python and native wiring APIs. The upstream test fails only when it imports the private Python implementation list to restore that list by mutation; hg_cpp deliberately does not reproduce that private layout.",
+      "decision": "docs/source/developer_guide/parity_matrix.rst",
+      "review_date": "2026-08-08",
+      "evidence": [
+        "python/tests/ported/_operators/test_to_json.py",
+        "tests/cpp/test_json.cpp"
       ]
     },
     {


### PR DESCRIPTION
## Summary

- centralize service/adaptor type resolution so explicit bindings, request inference, type-valued defaults, scalar values, and user resolvers follow one consistent wiring order
- make service resolvers receive the same bound wiring-time scalar values as graph/node resolvers, including when another type variable is already resolved
- add C++-first JSON compatibility for `date`, `time`, `datetime`, and `timedelta`, with a shared thread-safe datetime-format registry exposed through the Python bridge
- classify and exercise the upstream JSON conformance surface, and update the parity/developer documentation
- make `hg-linux` the documented primary Linux validation host, retaining OrbStack only as a fallback

## Root cause

Service interfaces had several separate resolution paths with different ordering. Some paths ran user resolvers before call-time scalar values were available, and interface construction could resolve too early. JSON temporal parsing and formatting also lacked the native implementation and registration surface needed to match released Python hgraph behavior.

This change keeps service resolution ordering in one helper and keeps JSON semantics in C++, with Python adapting to the native API.

## Compatibility result

The upstream JSON campaign now collects 52 cases: 48 are exact matches and the remaining 4 are documented representation conversions. There are no review, confirmed-gap, or unverified JSON cases.

## Validation

- macOS native acceptance preset, fresh configure and clean rebuild: 1,474/1,474 passed
- macOS stable-ABI wheel built with Python 3.12, installed into fresh Python 3.14 environment: 2,018 passed, 9 skipped
- `hg-linux` GCC 14 native acceptance preset, fresh configure and clean rebuild: 1,474/1,474 passed
- `hg-linux` stable-ABI wheel/Python 3.14 suite with Polars `rtcompat`: 2,016 passed, 9 skipped
- installed-SDK consumer test: 1/1 passed
- Sphinx warnings-as-errors build: 77 sources passed
- parity manifest validation: 60 recipes
- upstream JSON conformance: 52 collected, 48 exact, 4 documented conversions, 0 unresolved
- parity controller tests: 20 passed
- `git diff --check`: passed

The Linux counts predate the two service-resolver-only Python regressions added when the final branch was consolidated; the complete combined branch was rerun on macOS.