### PR TITLE
Centralize compiled subgraph output schemas

### DIFF
--- a/include/hgraph/lib/std/operators/impl/higher_order_impl.h
+++ b/include/hgraph/lib/std/operators/impl/higher_order_impl.h
@@ -1216,16 +1216,6 @@ namespace hgraph::stdlib
 
             const bool branch_has_output = compiled.output_schema != nullptr;
             const auto *branch_output_schema = compiled.output_schema;
-            if (compiled.output_is_structural_reference)
-            {
-                // A structural TSB/TSL return is given a synthetic REF
-                // terminal so the child graph has one peered endpoint. That
-                // REF is a child-graph implementation detail, not the public
-                // result type of switch_. Explicitly authored REF outputs do
-                // not carry this flag and retain their REF identity.
-                branch_output_schema =
-                    TypeRegistry::instance().dereference(branch_output_schema);
-            }
             if (!branches_have_output.has_value()) { branches_have_output = branch_has_output; }
             else if (*branches_have_output != branch_has_output)
             {
@@ -2471,6 +2461,62 @@ namespace hgraph::stdlib
             bool whole_variable{false};
         };
 
+        /** Configure a whole child terminal against one public container
+            element. A terminal with endpoint topology of its own, including
+            the synthetic REF used for composed fixed structures, stays owned
+            by the child and the element forwards to it. Only an ordinary
+            owned terminal with the exact public schema is re-homed so it can
+            write directly into the container element. */
+        [[nodiscard]] inline MapOutputBindingMode configure_mapped_child_terminal(
+            NodeBuilder &terminal,
+            const TSValueTypeMetaData *output_schema,
+            const TSValueTypeMetaData *terminal_output_schema,
+            std::string_view operation_name)
+        {
+            const NodeTypeMetaData *terminal_meta = terminal.type().schema();
+            const auto *declared_terminal_schema =
+                terminal_meta != nullptr ? terminal_meta->output_schema : nullptr;
+            if (output_schema == nullptr || terminal_output_schema == nullptr ||
+                declared_terminal_schema == nullptr ||
+                !time_series_schema_equivalent(
+                    declared_terminal_schema, terminal_output_schema))
+            {
+                throw std::logic_error(fmt::format(
+                    "{}: compiled child terminal schema is inconsistent",
+                    operation_name));
+            }
+
+            auto &registry = TypeRegistry::instance();
+            const bool exact_match = time_series_schema_equivalent(
+                output_schema, terminal_output_schema);
+            if (!exact_match &&
+                !time_series_schema_equivalent(
+                    registry.dereference(output_schema),
+                    registry.dereference(terminal_output_schema)))
+            {
+                throw std::invalid_argument(fmt::format(
+                    "{}: child terminal schema is incompatible with its public output",
+                    operation_name));
+            }
+
+            const TSEndpointSchema &terminal_override = terminal.output_endpoint();
+            const TSEndpointSchema &terminal_declared =
+                terminal_meta != nullptr
+                    ? terminal_meta->output_endpoint_schema
+                    : terminal_override;
+            const TSEndpointSchema &terminal_endpoint =
+                !terminal_override.empty() ? terminal_override : terminal_declared;
+            if (!exact_match ||
+                (!terminal_endpoint.empty() &&
+                 (terminal_endpoint.is_peered() || terminal_endpoint.is_non_peered())))
+            {
+                return MapOutputBindingMode::OutputElementForwardsToChildTerminal;
+            }
+
+            terminal.output_endpoint(TSEndpointSchema::peered(output_schema));
+            return MapOutputBindingMode::ChildTerminalWritesElement;
+        }
+
         /** Determine whether one mapped parameter accepts a TSD whole or its
             element. A bare pattern variable on a user callable denotes a
             whole-time-series parameter; abstract operator markers retain the
@@ -2719,15 +2765,6 @@ namespace hgraph::stdlib
             if (child_has_output)
             {
                 const auto *element_schema = compiled.output_schema;
-                if (compiled.output_is_structural_reference)
-                {
-                    // A structural return needs one internal REF terminal so
-                    // the child graph has a peered endpoint. That terminal is
-                    // an implementation detail even when a dynamic callable
-                    // (for example an unannotated Python lambda) cannot report
-                    // a declared output schema before it is compiled.
-                    element_schema = registry.dereference(compiled.output_schema);
-                }
                 if (const auto *declared = func.output_schema(); declared != nullptr)
                 {
                     const bool exact_match = time_series_schema_equivalent(
@@ -2742,14 +2779,10 @@ namespace hgraph::stdlib
                             "{}: the function's wired output is incompatible with its declared output schema",
                             operation_name));
                     }
-                    if (exact_match || declared->kind == TSTypeKind::REF ||
-                        compiled.output_is_structural_reference)
+                    if (exact_match || declared->kind == TSTypeKind::REF)
                     {
-                        // A structural graph return compiles through an
-                        // internal REF terminal; that implementation detail
-                        // collapses back to its declared TSB/TSL shape. A REF
-                        // produced by an actual operator such as switch_
-                        // remains the child's public output identity.
+                        // A REF produced by an actual operator such as
+                        // switch_ remains the child's public output identity.
                         element_schema = declared;
                     }
                 }
@@ -2793,42 +2826,9 @@ namespace hgraph::stdlib
                     NodeBuilder &terminal =
                         spec.child.graph_builder.node_at(spec.child.output_binding->source.node);
                     const auto *out = output_schema->element_ts();
-                    const TSEndpointSchema &terminal_override = terminal.output_endpoint();
-                    const NodeTypeMetaData *terminal_meta = terminal.type().schema();
-                    const TSEndpointSchema &terminal_declared =
-                        terminal_meta != nullptr ? terminal_meta->output_endpoint_schema : terminal_override;
-                    const TSEndpointSchema &terminal_endpoint =
-                        !terminal_override.empty() ? terminal_override : terminal_declared;
-                    const auto *terminal_schema = terminal_meta != nullptr
-                                                      ? terminal_meta->output_schema
-                                                      : nullptr;
-                    const bool requires_alternative_binding =
-                        !time_series_schema_equivalent(terminal_schema, out);
-                    if (requires_alternative_binding &&
-                        !time_series_schema_equivalent(
-                            registry.dereference(terminal_schema), registry.dereference(out)))
-                    {
-                        throw std::invalid_argument(fmt::format(
-                            "{}: child terminal schema is incompatible with its declared output",
-                            operation_name));
-                    }
-                    // A declared forwarding terminal already owns its link, and a
-                    // non-peered terminal has required child endpoint topology
-                    // (for example, map_ owns a TSD root whose elements forward).
-                    // Preserve either shape, as well as a REF terminal exposed
-                    // through its dereferenced schema, and make the parent map
-                    // element point at the terminal. Only an ordinary/owned
-                    // terminal of the same schema can be safely re-homed.
-                    if (requires_alternative_binding ||
-                        (!terminal_endpoint.empty() &&
-                         (terminal_endpoint.is_peered() || terminal_endpoint.is_non_peered())))
-                    {
-                        spec.output_binding_mode = MapOutputBindingMode::OutputElementForwardsToChildTerminal;
-                    }
-                    else
-                    {
-                        terminal.output_endpoint(TSEndpointSchema::peered(out));
-                    }
+                    spec.output_binding_mode = configure_mapped_child_terminal(
+                        terminal, out, compiled.terminal_output_schema,
+                        operation_name);
                 }
             }
 
@@ -4007,17 +4007,11 @@ namespace hgraph::stdlib
                     throw std::invalid_argument("map_: dynamic TSL function output node is out of range");
                 }
 
-                NodeBuilder            &terminal          = spec.child.graph_builder.node_at(binding.source.node);
-                const TSEndpointSchema &terminal_override = terminal.output_endpoint();
-                const NodeTypeMetaData *terminal_meta     = terminal.type().schema();
-                const TSEndpointSchema &terminal_declared =
-                    terminal_meta != nullptr ? terminal_meta->output_endpoint_schema : terminal_override;
-                const TSEndpointSchema &terminal_endpoint = !terminal_override.empty() ? terminal_override : terminal_declared;
-                if (!terminal_endpoint.empty() && (terminal_endpoint.is_peered() || terminal_endpoint.is_non_peered())) {
-                    throw std::invalid_argument("map_: dynamic TSL functions must return an "
-                                                "ordinary owned terminal output");
-                }
-                terminal.output_endpoint(TSEndpointSchema::peered(compiled.output_schema));
+                NodeBuilder &terminal =
+                    spec.child.graph_builder.node_at(binding.source.node);
+                spec.output_binding_mode = configure_mapped_child_terminal(
+                    terminal, compiled.output_schema,
+                    compiled.terminal_output_schema, "map_");
                 output_schema = registry.tsl(compiled.output_schema, 0);
             } else {
                 output_schema = nullptr;

--- a/include/hgraph/runtime/nested_bindings.h
+++ b/include/hgraph/runtime/nested_bindings.h
@@ -280,7 +280,13 @@ forwarding_output_endpoint_schema(const TSValueTypeMetaData *schema) {
     }
     return TSEndpointSchema::non_peered(schema, std::move(children));
   }
-  if (schema->kind == TSTypeKind::TSL) {
+  // A fixed list's owner constructs every element, so each stable element can
+  // carry its own forwarding tree. A dynamic list's size belongs to its
+  // producer; before that producer grows the list there are no target
+  // elements to walk, so its generic forwarding endpoint must remain peered
+  // as one whole output. Owner-managed dynamic containers (for example the
+  // outer result of dynamic TSL map_) opt into non_peered_list explicitly.
+  if (schema->kind == TSTypeKind::TSL && schema->fixed_size() != 0) {
     return TSEndpointSchema::non_peered_list(
         schema, forwarding_output_endpoint_schema(schema->element_ts()));
   }

--- a/include/hgraph/runtime/nested_bindings.h
+++ b/include/hgraph/runtime/nested_bindings.h
@@ -280,13 +280,9 @@ forwarding_output_endpoint_schema(const TSValueTypeMetaData *schema) {
     }
     return TSEndpointSchema::non_peered(schema, std::move(children));
   }
-  if (schema->kind == TSTypeKind::TSL && schema->fixed_size() != 0) {
-    children.reserve(schema->fixed_size());
-    for (std::size_t index = 0; index < schema->fixed_size(); ++index) {
-      children.push_back(
-          forwarding_output_endpoint_schema(schema->element_ts()));
-    }
-    return TSEndpointSchema::non_peered(schema, std::move(children));
+  if (schema->kind == TSTypeKind::TSL) {
+    return TSEndpointSchema::non_peered_list(
+        schema, forwarding_output_endpoint_schema(schema->element_ts()));
   }
   return TSEndpointSchema::peered(schema);
 }
@@ -311,7 +307,8 @@ inline bool clear_forwarding_output_tree(TSOutputView target,
       schema != nullptr && schema->kind == TSTypeKind::TSB
           ? schema->field_count()
       : schema != nullptr && schema->kind == TSTypeKind::TSL
-          ? schema->fixed_size()
+          ? (schema->fixed_size() != 0 ? schema->fixed_size()
+                                       : target.data_view().indexed_child_count())
           : 0;
   if (child_count == 0) {
     throw std::logic_error("Forwarding output tree has a non-forwarding leaf");
@@ -390,7 +387,8 @@ inline bool bind_forwarding_output_tree_to_source(TSOutputView target,
       schema != nullptr && schema->kind == TSTypeKind::TSB
           ? schema->field_count()
       : schema != nullptr && schema->kind == TSTypeKind::TSL
-          ? schema->fixed_size()
+          ? (schema->fixed_size() != 0 ? schema->fixed_size()
+                                       : target.data_view().indexed_child_count())
           : 0;
   if (child_count == 0) {
     throw std::logic_error("Forwarding output tree has a non-forwarding leaf");

--- a/include/hgraph/runtime/tsl_map_node.h
+++ b/include/hgraph/runtime/tsl_map_node.h
@@ -22,6 +22,10 @@ namespace hgraph
         std::vector<std::size_t> multiplexed_inputs{};
         /** Entry-owned ``TS<int64>`` used when the child accepts ``ndx``. */
         const TSValueTypeMetaData *index_output_schema{nullptr};
+        /** Whether the child terminal writes into the list element or the
+            element preserves and forwards to a child-owned terminal. */
+        MapOutputBindingMode output_binding_mode{
+            MapOutputBindingMode::ChildTerminalWritesElement};
     };
 
     /** Typed inspection surface for a dynamic-TSL arbitrary-function map. */

--- a/include/hgraph/types/subgraph_wiring.h
+++ b/include/hgraph/types/subgraph_wiring.h
@@ -65,11 +65,14 @@ namespace hgraph
         std::optional<NestedGraphOutputBinding> output_binding{};
         /** Boundary time-series input schemas, in compose ``Port`` parameter order. */
         std::vector<const TSValueTypeMetaData *> input_schemas{};
+        /** Public/logical result schema of the compiled graph. */
         const TSValueTypeMetaData               *output_schema{nullptr};
-        /** The output endpoint was synthesized from a structural TSB/TSL source.
-            Higher-order containers expose its referenced schema while preserving
-            explicitly authored REF outputs. */
-        bool output_is_structural_reference{false};
+        /** Physical schema of the endpoint named by ``output_binding``.
+            This differs from ``output_schema`` only when compilation adds an
+            internal terminal (for example REF<TSB/TSL> for a newly composed
+            fixed structural result). Consumers expose ``output_schema`` and
+            use this field only when configuring the child terminal itself. */
+        const TSValueTypeMetaData               *terminal_output_schema{nullptr};
         /**
          * Outer-port CAPTURES (nested_graphs.rst): OUTER-wiring ports the
          * compose body referenced (closure capture). One per boundary index

--- a/include/hgraph/types/time_series/endpoint_schema.h
+++ b/include/hgraph/types/time_series/endpoint_schema.h
@@ -56,18 +56,19 @@ namespace hgraph
          * while another index with the same element schema may remain
          * non-peered and expose deeper peered descendants.
          *
-         * A dynamic TSD has one child annotation: the endpoint topology used
-         * for every value slot. Use ``non_peered_list`` when every fixed TSL
-         * index has the same endpoint annotation and ``non_peered_dict`` for
-         * a dynamic TSD.
+         * A dynamic TSL or TSD has one child annotation: the endpoint topology
+         * used for every element/value slot. Use ``non_peered_list`` when
+         * every TSL element has the same annotation and ``non_peered_dict``
+         * for a dynamic TSD.
          */
         [[nodiscard]] static TSEndpointSchema non_peered(
             const TSValueTypeMetaData       *schema,
             std::vector<TSEndpointSchema>    children);
 
         /**
-         * Non-peered fixed-size TSL prefix where each list index uses the same
-         * element annotation.
+         * Non-peered TSL prefix where each list index uses the same element
+         * annotation. Fixed lists expand it once per index; dynamic lists
+         * retain one annotation for every runtime-created element.
          */
         [[nodiscard]] static TSEndpointSchema non_peered_list(
             const TSValueTypeMetaData *schema,

--- a/python/tests/ported/_wiring/test_error_handling.py
+++ b/python/tests/ported/_wiring/test_error_handling.py
@@ -1,6 +1,6 @@
-from hgraph import (REMOVE, NodeError, TSD, TS, TSB, TryExceptResult,
+from hgraph import (REMOVE, NodeError, TSD, TS, TSB, TimeSeriesSchema, TryExceptResult,
                     TryExceptTsdMapResult, compute_node, exception_time_series,
-                    graph, map_, sink_node, try_except)
+                    combine, graph, map_, sink_node, try_except)
 from hgraph.test import eval_node
 
 
@@ -61,6 +61,25 @@ def test_try_except_wraps_python_value_graph():
     assert "divide" in result[1]["exception"].activation_back_trace
     assert "*args*: value={_0: 9, _1: 0}" in result[1]["exception"].activation_back_trace
     assert result[2] == {"out": 2}
+
+
+def test_try_except_preserves_composed_structural_graph_output():
+    class Pair(TimeSeriesSchema):
+        value: TS[int]
+        offset: TS[int]
+
+    @graph
+    def pair(value: TS[int]) -> TSB[Pair]:
+        return combine[TSB[Pair]](value=value, offset=value + 1)
+
+    @graph
+    def protected(value: TS[int]):
+        return try_except(pair, value)
+
+    assert eval_node(protected, [1, 2]) == [
+        {"out": {"value": 1, "offset": 2}},
+        {"out": {"value": 2, "offset": 3}},
+    ]
 
 
 def test_try_except_uses_native_error_output_for_python_compute_node():

--- a/python/tests/test_dispatch_scalar.py
+++ b/python/tests/test_dispatch_scalar.py
@@ -116,7 +116,12 @@ def test_dispatch_uses_declared_concrete_output_schema():
     def app(animal: TS[Animal]) -> TSB[Result]:
         return sound(animal)
 
+    @graph
+    def projected(animal: TS[Animal]) -> TS[str]:
+        return sound(animal).sound
+
     assert eval_node(app, [Dog()]) == [{"sound": "woof"}]
+    assert eval_node(projected, [Dog()]) == ["woof"]
 
 
 def test_union_overload_is_registered_for_direct_operator_dispatch():

--- a/python/tests/test_python_authoring.py
+++ b/python/tests/test_python_authoring.py
@@ -217,6 +217,33 @@ def test_native_dynamic_tsl_map_runs_python_child_nodes_by_index():
     )
 
 
+def test_native_dynamic_tsl_map_preserves_composed_structural_child_outputs():
+    class Pair(hg.TimeSeriesSchema):
+        value: TS[int]
+        offset: TS[int]
+
+    @graph
+    def pair(value: TS[int]) -> hg.TSB[Pair]:
+        return hg.combine[hg.TSB[Pair]](value=value, offset=value + 100)
+
+    @graph
+    def app(
+        values: TSL[TS[int], Size[0]],
+    ) -> TSL[hg.TSB[Pair], Size[0]]:
+        return hg.map_(pair, values)
+
+    result = eval_node(app, [{0: 1}, {1: 2}, {0: 3}])
+    check(
+        result
+        == [
+            {0: {"value": 1, "offset": 101}},
+            {1: {"value": 2, "offset": 102}},
+            {0: {"value": 3, "offset": 103}},
+        ],
+        f"structural Python child in native dynamic TSL map: {result}",
+    )
+
+
 def test_python_sink_nodes_work_as_native_dynamic_tsl_map_children():
     seen = []
 

--- a/src/hgraph/runtime/nested_graph_node.cpp
+++ b/src/hgraph/runtime/nested_graph_node.cpp
@@ -364,7 +364,8 @@ namespace hgraph
             auto source     = walk_ts_path(root_input.borrowed_ref(), binding->parent_source_path).bound_output();
             if (!source.bound())
             {
-                if (target.forwarding_bound()) { target.clear_forwarding_target(); }
+                static_cast<void>(clear_forwarding_output_tree(
+                    std::move(target)));
                 return;
             }
             static_cast<void>(bind_forwarding_output_tree_to_source(
@@ -386,7 +387,7 @@ namespace hgraph
         if (!binding.has_value()) { return; }
 
         auto target = walk_forwarding_target_path(nested.node().output(evaluation_time), binding->target_path);
-        if (target.forwarding_bound()) { target.clear_forwarding_target(); }
+        static_cast<void>(clear_forwarding_output_tree(std::move(target)));
     }
 
     void single_nested_graph_propagate_schedule(const SingleNestedGraphNodeView &nested)

--- a/src/hgraph/runtime/nested_graph_node.cpp
+++ b/src/hgraph/runtime/nested_graph_node.cpp
@@ -129,7 +129,10 @@ namespace hgraph
             {
                 throw std::invalid_argument("single_nested_graph_node output binding requires an output schema");
             }
-            if (depth == target_path.size()) { return TSEndpointSchema::peered(schema); }
+            if (depth == target_path.size())
+            {
+                return forwarding_output_endpoint_schema(schema);
+            }
 
             const auto selected = target_path[depth];
             const auto count    = nested_output_child_count(*schema);
@@ -364,14 +367,16 @@ namespace hgraph
                 if (target.forwarding_bound()) { target.clear_forwarding_target(); }
                 return;
             }
-            bind_forwarding_output_to_source(target, source);
+            static_cast<void>(bind_forwarding_output_tree_to_source(
+                std::move(target), source));
             return;
         }
 
         auto source = walk_ts_path(
             nested.child_graph().node_at(binding->source.node).output(evaluation_time),
             binding->source.path);
-        bind_forwarding_output_to_source(target, source);
+        static_cast<void>(bind_forwarding_output_tree_to_source(
+            std::move(target), source));
     }
 
     void single_nested_graph_clear_output_binding(const SingleNestedGraphNodeView &nested,

--- a/src/hgraph/runtime/tsl_map_node.cpp
+++ b/src/hgraph/runtime/tsl_map_node.cpp
@@ -196,7 +196,7 @@ namespace hgraph
                                                      std::nullopt, false, true);
             runtime_detail::bind_mapped_child_output(view, entry.graph.view(), evaluation_time, spec.child.output_binding,
                                                      spec.args, entry.index.view(), index_source,
-                                                     MapOutputBindingMode::ChildTerminalWritesElement);
+                                                     spec.output_binding_mode);
             entry.graph.view().start(evaluation_time);
             schedule_sampled_input_consumers(entry.graph.view(), evaluation_time, spec.child.input_bindings);
             rollback.release();
@@ -247,6 +247,19 @@ namespace hgraph
                     if (!child.evaluate(evaluation_time)) {
                         storage.resume_index = index;
                         return false;
+                    }
+                    // Direct-write terminals already notify the list through
+                    // their re-homed output endpoint. Only a preserved child
+                    // terminal needs the explicit final-state reconciliation;
+                    // doing it for direct writes can expose a partially
+                    // evaluated list to same-cycle downstream nodes.
+                    if (context.spec.output_binding_mode !=
+                        MapOutputBindingMode::ChildTerminalWritesElement)
+                    {
+                        runtime_detail::finalize_mapped_child_output(
+                            view, evaluation_time,
+                            context.spec.child.output_binding,
+                            entry->index.view());
                     }
                 }
                 const DateTime next = child.next_scheduled_time();
@@ -304,6 +317,11 @@ namespace hgraph
                 if (binding.source.node >= child_node_count || !binding.source.path.empty() || !binding.target_path.empty()) {
                     throw std::invalid_argument("tsl_map_node child output binding must connect one whole child "
                                                 "terminal to the list element");
+                }
+                if (spec.output_binding_mode ==
+                    MapOutputBindingMode::OutputElementForwardsToParentSource) {
+                    throw std::invalid_argument(
+                        "tsl_map_node child output cannot use parent-source forwarding mode");
                 }
             }
 
@@ -398,6 +416,14 @@ namespace hgraph
             meta.requires_phase_runner || spec.child.graph_builder.requires_phase_runner();
         meta.node_kind    = NodeKind::Nested;
         meta.valid_inputs = std::vector<std::size_t>{};
+        if (meta.output_schema != nullptr &&
+            spec.output_binding_mode !=
+                MapOutputBindingMode::ChildTerminalWritesElement) {
+            meta.output_endpoint_schema = TSEndpointSchema::non_peered_list(
+                meta.output_schema,
+                forwarding_output_endpoint_schema(
+                    meta.output_schema->element_ts()));
+        }
 
         const GraphTypeRef child_graph_type = spec.child.graph_builder.nested_type();
         const ValueTypeRef index_type       = ValuePlanFactory::instance().type_for(scalar_descriptor<Int>::value_meta());

--- a/src/hgraph/types/graph_wiring.cpp
+++ b/src/hgraph/types/graph_wiring.cpp
@@ -2550,10 +2550,16 @@ CompiledSubGraph Wiring::finish_subgraph(
   }
   finalize_extensions();
 
+  // Keep the callable's logical result before materialising any child-only
+  // terminal. CompiledSubGraph exposes this schema to every consumer and
+  // records the physical terminal schema separately below.
+  const TSValueTypeMetaData *logical_output_schema =
+      output.has_value() ? output->schema : nullptr;
+
   // A composed TSB/TSL has no single endpoint of its own. Preserve its field
   // bindings through the structural-REF node instead of copying partial
-  // values through a materializer. Higher-order runtimes recognize that
-  // internal REF terminal and expose the declared structural value type.
+  // values through a materializer. The compiled graph records that internal
+  // REF terminal separately from the logical structural result type.
   // An unchanged structural boundary argument remains the zero-node alias
   // handled below.
   if (output.has_value() && output->is_structural_source()) {
@@ -2736,6 +2742,12 @@ CompiledSubGraph Wiring::finish_subgraph(
   const auto &index_of = build.index_of;
 
   if (output.has_value()) {
+    compiled.output_schema = logical_output_schema;
+    // Boundary and projected endpoints already carry their physical schema.
+    // A whole child-node output can expose a dereferenced logical view (for
+    // example Port<TS<T>> over an operator whose declared output is
+    // REF<TS<T>>), so replace this below from the terminal node metadata.
+    compiled.terminal_output_schema = output->schema;
     if (output->is_boundary_source()) {
       // Pass-through: the sub-graph returns a boundary input directly
       // (alias_parent_input) — the outer output aliases the upstream
@@ -2749,7 +2761,6 @@ CompiledSubGraph Wiring::finish_subgraph(
           .kind = NestedGraphOutputBinding::Kind::ParentInput,
           .parent_source_path = std::move(parent_path),
       };
-      compiled.output_schema = output->schema;
     } else if (output->is_peered_source()) {
       const auto external = external_sources.find(output->peered_node());
       if (external != external_sources.end()) {
@@ -2757,7 +2768,6 @@ CompiledSubGraph Wiring::finish_subgraph(
             .kind = NestedGraphOutputBinding::Kind::ParentInput,
             .parent_source_path = {external->second},
         };
-        compiled.output_schema = output->schema;
       } else {
         if (output->peered_output_kind() != GraphEdgeSourceKind::Output) {
           throw std::invalid_argument(
@@ -2771,17 +2781,20 @@ CompiledSubGraph Wiring::finish_subgraph(
               .parent_source_path = {captures.base_index +
                                      captures.index_for(*output)},
           };
-          compiled.output_schema = output->schema;
         } else {
+          const NodeTypeMetaData *terminal_meta =
+              compiled.graph_builder.node_at(it->second).type().schema();
+          if (terminal_meta == nullptr || terminal_meta->output_schema == nullptr) {
+            throw std::logic_error(
+                "Wiring::finish_subgraph: child output terminal has no output schema");
+          }
+          if (output->peered_path().empty()) {
+            compiled.terminal_output_schema = terminal_meta->output_schema;
+          }
           compiled.output_binding = NestedGraphOutputBinding{
               .source = NestedGraphEndpoint{.node = it->second,
                                             .path = output->peered_path()},
           };
-          compiled.output_schema = output->schema;
-          compiled.output_is_structural_reference =
-              output->peered_path().empty() &&
-              output->peered_node()->definition ==
-                  std::type_index(typeid(StructuralRefNodeTag));
         }
       }
     } else if (const auto ordinal =
@@ -2795,7 +2808,6 @@ CompiledSubGraph Wiring::finish_subgraph(
           .kind = NestedGraphOutputBinding::Kind::ParentInput,
           .parent_source_path = {*ordinal},
       };
-      compiled.output_schema = output->schema;
     } else {
       throw std::invalid_argument(
           "Wiring::finish_subgraph: the sub-graph output must be a node output "

--- a/src/hgraph/types/time_series/endpoint_schema.cpp
+++ b/src/hgraph/types/time_series/endpoint_schema.cpp
@@ -23,8 +23,12 @@ namespace hgraph
                 case TSTypeKind::TSL:
                     if (schema.fixed_size() == 0)
                     {
-                        throw std::invalid_argument(
-                            "TSEndpointSchema non-peered TSL annotations require a fixed size");
+                        if (index != 0)
+                        {
+                            throw std::out_of_range(
+                                "TSEndpointSchema child index is out of range for dynamic TSL");
+                        }
+                        return schema.element_ts();
                     }
                     if (index >= schema.fixed_size())
                     {
@@ -53,12 +57,7 @@ namespace hgraph
                     return schema.field_count();
 
                 case TSTypeKind::TSL:
-                    if (schema.fixed_size() == 0)
-                    {
-                        throw std::invalid_argument(
-                            "TSEndpointSchema non-peered TSL annotations require a fixed size");
-                    }
-                    return schema.fixed_size();
+                    return schema.fixed_size() == 0 ? 1 : schema.fixed_size();
 
                 case TSTypeKind::TSD:
                     return 1;

--- a/src/hgraph/types/time_series/ts_input.cpp
+++ b/src/hgraph/types/time_series/ts_input.cpp
@@ -85,8 +85,12 @@ namespace hgraph
                 const bool owned_dynamic = ((schema->kind == TSTypeKind::TSL && schema->fixed_size() == 0) ||
                                             schema->kind == TSTypeKind::TSW) &&
                                            endpoint_schema.is_owned();
-                const bool structural_root = (schema->kind == TSTypeKind::TSB || schema->kind == TSTypeKind::TSD) &&
-                                             endpoint_schema.is_non_peered();
+                const bool structural_root =
+                    (schema->kind == TSTypeKind::TSB ||
+                     schema->kind == TSTypeKind::TSD ||
+                     (schema->kind == TSTypeKind::TSL &&
+                      schema->fixed_size() == 0)) &&
+                    endpoint_schema.is_non_peered();
                 if (!direct_peered && !owned_scalar && !owned_fixed && !owned_keyed && !owned_dynamic &&
                     !structural_root)
                 {
@@ -106,13 +110,19 @@ namespace hgraph
                 validate_input_endpoint_schema(endpoint_schema.child(0), false);
                 return;
             }
+            if (schema->kind == TSTypeKind::TSL && schema->fixed_size() == 0)
+            {
+                if (endpoint_schema.child_count() != 1)
+                {
+                    throw std::invalid_argument(
+                        "TSInput non-peered dynamic TSL prefixes require one element annotation");
+                }
+                validate_input_endpoint_schema(endpoint_schema.child(0), false);
+                return;
+            }
             if (schema->kind != TSTypeKind::TSB && schema->kind != TSTypeKind::TSL)
             {
                 throw std::invalid_argument("TSInput non-peered prefixes require TSB or fixed-size TSL schemas");
-            }
-            if (schema->kind == TSTypeKind::TSL && schema->fixed_size() == 0)
-            {
-                throw std::invalid_argument("TSInput non-peered TSL prefixes currently require a fixed size");
             }
             for (const auto &child : endpoint_schema.children()) { validate_input_endpoint_schema(child, false); }
         }
@@ -646,6 +656,23 @@ namespace hgraph
                 if (plan == nullptr)
                 {
                     throw std::logic_error("TSInput non-peered TSD storage plan is not resolved");
+                }
+                return *plan;
+            }
+            if (schema != nullptr && schema->kind == TSTypeKind::TSL &&
+                schema->fixed_size() == 0)
+            {
+                if (endpoint_schema.child_count() != 1)
+                {
+                    throw std::logic_error(
+                        "TSInput non-peered dynamic TSL storage requires one element annotation");
+                }
+                const auto *plan =
+                    ts_data_plan_factory_detail::synthesise_dynamic_list_plan(*schema);
+                if (plan == nullptr)
+                {
+                    throw std::logic_error(
+                        "TSInput non-peered dynamic TSL storage plan is not resolved");
                 }
                 return *plan;
             }
@@ -2012,6 +2039,38 @@ namespace hgraph
                 return intern_ts_type(*schema, storage_role, root_plan, ops,
                                       implementation_label);
             }
+            if (schema != nullptr && schema->kind == TSTypeKind::TSL &&
+                schema->fixed_size() == 0)
+            {
+                if (endpoint_schema.child_count() != 1)
+                {
+                    throw std::logic_error(
+                        "TSInput non-peered dynamic TSL binding requires one element annotation");
+                }
+                const auto &child_schema = endpoint_schema.child(0);
+                const auto &child_plan = input_storage_plan(child_schema);
+                const auto element_type = input_storage_type_for(
+                    child_schema, child_plan, 0, true, storage_role);
+                if (!element_type)
+                {
+                    throw std::logic_error(
+                        "TSInput non-peered dynamic TSL element type is not resolved");
+                }
+                const auto *expected_plan =
+                    ts_data_plan_factory_detail::synthesise_dynamic_list_plan(*schema);
+                if (expected_plan == nullptr)
+                {
+                    throw std::logic_error(
+                        "TSInput non-peered dynamic TSL binding has no storage plan");
+                }
+                const bool root_record =
+                    storage_offset == 0 && expected_plan == &root_plan;
+                const auto &ops = ts_data_plan_factory_detail::dynamic_list_ts_data_ops(
+                    *schema, root_plan, storage_offset, element_type, storage_role,
+                    !root_record);
+                return intern_ts_type(*schema, storage_role, root_plan, ops,
+                                      implementation_label);
+            }
 
             const auto key = binding_cache_key(endpoint_schema, root_plan, storage_offset, storage_role);
             std::lock_guard lock{input_binding_context_cache_mutex()};
@@ -2330,6 +2389,29 @@ namespace hgraph
             throw std::invalid_argument("owned dynamic TSData label requires dynamic TSL or TSW");
         }
 
+        [[nodiscard]] std::string_view dynamic_composite_label(
+            TypeRole role, bool root_record)
+        {
+            switch (role)
+            {
+                case TypeRole::Data:
+                    return root_record
+                               ? std::string_view{"ts.tsl.dynamic.data.composite"}
+                               : std::string_view{"ts.tsl.dynamic.data.composite.embedded"};
+                case TypeRole::Input:
+                    return root_record
+                               ? std::string_view{"ts.tsl.dynamic.input.composite"}
+                               : std::string_view{"ts.tsl.dynamic.input.composite.embedded"};
+                case TypeRole::Output:
+                    return root_record
+                               ? std::string_view{"ts.tsl.dynamic.output.composite"}
+                               : std::string_view{"ts.tsl.dynamic.output.composite.embedded"};
+                default:
+                    throw std::invalid_argument(
+                        "dynamic TSL composite role is not supported");
+            }
+        }
+
         [[nodiscard]] TSRoleTypeRef input_storage_type_for(const TSEndpointSchema         &endpoint_schema,
                                                               const MemoryUtils::StoragePlan &root_plan,
                                                               std::size_t storage_offset,
@@ -2458,8 +2540,27 @@ namespace hgraph
                 return intern_ts_type(*schema, storage_role, root_plan, ops, label);
             }
 
-            if (dynamic_list || window)
-                throw std::invalid_argument("non-peered dynamic TSL and TSW inputs are not supported");
+            if (dynamic_list)
+            {
+                if (endpoint_schema.child_count() != 1)
+                {
+                    throw std::logic_error(
+                        "non-peered dynamic TSL storage requires one element annotation");
+                }
+                const auto &child_schema = endpoint_schema.child(0);
+                const auto &child_plan = input_storage_plan(child_schema);
+                const auto element_type = input_storage_type_for(
+                    child_schema, child_plan, 0, true, storage_role);
+                const auto &ops = ts_data_plan_factory_detail::dynamic_list_ts_data_ops(
+                    *schema, root_plan, storage_offset, element_type, storage_role,
+                    !root_record);
+                return intern_ts_type(
+                    *schema, storage_role, root_plan, ops,
+                    dynamic_composite_label(storage_role, root_record));
+            }
+
+            if (window)
+                throw std::invalid_argument("non-peered TSW inputs are not supported");
 
             const auto composite_label = schema->kind == TSTypeKind::TSD
                                              ? std::string_view{"ts.tsd.input.composite"}
@@ -2866,7 +2967,10 @@ namespace hgraph
                                     schema->kind == TSTypeKind::TSW) &&
                                    plan.endpoint_schema().is_owned();
         const bool structural_root = schema != nullptr &&
-                                     (schema->kind == TSTypeKind::TSB || schema->kind == TSTypeKind::TSD) &&
+                                     (schema->kind == TSTypeKind::TSB ||
+                                      schema->kind == TSTypeKind::TSD ||
+                                      (schema->kind == TSTypeKind::TSL &&
+                                       schema->fixed_size() == 0)) &&
                                      plan.endpoint_schema().is_non_peered();
         if (!direct_peered && !owned_scalar && !owned_fixed && !owned_keyed && !owned_dynamic && !structural_root)
         {

--- a/tests/cpp/test_dispatch.cpp
+++ b/tests/cpp/test_dispatch.cpp
@@ -319,6 +319,39 @@ namespace
             return wire<stdlib::dispatch_>(w, cases.value(), source_ref).as<TS<Str>>();
         }
     };
+
+    using DispatchStructuralResult =
+        UnNamedTSB<Field<"id", TS<Int>>, Field<"sound", TS<Str>>>;
+
+    struct StructuralSound
+    {
+        static constexpr auto name = "dispatch_structural_sound";
+
+        static Port<DispatchStructuralResult> compose(
+            Wiring &w, Port<void> animal)
+        {
+            auto id = wire<stdlib::getattr_, TS<Int>>(
+                w, animal, Str{"id"});
+            auto sound = wire<stdlib::getattr_, TS<Str>>(
+                w, animal, Str{"sound"});
+            return stdlib::to_tsb<DispatchStructuralResult>(w, id, sound);
+        }
+    };
+
+    struct StructuralDispatchGraph
+    {
+        static constexpr auto name = "structural_dispatch_graph";
+
+        static Port<TS<Str>> compose(
+            Wiring &w, Port<TS<Animal>> animal,
+            Scalar<"cases", stdlib::DispatchCases> cases)
+        {
+            auto result = wire<stdlib::dispatch_>(w, cases.value(), animal)
+                              .as<DispatchStructuralResult>();
+            return wire<stdlib::getitem_>(w, result, Str{"sound"})
+                .as<TS<Str>>();
+        }
+    };
 }
 
 TEST_CASE("dispatch_: C++ wiring selects exact and inherited Bundle cases")
@@ -341,6 +374,25 @@ TEST_CASE("dispatch_: C++ wiring selects exact and inherited Bundle cases")
                 cat_value(types, 3)),
             arg<"count">(testing::values<Int>(1, 2, 3)))),
         string_values({"woof", "yip", "meow"}));
+}
+
+TEST_CASE("dispatch_: composed structural branch outputs retain their public schema")
+{
+    using namespace hgraph;
+    stdlib::register_standard_operators();
+    const auto types = register_dispatch_types();
+
+    const auto cases = stdlib::dispatch_cases({
+        stdlib::dispatch_case(types.dog, fn<StructuralSound>()),
+        stdlib::dispatch_case(types.cat, fn<StructuralSound>()),
+    });
+
+    CHECK_OUTPUT(
+        (testing::eval_node<StructuralDispatchGraph>(
+            testing::values<Value>(dog_value(types, 1, "woof"),
+                                   cat_value(types, 2)),
+            cases)),
+        testing::values<Str>(Str{"woof"}, Str{"meow"}));
 }
 
 TEST_CASE("dispatch_: compiled branches import an enclosing context")

--- a/tests/cpp/test_error_handling.cpp
+++ b/tests/cpp/test_error_handling.cpp
@@ -230,6 +230,57 @@ namespace
     };
 
     using TryIntResult = UnNamedTSB<Field<"exception", TS<NodeError>>, Field<"out", TS<Int>>>;
+    using TryStructuralPair =
+        UnNamedTSB<Field<"value", TS<Int>>, Field<"offset", TS<Int>>>;
+    using TryStructuralResult =
+        UnNamedTSB<Field<"exception", TS<NodeError>>,
+                   Field<"out", TryStructuralPair>>;
+
+    struct TryStructuralPairG
+    {
+        static constexpr auto name = "try_structural_pair_g";
+
+        static Port<TryStructuralPair> compose(
+            Wiring &w, Port<TS<Int>> value)
+        {
+            using namespace hgraph::stdlib::syntax;
+            auto offset = (value + Int{1}).as<TS<Int>>();
+            return stdlib::to_tsb<TryStructuralPair>(w, value, offset);
+        }
+    };
+
+    [[nodiscard]] Port<TS<Int>> try_structural_value(
+        Wiring &w, Port<TryStructuralResult> result)
+    {
+        auto out = wire<stdlib::getitem_>(w, result, Str{"out"})
+                       .as<TryStructuralPair>();
+        return wire<stdlib::getitem_>(w, out, Str{"value"}).as<TS<Int>>();
+    }
+
+    struct StaticTryStructuralGraph
+    {
+        static constexpr auto name = "static_try_structural_graph";
+
+        static Port<TS<Int>> compose(Wiring &w, Port<TS<Int>> value)
+        {
+            return try_structural_value(
+                w, try_except_<TryStructuralPairG>(w, value)
+                       .as<TryStructuralResult>());
+        }
+    };
+
+    struct DynamicTryStructuralGraph
+    {
+        static constexpr auto name = "dynamic_try_structural_graph";
+
+        static Port<TS<Int>> compose(Wiring &w, Port<TS<Int>> value)
+        {
+            return try_structural_value(
+                w, wire<stdlib::try_except>(
+                       w, fn<TryStructuralPairG>(), value)
+                       .as<TryStructuralResult>());
+        }
+    };
 
     // Splits the try_except TSB result: the ``out`` value when it ticks.
     struct TryOutValue
@@ -658,6 +709,17 @@ TEST_CASE("error handling: try_except over a sub-graph routes value and exceptio
 
     CHECK_OUTPUT(get_recorded_values<Int>(gs, "out"), values<Int>(10, none, 14));
     CHECK_OUTPUT(get_recorded_values<Str>(gs, "err"), values<Str>(none, "negative input"s));
+}
+
+TEST_CASE("error handling: static and dynamic try_except preserve structural child outputs")
+{
+    using namespace hgraph;
+    using namespace hgraph::testing;
+    stdlib::register_standard_operators();
+
+    const auto input = values<Int>(1, 2, 3);
+    CHECK_OUTPUT(eval_node<StaticTryStructuralGraph>(input), input);
+    CHECK_OUTPUT(eval_node<DynamicTryStructuralGraph>(input), input);
 }
 
 TEST_CASE("error handling: try_except catches non-standard exceptions as unknown errors")

--- a/tests/cpp/test_map.cpp
+++ b/tests/cpp/test_map.cpp
@@ -2154,6 +2154,34 @@ namespace
         }
     };
 
+    using DynamicStructuralPair =
+        UnNamedTSB<Field<"value", TS<Int>>, Field<"offset", TS<Int>>>;
+
+    struct DynamicStructuralPairG
+    {
+        static constexpr auto name = "dynamic_structural_pair_g";
+
+        static Port<DynamicStructuralPair> compose(
+            Wiring &w, Port<TS<Int>> value)
+        {
+            using namespace hgraph::stdlib::syntax;
+            auto offset = (value + Int{100}).as<TS<Int>>();
+            return stdlib::to_tsb<DynamicStructuralPair>(w, value, offset);
+        }
+    };
+
+    struct MapDynamicStructuralPairG
+    {
+        static constexpr auto name = "map_dynamic_structural_pair_g";
+
+        static Port<TSL<DynamicStructuralPair>> compose(
+            Wiring &w, Port<TSL<TS<Int>>> values)
+        {
+            return wire<stdlib::map_>(w, fn<DynamicStructuralPairG>(), values)
+                .as<TSL<DynamicStructuralPair>>();
+        }
+    };
+
     struct MapDynamicCounterG
     {
         static constexpr auto name = "map_dynamic_counter_g";
@@ -2639,6 +2667,25 @@ TEST_CASE("map_ over dynamic TSL: arbitrary graphs grow stable children and "
             values<Value>(list_delta<TS<Int>>({{0, 1}, {1, 2}}), none, list_delta<TS<Int>>({{0, 5}})),
             values<Value>(list_delta<TS<Int>>({{0, 10}}), list_delta<TS<Int>>({{1, 20}}), none), values<Int>(100, none, 200))),
         values<Value>(list_delta<TS<Int>>({{0, 111}}), list_delta<TS<Int>>({{1, 123}}), list_delta<TS<Int>>({{0, 215}, {1, 223}})));
+}
+
+TEST_CASE("map_ over dynamic TSL: composed structural child results retain their element schema")
+{
+    using namespace hgraph;
+    stdlib::register_standard_operators();
+
+    CHECK_OUTPUT(
+        (eval_node<MapDynamicStructuralPairG>(values<Value>(
+            list_delta<TS<Int>>({{0, 1}}),
+            list_delta<TS<Int>>({{1, 2}}),
+            list_delta<TS<Int>>({{0, 3}})))),
+        values<Value>(
+            list_delta<DynamicStructuralPair>(
+                {{0, tsb_delta<DynamicStructuralPair>(Int{1}, Int{101})}}),
+            list_delta<DynamicStructuralPair>(
+                {{1, tsb_delta<DynamicStructuralPair>(Int{2}, Int{102})}}),
+            list_delta<DynamicStructuralPair>(
+                {{0, tsb_delta<DynamicStructuralPair>(Int{3}, Int{103})}})));
 }
 
 TEST_CASE("map_ over dynamic TSL: each index preserves isolated child state") {

--- a/tests/cpp/test_nested_wiring.cpp
+++ b/tests/cpp/test_nested_wiring.cpp
@@ -222,6 +222,41 @@ namespace
         }
     };
 
+    struct DynamicListPassThroughSubGraph
+    {
+        static constexpr auto name = "dynamic_list_pass_through_subgraph";
+
+        static Port<TSL<TS<Int>>> compose(
+            Wiring &, Port<TSL<TS<Int>>> values)
+        {
+            return values;
+        }
+    };
+
+    struct StructuralPairPassThroughSubGraph
+    {
+        static constexpr auto name = "structural_pair_pass_through_subgraph";
+
+        static Port<StructuralPair> compose(
+            Wiring &w, Port<StructuralPair> value, Port<TS<Int>> trigger)
+        {
+            static_cast<void>(wire<stdlib::null_sink>(w, trigger));
+            return value;
+        }
+    };
+
+    struct EmptyStructuralPairReferenceSource
+    {
+        static constexpr auto name = "empty_structural_pair_reference_source";
+        static constexpr bool schedule_on_start = true;
+
+        static void eval(Out<REF<StructuralPair>> out)
+        {
+            out.set(TimeSeriesReference::empty(
+                schema_descriptor<StructuralPair>::ts_meta()));
+        }
+    };
+
     // A structural-initializer boundary: the outer arg is a non-peered TSL whose
     // shape is mirrored into the child compile (boundary leaves), so the child
     // consumer binds leaf-wise.
@@ -389,6 +424,36 @@ namespace
         }
     };
 
+    struct NestedDynamicListPassThroughGraph
+    {
+        static constexpr auto name = "nested_dynamic_list_pass_through_graph";
+
+        static Port<TSL<TS<Int>>> compose(
+            Wiring &w, Port<TSL<TS<Int>>> values)
+        {
+            return nested_<DynamicListPassThroughSubGraph>(w, values);
+        }
+    };
+
+    struct NestedStructuralPairUnbindGraph
+    {
+        static constexpr auto name = "nested_structural_pair_unbind_graph";
+
+        static Port<StructuralPair> compose(
+            Wiring &w, Port<TS<Int>> lhs, Port<TS<Int>> rhs,
+            Port<TS<Int>> choice, Port<TS<Int>> trigger)
+        {
+            auto value = stdlib::to_tsb<StructuralPair>(w, lhs, rhs);
+            auto empty = wire<EmptyStructuralPairReferenceSource>(w);
+            auto choices = stdlib::to_tsl<TSL<StructuralPair, 2>>(
+                w, value, empty);
+            auto selected = wire<stdlib::getitem_>(w, choices, choice)
+                                .as<StructuralPair>();
+            return nested_<StructuralPairPassThroughSubGraph>(
+                w, selected, trigger);
+        }
+    };
+
     struct NestedTslGraph
     {
         static constexpr auto name = "nested_tsl_graph";
@@ -485,6 +550,40 @@ TEST_CASE("nested wiring: newly composed fixed structural results retain their p
             values<Int>(1, 2), values<Int>(10, 20))),
         values<Value>(list_delta<TS<Int>>({1, 10}),
                       list_delta<TS<Int>>({2, 20})));
+}
+
+TEST_CASE("nested wiring: a dynamic TSL pass-through binds before the producer grows the list")
+{
+    using namespace hgraph;
+    stdlib::register_standard_operators();
+
+    const auto input = values<Value>(
+        list_delta<TS<Int>>({}),
+        list_delta<TS<Int>>({{0, 1}, {1, 2}}),
+        list_delta<TS<Int>>({{1, 3}}));
+    CHECK_OUTPUT(
+        eval_node<NestedDynamicListPassThroughGraph>(input),
+        values<Value>(none,
+                      list_delta<TS<Int>>({{0, 1}, {1, 2}}),
+                      list_delta<TS<Int>>({{1, 3}})));
+}
+
+TEST_CASE("nested wiring: structural pass-through leaves clear while their source is unbound")
+{
+    using namespace hgraph;
+    stdlib::register_standard_operators();
+
+    CHECK_OUTPUT(
+        (eval_node<NestedStructuralPairUnbindGraph>(
+            values<Int>(1, none, 2, none),
+            values<Int>(10, none, 20, none),
+            values<Int>(0, 1, none, 0),
+            values<Int>(0, 1, 2, 3))),
+        values<Value>(
+            tsb_delta<StructuralPair>(Int{1}, Int{10}),
+            none,
+            none,
+            tsb_delta<StructuralPair>(Int{2}, Int{20})));
 }
 
 TEST_CASE("nested wiring: every dynamic child graph uses planned or stable in-place storage")

--- a/tests/cpp/test_nested_wiring.cpp
+++ b/tests/cpp/test_nested_wiring.cpp
@@ -32,6 +32,8 @@ namespace
     using namespace hgraph::testing;
 
     using IntPair = TSL<TS<Int>, 2>;
+    using StructuralPair =
+        UnNamedTSB<Field<"lhs", TS<Int>>, Field<"rhs", TS<Int>>>;
 
     // ---------------- sub-graph definitions under test ----------------
 
@@ -164,6 +166,21 @@ namespace
         static Port<REF<TS<Int>>> compose(Wiring &, Port<REF<TS<Int>>> in) { return in; }
     };
 
+    // The callable exposes a plain logical result while its actual terminal
+    // remains a REF-producing node. CompiledSubGraph must retain both views.
+    struct DereferencedRefOutputSubGraph
+    {
+        static constexpr auto name = "dereferenced_ref_output_subgraph";
+
+        static Port<TS<Int>> compose(Wiring &w,
+                                     Port<TS<Bool>> pick_rhs,
+                                     Port<TS<Int>> lhs,
+                                     Port<TS<Int>> rhs)
+        {
+            return wire<RefSelector>(w, pick_rhs, lhs, rhs).as<TS<Int>>();
+        }
+    };
+
     struct PairSum
     {
         static constexpr auto name = "pair_sum";
@@ -180,6 +197,28 @@ namespace
         static Port<TS<Int>>  compose(Wiring &w, Port<REF<IntPair>> in)
         {
             return wire<PairSum>(w, in);
+        }
+    };
+
+    struct StructuralPairSubGraph
+    {
+        static constexpr auto name = "structural_pair_subgraph";
+
+        static Port<StructuralPair> compose(
+            Wiring &w, Port<TS<Int>> lhs, Port<TS<Int>> rhs)
+        {
+            return stdlib::to_tsb<StructuralPair>(w, lhs, rhs);
+        }
+    };
+
+    struct StructuralListSubGraph
+    {
+        static constexpr auto name = "structural_list_subgraph";
+
+        static Port<IntPair> compose(
+            Wiring &w, Port<TS<Int>> lhs, Port<TS<Int>> rhs)
+        {
+            return stdlib::to_tsl<IntPair>(w, lhs, rhs).as<IntPair>();
         }
     };
 
@@ -328,6 +367,28 @@ namespace
         }
     };
 
+    struct NestedStructuralPairGraph
+    {
+        static constexpr auto name = "nested_structural_pair_graph";
+
+        static Port<StructuralPair> compose(
+            Wiring &w, Port<TS<Int>> lhs, Port<TS<Int>> rhs)
+        {
+            return nested_<StructuralPairSubGraph>(w, lhs, rhs);
+        }
+    };
+
+    struct NestedStructuralListGraph
+    {
+        static constexpr auto name = "nested_structural_list_graph";
+
+        static Port<IntPair> compose(
+            Wiring &w, Port<TS<Int>> lhs, Port<TS<Int>> rhs)
+        {
+            return nested_<StructuralListSubGraph>(w, lhs, rhs);
+        }
+    };
+
     struct NestedTslGraph
     {
         static constexpr auto name = "nested_tsl_graph";
@@ -383,6 +444,47 @@ TEST_CASE("nested wiring: nested_<G> binds an outer input into the child graph a
     stdlib::register_standard_operators();
 
     CHECK_OUTPUT(eval_node<NestedAddOneGraph>(values<Int>(1, 2, 3)), values<Int>(2, 3, 4));
+}
+
+TEST_CASE("nested wiring: compiled structural results keep logical and terminal schemas distinct")
+{
+    using namespace hgraph;
+    stdlib::register_standard_operators();
+
+    const auto *bundle_schema = schema_descriptor<StructuralPair>::ts_meta();
+    const CompiledSubGraph bundle = compile_subgraph<StructuralPairSubGraph>();
+    CHECK(bundle.output_schema == bundle_schema);
+    CHECK(bundle.terminal_output_schema ==
+          TypeRegistry::instance().ref(bundle_schema));
+
+    const auto *list_schema = schema_descriptor<IntPair>::ts_meta();
+    const CompiledSubGraph list = compile_subgraph<StructuralListSubGraph>();
+    CHECK(list.output_schema == list_schema);
+    CHECK(list.terminal_output_schema == TypeRegistry::instance().ref(list_schema));
+
+    const auto *plain_schema = schema_descriptor<TS<Int>>::ts_meta();
+    const CompiledSubGraph dereferenced_ref =
+        compile_subgraph<DereferencedRefOutputSubGraph>();
+    CHECK(dereferenced_ref.output_schema == plain_schema);
+    CHECK(dereferenced_ref.terminal_output_schema ==
+          TypeRegistry::instance().ref(plain_schema));
+}
+
+TEST_CASE("nested wiring: newly composed fixed structural results retain their public schemas")
+{
+    using namespace hgraph;
+    stdlib::register_standard_operators();
+
+    CHECK_OUTPUT(
+        (eval_node<NestedStructuralPairGraph>(
+            values<Int>(1, 2), values<Int>(10, 20))),
+        values<Value>(tsb_delta<StructuralPair>(Int{1}, Int{10}),
+                      tsb_delta<StructuralPair>(Int{2}, Int{20})));
+    CHECK_OUTPUT(
+        (eval_node<NestedStructuralListGraph>(
+            values<Int>(1, 2), values<Int>(10, 20))),
+        values<Value>(list_delta<TS<Int>>({1, 10}),
+                      list_delta<TS<Int>>({2, 20})));
 }
 
 TEST_CASE("nested wiring: every dynamic child graph uses planned or stable in-place storage")

--- a/tests/cpp/test_ts_type_ref.cpp
+++ b/tests/cpp/test_ts_type_ref.cpp
@@ -885,6 +885,18 @@ TEST_CASE("dynamic TSL and TSW role records are canonical distinct and exactly l
     REQUIRE_THROWS_AS(TSEndpointSchema::non_peered(dynamic, {}), std::invalid_argument);
     REQUIRE_THROWS_AS(TSEndpointSchema::non_peered(tick, {}), std::invalid_argument);
 
+    const auto dynamic_composite = TSEndpointSchema::non_peered_list(
+        dynamic, TSEndpointSchema::peered(ts));
+    REQUIRE(dynamic_composite.is_non_peered());
+    REQUIRE(dynamic_composite.child_count() == 1);
+    REQUIRE(dynamic_composite.child(0).schema() == ts);
+    TSInput dynamic_composite_input{
+        TSInputBuilderFactory::checked_builder_for(
+            *dynamic, dynamic_composite)};
+    REQUIRE(std::string{
+                dynamic_composite_input.type_ref().record()->implementation_name()} ==
+            "ts.tsl.dynamic.input.composite");
+
     for (const auto &item : cases)
     {
         const auto data = factory.data_type_for(item.schema);


### PR DESCRIPTION
## Summary

- separate each compiled subgraph's public/logical result schema from the physical terminal endpoint schema
- centralize mapped-child terminal wiring so TSD and dynamic TSL map use the same classification and forwarding behavior
- preserve composed TSB/TSL outputs through nested graphs, try/except, dispatch, TSD map, and dynamic TSL map
- support non-peered dynamic TSL endpoint templates for runtime-created forwarding elements
- add matching C++ and Python compatibility regressions, including sparse-update scheduling coverage

## Context

This is the follow-up to #295 and addresses the unresolved [P1 review thread](https://github.com/hhenson/hg_cpp/pull/295#discussion_r3740778322).

The root problem was that `CompiledSubGraph::output_schema` sometimes described the synthetic physical REF terminal and sometimes the callable's public result. Consumers then corrected that mismatch independently. The new contract records the logical and terminal schemas separately in `finish_subgraph`, so consumers share one wiring-time interpretation. Map-specific terminal selection is also centralized for TSD and dynamic TSL paths.

## Validation

macOS local acceptance:

- `cmake --preset cpp --fresh`
- `cmake --build --preset cpp --target clean`
- `cmake --build --preset cpp --parallel`
- `ctest --preset cpp --parallel 2`: 1,486/1,486 passed
- stable-ABI wheel built with Python 3.12 and installed into a fresh Python 3.14 environment
- `python -m pytest python/tests -q -m "not wip"`: 2,015 passed, 9 skipped

Linux and Windows are left to CI because the local hg-linux and hg-windows environments are currently unavailable.